### PR TITLE
[clipboard] fix ClipboardPasteButton asking for permission unexpectedly

### DIFF
--- a/apps/native-component-list/src/screens/ClipboardPasteButtonScreen.tsx
+++ b/apps/native-component-list/src/screens/ClipboardPasteButtonScreen.tsx
@@ -21,6 +21,7 @@ export default function ClipboardPasteButtonScreen() {
   return (
     <ScrollView>
       <View style={styles.screen}>
+        <Text selectable>Random text you can copy</Text>
         <ClipboardPasteButton
           imageOptions={{ format: 'png' }}
           onPress={(data) => {

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] fix ClipboardPasteButton's active state 
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
 - Add missing `react`/`react-native` peer dependencies for isolated modules. ([#30463](https://github.com/expo/expo/pull/30463) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] fix ClipboardPasteButton's active state ([#30623](https://github.com/expo/expo/pull/30623) by [@vonovak](https://github.com/vonovak))
+- [iOS] fix ClipboardPasteButton asking for paste permission ([#30623](https://github.com/expo/expo/pull/30623) by [@vonovak](https://github.com/vonovak))
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
 - Add missing `react`/`react-native` peer dependencies for isolated modules. ([#30463](https://github.com/expo/expo/pull/30463) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] fix ClipboardPasteButton's active state 
+- [iOS] fix ClipboardPasteButton's active state ([#30623](https://github.com/expo/expo/pull/30623) by [@vonovak](https://github.com/vonovak))
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
 - Add missing `react`/`react-native` peer dependencies for isolated modules. ([#30463](https://github.com/expo/expo/pull/30463) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/expo-clipboard/ios/ClipboardPasteButton.swift
+++ b/packages/expo-clipboard/ios/ClipboardPasteButton.swift
@@ -47,6 +47,24 @@ class ClipboardPasteButton: ExpoView {
     ])
   }
 
+  override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
+    guard #available(iOS 14.0, *) else {
+      // never called below iOS 16
+      return true
+    }
+    let hasConformantItem = itemProviders.contains { provider in
+      provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) ||
+      provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) ||
+      provider.hasItemConformingToTypeIdentifier(UTType.html.identifier) && acceptedContentTypes.contains(.html) ||
+      provider.hasItemConformingToTypeIdentifier(UTType.utf8PlainText.identifier) && !acceptedContentTypes.contains(.html)
+    }
+    if hasConformantItem {
+      return true
+    }
+    // intra-device, when copying simple stuff like images and plain text, `itemProviders` are empty
+    return itemProviders.isEmpty
+  }
+
   override func paste(itemProviders: [NSItemProvider]) {
     guard #available(iOS 14.0, *) else {
       return

--- a/packages/expo-clipboard/ios/ClipboardPasteButton.swift
+++ b/packages/expo-clipboard/ios/ClipboardPasteButton.swift
@@ -58,11 +58,9 @@ class ClipboardPasteButton: ExpoView {
       provider.hasItemConformingToTypeIdentifier(UTType.html.identifier) && acceptedContentTypes.contains(.html) ||
       provider.hasItemConformingToTypeIdentifier(UTType.utf8PlainText.identifier) && !acceptedContentTypes.contains(.html)
     }
-    if hasConformantItem {
-      return true
-    }
+
     // intra-device, when copying simple stuff like images and plain text, `itemProviders` are empty
-    return itemProviders.isEmpty
+    return hasConformantItem || itemProviders.isEmpty
   }
 
   override func paste(itemProviders: [NSItemProvider]) {


### PR DESCRIPTION
# Why

closes #30617

# How

implemented [canPaste](https://developer.apple.com/documentation/uikit/uipasteconfigurationsupporting/2887578-canpaste)

# Test Plan

bare expo app

Tested on real device both with and without interplay with my mbp. There is still some asynchronicity with how the button is greyed out or not but the dialog asking for permissions is no longer shown.

Perhaps it'd make sense to support the [`target`](https://developer.apple.com/documentation/uikit/uipastecontrol/3975881-target) property to point directly to a TextInput.


# Checklist

doesn't apply here

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
