### PR TITLE
[docs] update name of folders to be ignore by eas and git

### DIFF
--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -31,8 +31,8 @@ For a project that has **android** and **ios** directories, EAS Build will not r
 If you troubleshoot your app by [compiling it locally](/guides/local-app-development/#local-app-compilation) (running `npx expo prebuild`, or `npx expo run:android` or `npx expo run:ios`), you can still use Prebuild with EAS Build to generate fresh native directories during the build process. In this scenario, add the **android** and **ios** directories to **.gitignore** or **.easignore** files:
 
 ```diff .gitignore
-+ android/
-+ ios/
++ /android
++ /ios
 ```
 
 ### Usage with Expo CLI run commands


### PR DESCRIPTION
# Why
The suggested paths for the  `.easignore` and `.gitignore` are a little misleading. 
Has mentioned [here](https://github.com/zoontek/react-native-bootsplash/issues/595#issuecomment-2254211269)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
