### PR TITLE
[docs] add information about submit credentials to `security` docs

### DIFF
--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -43,8 +43,7 @@ Expo tools never ask you to provide your Google account credentials.
 
 ### Google Service Account Key
 
-Google Service Account Key is the authentication method required to be used to submit an Android app to the Google Play Store using the EAS Submit service.
-The Google Service Account Key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
+Google Service Account Key is the authentication method required to be used to submit an Android app to the Google Play Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
 
 #### Consequences if compromised
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -48,10 +48,9 @@ Google Service Account Key is the authentication method required to be used to s
 #### Consequences if compromised
 
 If a malicious actor were to somehow gain access to the Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key.
-They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
-When it comes to submitting an existing app to the Google Play Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
-The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
+If a malicious actor somehow gains access to your Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key. They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
 
+If an attacker doesn't have access to your build credentials, they won't be able to do much when it comes to submitting an existing app to the Google Play Store. They would only be able to submit the app signed with them. The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
 #### Consequences if lost
 
 None. If you lose the Google Service Account Key, you can revoke it using the Google Cloud Console and create a new one.
@@ -118,16 +117,15 @@ None. They are available through the Apple Developer console.
 ### Apple App Store Connect (ASC) API key
 
 Apple App Store Connect (ASC) API key authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
-The ASC API key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
-The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
+Apple App Store Connect (ASC) API key is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
 
+The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
 #### Consequences if compromised
 
 If a malicious actor were to somehow gain access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key.
-They would also be able to submit an app signed by your build credentials to the App Store.
-When it comes to submitting an app to the App Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
-It means that they wouldn't be able to submit any arbitrary app to the App Store in your name.
+If a malicious actor somehow gains access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key. They would also be able to submit an app signed by your build credentials to the App Store.
 
+If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
 #### Consequences if lost
 
 None. If you lose the ASC API key, you can revoke it using the App Store Connect portal and create a new one.
@@ -135,17 +133,17 @@ None. If you lose the ASC API key, you can revoke it using the App Store Connect
 ### Apple app-specific password
 
 Apple app-specific password authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
-Unlike other credentials, the app-specific password is not permanently stored in the Expo servers. The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store + 24 hours for retries.
-Once this period is over, the password is deleted from the Expo servers. This authentication method is **not recommended**. We recommend using the Apple Store Connect (ASC) API key for submitting your apps to the App Store instead.
-Expo won't use the Apple app-specific password in any other way than for submitting your app to the App Store.
+Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not permanently stored in the Expo servers. 
 
+The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours for retries. Once this period is over, the password is deleted from the Expo servers. 
+
+This authentication method is **not recommended**. We recommend using the Apple Store Connect (ASC) API key for submitting your apps to the App Store instead. Expo won't use the Apple app-specific password in any way other than to submit your app to the App Store.
 #### Consequences if compromised
 
 If a malicious actor were to somehow gain access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud.
-They would also be able to submit an app signed by your build credentials to the App Store.
-When it comes to submitting an app to the App Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
-It means that they wouldn't be able to submit any arbitrary app to the App Store in your name.
+If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud. They would also be able to submit an app signed by your build credentials to the App Store.
 
+If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
 #### Consequences if lost
 
 None. If you lose the app-specific password, you can revoke it and create a new one in the Apple account settings.

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -39,6 +39,24 @@ You will not be able to update your app on Google Play. You may want to download
 
 Expo tools never ask you to provide your Google account credentials.
 
+## Android submit credentials
+
+### Google Service Account Key
+
+Google Service Account Key is the authentication method required to be used to submit an Android app to the Google Play Store using the EAS Submit service.
+The Google Service Account Key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
+
+#### Consequences if compromised
+
+If a malicious actor were to somehow gain access to the Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key.
+They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
+When it comes to submitting an existing app to the Google Play Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
+The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
+
+#### Consequences if lost
+
+None. If you lose the Google Service Account Key, you can revoke it using the Google Cloud Console and create a new one.
+
 ## iOS Push Notification credentials
 
 There are two types of iOS push notification credentials: one modern approach recommended by Apple and the legacy approach. The default behavior is to use the modern approach, but developers may opt-in to the legacy approach by providing a p12 certificate.
@@ -95,6 +113,43 @@ For ad-hoc builds, if a user were to gain access to your session token it would 
 ### Consequences if lost
 
 None. They are available through the Apple Developer console.
+
+## iOS submit credentials
+
+### Apple App Store Connect (ASC) API key
+
+Apple App Store Connect (ASC) API key authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
+The ASC API key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
+The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
+
+#### Consequences if compromised
+
+If a malicious actor were to somehow gain access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key.
+They would also be able to submit an app signed by your build credentials to the App Store.
+When it comes to submitting an app to the App Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
+It means that they wouldn't be able to submit any arbitrary app to the App Store in your name.
+
+#### Consequences if lost
+
+None. If you lose the ASC API key, you can revoke it using the App Store Connect portal and create a new one.
+
+### Apple app-specific password
+
+Apple app-specific password authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
+Unlike other credentials, the app-specific password is not permanently stored in the Expo servers. The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store + 24 hours for retries.
+Once this period is over, the password is deleted from the Expo servers. This authentication method is **not recommended**. We recommend using the Apple Store Connect (ASC) API key for submitting your apps to the App Store instead.
+Expo won't use the Apple app-specific password in any other way than for submitting your app to the App Store.
+
+#### Consequences if compromised
+
+If a malicious actor were to somehow gain access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud.
+They would also be able to submit an app signed by your build credentials to the App Store.
+When it comes to submitting an app to the App Store, if an attacker doesn't have access to your build credentials, they won't be able to do much, as they would only be able to submit the app signed with them.
+It means that they wouldn't be able to submit any arbitrary app to the App Store in your name.
+
+#### Consequences if lost
+
+None. If you lose the app-specific password, you can revoke it and create a new one in the Apple account settings.
 
 ## Device tokens for Android and iOS push notifications
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -47,7 +47,6 @@ Google Service Account Key is the authentication method required to be used to s
 
 #### Consequences if compromised
 
-If a malicious actor were to somehow gain access to the Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key.
 If a malicious actor somehow gains access to your Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key. They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when it comes to submitting an existing app to the Google Play Store. They would only be able to submit the app signed with them. The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
@@ -117,14 +116,12 @@ None. They are available through the Apple Developer console.
 
 ### Apple App Store Connect (ASC) API key
 
-Apple App Store Connect (ASC) API key authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
 Apple App Store Connect (ASC) API key is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
 
 The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
 
 #### Consequences if compromised
 
-If a malicious actor were to somehow gain access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key.
 If a malicious actor somehow gains access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key. They would also be able to submit an app signed by your build credentials to the App Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
@@ -135,7 +132,6 @@ None. If you lose the ASC API key, you can revoke it using the App Store Connect
 
 ### Apple app-specific password
 
-Apple app-specific password authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
 Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not permanently stored in the Expo servers.
 
 The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours for retries. Once this period is over, the password is deleted from the Expo servers.
@@ -144,8 +140,7 @@ This authentication method is **not recommended**. We recommend using the Apple 
 
 #### Consequences if compromised
 
-If a malicious actor were to somehow gain access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud.
-If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud. They would also be able to submit an app signed by your build credentials to the App Store.
+If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud (check [Apple's documentation](https://support.apple.com/en-us/102654) for more details). They would also be able to submit an app signed by your build credentials to the App Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -51,6 +51,7 @@ If a malicious actor were to somehow gain access to the Google Service Account K
 If a malicious actor somehow gains access to your Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key. They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when it comes to submitting an existing app to the Google Play Store. They would only be able to submit the app signed with them. The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
+
 #### Consequences if lost
 
 None. If you lose the Google Service Account Key, you can revoke it using the Google Cloud Console and create a new one.
@@ -120,12 +121,14 @@ Apple App Store Connect (ASC) API key authentication is one of the authenticatio
 Apple App Store Connect (ASC) API key is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
 
 The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
+
 #### Consequences if compromised
 
 If a malicious actor were to somehow gain access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key.
 If a malicious actor somehow gains access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key. They would also be able to submit an app signed by your build credentials to the App Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
+
 #### Consequences if lost
 
 None. If you lose the ASC API key, you can revoke it using the App Store Connect portal and create a new one.
@@ -133,17 +136,19 @@ None. If you lose the ASC API key, you can revoke it using the App Store Connect
 ### Apple app-specific password
 
 Apple app-specific password authentication is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service.
-Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not permanently stored in the Expo servers. 
+Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not permanently stored in the Expo servers.
 
-The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours for retries. Once this period is over, the password is deleted from the Expo servers. 
+The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours for retries. Once this period is over, the password is deleted from the Expo servers.
 
 This authentication method is **not recommended**. We recommend using the Apple Store Connect (ASC) API key for submitting your apps to the App Store instead. Expo won't use the Apple app-specific password in any way other than to submit your app to the App Store.
+
 #### Consequences if compromised
 
 If a malicious actor were to somehow gain access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud.
 If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud. They would also be able to submit an app signed by your build credentials to the App Store.
 
 If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
+
 #### Consequences if lost
 
 None. If you lose the app-specific password, you can revoke it and create a new one in the Apple account settings.

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -51,7 +51,6 @@ If a malicious actor somehow gains access to your Google Service Account Key, th
 
 If the attacker has additionally gained access to your upload keystore, they would be able to submit a new version of an existing app. The actor would not be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done through the web console.
 
-
 #### Consequences if lost
 
 None. If you lose the Google Service Account Key, you can revoke it using the Google Cloud Console and create a new one.

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -43,13 +43,14 @@ Expo tools never ask you to provide your Google account credentials.
 
 ### Google Service Account Key
 
-Google Service Account Key is the authentication method required to be used to submit an Android app to the Google Play Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
+Google Service Account Key is the authentication method used to submit an Android app to the Google Play Store with EAS Submit. This key is stored on Expo servers and encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest. The key will remain on Expo servers to be re-used for subsequent submissions, and it can be removed at any time by a user with the requisite permissions.
 
 #### Consequences if compromised
 
-If a malicious actor somehow gains access to your Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key. They would also be able to submit an existing app signed by your build credentials to the Google Play Store.
+If a malicious actor somehow gains access to your Google Service Account Key, they would be able to perform actions in the Google Play Console on your behalf. The actions they could perform would be limited to the permissions granted to the service account key.
 
-If an attacker doesn't have access to your build credentials, they won't be able to do much when it comes to submitting an existing app to the Google Play Store. They would only be able to submit the app signed with them. The actor also wouldn't be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done manually.
+If the attacker has additionally gained access to your upload keystore, they would be able to submit a new version of an existing app. The actor would not be able to submit a new app to the Google Play Store in your name, as the first Google Play submission needs to be done through the web console.
+
 
 #### Consequences if lost
 
@@ -116,15 +117,15 @@ None. They are available through the Apple Developer console.
 
 ### Apple App Store Connect (ASC) API key
 
-Apple App Store Connect (ASC) API key is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service. This key is permanently stored on the Expo servers (unless deleted by a developer) while being encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest.
+Apple App Store Connect (ASC) API key is one of the authentication methods that can be used to submit an iOS app to Apple's App Store using the EAS Submit service. This key is stored on the Expo servers and encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) when at rest. The key will remain on Expo servers to be re-used for subsequent submissions, and it can be removed at any time by a user with the requisite permissions.
 
 The ASC API key is the default and **recommended** authentication method for submitting your apps to the App Store using EAS Submit.
 
 #### Consequences if compromised
 
-If a malicious actor somehow gains access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key. They would also be able to submit an app signed by your build credentials to the App Store.
+If a malicious actor somehow gains access to the ASC API key, they would be able to perform actions in the App Store Connect on your behalf. The actions they could perform would be limited to the permissions granted to the API key.
 
-If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
+If the attacker has additionally gained access to your build credentials, they would be able to submit a new version of an existing app. They would only be able to submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
 
 #### Consequences if lost
 
@@ -132,17 +133,17 @@ None. If you lose the ASC API key, you can revoke it using the App Store Connect
 
 ### Apple app-specific password
 
-Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not permanently stored in the Expo servers.
+Apple app-specific password is another authentication method that can be used to submit an iOS app to Apple's App Store using the EAS Submit. Unlike other credentials, the app-specific password is not stored in the Expo servers between submissions, it must be provided each time it is to be used.
 
-The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours for retries. Once this period is over, the password is deleted from the Expo servers.
+The password is encrypted using [KMS](https://cloud.google.com/security/products/security-key-management) and stored only for the period required to submit the app to the App Store plus 24 hours, to allow for retries during that time. Once this period is over, the password is deleted from the Expo servers.
 
 This authentication method is **not recommended**. We recommend using the Apple Store Connect (ASC) API key for submitting your apps to the App Store instead. Expo won't use the Apple app-specific password in any way other than to submit your app to the App Store.
 
 #### Consequences if compromised
 
-If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud (check [Apple's documentation](https://support.apple.com/en-us/102654) for more details). They would also be able to submit an app signed by your build credentials to the App Store.
+If a malicious actor somehow gains access to the app-specific password, they would be able to access information like mail, contacts, and calendars that you store in iCloud (check [Apple's documentation](https://support.apple.com/en-us/102654) for more details).
 
-If an attacker doesn't have access to your build credentials, they won't be able to do much when submitting an app to the App Store. They can only submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
+If the attacker has additionally gained access to your build credentials, they would be able to submit a new version of an existing app. They would only be able to submit the app signed with those build credentials, and they can't submit any arbitrary app to the App Store in your name.
 
 #### Consequences if lost
 


### PR DESCRIPTION
# Why

Add info about submit credentials to security docs

# How

Add info about submit credentials to security docs

# Test Plan

Preview.

The docs I wrote here represent my current understanding of how the security for these credentials works. Please double-check if it makes sense to you.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
