### PR TITLE
[core][Android] Add support for primitive arrays in functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [Android] Add the ability to change the name of the exported shared object. ([#30040](https://github.com/expo/expo/pull/30040) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Supported returning of the `SharedObject` from functions. ([#30426](https://github.com/expo/expo/pull/30426) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Support implementing `customizeRootView` in `ExpoAppDelegateSubscriber`. ([#30550](https://github.com/expo/expo/pull/30550) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Added support for primitive arrays in functions.
+- [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Android] Add the ability to change the name of the exported shared object. ([#30040](https://github.com/expo/expo/pull/30040) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Supported returning of the `SharedObject` from functions. ([#30426](https://github.com/expo/expo/pull/30426) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Support implementing `customizeRootView` in `ExpoAppDelegateSubscriber`. ([#30550](https://github.com/expo/expo/pull/30550) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Added support for primitive arrays in functions.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -259,6 +259,22 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(e4).isEqualTo(4)
   }
 
+  @Test
+  fun long_array_should_be_convertible() = withSingleModule({
+    AsyncFunction("longArray") { a: LongArray -> a }
+  }) {
+    val array = callAsync("longArray", "[1, 2, 3]").getArray()
+    Truth.assertThat(array.size).isEqualTo(3)
+
+    val e1 = array[0].getDouble()
+    val e2 = array[1].getDouble()
+    val e3 = array[2].getDouble()
+
+    Truth.assertThat(e1).isEqualTo(1.0)
+    Truth.assertThat(e2).isEqualTo(2.0)
+    Truth.assertThat(e3).isEqualTo(3.0)
+  }
+
   private class MySharedRef(value: Int, runtimeContext: RuntimeContext) : SharedRef<Int>(value, runtimeContext)
 
   @Test

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -354,6 +354,22 @@ class JSIFunctionsTest {
   }
 
   @Test
+  fun long_array_should_be_convertible() = withSingleModule({
+    Function("longArray") { a: LongArray -> a }
+  }) {
+    val array = call("longArray", "[1, 2, 3]").getArray()
+    Truth.assertThat(array.size).isEqualTo(3)
+
+    val e1 = array[0].getDouble()
+    val e2 = array[1].getDouble()
+    val e3 = array[2].getDouble()
+
+    Truth.assertThat(e1).isEqualTo(1.0)
+    Truth.assertThat(e2).isEqualTo(2.0)
+    Truth.assertThat(e3).isEqualTo(3.0)
+  }
+
+  @Test
   fun string_array_should_be_convertible() = withSingleModule({
     Function("stringArray") { a: Array<String> -> a }
   }) {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -81,14 +81,22 @@ private:
 
   void invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage);
 
+  void invokeIntArray(jni::alias_ref<jni::JArrayInt> result);
+  void invokeLongArray(jni::alias_ref<jni::JArrayLong> result);
+  void invokeDoubleArray(jni::alias_ref<jni::JArrayDouble> result);
+  void invokeFloatArray(jni::alias_ref<jni::JArrayFloat> result);
+
   template<class T>
   using ArgsConverter = std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction, T arg)>;
 
   template<class T>
   inline void invokeJSFunction(
-    ArgsConverter<T> argsConverter,
+    ArgsConverter<typename std::remove_const<T>::type> argsConverter,
     T arg
   );
+
+  template<class T>
+  void invokeJSFunctionForArray(T &arg);
 
   template<class T>
   inline void invokeJSFunction(T arg);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -31,6 +31,12 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
     {"<init>", "(F)V"}
   });
 
+  loadJClass(env, "[D", {});
+  loadJClass(env, "[Z", {});
+  loadJClass(env, "[I", {});
+  loadJClass(env, "[J", {});
+  loadJClass(env, "[F", {});
+
   loadJClass(env, "com/facebook/react/bridge/PromiseImpl", {
     {"<init>", "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V"}
   });

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -69,8 +69,16 @@ jsi::Value convert(
   CAST_AND_RETURN(JSharedObject::javaobject, expo/modules/kotlin/sharedobjects/SharedObject)
   CAST_AND_RETURN(JavaScriptTypedArray::javaobject, expo/modules/kotlin/jni/JavaScriptTypedArray)
 
-  return jsi::Value::undefined();
+  // Primitives arrays
+  CAST_AND_RETURN(jni::JArrayDouble, [D)
+  CAST_AND_RETURN(jni::JArrayBoolean, [Z)
+  CAST_AND_RETURN(jni::JArrayInt, [I)
+  CAST_AND_RETURN(jni::JArrayLong, [J)
+  CAST_AND_RETURN(jni::JArrayFloat, [F)
+
 #undef CAST_AND_RETURN
+
+  return jsi::Value::undefined();
 }
 
 std::optional<jsi::Value> decorateValueForDynamicExtension(jsi::Runtime &rt, const jsi::Value &value) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -85,12 +85,12 @@ open class KEventEmitterWrapper(
 
   override fun emit(eventName: String, eventBody: Record?) {
     deviceEventEmitter
-      ?.emit(eventName, JSTypeConverter.convertToJSValue(eventBody))
+      ?.emit(eventName, JSTypeConverter.legacyConvertToJSValue(eventBody))
   }
 
   override fun emit(eventName: String, eventBody: Map<*, *>?) {
     deviceEventEmitter
-      ?.emit(eventName, JSTypeConverter.convertToJSValue(eventBody))
+      ?.emit(eventName, JSTypeConverter.legacyConvertToJSValue(eventBody))
   }
 
   override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -25,6 +25,10 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
       is WritableNativeArray -> invokeNative(result)
       is WritableNativeMap -> invokeNative(result)
       is SharedObject -> invokeNative(result)
+      is IntArray -> invokeIntArray(result)
+      is LongArray -> invokeLongArray(result)
+      is FloatArray -> invokeFloatArray(result)
+      is DoubleArray -> invokeDoubleArray(result)
       else -> throw UnexpectedException("Unknown type: ${result.javaClass}")
     }
   }
@@ -67,6 +71,11 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
   private external fun invokeNative(result: WritableNativeMap)
   private external fun invokeNative(result: SharedObject)
   private external fun invokeNative(code: String, errorMessage: String)
+
+  private external fun invokeIntArray(result: IntArray)
+  private external fun invokeLongArray(result: LongArray)
+  private external fun invokeFloatArray(result: FloatArray)
+  private external fun invokeDoubleArray(result: DoubleArray)
 
   private inline fun checkIfValid(body: () -> Unit) {
     try {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -23,7 +23,13 @@ object JSTypeConverter {
     override fun createArray(): WritableArray = Arguments.createArray()
   }
 
-  fun convertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
+  /**
+   * To support WritableArray and WritableMap, we must refrain from using types that are not supported by folly::dynamic.
+   * Therefore, we need two separate methods for converting values to JSValue.
+   * The legacy method is fully compatible with folly::dynamic, and in the new method,
+   * we are beginning to transition to custom converters.
+   */
+  fun legacyConvertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
     return when (value) {
       null, is Unit -> null
       is Bundle -> value.toJSValue(containerProvider)
@@ -32,6 +38,28 @@ object JSTypeConverter {
       is FloatArray -> value.toJSValue(containerProvider)
       is DoubleArray -> value.toJSValue(containerProvider)
       is BooleanArray -> value.toJSValue(containerProvider)
+      is ByteArray -> FollyDynamicExtensionConverter.put(value)
+      is Map<*, *> -> value.toJSValue(containerProvider)
+      is Enum<*> -> value.toJSValue()
+      is Record -> value.toJSValue(containerProvider)
+      is URI -> value.toJSValue()
+      is URL -> value.toJSValue()
+      is Uri -> value.toJSValue()
+      is File -> value.toJSValue()
+      is Pair<*, *> -> value.toJSValue(containerProvider)
+      is Long -> value.toDouble()
+      is RawTypedArrayHolder -> value.rawArray
+      is Iterable<*> -> value.toJSValue(containerProvider)
+      else -> value
+    }
+  }
+
+  fun convertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
+    return when (value) {
+      null, is Unit -> null
+      is Bundle -> value.toJSValue(containerProvider)
+      is Array<*> -> value.toJSValue(containerProvider)
+      is IntArray, is FloatArray, is DoubleArray, is BooleanArray, is LongArray -> value
       is ByteArray -> FollyDynamicExtensionConverter.put(value)
       is Map<*, *> -> value.toJSValue(containerProvider)
       is Enum<*> -> value.toJSValue()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
@@ -30,7 +30,7 @@ fun Record.toJSValue(containerProvider: JSTypeConverter.ContainerProvider): Writ
       property.isAccessible = true
 
       val value = property.get(this)
-      val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+      val convertedValue = JSTypeConverter.legacyConvertToJSValue(value, containerProvider)
       result.putGeneric(jsKey, convertedValue)
     }
 
@@ -42,7 +42,7 @@ fun Bundle.toJSValue(containerProvider: JSTypeConverter.ContainerProvider): Writ
 
   for (key in keySet()) {
     val value = get(key)
-    val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+    val convertedValue = JSTypeConverter.legacyConvertToJSValue(value, containerProvider)
     result.putGeneric(key, convertedValue)
   }
 
@@ -53,7 +53,7 @@ fun <K, V> Map<K, V>.toJSValue(containerProvider: JSTypeConverter.ContainerProvi
   val result = containerProvider.createMap()
 
   for ((key, value) in entries) {
-    val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+    val convertedValue = JSTypeConverter.legacyConvertToJSValue(value, containerProvider)
     result.putGeneric(key.toString(), convertedValue)
   }
 
@@ -64,7 +64,7 @@ fun <T> Iterable<T>.toJSValue(containerProvider: JSTypeConverter.ContainerProvid
   val result = containerProvider.createArray()
 
   for (value in this) {
-    val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+    val convertedValue = JSTypeConverter.legacyConvertToJSValue(value, containerProvider)
     result.putGeneric(convertedValue)
   }
 
@@ -75,7 +75,7 @@ fun <T> Array<T>.toJSValue(containerProvider: JSTypeConverter.ContainerProvider)
   val result = containerProvider.createArray()
 
   for (value in this) {
-    val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+    val convertedValue = JSTypeConverter.legacyConvertToJSValue(value, containerProvider)
     result.putGeneric(convertedValue)
   }
 
@@ -152,8 +152,8 @@ fun File.toJSValue(): String {
 
 fun Pair<*, *>.toJSValue(containerProvider: JSTypeConverter.ContainerProvider): WritableArray {
   return containerProvider.createArray().also {
-    val convertedFirst = JSTypeConverter.convertToJSValue(first, containerProvider)
-    val convertedSecond = JSTypeConverter.convertToJSValue(second, containerProvider)
+    val convertedFirst = JSTypeConverter.legacyConvertToJSValue(first, containerProvider)
+    val convertedSecond = JSTypeConverter.legacyConvertToJSValue(second, containerProvider)
     it.putGeneric(convertedFirst)
     it.putGeneric(convertedSecond)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -215,6 +215,14 @@ object TypeConverterProviderImpl : TypeConverterProvider {
           jsArray.getInt(index)
         }
       },
+      LongArray::class to createTrivialTypeConverter(
+        isOptional, ExpectedType.forPrimitiveArray(CppType.LONG)
+      ) {
+        val jsArray = it.asArray()
+        LongArray(jsArray.size()) { index ->
+          jsArray.getDouble(index).toLong()
+        }
+      },
       DoubleArray::class to createTrivialTypeConverter(
         isOptional, ExpectedType.forPrimitiveArray(CppType.DOUBLE)
       ) {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
@@ -31,7 +31,7 @@ class JSTypeConverterTest {
       putStringArray("stringArray", arrayOf("s1", "s2"))
     }
 
-    val converted = JSTypeConverter.convertToJSValue(bundle, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(bundle, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableMap::class.java)
     val map = converted as WritableMap
@@ -52,7 +52,7 @@ class JSTypeConverterTest {
     val collections = listOf(list, set, linkedList)
 
     for (collection in collections) {
-      val converted = JSTypeConverter.convertToJSValue(collection, TestContainerProvider)
+      val converted = JSTypeConverter.legacyConvertToJSValue(collection, TestContainerProvider)
       Truth.assertThat(converted).isInstanceOf(WritableArray::class.java)
       val array = converted as WritableArray
       Truth.assertThat(array.getInt(0)).isEqualTo(1)
@@ -65,7 +65,7 @@ class JSTypeConverterTest {
   fun `should convert Array`() {
     val array = arrayOf("s1", "s2", "s3")
 
-    val converted = JSTypeConverter.convertToJSValue(array, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(array, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableArray::class.java)
     val convertedArray = converted as WritableArray
@@ -78,7 +78,7 @@ class JSTypeConverterTest {
   fun `should convert IntArray`() {
     val array = IntArray(3) { it }
 
-    val converted = JSTypeConverter.convertToJSValue(array, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(array, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableArray::class.java)
     val convertedArray = converted as WritableArray
@@ -91,7 +91,7 @@ class JSTypeConverterTest {
   fun `should convert DoubleArray`() {
     val array = DoubleArray(3) { it.toDouble() }
 
-    val converted = JSTypeConverter.convertToJSValue(array, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(array, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableArray::class.java)
     val convertedArray = converted as WritableArray
@@ -107,7 +107,7 @@ class JSTypeConverterTest {
       "k2" to "v2"
     )
 
-    val converted = JSTypeConverter.convertToJSValue(map, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(map, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableMap::class.java)
     val convertedMap = converted as WritableMap
@@ -128,7 +128,7 @@ class JSTypeConverterTest {
 
     val record = MyRecord()
 
-    val converted = JSTypeConverter.convertToJSValue(record, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(record, TestContainerProvider)
 
     Truth.assertThat(converted).isInstanceOf(WritableMap::class.java)
     val convertedRecord = converted as WritableMap
@@ -166,7 +166,7 @@ class JSTypeConverterTest {
 
     val record = MyRecord()
 
-    val converted = JSTypeConverter.convertToJSValue(record, TestContainerProvider)
+    val converted = JSTypeConverter.legacyConvertToJSValue(record, TestContainerProvider)
     Truth.assertThat(converted).isInstanceOf(WritableMap::class.java)
     val convertedRecord = converted as WritableMap
 


### PR DESCRIPTION
# Why

Adds support for primitive arrays (`LongArray`, etc.) in functions.

# How

Now, you can return primitive arrays from sync and async function. You can't nest them, because those types aren't supported by folly::dynamic.

# Test Plan

- unit tests ✅ 