### PR TITLE
chore(expo-tools): mark `jest-expo` as expected failure due to new constraints

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -46,6 +46,7 @@ const IGNORED_PACKAGES = [
   'expo-store-review', // package: expo-constants
   'expo-system-ui', // package: react-native-web
   'expo-updates', // cli: @expo/plist, debug, getenv - utils: @expo/cli, @expo/metro-config, metro
+  'jest-expo', // package: expect, jest-snapshot, react, server-only
 ];
 
 /**


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/29404 introduced new but failing dependencies, this unblocks CI by temporarily ignoring `jest-expo` again.

# How

- Added `jest-expo` as ignored packages in dependency check

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
