### PR TITLE
[docs] Fix Table of Contents for Google Play Section in App credentials guide

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -7,7 +7,6 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 Expo automates the process of signing your app for Android and iOS, but in both cases, you can choose to provide your overrides. [EAS Build](/build/introduction) can generate signed or unsigned applications, but to distribute your application through the stores, it **must** be a signed application.
 
@@ -34,22 +33,16 @@ If you currently manage your app signing key and want Google to manage it for yo
 
 To sync your Expo keystore with Google, follow these steps:
 
-<Step label="1">
-
 #### Download credentials
 
 In a terminal window:
 
-1. Run `eas credentials`
+1. Run `eas credentials` command.
 2. Select `Android` for the platform and the profile whose credentials you wish to download.
-3. Select the option `credentials.json: Upload/Download credentials between EAS servers and your local json`
-4. Select `Download credentials from EAS to credentials.json`
+3. Select the option `credentials.json: Upload/Download credentials between EAS servers and your local json`.
+4. Select `Download credentials from EAS to credentials.json`.
 
 Your application's keystore should be kept private. **Under no circumstances should you check it into your repository.** Debug keystores are the only exception because we don't use them for uploading apps to the Google Play Store.
-
-</Step>
-
-<Step label="2">
 
 #### Export keystore to `pem` format
 
@@ -64,17 +57,11 @@ Once you have downloaded your credentials and the keystore, export it to the `pe
   ]}
 />
 
-</Step>
-
-<Step label="3">
-
 #### Contact Google support
 
 Contact Google Support and request them to change your key using [this support form](https://support.google.com/googleplay/android-developer/contact/key). While filling out the form, attach the `pem` file exported from the keystore.
 
 Once Google updates this on your account, builds created through `eas build` will be correctly signed as expected by the Google Play Store. Note that Google will set the validity start date of the new upload certificate to 72 hours in the future so you'll have to wait before your first submission after performing this process.
-
-</Step>
 
 </Collapsible>
 
@@ -90,8 +77,7 @@ Whether you let EAS handle all your credentials, or you handle them yourself, it
 
 ### Distribution certificate
 
-The distribution certificate is all about you, the developer, and not about any particular app. You may only have one distribution certificate associated with your Apple Developer account.
-This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `eas credentials` and following the prompts.
+The distribution certificate is all about you, the developer, and not about any particular app. You may only have one distribution certificate associated with your Apple Developer account. This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `eas credentials` and following the prompts.
 
 ### Push Notification keys
 
@@ -117,7 +103,7 @@ Provisioning profiles expire after 12 months, but this won't affect apps in prod
 
 ### Clearing credentials
 
-When you use the `eas credentials` command to delete your credentials, this only removes those credentials from Expo's servers, **it does not delete the credentials from Apple's perspective**. This means that to fully delete your credentials (for example, if you want a new push notification key, however, you already have two), you'll need to do so from the [Apple Developer Console](https://developer.apple.com/account/resources/certificates/list).
+When you use the `eas credentials` command to delete your credentials, this only removes those credentials from Expo's servers. **It does not delete the credentials from Apple's perspective**. This means that to fully delete your credentials (for example, if you want a new push notification key, however, you already have two), you'll need to do so from the [Apple Developer Console](https://developer.apple.com/account/resources/certificates/list).
 
 ### Re-signing new credentials
 

--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -35,7 +35,8 @@ If you currently manage your app signing key and want Google to manage it for yo
 To sync your Expo keystore with Google, follow these steps:
 
 <Step label="1">
-### Download credentials
+
+#### Download credentials
 
 In a terminal window:
 
@@ -49,7 +50,8 @@ Your application's keystore should be kept private. **Under no circumstances sho
 </Step>
 
 <Step label="2">
-### Export keystore to `pem` format
+
+#### Export keystore to `pem` format
 
 Once you have downloaded your credentials and the keystore, export it to the `pem` format so that you can submit it to Google:
 
@@ -65,7 +67,8 @@ Once you have downloaded your credentials and the keystore, export it to the `pe
 </Step>
 
 <Step label="3">
-### Contact Google support
+
+#### Contact Google support
 
 Contact Google Support and request them to change your key using [this support form](https://support.google.com/googleplay/android-developer/contact/key). While filling out the form, attach the `pem` file exported from the keystore.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The last 3 sub-sections in the ToC under "Android" section are part of the Collapsible which has a different heading and context than the sections under main ToC.

![CleanShot 2024-07-24 at 03 00 07](https://github.com/user-attachments/assets/f005878f-a77e-4ca0-a680-5198fa060a05)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the heading level of these sections by removing them from the main ToC and also remove the `Step` component usage as I don't think we need them. The Collapsible is already long enough.

Add missing periods to the list items in these sub-sections and fix other formatting issues.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/app-signing/app-credentials/#app-signing-by-google-play

## Preview

![CleanShot 2024-07-24 at 03 10 12](https://github.com/user-attachments/assets/0b0772c2-d94e-4e9f-962e-f6b8cc25dbce)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
