### PR TITLE
[docs] Add missing BoxLink icons for docs under Distribution section

### DIFF
--- a/docs/pages/distribution/app-stores.mdx
+++ b/docs/pages/distribution/app-stores.mdx
@@ -3,6 +3,12 @@ title: App stores best practices
 description: Learn about the best practices when submitting an app to the app stores.
 ---
 
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
+import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
+import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 
 This guide offers best practices for submitting your app to the app stores. To learn how to generate native binaries for submission, see [Create your first build](/build/setup/).
@@ -12,42 +18,50 @@ This guide offers best practices for submitting your app to the app stores. To l
 <BoxLink
   title="Versioning your app"
   description="Learn how to configure native runtime versions for your apps."
-  href="/build-reference/app-versions"
+  href="/build-reference/app-versions/"
+  Icon={BuildIcon}
 />
 <BoxLink
   title="App Store presence"
   description="Manage your Apple App Store metadata from the command line."
   href="/eas/metadata/"
+  Icon={EasMetadataIcon}
 />
 <BoxLink
   title="Permissions"
-  description="Refine native permissions and system dialog messages."
+  description="Refine native permissions and system dialog messages by using app config."
   href="/guides/permissions"
+  Icon={CodeSquare01Icon}
 />
 <BoxLink
   title="App icons"
   description="App stores have strict rules for home screen icons."
   href="/develop/user-interface/splash-screen-and-app-icon/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Splash screen"
   description="Create a seamless loading experience using the splash screen API."
   href="/develop/user-interface/splash-screen-and-app-icon/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="App store assets"
   description="Learn how to create screenshots and previews for your app's store pages."
   href="/guides/store-assets/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Localizing your app"
   description="Prepare versions of your app for different languages and regions."
-  href="/guides/localization"
+  href="/guides/localization/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Apple: Review guidelines"
   description="Official Apple guide on preparing your app for App Store review."
-  href="https://developer.apple.com/app-store/review"
+  href="https://developer.apple.com/distribute/app-review/"
+  Icon={AppleAppStoreIcon}
 />
 
 ## Responsive design

--- a/docs/pages/distribution/app-transfers.mdx
+++ b/docs/pages/distribution/app-transfers.mdx
@@ -4,6 +4,10 @@ hideTOC: true
 description: An overview of transferring the ownership of an app to a different entity.
 ---
 
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
+import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStoreIcon';
+import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 
 There are two different representations of your app to consider when handing over ownership to another entity: the app as it exists on Expo Application Services (to create builds with EAS Build, send updates with EAS Update, and so on) and the app records on the app stores (to distribute the app to end-users). The following guides explain how to handle app transfers in each case.
@@ -12,16 +16,19 @@ There are two different representations of your app to consider when handing ove
   title="EAS project transfers"
   description="Transfer an EAS project to a different Expo account."
   href="/accounts/account-types/#transfer-projects-between-accounts"
+  Icon={PlanEnterpriseIcon}
 />
 
 <BoxLink
   title="Google project transfers"
   description="Transfer an Android app to a different Google Play developer account."
   href="https://support.google.com/googleplay/android-developer/answer/6230247"
+  Icon={GoogleAppStoreIcon}
 />
 
 <BoxLink
   title="Apple project transfers"
   description="Transfer an iOS app to a different Apple Developer account."
-  href="https://help.apple.com/app-store-connect/#/deved688524f"
+  href="https://developer.apple.com/help/app-store-connect/transfer-an-app/overview-of-app-transfer"
+  Icon={AppleAppStoreIcon}
 />

--- a/docs/pages/distribution/introduction.mdx
+++ b/docs/pages/distribution/introduction.mdx
@@ -5,8 +5,8 @@ hideTOC: true
 description: An overview of submitting an app to the app stores or with the internal distribution.
 ---
 
-import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
-import { AppleIcon } from '@expo/styleguide-icons/custom/AppleIcon';
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
+import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStoreIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Earth02Icon } from '@expo/styleguide-icons/outline/Earth02Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
@@ -40,14 +40,14 @@ This automatically manages **all native code signing** for Android and iOS for a
   title="Submit to the Google Play Store"
   description="Learn how to submit an Android app to the Google Play Store."
   href="/submit/android"
-  Icon={AndroidIcon}
+  Icon={GoogleAppStoreIcon}
 />
 
 <BoxLink
   title="Submit to the Apple App Store"
   description="Learn how to submit an iOS or an iPadOS app to the Apple App Store from any operating system."
   href="/submit/ios"
-  Icon={AppleIcon}
+  Icon={AppleAppStoreIcon}
 />
 
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add missing icons for different BoxLinks for pages under the Distribution section. Also, update outdated external links to Apple documentation for two BoxLinks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting:
- http://localhost:3002/distribution/introduction/
- http://localhost:3002/distribution/app-stores/
- http://localhost:3002/distribution/app-transfers/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
