### PR TITLE
[ci] Sync template only from current SDK

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [main]
+    branches: [sdk-51]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
# Why

We were syncing `main` branch to the external template repo used by expo.new onboarding.

# How

By switching to the current SDK branch.

# Test Plan

If it doesn't work it will not break anything and will be easy to spot and fix.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
