### PR TITLE
fix(expo): add support for workspace root in `expo/scripts/resolveAppEntry`

### DIFF
--- a/packages/@expo/config/src/paths/paths.ts
+++ b/packages/@expo/config/src/paths/paths.ts
@@ -133,5 +133,10 @@ function getMetroServerRoot(projectRoot: string): string {
  * accounting for possible monorepos and keeping the cache sharable (no absolute paths).
  */
 export const resolveRelativeEntryPoint: typeof resolveEntryPoint = (projectRoot, options) => {
-  return path.relative(getMetroServerRoot(projectRoot), resolveEntryPoint(projectRoot, options));
+  // The project root could be using a different root on MacOS (`/var` vs `/private/var`)
+  // We need to make sure to get the non-symlinked path to the server or project root.
+  return path.relative(
+    fs.realpathSync(getMetroServerRoot(projectRoot)),
+    fs.realpathSync(resolveEntryPoint(projectRoot, options))
+  );
 };

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))
 - Fixed fetch streaming error on iOS. ([#30604](https://github.com/expo/expo/pull/30604) by [@kudo](https://github.com/kudo))
 - Fixed fetch import on Web. ([#30605](https://github.com/expo/expo/pull/30605) by [@kudo](https://github.com/kudo))
+- Add support for server root in `expo/scripts/resolveAppEntry.js`.
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))
 - Fixed fetch streaming error on iOS. ([#30604](https://github.com/expo/expo/pull/30604) by [@kudo](https://github.com/kudo))
 - Fixed fetch import on Web. ([#30605](https://github.com/expo/expo/pull/30605) by [@kudo](https://github.com/kudo))
-- Add support for server root in `expo/scripts/resolveAppEntry.js`.
+- Add support for server root in `expo/scripts/resolveAppEntry.js`. ([#30652](https://github.com/expo/expo/pull/30652) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo/scripts/resolveAppEntry.js
+++ b/packages/expo/scripts/resolveAppEntry.js
@@ -14,8 +14,7 @@
 // Limitations:
 //   Currently only supports android and ios.
 
-const { resolveEntryPoint } = require('@expo/config/paths');
-const fs = require('fs');
+const { resolveEntryPoint, resolveRelativeEntryPoint } = require('@expo/config/paths');
 const path = require('path');
 
 const projectRoot = process.argv[1];
@@ -29,20 +28,17 @@ if (!platform || !projectRoot) {
   process.exit(1);
 }
 
-const entry = resolveEntryPoint(projectRoot, { platform });
+const entry = absolute
+  ? resolveEntryPoint(projectRoot, { platform })
+  : resolveRelativeEntryPoint(projectRoot, { platform });
 
-if (entry) {
+if (!entry) {
+  console.error(`Error: Could not find entry file for project at: ${projectRoot}`);
+  process.exit(1);
+} else {
   // Prevent any logs from the app.config.js
   // from being used in the output of this command.
   console.clear();
-  // React Native's `PROJECT_ROOT` could be using a different root on MacOS (`/var` vs `/private/var`)
-  // We need to make sure to get the real path, `resolveEntryPoint` is using this too
-  console.log(
-    absolute
-      ? path.resolve(entry)
-      : path.relative(fs.realpathSync(projectRoot), fs.realpathSync(entry))
-  );
-} else {
-  console.error(`Error: Could not find entry file for project at: ${projectRoot}`);
-  process.exit(1);
+
+  console.log(absolute ? path.resolve(entry) : entry);
 }


### PR DESCRIPTION
# Why

Fixes ENG-10695

This is a follow-up of #30633, #30621

# How

It fixes the initial app entry resolution, by reusing the `@expo/config/paths` method to resolve the entry point relatively to possible server roots (instead of project roots).

- If the path requested is relative, it will use the `resolveRelativeEntryPoint` method which takes the server root into account.
- If the path requested is absolute, nothing changes and the output will remain the same.

> Note, this is only used on iOS. On Android, we generally use an absolute entry path, which we [incorrectly relativize in the gradle layer](https://github.com/expo/expo/blob/93aa0d39a202472647cb2cf5af49f554a3a2f6e4/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt#L37). Instead of handling it here, I'll create _yet another_ follow-up PR where we allow absolute paths in the node script it's calling. From there, we can properly resolve the entry point using the `@expo/config/paths` helpers.

# Test Plan

See CI (Test Suite)

android ❌ | ios ✅
--- | ---
See follow-up PR #30654 | ![image](https://github.com/user-attachments/assets/4d48f670-9d85-425b-b2fa-2d01df9f76aa) <br /> [link](https://github.com/expo/expo/actions/runs/10116784957/job/27980367572?pr=30652#step:13:5927)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
