### PR TITLE
[expo] fix fetch error on web

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))
 - Fixed fetch streaming error on iOS. ([#30604](https://github.com/expo/expo/pull/30604) by [@kudo](https://github.com/kudo))
+- Fixed fetch import on Web. ([#30605](https://github.com/expo/expo/pull/30605) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/build/winter/fetch/ExpoFetchModule.web.d.ts
+++ b/packages/expo/build/winter/fetch/ExpoFetchModule.web.d.ts
@@ -1,0 +1,10 @@
+declare class StubNativeRequest {
+}
+declare class StubNativeResponse {
+}
+export declare const ExpoFetchModule: {
+    NativeRequest: typeof StubNativeRequest;
+    NativeResponse: typeof StubNativeResponse;
+};
+export {};
+//# sourceMappingURL=ExpoFetchModule.web.d.ts.map

--- a/packages/expo/build/winter/fetch/ExpoFetchModule.web.d.ts.map
+++ b/packages/expo/build/winter/fetch/ExpoFetchModule.web.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ExpoFetchModule.web.d.ts","sourceRoot":"","sources":["../../../src/winter/fetch/ExpoFetchModule.web.ts"],"names":[],"mappings":"AAAA,cAAM,iBAAiB;CAAG;AAC1B,cAAM,kBAAkB;CAAG;AAE3B,eAAO,MAAM,eAAe;;;CAG3B,CAAC"}

--- a/packages/expo/src/winter/fetch/ExpoFetchModule.web.ts
+++ b/packages/expo/src/winter/fetch/ExpoFetchModule.web.ts
@@ -1,0 +1,7 @@
+class StubNativeRequest {}
+class StubNativeResponse {}
+
+export const ExpoFetchModule = {
+  NativeRequest: StubNativeRequest,
+  NativeResponse: StubNativeResponse,
+};


### PR DESCRIPTION
# Why

FetchResponse failed to be resolved on web because its parent class is a native module.

# How

regression when inherit `ExpoFetchModule.NativeReponse` directly for `FetchResponse`.
this pr tries to add a stub ExpoFetchModule for web.

# Test Plan

bare-expo web

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
