### PR TITLE
[docs] Multiple minor fixes in various docs

### DIFF
--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -57,7 +57,7 @@ If you want to build an Android app binary you'll need to have a keystore. If yo
   cmdCopy='keytool -genkey -v -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -storepass KEYSTORE_PASSWORD -keypass KEY_PASSWORD -alias KEY_ALIAS -keystore release.keystore -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"'
 />
 
-Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the `android/keystores` directory. **Remember to git-ignore all your release keystores!** If you have run the above keytool command and placed the keystore at `android/keystores/release.keystore`, you can ignore that file by adding the following line to `.gitignore`:
+Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the **android/keystores** directory. **Remember to git-ignore all your release keystores!** If you have run the above keytool command and placed the keystore at **android/keystores/release.keystore**, you can ignore that file by adding the following line to **.gitignore**:
 
 ```sh .gitignore
 android/keystores/release.keystore

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -202,9 +202,9 @@ The rest of the configuration at this point is not specific to EAS, it's the sam
       <string name="app_name">MyApp - Dev</string>
   </resources>
   ```
-- To change the icon of the app built with the development profile, create `android/app/src/development/res/mipmap-*` directories with appropriate assets (you can copy them from **android/app/src/main/res** and replace the icon files).
+- To change the icon of the app built with the development profile, create **android/app/src/development/res/mipmap-\*** directories with appropriate assets (you can copy them from **android/app/src/main/res** and replace the icon files).
 - To specify **google-services.json** for a specific flavor, put it in the **android/app/src/&lbrace;flavor&rbrace;/google-services.json** file.
-- To configure sentry, add `project.ext.sentryCli = [ flavorAware: true ]` to **android/app/build.gradle** and name your properties file `android/sentry-{flavor}-{buildType}.properties` (for example, **android/sentry-production-release.properties**)
+- To configure sentry, add `project.ext.sentryCli = [ flavorAware: true ]` to **android/app/build.gradle** and name your properties file **android/sentry-\{flavor\}-\{buildType\}.properties** (for example, **android/sentry-production-release.properties**)
 
 #### iOS
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -5,7 +5,6 @@ description: The Expo CLI is a command-line tool that is the primary interface b
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 import { StatusTag } from '~/ui/components/Tag';
 
 > **info** This documentation refers to the Local Expo CLI. For information on legacy CLI, see [Global Expo CLI](/archive/expo-cli).
@@ -258,10 +257,6 @@ The following options are provided:
 
 > Experimental functionality. Available from SDK 50.
 
-<Tabs>
-
-<Tab label="SDK 50 and above">
-
 You can configure the prefix for static assets by setting the `experiments.baseUrl` field in your [app config](/workflow/configuration/):
 
 ```json app.json
@@ -319,16 +314,6 @@ export default function Blog() {
   return <img src="/my-root/assets/image.png" />;
 }
 ```
-
-</Tab>
-
-<Tab label="SDK 49 and below">
-
-    Exporting for a sub-path is not supported in SDK 49 and below.
-
-</Tab>
-
-</Tabs>
 
 ### Exporting with webpack
 

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-[Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
+[Lottie](https://airbnb.io/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -523,7 +523,7 @@ You can also manually add notification files to your Android and iOS projects if
 On Androids 8.0+, playing a custom sound for a notification requires more than setting the `sound` property on the `NotificationContentInput`.
 You will also need to configure the `NotificationChannel` with the appropriate `sound`, and use it when sending/scheduling the notification.
 
-For the example below to work, you would place your `email-sound.wav` file in `android/app/src/main/res/raw/`.
+For the example below to work, you would place your **email-sound.wav** file in **android/app/src/main/res/raw/**.
 
 ```ts
 // Prepare the notification channel

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-[Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
+[Lottie](https://airbnb.io/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -488,7 +488,7 @@ You can also manually add notification files to your Android and iOS projects if
 On Androids 8.0+, playing a custom sound for a notification requires more than setting the `sound` property on the `NotificationContentInput`.
 You will also need to configure the `NotificationChannel` with the appropriate `sound`, and use it when sending/scheduling the notification.
 
-For the example below to work, you would place your `email-sound.wav` file in `android/app/src/main/res/raw/`.
+For the example below to work, you would place your **email-sound.wav** file in **android/app/src/main/res/raw/**.
 
 ```ts
 // Prepare the notification channel

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-[Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
+[Lottie](https://airbnb.io/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/notifications.mdx
@@ -488,7 +488,7 @@ You can also manually add notification files to your Android and iOS projects if
 On Androids 8.0+, playing a custom sound for a notification requires more than setting the `sound` property on the `NotificationContentInput`.
 You will also need to configure the `NotificationChannel` with the appropriate `sound`, and use it when sending/scheduling the notification.
 
-For the example below to work, you would place your `email-sound.wav` file in `android/app/src/main/res/raw/`.
+For the example below to work, you would place your **email-sound.wav** file in **android/app/src/main/res/raw/**.
 
 ```ts
 // Prepare the notification channel

--- a/docs/pages/versions/v51.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/lottie.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-[Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
+[Lottie](https://airbnb.io/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/notifications.mdx
@@ -523,7 +523,7 @@ You can also manually add notification files to your Android and iOS projects if
 On Androids 8.0+, playing a custom sound for a notification requires more than setting the `sound` property on the `NotificationContentInput`.
 You will also need to configure the `NotificationChannel` with the appropriate `sound`, and use it when sending/scheduling the notification.
 
-For the example below to work, you would place your `email-sound.wav` file in `android/app/src/main/res/raw/`.
+For the example below to work, you would place your **email-sound.wav** file in **android/app/src/main/res/raw/**.
 
 ```ts
 // Prepare the notification channel

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
@@ -42,11 +42,7 @@ Plug in your Android device via USB to your computer.
 
 Check that your device is properly connecting to ADB, the Android Debug Bridge, by running `adb devices` in your terminal. You should see your device listed with `device` listed next to it. For example:
 
-```bash
-$ adb devices
-List of devices attached
-8AHX0T32K	device
-```
+<Terminal cmd={['$ adb devices', '', 'List of devices attached', '8AHX0T32K	device']} />
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
@@ -19,7 +19,7 @@ import { Step } from '~/ui/components/Step';
 
 ### Install expo-dev-client
 
-Run the following command in your project's root directory:
+Run the following command in your Expo project's root directory:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
@@ -22,7 +22,7 @@ import { Step } from '~/ui/components/Step';
 
 ### Install expo-dev-client
 
-Run the following command in your project's root directory:
+Run the following command in your Expo project's root directory:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -18,7 +18,7 @@ import { Step } from '~/ui/components/Step';
 
 ### Install expo-dev-client
 
-Run the following command in your project's root directory:
+Run the following command in your Expo project's root directory:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
@@ -18,7 +18,7 @@ import { Step } from '~/ui/components/Step';
 
 ### Install expo-dev-client
 
-Run the following command in your project's root directory:
+Run the following command in your Expo project's root directory:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on the external feedback, this PR:
- Fixes link to the Lottie documentation in Lottie API reference ([context](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1721731393361439))
- Updates Set up your environment guide with
  - Using Terminal component to represent `adb devices` command and its output
  - Clarify the "project's root directory" by prefixing it with "Expo" to mention that the command needs to be run from the Expo project's root ([context](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1721491772882029))
- Remove SDK 49 and below tab for exporting sub-path in Expo CLI reference
- Fix multiple directory and files to use bold syntax as per our writing style guide

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
