### PR TITLE
[docs] Explain the Last-Modified and Expires timestamps

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -11,7 +11,7 @@ import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
 ## Builder IP addresses
 
-A list of the IP addresses of the build servers is available [in this file](https://expo.dev/eas-build-worker-ips.txt). We do not expect to change the list often. Every time we improve the infrastructure and do need to update the IPs, we will also update the timestamp in the header of the file.
+A list of the IP addresses of the build servers is available [in this file](https://expo.dev/eas-build-worker-ips.txt). We do not expect to change the list often. The list includes "Last-Modified" and "Expires" ISO 8601 timestamps that respectively specify the last time the list was updated and the time until which we commit to not change the list.
 
 Linux runners are hosted in Google Cloud Platform. macOS runners are hosted in our own macOS cloud.
 


### PR DESCRIPTION
# Why/How

Tell people to use the timestamps in the IP list to stay updated. This makes these timestamps part of the public API of this list.

# Test Plan

None/CI