### PR TITLE
docs: fonts docs misses font import in example

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -282,7 +282,7 @@ After installing the font package, map the font using the `useFonts` hook in a t
 ```tsx app/_layout.tsx
 // Rest of the import statements
 /* @info Import <CODE>useFonts</CODE> hook from <CODE>expo-font</CODE>. */ import { useFonts } from 'expo-font'; /* @end */
-/* @info Import <CODE>Inter_900Black</CODE> from <CODE>@expo-google-fonts/inter</CODE>*/ Import { Inter_900Black } from "@expo-google-fonts/inter"
+/* @info Import <CODE>Inter_900Black</CODE> from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black } from "@expo-google-fonts/inter"
 /* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
 import {useEffect} from 'react';
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -282,6 +282,7 @@ After installing the font package, map the font using the `useFonts` hook in a t
 ```tsx app/_layout.tsx
 // Rest of the import statements
 /* @info Import <CODE>useFonts</CODE> hook from <CODE>expo-font</CODE>. */ import { useFonts } from 'expo-font'; /* @end */
+/* @info Import <CODE>Inter_900Black</CODE> from <CODE>@expo-google-fonts/inter</CODE>*/ Import { Inter_900Black } from "@expo-google-fonts/inter"
 /* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
 import {useEffect} from 'react';
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -281,8 +281,7 @@ After installing the font package, map the font using the `useFonts` hook in a t
 
 ```tsx app/_layout.tsx
 // Rest of the import statements
-/* @info Import <CODE>useFonts</CODE> hook from <CODE>expo-font</CODE>. */ import { useFonts } from 'expo-font'; /* @end */
-/* @info Import <CODE>Inter_900Black</CODE> from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black } from "@expo-google-fonts/inter"
+/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black, useFonts } from "@expo-google-fonts/inter"
 /* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
 import {useEffect} from 'react';
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -281,7 +281,7 @@ After installing the font package, map the font using the `useFonts` hook in a t
 
 ```tsx app/_layout.tsx
 // Rest of the import statements
-/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black, useFonts } from "@expo-google-fonts/inter"
+/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black, useFonts } from '@expo-google-fonts/inter';
 /* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
 import {useEffect} from 'react';
 


### PR DESCRIPTION
confused me a little when using this code, update example to explicitly import the font used in the `useFonts` hook (current code will error)

