### PR TITLE
[camera] Stop session when view is removed

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,7 @@
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30462](https://github.com/expo/expo/pull/30462) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
+- On `iOS`, correctly stop the session when the `CameraView` is removed.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30462](https://github.com/expo/expo/pull/30462) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
-- On `iOS`, correctly stop the session when the `CameraView` is removed.
+- On `iOS`, correctly stop the session when the `CameraView` is removed. ([#30580](https://github.com/expo/expo/pull/30580) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -678,6 +678,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
 
   public override func removeFromSuperview() {
     lifecycleManager?.unregisterAppLifecycleListener(self)
+    self.stopSession()
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
     super.removeFromSuperview()


### PR DESCRIPTION
# Why
@Titozzz noticed this issue when leaving a screen with the camera and trying to play a video on the next screen. The camera session was not stopped causing it to interfere with the video when it is rendered.

# How
Stop the session in `removeFromSuperview`. This initially caused problems and was temporarily removed until I fixed all the lifecycle coordination. I forgot to add it back. 

# Test Plan
Bare-expo and tested in the repro that @Titozzz provided. 
