### PR TITLE
[jest-expo] add missing dependencies

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 💡 Others
 
 - Mock files from the `src` folder instead of `build`. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))
+- Added missing dependencies from imports. ([#30588](https://github.com/expo/expo/pull/30588) by [@kudo](https://github.com/kudo))
 
 ## 51.0.2 — 2024-05-16
 

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -40,19 +40,23 @@
     "@expo/json-file": "^8.3.0",
     "@jest/create-cache-key-function": "^29.2.1",
     "babel-jest": "^29.2.1",
+    "expect": "^29.7.0",
     "fbemitter": "^3.0.0",
     "find-up": "^5.0.0",
     "jest-environment-jsdom": "^29.2.1",
+    "jest-snapshot": "^29.7.0",
     "jest-watch-select-projects": "^2.0.0",
     "jest-watch-typeahead": "2.2.1",
     "json5": "^2.2.3",
     "lodash": "^4.17.19",
     "react-test-renderer": "18.2.0",
+    "server-only": "^0.0.1",
     "stacktrace-js": "^2.0.2",    
     "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610"
   },
   "peerDependencies": {
     "expo": "*",
+    "react": "*",
     "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

fix sdk ci error: https://github.com/expo/expo/actions/runs/10069148240/job/27835678389

# How

add missing dependencies for jest-expo

# Test Plan

`et cp jest-expo`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
