### PR TITLE
[template-default] do not duplicate headerHeight value in styles

### DIFF
--- a/templates/expo-template-default/components/ParallaxScrollView.tsx
+++ b/templates/expo-template-default/components/ParallaxScrollView.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   header: {
-    height: 250,
+    height: HEADER_HEIGHT,
     overflow: 'hidden',
   },
   content: {


### PR DESCRIPTION
Constant HEADER_HEIGHT was declared but not used in styles that are used for rendering, there was hard-coded value of 250 instead of the constant. So updating the constant doesn't change component's output, it always had header height of 250 px.

# Why

When I've tried to customize the ParallaxScrollView component I've notices that change o the constant doesn't impact the result as it wasn't used in component's styles.

# How

Used constant HEADER_HEIGHT in ParallaxScrollView's styles for height instead of hard-coded value of 250.

# Test Plan

Create an app with default template, update HEADER_HEIGHT constant, check that actual height of the header changed.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).