### PR TITLE
[doctor] Fix a case where we accidentally print "0" at the end of a sentence0

### DIFF
--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -70,10 +70,11 @@ export class SupportPackageVersionCheck implements DoctorCheck {
       issues,
       advice: issues.length
         ? 'Upgrade dependencies that are using the invalid package versions' +
-          (supportPackagesPinnedByResolution.length ? (
-            ` and remove resolutions from package.json that are pinning ${joinWithCommasAnd(
-              supportPackagesPinnedByResolution
-            )} to an invalid version`) : '') +
+          (supportPackagesPinnedByResolution.length
+            ? ` and remove resolutions from package.json that are pinning ${joinWithCommasAnd(
+                supportPackagesPinnedByResolution
+              )} to an invalid version`
+            : '') +
           '.'
         : undefined,
     };

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -70,10 +70,10 @@ export class SupportPackageVersionCheck implements DoctorCheck {
       issues,
       advice: issues.length
         ? 'Upgrade dependencies that are using the invalid package versions' +
-          (supportPackagesPinnedByResolution.length &&
+          (supportPackagesPinnedByResolution.length ? (
             ` and remove resolutions from package.json that are pinning ${joinWithCommasAnd(
               supportPackagesPinnedByResolution
-            )} to an invalid version`) +
+            )} to an invalid version`) : '') +
           '.'
         : undefined,
     };

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -91,7 +91,9 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.advice).toEqual('Upgrade dependencies that are using the invalid package versions.');
+    expect(result.advice).toEqual(
+      'Upgrade dependencies that are using the invalid package versions.'
+    );
   });
 
   it('warns if package.json resolutions are not pinned to a valid version', async () => {
@@ -111,11 +113,13 @@ describe('runAsync', () => {
       pkg: {
         ...additionalProjectProps.pkg,
         resolutions: {
-          'metro': '999.999.999',
-        }
-      }
+          metro: '999.999.999',
+        },
+      },
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.advice).toContain('Upgrade dependencies that are using the invalid package versions and remove resolutions');
+    expect(result.advice).toContain(
+      'Upgrade dependencies that are using the invalid package versions and remove resolutions'
+    );
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -91,5 +91,31 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice).toEqual('Upgrade dependencies that are using the invalid package versions.');
+  });
+
+  it('warns if package.json resolutions are not pinned to a valid version', async () => {
+    jest
+      .mocked(getRemoteVersionsForSdkAsync)
+      .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
+    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
+      if (pkg.name === 'metro') {
+        return 'warning';
+      }
+      return null;
+    });
+    const check = new SupportPackageVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      pkg: {
+        ...additionalProjectProps.pkg,
+        resolutions: {
+          'metro': '999.999.999',
+        }
+      }
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice).toContain('Upgrade dependencies that are using the invalid package versions and remove resolutions');
   });
 });


### PR DESCRIPTION
# Why

I noticed this in the build logs for a build I was investigating in the support inbox. I repro'd it in a test and then fixed it.

<img width="1624" alt="Screenshot 2024-07-24 at 3 44 04 PM" src="https://github.com/user-attachments/assets/09ee99fb-8f3d-42b1-bdde-c744e3f5c928">

# Test Plan

Run tests