### PR TITLE
[android][test-suite] Disable "copy from bundle" test on Android

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -495,27 +495,31 @@ export async function test({ describe, expect, it, ...t }) {
       expect(newDirInfo.isDirectory).toBeTruthy();
     }, 30000);
 
-    it('delete(idempotent) -> !exists -> copy(from bundle) -> exists -> delete -> !exists', async () => {
-      const from = 'file://' + FS.bundleDirectory + 'Info.plist';
-      const to = FS.documentDirectory + 'Info.plist.copy';
+    if (Platform.OS === 'ios') {
+      // We cannot run this test on Android because bundleDirectory
+      // on Android cannot be accessed using 'file://' protocol.
+      it('delete(idempotent) -> !exists -> copy(from bundle) -> exists -> delete -> !exists', async () => {
+        const from = 'file://' + FS.bundleDirectory + 'Info.plist';
+        const to = FS.documentDirectory + 'Info.plist.copy';
 
-      const assertExists = async (expectedToExist) => {
-        const { exists } = await FS.getInfoAsync(to);
-        if (expectedToExist) {
-          expect(exists).toBeTruthy();
-        } else {
-          expect(exists).not.toBeTruthy();
-        }
-      };
+        const assertExists = async (expectedToExist) => {
+          const { exists } = await FS.getInfoAsync(to);
+          if (expectedToExist) {
+            expect(exists).toBeTruthy();
+          } else {
+            expect(exists).not.toBeTruthy();
+          }
+        };
 
-      await FS.deleteAsync(to, { idempotent: true });
-      await assertExists(false);
+        await FS.deleteAsync(to, { idempotent: true });
+        await assertExists(false);
 
-      await FS.copyAsync({ from, to });
-      await assertExists(true);
+        await FS.copyAsync({ from, to });
+        await assertExists(true);
 
-      await FS.deleteAsync(to);
-      await assertExists(false);
-    });
+        await FS.deleteAsync(to);
+        await assertExists(false);
+      });
+    }
   });
 }


### PR DESCRIPTION
# Why

Test introduced by this PR [#30540](https://github.com/expo/expo/pull/30540) fails on Android because `bundleDirectory` on Android has different structure and protocol.

# How

Enabled the test only for iOS platform.

# Test Plan

Run `FileSystem` tests using `bare-expo`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
