### PR TITLE
[docs] Update native-intent document

### DIFF
--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -27,7 +27,7 @@ In such scenarios, the URL needs to be rewritten to correctly target a route.
 
 To facilitate this, create a special file called **+native-intent.ts** at the top level of your project's **app** directory. This file exports a unique `redirectSystemPath` method designed to handle URL/path processing.
 
-<FileTree files={['app/+native-intent.ts']} />
+<FileTree files={['app/+native-intent.tsx']} />
 
 <APIBox header="redirectSystemPath()">
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I was trying to use `native-intent`.
I checked the documentation to make sure it worked, but could not get it to work.
We checked the code and found that the file extensions mentioned in the documentation are not valid.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated documentation.
Native-intent files had the extension `ts` in the documentation.
In reality, the valid extension was `tsx` or `jsx`.

https://github.com/expo/expo/blob/f18f5ab02eb857400c605e0c8d36e4f531454885/packages/expo-router/src/getLinkingConfig.ts#L38-L40

The documentation seems to be based on TypeScript, so we replaced the extension from `ts` to `tsx` accordingly.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Nothing specific as the code has not been changed.

I have confirmed that on the code of my product, the code does not work when the extension is `ts`, but it works when the extension is changed to `tsx`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
