### PR TITLE
[docs] Fix Android and iOS versions in FAQ item and other minor fixes

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -63,7 +63,7 @@ Traditionally you needed a macOS to develop iOS apps, however, you can use [EAS 
 
 ## What versions of Android and iOS are supported by the Expo SDK?
 
-Expo SDK supports Android 5+ and iOS 13+. For more information, see [Support for Android and iOS versions](/versions/latest/#support-for-android-and-ios-versions).
+Expo SDK supports Android 6+ and iOS 13+. For more information, see [Support for Android and iOS versions](/versions/latest/#support-for-android-and-ios-versions).
 
 ## What is the minimal size of a "hello world" expo app?
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -63,7 +63,7 @@ Traditionally you needed a macOS to develop iOS apps, however, you can use [EAS 
 
 ## What versions of Android and iOS are supported by the Expo SDK?
 
-Expo SDK supports Android 6+ and iOS 13+. For more information, see [Support for Android and iOS versions](/versions/latest/#support-for-android-and-ios-versions).
+Expo SDK supports Android 6+ and iOS 13.4+. For more information, see [Support for Android and iOS versions](/versions/latest/#support-for-android-and-ios-versions).
 
 ## What is the minimal size of a "hello world" expo app?
 

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -16,7 +16,7 @@ import {
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-secure-store` provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
 
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 

--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` is a library that provides access to `ReviewManager` API on Android 5+ and `SKStoreReviewController` API on iOS. It allows you to ask the user to rate your app without leaving the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v49.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/securestore.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-secure-store` provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
 
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 

--- a/docs/pages/versions/v49.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` is a library that provides access to `ReviewManager` API on Android 5+ and `SKStoreReviewController` API on iOS. It allows you to ask the user to rate your app without leaving the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -16,7 +16,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-secure-store` provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
 
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 

--- a/docs/pages/versions/v50.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` is a library that provides access to `ReviewManager` API on Android 5+ and `SKStoreReviewController` API on iOS. It allows you to ask the user to rate your app without leaving the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v51.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` is a library that provides access to `ReviewManager` API on Android 5+ and `SKStoreReviewController` API on iOS. It allows you to ask the user to rate your app without leaving the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Bump the Android and iOS versions to be in sync with the latest SDK version support table in the FAQ item. Context in [Slack](https://exponent-internal.slack.com/archives/C1QNF5L3C/p1721968643501629)
- Minor verbiage update to follow platform order from writing style guide in StorReview API references.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
