### PR TITLE
[expo] fix fetch streaming error on ios

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))
+- Fixed fetch streaming error on iOS. ([#30604](https://github.com/expo/expo/pull/30604) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -37,12 +37,18 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate {
   }
 
   func startStreaming() {
-    if isInvalidState(.responseReceived) {
+    if isInvalidState(.responseReceived, .bodyCompleted) {
       return
     }
-    state = .bodyStreamingStarted
-    let queuedData = self.sink.finalize()
-    emit(event: "didReceiveResponseData", arguments: queuedData)
+    if state == .responseReceived {
+      state = .bodyStreamingStarted
+      let queuedData = self.sink.finalize()
+      emit(event: "didReceiveResponseData", arguments: queuedData)
+    } else if state == .bodyCompleted {
+      let queuedData = self.sink.finalize()
+      emit(event: "didReceiveResponseData", arguments: queuedData)
+      emit(event: "didComplete")
+    }
   }
 
   func cancelStreaming() {


### PR DESCRIPTION
# Why

fix fetch streaming error on ios when server finishing response too fast, callsites will not miss the response.

# How

i missed the implementation on ios that i did for android: https://github.com/expo/expo/blob/fdf4564c3ad5a92c957eabb23328cafbbd92af6a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt#L45-L58
this pr tries to fix that for ios.

# Test Plan

router-e2e ios + rsc

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
