### PR TITLE
[docs] Fix `Step` component usage in SSO guide

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -175,11 +175,11 @@ If you no longer need your old user account, log out of your new SSO account, th
 ### Remove SSO users
 
 If someone has left your organization, remove or disable them in your IdP. Depending on the token refresh duration you configured with your IdP, the removed user will subsequently lose access to their Expo account.
-If you wish to remove them ahead of that time or you wish to remove them to clean up users on your account, you may do so on the organization member settings page:
+If you wish to remove them ahead of that time or you wish to remove them to clean up users on your account, you may do so on the organization **Member** settings page:
 
 <Step label="1">
 
-Navigate to your [organization account member settings](https://expo.dev/accounts/[account]/settings/members).
+Navigate to your [organization account **Member** settings](https://expo.dev/accounts/[account]/settings/members).
 
 </Step>
 

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -28,30 +28,37 @@ We implement the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-
 ## Setting up SSO on an organization
 
 <Step label="1">
-  Log in as the Organization account owner, select the Organization, then go to **Organization
-  settings** > **Overview**.
+
+Log in as the Organization account owner, select the Organization, then go to **Organization settings** > **Overview**.
+
 </Step>
 
 <Step label="2">
-  Click the **Start** button next to the **Create SSO configuration for account** option.
+
+Click the **Start** button next to the **Create SSO configuration for account** option.
+
 </Step>
 
 <Step label="3">
-  Enter the configuration details for your IdP using the information you collected during the IdP
-  setup:
+
+Enter the configuration details for your IdP using the information you collected during the IdP setup:
 
 - Client ID
 - Client secret
-- IdP subdomain/tenant ID, if needed. Click the **?** icon
-  above the Issuer field for help with what to enter.
+- IdP subdomain/tenant ID, if needed. Click the **?** icon above the Issuer field for help with what to enter.
 
 </Step>
 
-<Step label="4">Click **Create SSO Configuration**.</Step>
+<Step label="4">
+
+Click **Create SSO Configuration**.
+
+</Step>
 
 <Step label="5">
-  The **Organization settings** > **Overview** page will now display an **Update SSO configuration**
-  option. Use this option to update the client secret if it changes.
+
+The **Organization settings** > **Overview** page will now display an **Update SSO configuration** option. Use this option to update the client secret if it changes.
+
 </Step>
 
 ## SSO user sign in
@@ -59,16 +66,21 @@ We implement the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-
 ### Expo website
 
 <Step label="1">
-  Navigate to [expo.dev/sso-login](https://expo.dev/sso-login) and enter the account name of your
-  organization. You can create a link that pre-fills the organization name. For example,
-  [expo.dev/sso-login/test-org](https://expo.dev/sso-login/test-org) pre-fills `test-org`.
+
+Navigate to [expo.dev/sso-login](https://expo.dev/sso-login) and enter the account name of your organization. You can create a link that pre-fills the organization name. For example, [expo.dev/sso-login/test-org](https://expo.dev/sso-login/test-org) pre-fills `test-org`.
+
 </Step>
 
-<Step label="2">Log in to your identity provider (IdP).</Step>
+<Step label="2">
+
+Log in to your identity provider (IdP).
+
+</Step>
 
 <Step label="3">
-  Next, you'll be prompted to select an Expo username. This will be the username for your Expo
-  account.
+
+You'll be prompted to select an Expo username. This will be the username for your Expo account.
+
 </Step>
 
 ### Expo CLI
@@ -92,10 +104,16 @@ You will be prompted to log in via the Expo website in a browser and will be red
 ### Expo Go
 
 <Step label="1">
-  Click the **Continue with SSO** button on the sign-in page when going through the sign-in flow.
+
+Click the **Continue with SSO** button on the sign-in page when going through the sign-in flow.
+
 </Step>
 
-<Step label="2">Follow the [above steps](#expo-website) to sign in to the Expo website.</Step>
+<Step label="2">
+
+Follow the [above steps](#expo-website) to sign in to the Expo website.
+
+</Step>
 
 ## SSO user restrictions
 
@@ -117,37 +135,42 @@ Regular users may be a member of one or many personal, team, and organization ac
 To transition from using a regular Expo account to an SSO account, follow these steps:
 
 <Step label="1">
-  Check if you're already logged in at [expo.dev](https://expo.dev). If so, log out.
+
+Check if you're already logged in at [expo.dev](https://expo.dev). If so, log out.
+
 </Step>
 
 <Step label="2">
-  Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, such as entering
-  your organization name, creating a new Expo username, and logging in to your identity provider.
+
+Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, such as entering your organization name, creating a new Expo username, and logging in to your identity provider.
+
 </Step>
 
 <Step label="3">
-  By default, your new SSO user will have the View Only role. If you need a different role, ask an
-  Admin or Owner to update your role in [member
-  settings](https://expo.dev/accounts/[account]/settings/members).
+
+By default, your new SSO user will have the View Only role. If you need a different role, ask an Admin or Owner to update your role in [**Member**](https://expo.dev/accounts/[account]/settings/members) settings.
+
 </Step>
 
-<Step label="4">Run `eas login --sso` to switch to your new account on the CLI.</Step>
+<Step label="4">
+
+Run `eas login --sso` to switch to your new account on the CLI.
+
+</Step>
 
 <Step label="5">
-  At this time, the Admin or Owner can remove your old user from the organization. In [member
-  settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members
-  indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next
-  to the old user and click **Remove member**.
+
+At this time, the Admin or Owner can remove your old user from the organization. In [**Member**](https://expo.dev/accounts/[account]/settings/members) settings, the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.
+
 </Step>
 
 <Step label="6">
-  If you no longer need your old user account, log out of your new SSO account, then log in to your
-  old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete
-  Account**. **Note that this will delete any projects under your old user account.** It will not
-  affect any projects owned by the organization.
+
+If you no longer need your old user account, log out of your new SSO account, then log in to your old account and go to [**User settings**](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under your old user account.** It will not affect any projects owned by the organization.
+
 </Step>
 
-> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it before creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user. While Expo usernames need to be unique, it is OK if your email address on your identity provider matches the email address of your old user.
+> If you wish to reuse your old username on your new SSO user account, you can go to [**User settings**](https://expo.dev/settings) under your old user and rename it before creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user. While Expo usernames need to be unique, it is OK if your email address on your identity provider matches the email address of your old user.
 
 ### Remove SSO users
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `Step` component when wraps the content in an inline manner, DOM considers it a `div` and prose styles are not applied. It breaks the formatting of how the step number is displayed and in dark mode the text styles are not applied. An example is one of the steps used in the SSO guide:

![CleanShot 2024-07-24 at 02 41 49@2x](https://github.com/user-attachments/assets/0dfba24d-4694-40fe-89a0-29c3450e152f)

![CleanShot 2024-07-24 at 02 41 35@2x](https://github.com/user-attachments/assets/95883bd9-b314-4de6-9d70-f600639bd80d)


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the usage of `Step` component in the SSO guide by using newline characters when wrapping the content.

Also, fix Member settings and User settings usage throughout the doc by using bold syntax since they represent the actual settings pages from Expo dashboard.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally and visit: http://localhost:3002/accounts/sso/#expo-go

## Preview

![CleanShot 2024-07-24 at 02 46 19](https://github.com/user-attachments/assets/366d4cd1-a0c2-4e73-bc5c-39137b9b10ac)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
