### PR TITLE
[docs] Update UI Next steps page

### DIFF
--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -28,7 +28,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 <BoxLink
   title="Use TypeScript"
   Icon={Settings02Icon}
-  description="An in-depth guide on configuring an Expo project with TypeScript and includes instructions to migrate an existing JavaScript project."
+  description="An in-depth guide on configuring an Expo project with TypeScript or migrating an existing JavaScript project."
   href="/guides/typescript/"
 />
 

--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -4,19 +4,12 @@ description: A list of useful resources to learn more about implementing navigat
 hideTOC: true
 ---
 
-import { RouterLogo } from '@expo/styleguide';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Brush01Icon } from '@expo/styleguide-icons/outline/Brush01Icon';
 import { Settings02Icon } from '@expo/styleguide-icons/outline/Settings02Icon';
 import { TableIcon } from '@expo/styleguide-icons/outline/TableIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-
-<BoxLink
-  title="Expo Router"
-  Icon={RouterLogo}
-  description="Expo Router is an open-source file system-based routing library for Universal React Native applications built with Expo."
-  href="/router/introduction/"
-/>
 
 <BoxLink
   title="UI programming"
@@ -33,8 +26,22 @@ import { BoxLink } from '~/ui/components/BoxLink';
 />
 
 <BoxLink
-  title="Using TypeScript"
+  title="Use TypeScript"
   Icon={Settings02Icon}
-  description="An in-depth guide on configuring an Expo project with TypeScript."
+  description="An in-depth guide on configuring an Expo project with TypeScript and includes instructions to migrate an existing JavaScript project."
   href="/guides/typescript/"
+/>
+
+<BoxLink
+  title="Icons"
+  Icon={BookOpen02Icon}
+  description="Learn how to use various types of icons in your Expo app, including vector icons, custom icon fonts, icon images, and icon buttons."
+  href="/guides/icons/"
+/>
+
+<BoxLink
+  title="ESLint and Prettier"
+  Icon={BookOpen02Icon}
+  description="A guide on configuring ESLint and Prettier to format Expo projects."
+  href="/guides/icons/"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Develop > User interface section is outdated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- Removes link to Expo Router section because Navigation section already contains links to different Expo Router docs.
- Add links to Icons and ESLIint guides.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
