### PR TITLE
[docs] Update from-react-navigation.mdx

### DIFF
--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -24,7 +24,7 @@ If your app uses a custom `getPathFromState` or `getStateFromPath` component, it
 We recommend making the following modifications to your codebase before beginning the migration:
 
 - Split React Navigation screen components into individual files. For example, if you have `<Stack.Screen component={HomeScreen} />`, then ensure the `HomeScreen` class is in its own file.
-- Convert the project to [TypeScript](/guides/typescript/#path-aliases-optional). This will make it easier to spot errors that may occur during the migration.
+- Convert the project to [TypeScript](/guides/typescript/#migrating-existing-javascript-project). This will make it easier to spot errors that may occur during the migration.
 - Convert relative imports to [typed aliases](/guides/typescript/#path-aliases-optional). For example, `../../components/button.tsx` to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
 - Migrate away from `resetRoot`. This is used to "restart" the app while running. This is generally considered bad practice, and you should restructure your app's navigation so this never needs to happen.
 - Rename the initial route to `index`. Expo Router considers the route that is opened on launch to match `/`, React Navigation users will generally use something such as "Home" for the initial route.


### PR DESCRIPTION
# Why

This PR updates the from-react-navigation.md guide by fixing a link to send to the right header.

# How

This PR updates the from-react-navigation.md guide by:
*Fixing a link to ensure it directs to the correct header.

# Test Plan

Run the docs locally and verify that the fixed link directs to the correct header in the from-react-navigation.md guide.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
