### PR TITLE
[sqlite] utf8 encode for prepare statements

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Android] Reduce the number of global references to `NativeStatementBinding`. ([#29937](https://github.com/expo/expo/pull/29937) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed `<SQLiteProvider assetSource={{ assetId: require(...) }}>` database always being overwrite on iOS 16 and lower. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30483](https://github.com/expo/expo/pull/30483) by [@byCedric](https://github.com/byCedric))
+- Fixed invalid characters for prepared statements on iOS. ([#30579](https://github.com/expo/expo/pull/30579) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -265,7 +265,8 @@ public final class SQLiteModuleNext: Module {
   private func prepareStatement(database: NativeDatabase, statement: NativeStatement, source: String) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
-    if sqlite3_prepare_v2(database.pointer, source, Int32(source.count), &statement.pointer, nil) != SQLITE_OK {
+    let sourceString = source.cString(using: .utf8)
+    if sqlite3_prepare_v2(database.pointer, sourceString, -1, &statement.pointer, nil) != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     maybeAddCachedStatement(database: database, statement: statement)


### PR DESCRIPTION
# Why

fix invalid characters for prepare statements on ios
fixes #30177 
fixes #30492 
close ENG-12819
close ENG-12820

# How

use utf8 encoding c string for `sqlite3_prepare_v2`

# Test Plan

- test repro from #30177 and #30492
- sqlite test-suite

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
