### PR TITLE
fix(metro-runtime): Update DevLoadingView on native.

### DIFF
--- a/packages/@expo/metro-runtime/.npmignore
+++ b/packages/@expo/metro-runtime/.npmignore
@@ -8,6 +8,7 @@
 
 __mocks__
 __tests__
+__rsc_tests__
 
 /babel.config.js
 /android/src/androidTest/

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Update DevLoadingView on native.
+- Update DevLoadingView on native. ([#30606](https://github.com/expo/expo/pull/30606) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix metro symbolication issue with web import errors. ([#30544](https://github.com/expo/expo/pull/30544) by [@EvanBacon](https://github.com/EvanBacon))
 - Remount the failed component when a refresh event occurs. ([#30544](https://github.com/expo/expo/pull/30544) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web styling bug. ([#30438](https://github.com/expo/expo/pull/30438) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Update DevLoadingView on native.
 - Fix metro symbolication issue with web import errors. ([#30544](https://github.com/expo/expo/pull/30544) by [@EvanBacon](https://github.com/EvanBacon))
 - Remount the failed component when a refresh event occurs. ([#30544](https://github.com/expo/expo/pull/30544) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web styling bug. ([#30438](https://github.com/expo/expo/pull/30438) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/metro-runtime/build/LoadingView.native.d.ts
+++ b/packages/@expo/metro-runtime/build/LoadingView.native.d.ts
@@ -1,3 +1,3 @@
-import LoadingView from 'react-native/Libraries/Utilities/LoadingView';
+import LoadingView from 'react-native/Libraries/Utilities/DevLoadingView';
 export default LoadingView;
 //# sourceMappingURL=LoadingView.native.d.ts.map

--- a/packages/@expo/metro-runtime/build/LoadingView.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/LoadingView.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"LoadingView.native.d.ts","sourceRoot":"","sources":["../src/LoadingView.native.ts"],"names":[],"mappings":"AAAA,OAAO,WAAW,MAAM,8CAA8C,CAAC;AAEvE,eAAe,WAAW,CAAC"}
+{"version":3,"file":"LoadingView.native.d.ts","sourceRoot":"","sources":["../src/LoadingView.native.ts"],"names":[],"mappings":"AAAA,OAAO,WAAW,MAAM,iDAAiD,CAAC;AAE1E,eAAe,WAAW,CAAC"}

--- a/packages/@expo/metro-runtime/src/LoadingView.native.ts
+++ b/packages/@expo/metro-runtime/src/LoadingView.native.ts
@@ -1,3 +1,3 @@
-import LoadingView from 'react-native/Libraries/Utilities/LoadingView';
+import LoadingView from 'react-native/Libraries/Utilities/DevLoadingView';
 
 export default LoadingView;


### PR DESCRIPTION
# Why

- Changed with the RN upgrade.
