### PR TITLE
[go] integrate network fetch

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2533,7 +2533,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: fa6c5cd41afdcec8f0eca28a78b96abb86c28493
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
   EXNotifications: a01203397855862df7e4ac3bcf9fc7bc6914893e
-  Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
+  Expo: a4053ae9e65c5f14e5bd7400d532e4b10942a57b
   expo-dev-client: 5fabdda30d7494ed2110775479864463171e9a0e
   expo-dev-launcher: 83e5b141c512a1fae37bc0cced8c9ac4e8144eb9
   expo-dev-menu: 8559d77f4037c6105b21a424dec68f235496c391

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -26,6 +26,7 @@ import expo.modules.documentpicker.DocumentPickerModule
 import expo.modules.easclient.EASClientModule
 import expo.modules.facedetector.FaceDetectorModule
 import expo.modules.facedetector.FaceDetectorPackage
+import expo.modules.fetch.ExpoFetchModule
 import expo.modules.filesystem.FileSystemModule
 import expo.modules.filesystem.FileSystemPackage
 import expo.modules.font.FontLoaderModule
@@ -53,7 +54,6 @@ import expo.modules.medialibrary.MediaLibraryModule
 import expo.modules.navigationbar.NavigationBarModule
 import expo.modules.navigationbar.NavigationBarPackage
 import expo.modules.network.NetworkModule
-import expo.modules.networkfetch.ExpoNetworkFetchModule
 import expo.modules.notifications.NotificationsPackage
 import expo.modules.notifications.badge.BadgeModule
 import expo.modules.notifications.notifications.background.ExpoBackgroundNotificationTasksModule
@@ -159,8 +159,8 @@ object ExperiencePackagePicker : ModulesProvider {
     DeviceModule::class.java,
     DocumentPickerModule::class.java,
     EASClientModule::class.java,
+    ExpoFetchModule::class.java,
     ExpoLinkingModule::class.java,
-    ExpoNetworkFetchModule::class.java,
     FileSystemModule::class.java,
     FaceDetectorModule::class.java,
     FontLoaderModule::class.java,

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -53,6 +53,7 @@ import expo.modules.medialibrary.MediaLibraryModule
 import expo.modules.navigationbar.NavigationBarModule
 import expo.modules.navigationbar.NavigationBarPackage
 import expo.modules.network.NetworkModule
+import expo.modules.networkfetch.ExpoNetworkFetchModule
 import expo.modules.notifications.NotificationsPackage
 import expo.modules.notifications.badge.BadgeModule
 import expo.modules.notifications.notifications.background.ExpoBackgroundNotificationTasksModule
@@ -159,6 +160,7 @@ object ExperiencePackagePicker : ModulesProvider {
     DocumentPickerModule::class.java,
     EASClientModule::class.java,
     ExpoLinkingModule::class.java,
+    ExpoNetworkFetchModule::class.java,
     FileSystemModule::class.java,
     FaceDetectorModule::class.java,
     FontLoaderModule::class.java,

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.m
@@ -39,7 +39,7 @@
     RCTSetCustomNSURLSessionConfigurationProvider(^{
       return [self createDefaultURLSessionConfiguration];
     });
-    [EXNetworkFetchCustomExtension setCustomURLSessionConfigurationProvider:^{
+    [EXFetchCustomExtension setCustomURLSessionConfigurationProvider:^{
       return [self createDefaultURLSessionConfiguration];
     }];
   }

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.m
@@ -7,7 +7,9 @@
 #import <React/RCTInspectorPackagerConnection.h>
 #import <SocketRocket/SRWebSocket.h>
 
+#import <ExpoModulesCore/ExpoModulesCore.h>
 #import "ExpoModulesCore-Swift.h"
+#import "Expo-Swift.h"
 
 #pragma mark - RCTInspectorPackagerConnection category interface
 
@@ -34,22 +36,30 @@
     self.inspectorPackgerConnection = inspectorPackgerConnection;
     [EXRequestCdpInterceptor.shared setDelegate:self];
 
-    Class requestInterceptorClass = [EXRequestInterceptorProtocol class];
     RCTSetCustomNSURLSessionConfigurationProvider(^{
-      NSURLSessionConfiguration *urlSessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-      NSMutableArray<Class> *protocolClasses = [urlSessionConfiguration.protocolClasses mutableCopy];
-      if (![protocolClasses containsObject:requestInterceptorClass]) {
-        [protocolClasses insertObject:requestInterceptorClass atIndex:0];
-      }
-      urlSessionConfiguration.protocolClasses = protocolClasses;
-
-      [urlSessionConfiguration setHTTPShouldSetCookies:YES];
-      [urlSessionConfiguration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
-      [urlSessionConfiguration setHTTPCookieStorage:[NSHTTPCookieStorage sharedHTTPCookieStorage]];
-      return urlSessionConfiguration;
+      return [self createDefaultURLSessionConfiguration];
     });
+    [EXNetworkFetchCustomExtension setCustomURLSessionConfigurationProvider:^{
+      return [self createDefaultURLSessionConfiguration];
+    }];
   }
   return self;
+}
+
+- (NSURLSessionConfiguration *)createDefaultURLSessionConfiguration
+{
+  Class requestInterceptorClass = [EXRequestInterceptorProtocol class];
+  NSURLSessionConfiguration *urlSessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+  NSMutableArray<Class> *protocolClasses = [urlSessionConfiguration.protocolClasses mutableCopy];
+  if (![protocolClasses containsObject:requestInterceptorClass]) {
+    [protocolClasses insertObject:requestInterceptorClass atIndex:0];
+  }
+  urlSessionConfiguration.protocolClasses = protocolClasses;
+
+  [urlSessionConfiguration setHTTPShouldSetCookies:YES];
+  [urlSessionConfiguration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
+  [urlSessionConfiguration setHTTPCookieStorage:[NSHTTPCookieStorage sharedHTTPCookieStorage]];
+  return urlSessionConfiguration;
 }
 
 - (void)dealloc

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2357,7 +2357,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: fa6c5cd41afdcec8f0eca28a78b96abb86c28493
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
   EXNotifications: a01203397855862df7e4ac3bcf9fc7bc6914893e
-  Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
+  Expo: a4053ae9e65c5f14e5bd7400d532e4b10942a57b
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
   ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
   ExpoAudio: 7a5deb52fb0691bb3f51f573013ffbc962fec2d0

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add minimal `TextDecoder` support to native client platforms. ([#29620](https://github.com/expo/expo/pull/29620) by [@EvanBacon](https://github.com/EvanBacon))
 - Introduced `useEvent` hook for EventEmitter objects (e.g. native modules and shared objects). ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
-- Added fetch API support. ([#30173](https://github.com/expo/expo/pull/30173), [#30219](https://github.com/expo/expo/pull/30219) by [@kudo](https://github.com/kudo))
+- Added fetch API support. ([#30173](https://github.com/expo/expo/pull/30173), [#30219](https://github.com/expo/expo/pull/30219), [#30576](https://github.com/expo/expo/pull/30576) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -43,4 +43,7 @@ Pod::Spec.new do |s|
   end
 
   s.source_files = 'ios/**/*.{h,m,swift}'
+  s.user_target_xcconfig = {
+    'HEADER_SEARCH_PATHS' => '"${PODS_CONFIGURATION_BUILD_DIR}/Expo/Swift Compatibility Header"',
+  }
 end

--- a/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
@@ -3,8 +3,8 @@
 /**
  For callsites to customize network fetch functionalities like having custom `URLSessionConfiguration`.
  */
-@objc(EXNetworkFetchCustomExtension)
-public class ExpoNetworkFetchCustomExtension: NSObject {
+@objc(EXFetchCustomExtension)
+public class ExpoFetchCustomExtension: NSObject {
   @objc
   public static func setCustomURLSessionConfigurationProvider(_ provider: NSURLSessionConfigurationProvider?) {
     urlSessionConfigurationProvider = provider

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
-internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider? = nil
+internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
 
 public final class ExpoFetchModule: Module {
   private lazy var urlSession = createURLSession()

--- a/packages/expo/ios/Fetch/ExpoNetworkFetchCustomExtension.swift
+++ b/packages/expo/ios/Fetch/ExpoNetworkFetchCustomExtension.swift
@@ -1,0 +1,12 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ For callsites to customize network fetch functionalities like having custom `URLSessionConfiguration`.
+ */
+@objc(EXNetworkFetchCustomExtension)
+public class ExpoNetworkFetchCustomExtension: NSObject {
+  @objc
+  public static func setCustomURLSessionConfigurationProvider(_ provider: NSURLSessionConfigurationProvider?) {
+    urlSessionConfigurationProvider = provider
+  }
+}

--- a/packages/expo/ios/Fetch/FetchExceptions.swift
+++ b/packages/expo/ios/Fetch/FetchExceptions.swift
@@ -2,12 +2,6 @@
 
 import ExpoModulesCore
 
-internal class FetchURLSessionLostException: Exception {
-  override var reason: String {
-    "The URL session has been lost"
-  }
-}
-
 internal class FetchUnknownException: Exception {
   override var reason: String {
     "Unknown error"


### PR DESCRIPTION
# Why

integrate fetch to expo-go
close ENG-12516

# How

- add `ExpoNetworkFetchModule` to android module list
- integrate `setCustomURLSessionConfigurationProvider` to support network inspector

# Test Plan

- expo-go + fetch test-suite

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
