### PR TITLE
[expo-dev-launcher][expo-dev-menu] Make menu button available

### DIFF
--- a/packages/expo-dev-launcher/bundle/native-modules/DevMenuPreferences.ts
+++ b/packages/expo-dev-launcher/bundle/native-modules/DevMenuPreferences.ts
@@ -5,6 +5,7 @@ const DevMenuPreferences = requireNativeModule('DevMenuPreferences');
 export type DevMenuPreferencesType = Partial<{
   motionGestureEnabled: boolean;
   touchGestureEnabled: boolean;
+  buttonGestureEnabled: boolean;
   keyCommandsEnabled: boolean;
   showsAtLaunch: boolean;
 }>;

--- a/packages/expo-dev-launcher/bundle/providers/DevMenuPreferencesProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/DevMenuPreferencesProvider.tsx
@@ -11,6 +11,8 @@ export type DevMenuPreferencesContext = {
   setMotionGestureEnabled: (enabled: boolean) => void;
   touchGestureEnabled: boolean;
   setTouchGestureEnabled: (enabled: boolean) => void;
+  buttonGestureEnabled: boolean;
+  setButtonGestureEnabled: (enabled: boolean) => void;
   showsAtLaunch: boolean;
   setShowsAtLaunch: (enabled: boolean) => void;
 };
@@ -33,6 +35,9 @@ export function DevMenuPreferencesProvider({
   const [touchGestureEnabled, setTouchGestureEnabled] = React.useState(
     initialPreferences?.touchGestureEnabled
   );
+  const [buttonGestureEnabled, setButtonGestureEnabled] = React.useState(
+    initialPreferences?.buttonGestureEnabled
+  );
   const [showsAtLaunch, setShowsAtLaunch] = React.useState(initialPreferences?.showsAtLaunch);
 
   React.useEffect(() => {
@@ -43,6 +48,10 @@ export function DevMenuPreferencesProvider({
 
       if (settings.touchGestureEnabled) {
         setTouchGestureEnabled(true);
+      }
+
+      if (settings.buttonGestureEnabled) {
+        setButtonGestureEnabled(true);
       }
 
       if (settings.showsAtLaunch) {
@@ -84,6 +93,17 @@ export function DevMenuPreferencesProvider({
     setTouchGestureEnabled(enabled);
   };
 
+  const onButtonGestureChange = (enabled: boolean) => {
+    setMenuPreferencesAsync({
+      buttonGestureEnabled: enabled,
+    }).catch(() => {
+      // restore to previous value in case of error
+      setButtonGestureEnabled(buttonGestureEnabled);
+    });
+
+    setButtonGestureEnabled(enabled);
+  };
+
   return (
     <Context.Provider
       value={{
@@ -91,6 +111,8 @@ export function DevMenuPreferencesProvider({
         setMotionGestureEnabled: onMotionGestureChange,
         touchGestureEnabled,
         setTouchGestureEnabled: onTouchGestureChange,
+        buttonGestureEnabled,
+        setButtonGestureEnabled: onButtonGestureChange,
         showsAtLaunch,
         setShowsAtLaunch: onShowsAtLaunchChange,
       }}>

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import {
   ShowMenuIcon,
   ThreeFingerPressIcon,
   CheckIcon,
+  ToolbarOverlayIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ScrollView, Switch } from 'react-native';
@@ -38,6 +39,8 @@ export function SettingsScreen() {
     setTouchGestureEnabled,
     motionGestureEnabled,
     setMotionGestureEnabled,
+    buttonGestureEnabled,
+    setButtonGestureEnabled,
   } = useDevMenuPreferences();
 
   const buildInfo = useBuildInfo();
@@ -147,6 +150,26 @@ export function SettingsScreen() {
                 </Text>
                 <Spacer.Horizontal />
                 {touchGestureEnabled && <CheckIcon />}
+              </Row>
+            </Button.FadeOnPressContainer>
+
+            <Divider />
+
+            <Button.FadeOnPressContainer
+              bg="default"
+              roundedBottom="large"
+              roundedTop="none"
+              onPress={() => setButtonGestureEnabled(!buttonGestureEnabled)}
+              accessibilityState={{ checked: buttonGestureEnabled }}>
+              <Row px="medium" py="small" bg="default">
+                {/* TODO: Replace with a floating button icon, this is kind of close enough for now */}
+                <ToolbarOverlayIcon />
+                <Spacer.Horizontal size="small" />
+                <Text size="large" color="default">
+                  Floating button
+                </Text>
+                <Spacer.Horizontal />
+                {buttonGestureEnabled && <CheckIcon />}
               </Row>
             </Button.FadeOnPressContainer>
           </View>

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuPreferencesInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuPreferencesInterface.kt
@@ -15,6 +15,11 @@ interface DevMenuPreferencesInterface {
   var touchGestureEnabled: Boolean
 
   /**
+   * Whether to enable button gesture.
+   */
+  var buttonGestureEnabled: Boolean
+
+  /**
    * Whether to enable key commands.
    */
   var keyCommandsEnabled: Boolean

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultPreferences.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultPreferences.kt
@@ -18,6 +18,10 @@ open class DevMenuDefaultPreferences : DevMenuPreferencesInterface {
     get() = true
     set(_) = methodUnavailable()
 
+  override var buttonGestureEnabled: Boolean
+    get() = false
+    set(_) = methodUnavailable()
+
   override var keyCommandsEnabled: Boolean
     get() = true
     set(_) = methodUnavailable()

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -12,11 +12,6 @@ import androidx.core.view.doOnLayout
 import com.facebook.react.ReactRootView
 import expo.modules.devmenu.fab.MovableFloatingActionButton
 
-/**
- * We want to hide the FAB behind the feature flag for now.
- */
-private const val enableFAB = false
-
 class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
   @RequiresApi(Build.VERSION_CODES.Q)
   private val updateSystemGestureExclusionRects: () -> Unit = {
@@ -60,7 +55,10 @@ class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
 
   override fun addView(child: View?, index: Int, params: ViewGroup.LayoutParams?) {
     super.addView(child, index, params)
-    if (enableFAB && child is ReactRootView) {
+
+    // TODO: figure out why getSettings() is null when you boot directly into
+    // the app, without going through the dev launcher
+    if (DevMenuManager.getSettings()?.buttonGestureEnabled == true && child is ReactRootView) {
       addView(fab)
     }
   }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuPreferences.kt
@@ -30,6 +30,14 @@ class DevMenuPreferencesHandle(context: Context) : DevMenuPreferencesInterface {
     set(value) = saveBoolean("touchGestureEnabled", value)
 
   /**
+   * Whether to enable button tap gesture.
+   */
+  override var buttonGestureEnabled: Boolean
+    /* TODO: enable by default on headsets */
+    get() = sharedPreferences.getBoolean("buttonGestureEnabled", false)
+    set(value) = saveBoolean("buttonGestureEnabled", value)
+
+  /**
    * Whether to enable key commands.
    */
   override var keyCommandsEnabled: Boolean
@@ -59,6 +67,7 @@ class DevMenuPreferencesHandle(context: Context) : DevMenuPreferencesInterface {
       .apply {
         putBoolean("motionGestureEnabled", motionGestureEnabled)
         putBoolean("touchGestureEnabled", touchGestureEnabled)
+        putBoolean("buttonGestureEnabled", buttonGestureEnabled)
         putBoolean("keyCommandsEnabled", keyCommandsEnabled)
         putBoolean("showsAtLaunch", showsAtLaunch)
         putBoolean("isOnboardingFinished", isOnboardingFinished)
@@ -86,6 +95,10 @@ class DevMenuPreferencesHandle(context: Context) : DevMenuPreferencesInterface {
 
     if (settings.hasKey("touchGestureEnabled")) {
       touchGestureEnabled = settings.getBoolean("touchGestureEnabled")
+    }
+
+    if (settings.hasKey("buttonGestureEnabled")) {
+      buttonGestureEnabled = settings.getBoolean("buttonGestureEnabled")
     }
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -28,6 +28,7 @@ public class DevMenuPreferences: Module {
     UserDefaults.standard.register(defaults: [
       motionGestureEnabledKey: true,
       touchGestureEnabledKey: true,
+      buttonGestureEnabledKey: false,
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false
@@ -66,6 +67,20 @@ public class DevMenuPreferences: Module {
     set {
       setBool(newValue, forKey: touchGestureEnabledKey)
       DevMenuTouchInterceptor.isInstalled = newValue
+    }
+  }
+
+  /**
+    Whether to enable button tap gesture.
+   */
+  static var buttonGestureEnabled: Bool {
+    get {
+      return boolForKey(buttonGestureEnabledKey)
+    }
+    set {
+      setBool(newValue, forKey: buttonGestureEnabledKey)
+      // TODO: Implement button gesture
+      // DevMenuButtonInterceptor.isInstalled = newValue
     }
   }
 


### PR DESCRIPTION
# Why

Follow up from #30184

# How

- Add an option to the launcher to enable/disable it (default false)
- Make the button less magenta and more grey. Also make it fade out when not in use

# Test Plan

It's a bit gnarly getting dev launcher running at the moment, but if you do, it looks like this:

<img width="405" alt="Screenshot 2024-07-23 at 7 06 18 PM" src="https://github.com/user-attachments/assets/325bc212-4e35-4c01-8897-299d0b56c110">

https://github.com/user-attachments/assets/4bdf9434-50e8-4fb4-a0f4-10706f076110

# Todo

Lots of todos inside of the code, but calling out a couple here:

- [ ] Dev menu preferences don't appear to be loaded correctly when you launch a dev build unless you go through the launcher first -- it seems to always be null when booting directly to the app.
- [ ] Put this behind a feature flag again but also enable it by default on appropriate platforms, eg: headsets

In the future, better looking button with a menu icon in it, remembering the previous position of the button when you close/reopen the app, a nicer animation via a spring (so it just feels fun to drag around and throw), and support for iOS.