### PR TITLE
chore(expo): expose private or unstable APIs from `expo-modules-core`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add minimal `TextDecoder` support to native client platforms. ([#29620](https://github.com/expo/expo/pull/29620) by [@EvanBacon](https://github.com/EvanBacon))
 - Introduced `useEvent` hook for EventEmitter objects (e.g. native modules and shared objects). ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
 - Added fetch API support. ([#30173](https://github.com/expo/expo/pull/30173), [#30219](https://github.com/expo/expo/pull/30219), [#30576](https://github.com/expo/expo/pull/30576) by [@kudo](https://github.com/kudo))
-- Expose stable APIs from `expo-modules-core`.
+- Expose stable APIs from `expo-modules-core`. ([#30575](https://github.com/expo/expo/pull/30575) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/internal.d.ts
+++ b/packages/expo/internal.d.ts
@@ -1,0 +1,30 @@
+export {
+  // Errors
+  CodedError,
+  UnavailabilityError,
+
+  // Permissions
+  createPermissionHook,
+  type PermissionExpiration,
+  type PermissionHookOptions,
+  type PermissionResponse,
+  PermissionStatus,
+
+  // Methods
+  createSnapshotFriendlyRef,
+  createWebModule,
+
+  // Utilities
+  reloadAppAsync,
+  uuid,
+
+  // Typed arrays
+  type TypedArray,
+  type UintBasedTypedArray,
+  type IntBasedTypedArray,
+
+  // Legacy exports
+  LegacyEventEmitter,
+  NativeModulesProxy,
+  type ProxyNativeModule,
+} from 'expo-modules-core';

--- a/packages/expo/internal.js
+++ b/packages/expo/internal.js
@@ -1,0 +1,34 @@
+const {
+  CodedError,
+  createPermissionHook,
+  createSnapshotFriendlyRef,
+  createWebModule,
+  LegacyEventEmitter,
+  NativeModulesProxy,
+  PermissionStatus,
+  reloadAppAsync,
+  UnavailabilityError,
+  uuid,
+} = require('expo-modules-core');
+
+module.exports = {
+  // Errors
+  CodedError,
+  UnavailabilityError,
+
+  // Permissions
+  createPermissionHook,
+  PermissionStatus,
+
+  // Methods
+  createSnapshotFriendlyRef,
+  createWebModule,
+
+  // Utilities
+  reloadAppAsync,
+  uuid,
+
+  // Legacy exports
+  LegacyEventEmitter,
+  NativeModulesProxy,
+};

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -32,6 +32,8 @@
     "devtools.d.ts",
     "fetch.js",
     "fetch.d.ts",
+    "internal.js",
+    "internal.d.ts",
     "react-native.config.js",
     "requiresExtraSetup.json",
     "tsconfig.base.json"


### PR DESCRIPTION
> ⚠️ This PR is on hold, waiting until people are back from OOO, the PR got created by Graphite automatically.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
