### PR TITLE
[core][Android] Fixed `Class declares 0 type parameters, but X were provided`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
 - [Android] Fixed not throwing when setting read-only properties. ([#30428](https://github.com/expo/expo/pull/30428) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `expo.modules.kotlin.jni.tests.RuntimeHolder` class not found crash when R8 is enabled. ([#30572](https://github.com/expo/expo/pull/30572) by [@kudo](https://github.com/kudo))
-- [Android] Fixed `Class declares 0 type parameters, but X were provided` on Android when R8 is enabled.
+- [Android] Fixed `Class declares 0 type parameters, but X were provided` on Android when R8 is enabled. ([#30659](https://github.com/expo/expo/pull/30659) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
 - [Android] Fixed not throwing when setting read-only properties. ([#30428](https://github.com/expo/expo/pull/30428) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `expo.modules.kotlin.jni.tests.RuntimeHolder` class not found crash when R8 is enabled. ([#30572](https://github.com/expo/expo/pull/30572) by [@kudo](https://github.com/kudo))
+- [Android] Fixed `Class declares 0 type parameters, but X were provided` on Android when R8 is enabled.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -2,6 +2,7 @@
 
 package expo.modules.kotlin.types
 
+import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.apifeatures.EitherType
 import java.lang.ref.WeakReference
@@ -33,6 +34,8 @@ class UnconvertedValue(
 data class ConvertedValue(val convertedValue: Any) : DeferredValue()
 
 @EitherType
+@DoNotStrip
+// We can't strip this class because typeOf<Either<T,P>> won't work in the release builds.
 open class Either<FirstType : Any, SecondType : Any>(
   private val bareValue: Any,
   private val deferredValue: MutableList<DeferredValue>,


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/30267.

# How

The check inside the `typeOf` function fails when it cannot determine the number of generic parameters. When `Either` is stripped, this information is, for some reason, removed from the binary.

# Test Plan

- [RRaideRR/expo-video-proguard](https://github.com/RRaideRR/expo-video-proguard) ✅ 