### PR TITLE
[docs] Update Assets guide

### DIFF
--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -44,7 +44,7 @@ Install the `expo-asset` library.
 
 <Step label="2">
 
-Add the config plugin to your project's [app config](https://docs.expo.dev/versions/latest/config/app/#plugins) file. The configuration must contain the path to the asset file using [`assets`](/versions/latest/sdk/asset/#configurable-properties) property which takes an array of one or more files or directories to link to the native project.
+Add the config plugin to your project's [app config](/versions/latest/config/app/#plugins) file. The configuration must contain the path to the asset file using [`assets`](/versions/latest/sdk/asset/#configurable-properties) property which takes an array of one or more files or directories to link to the native project.
 
 The path to each asset file must be relative to your project's root since the app config file is located in the project's root directory.
 

--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -3,7 +3,12 @@ title: Assets
 description: Learn about using static assets in your project, including images, videos, sounds, database files, and fonts.
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
 Files such as images, videos, sounds, database files for SQLite, or fonts are considered **static assets**. They are not part of your project's JavaScript but are part of your app. These assets can be served locally from your project or remotely over the network.
+
+This guide covers different ways you can load and use static assets in your project and also provides additional information on how to optimize and minify assets.
 
 ## Serve an asset locally
 
@@ -11,11 +16,11 @@ When an asset is stored in your project's file system, it can be embedded in you
 
 For example, to render an image called **example.png** in **App.js**, you can directly use `require` to import the image from the project's **assets/images** directory and pass it to the `<Image>` component:
 
-```jsx App.js
+```tsx app/index.tsx
 <Image source={require('./assets/images/example.png')} />
 ```
 
-The bundler automatically provides a width and height for the images imported, as shown in the above example. For more information, see [Static Image Resources](https://reactnative.dev/docs/images#static-image-resources).
+In the above example, the bundler reads the imported image's metadata and automatically provides the width and height. For more information, see [Static Image Resources](https://reactnative.dev/docs/images#static-image-resources).
 
 Libraries such as `expo-image` and `expo-file-system` work similarly to the `<Image>` component with local assets.
 
@@ -23,53 +28,86 @@ Libraries such as `expo-image` and `expo-file-system` work similarly to the `<Im
 
 Locally stored assets are served over HTTP in development. They are automatically bundled into your app binary at the build time for production apps and served from disk on a device.
 
-### Load an asset at build time
+### Load an asset at build time with `expo-asset` config plugin
 
-> **Note:** The `expo-asset` config plugin is only available for SDK 51 and above. If you are using an older SDK, you can load a [using the `useAssets` hook](/versions/v51.0.0/sdk/asset/#useassetsmoduleids).
+> **Note:** The `expo-asset` config plugin is only available for SDK 51 and above. If you are using an older SDK, you can load a [using the `useAssets` hook](/versions/latest/sdk/asset/#useassetsmoduleids).
 
-Install the `expo-asset` library and add the config plugin to the app config file. This plugin will embed the asset file in your native project.
+To load an asset at build time, you can use the [config plugin](/versions/latest/sdk/asset/#example-appjson-with-config-plugin) from the `expo-asset` library. This plugin will embed the asset file in your native project.
+
+<Step label="1">
+
+Install the `expo-asset` library.
+
+<Terminal cmd={['$ npx expo install expo-asset']} />
+
+</Step>
+
+<Step label="2">
+
+Add the config plugin to your project's [app config](https://docs.expo.dev/versions/latest/config/app/#plugins) file. The configuration must contain the path to the asset file using [`assets`](/versions/latest/sdk/asset/#configurable-properties) property which takes an array of one or more files or directories to link to the native project.
+
+The path to each asset file must be relative to your project's root since the app config file is located in the project's root directory.
 
 ```json app.json
 {
-  "plugins": [
-    [
-      "expo-asset",
-
-      {
-        "assets": ["./assets/images/example.png"]
-      }
+  "expo": {
+    "plugins": [
+      [
+        "expo-asset",
+        {
+          /* @info The path to the asset file is relative to the project's root. */
+          "assets": ["./assets/images/example.png"]
+          /* @end */
+        }
+      ]
     ]
-  ]
+  }
 }
 ```
 
-The `assets` option takes an array of one or more asset files or directory names to link the file to the native project. The path to each file is relative to the project's root.
+</Step>
 
-When you [create a new native build](/develop/development-builds/create-a-build/), you can import and use the asset in your project without using a `require` or an `import` statement.
+<Step label="3">
+
+After embedding the asset with the config plugin, [create a new development build](/develop/development-builds/create-a-build/). Now, you can import and use the asset in your project without using a `require` or an `import` statement.
 
 For example, the **example.png** is linked by the above config plugin. You can directly import it into your component and use its resource name.
 
-```jsx App.js
+```tsx app/index.tsx
 import { Image } from 'expo-image';
 /* @hide ... */ /* @end */
 
-function App() {
+export default function HomeScreen() {
   return <Image source="example" />;
 }
 ```
 
+</Step>
+
 The above example is quite concise. However, when a native API expects a specific file and its resource name, this method makes it convenient to integrate with that API and use the resource name directly.
 
-> **info** For more information on supported file formats used with the config plugin, see [Assets API reference](/versions/v51.0.0/sdk/asset/#configurable-properties).
+> **info** Different file formats are supported with the `expo-asset` config plugin. For more information on these formats, see [Assets API reference](/versions/latest/sdk/asset/#configurable-properties). If you don't see a file format supported by the config plugin, you can use the [`useAssets`](#load-an-asset-at-runtime-with-useassets-hook) hook to load the asset at runtime.
 
-### Load an asset at runtime
+### Load an asset at runtime with `useAssets` hook
 
-Install the `expo-asset` library in your project. Once the installation step is complete, import the `useAssets` hook from the `expo-asset` library. The hook downloads and stores an asset locally, and after the asset is loaded, it returns a list of that asset's instances.
+The `useAssets` hook from `expo-asset` library allows loading assets asynchronously. This hook downloads and stores an asset locally and after the asset is loaded, it returns a list of that asset's instances.
 
-```jsx App.js
+<Step label="1">
+
+Install the `expo-asset` library.
+
+<Terminal cmd={['$ npx expo install expo-asset']} />
+
+</Step>
+
+<Step label="2">
+
+Import the [`useAssets`](/versions/latest/sdk/asset/#useassetsmoduleids) hook from the `expo-asset` library in your screen component:
+
+```tsx app/index.tsx
 import { useAssets } from 'expo-asset';
 
-export default function App() {
+export default function HomeScreen() {
   const [assets, error] = useAssets([
     require('path/to/example-1.jpg'),
     require('path/to/example-2.png'),
@@ -79,9 +117,11 @@ export default function App() {
 }
 ```
 
+</Step>
+
 ## Serve an asset remotely
 
-When an asset is served remotely, it is not bundled into the app binary at build time. You can use the URL of the asset resource in your project if it is hosted remotely. For example, pass the URL to the `<Image>` component to render a remote image.
+When an asset is served remotely, it is not bundled into the app binary at build time. You can use the URL of the asset resource in your project if it is hosted remotely. For example, pass the URL to the `<Image>` component to render a remote image:
 
 ```jsx App.js
 import { Image } from 'expo-image';
@@ -96,11 +136,13 @@ function App() {
 
 There is no guarantee about the availability of images served remotely using a web URL because an internet connection may not be available, or the asset might be removed.
 
-Additionally, loading assets remotely also requires you to provide metadata about the asset. In this example, the bundler cannot retrieve the image's width and height, so you have to pass that explicitly to the `<Image>` component. If you don't, the image will default to 0px by 0px.
+Additionally, loading assets remotely also requires you to provide an asset's metadata. In the above example, since the bundler cannot retrieve the image's width and height, those values are passed explicitly to the `<Image>` component. If you don't, the image will default to 0px by 0px.
 
-## Manual optimization methods
+## Additional information
 
-### Images
+### Manual optimization methods
+
+#### Images
 
 You can compress images using the following:
 
@@ -112,12 +154,12 @@ Some image optimizers are lossless. They re-encode your image to be smaller with
 
 Other image optimizers are lossy. The optimized image differs from the original image. Often, lossy optimizers are more efficient because they discard visual information that reduces file size while making the image look nearly identical to humans. Tools like `imagemagick` can use comparison algorithms like [SSIM](https://en.wikipedia.org/wiki/Structural_similarity) to show how similar two images look. It's quite common for an optimized image that is over 95% similar to the original image to be far less than 95% of the original file size.
 
-### Fonts
+#### Other assets
 
-See [Wait for fonts to load in the Fonts guide](/develop/user-interface/fonts/#wait-for-fonts-to-load) for more information.
-
-### Other assets
-
-For assets like GIFs or movies, or non-code and non-image assets, it's up to you to optimize and minify those assets.
+For assets like GIFs or videos, or non-code and non-image assets, it's up to you to optimize and minify those assets.
 
 > **Note**: GIFs are a very inefficient format. Modern video codecs can produce significantly smaller file sizes with better quality.
+
+### Fonts
+
+See [Add a custom font](/develop/user-interface/fonts/#add-a-custom-font) for more information on how to add a custom font to your app.

--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -12,9 +12,9 @@ This guide covers different ways you can load and use static assets in your proj
 
 ## Serve an asset locally
 
-When an asset is stored in your project's file system, it can be embedded in your app binary at build time or loaded at runtime. You can import them like JavaScript modules using `require` or `import` statements.
+When an asset is stored in your project's file system, it can be embedded in your app binary at build time or loaded at runtime. You can import it like a JavaScript module using `require` or `import` statements.
 
-For example, to render an image called **example.png** in **App.js**, you can directly use `require` to import the image from the project's **assets/images** directory and pass it to the `<Image>` component:
+For example, to render an image called **example.png** in **App.js**, you can use `require` to import the image from the project's **assets/images** directory and pass it to the `<Image>` component:
 
 ```tsx app/index.tsx
 <Image source={require('./assets/images/example.png')} />
@@ -30,7 +30,7 @@ Locally stored assets are served over HTTP in development. They are automaticall
 
 ### Load an asset at build time with `expo-asset` config plugin
 
-> **Note:** The `expo-asset` config plugin is only available for SDK 51 and above. If you are using an older SDK, you can load a [using the `useAssets` hook](/versions/latest/sdk/asset/#useassetsmoduleids).
+> **Note:** The `expo-asset` config plugin is only available for SDK 51 and above. If you are using an older SDK, you can load a [using the `useAssets` hook](#load-an-asset-at-runtime-with-useassets-hook).
 
 To load an asset at build time, you can use the [config plugin](/versions/latest/sdk/asset/#example-appjson-with-config-plugin) from the `expo-asset` library. This plugin will embed the asset file in your native project.
 

--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -6,7 +6,7 @@ description: Learn about using static assets in your project, including images, 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Files such as images, videos, sounds, database files for SQLite, or fonts are considered **static assets**. They are not part of your project's JavaScript but are part of your app. These assets can be served locally from your project or remotely over the network.
+A **static asset** is a file that is bundled with your app's binary (native binary). This file type is not part of your app's JavaScript bundle which contain your app's code. Common types of static assets include images, videos, sounds, database files for SQLite, and fonts. These assets can be served locally from your project or remotely over the network.
 
 This guide covers different ways you can load and use static assets in your project and also provides additional information on how to optimize and minify assets.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of the ongoing improvements for docs are under the Develop section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the Assets guide by:

- Restructuring the guide to provide actionable user-facing steps for loading an asset using either the config plugin or `useAssets` hook from `expo-asset` library.
- Also mention these two methods in the section headings.
- Updating the examples to use TypeScript file extensions by default
- Updating verbiage.
- Adding an additional information section and moving sections on optimizing assets and fonts under it.
- Fix a broken link to the Fonts guide on adding a custom font. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/user-interface/assets

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
