### PR TITLE
SSR support for useColorScheme hook

### DIFF
--- a/templates/expo-template-default/hooks/useColorScheme.web.ts
+++ b/templates/expo-template-default/hooks/useColorScheme.web.ts
@@ -16,7 +16,7 @@ export function useColorScheme() {
   return 'light'
 }
 
-export const useHasHydrated = () => {
+const useHasHydrated = () => {
   const [hasHydrated, setHasHydrated] = useState(false)
 
   useEffect(() => {

--- a/templates/expo-template-default/hooks/useColorScheme.web.ts
+++ b/templates/expo-template-default/hooks/useColorScheme.web.ts
@@ -1,8 +1,27 @@
-// NOTE: The default React Native styling doesn't support server rendering.
-// Server rendered styles should not change between the first render of the HTML
-// and the first render on the client. Typically, web developers will use CSS media queries
-// to render different styles on the client and server, these aren't directly supported in React Native
-// but can be achieved using a styling library like Nativewind.
+import { useColorScheme as useRNColorScheme } from 'react-native'
+import { useState, useEffect } from 'react'
+
 export function useColorScheme() {
-  return 'light';
+  // NOTE: The default React Native styling doesn't support server rendering.
+  // Server rendered styles should not change between the first render of the HTML
+  // and the first render on the client. So, we need to ensure that the color scheme
+  // is only determined on the client side after hydration. This way, we avoid any
+  // mismatch in styles that could occur if the server-rendered styles were different
+  // from the client-rendered styles.
+  const hasHydrated = useHasHydrated()
+
+  const colorScheme = useRNColorScheme()
+
+  if (hasHydrated) return colorScheme
+  return 'light'
+}
+
+export const useHasHydrated = () => {
+  const [hasHydrated, setHasHydrated] = useState(false)
+
+  useEffect(() => {
+    setHasHydrated(true)
+  }, [])
+
+  return hasHydrated
 }

--- a/templates/expo-template-default/hooks/useColorScheme.web.ts
+++ b/templates/expo-template-default/hooks/useColorScheme.web.ts
@@ -2,12 +2,10 @@ import { useColorScheme as useRNColorScheme } from 'react-native'
 import { useState, useEffect } from 'react'
 
 export function useColorScheme() {
-  // NOTE: The default React Native styling doesn't support server rendering.
-  // Server rendered styles should not change between the first render of the HTML
-  // and the first render on the client. So, we need to ensure that the color scheme
-  // is only determined on the client side after hydration. This way, we avoid any
-  // mismatch in styles that could occur if the server-rendered styles were different
-  // from the client-rendered styles.
+  // Server rendered content and the content on first render on the clien must be same.
+  // So, we need to ensure that the color scheme is only determined on the client side
+  // after hydration in order to avoid style mismatches between server-rendered and
+  // client-rendered content.
   const hasHydrated = useHasHydrated()
 
   const colorScheme = useRNColorScheme()

--- a/templates/expo-template-default/hooks/useColorScheme.web.ts
+++ b/templates/expo-template-default/hooks/useColorScheme.web.ts
@@ -12,7 +12,9 @@ export function useColorScheme() {
 
   const colorScheme = useRNColorScheme()
 
-  if (hasHydrated) return colorScheme
+  if (hasHydrated) {
+    return colorScheme
+  }
   return 'light'
 }
 

--- a/templates/expo-template-tabs/components/useColorScheme.web.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.web.ts
@@ -1,8 +1,27 @@
-// NOTE: The default React Native styling doesn't support server rendering.
-// Server rendered styles should not change between the first render of the HTML
-// and the first render on the client. Typically, web developers will use CSS media queries
-// to render different styles on the client and server, these aren't directly supported in React Native
-// but can be achieved using a styling library like Nativewind.
+import { useColorScheme as useRNColorScheme } from 'react-native'
+import { useState, useEffect } from 'react'
+
 export function useColorScheme() {
-  return 'light';
+  // NOTE: The default React Native styling doesn't support server rendering.
+  // Server rendered styles should not change between the first render of the HTML
+  // and the first render on the client. So, we need to ensure that the color scheme
+  // is only determined on the client side after hydration. This way, we avoid any
+  // mismatch in styles that could occur if the server-rendered styles were different
+  // from the client-rendered styles.
+  const hasHydrated = useHasHydrated()
+
+  const colorScheme = useRNColorScheme()
+
+  if (hasHydrated) return colorScheme
+  return 'light'
+}
+
+export const useHasHydrated = () => {
+  const [hasHydrated, setHasHydrated] = useState(false)
+
+  useEffect(() => {
+    setHasHydrated(true)
+  }, [])
+
+  return hasHydrated
 }

--- a/templates/expo-template-tabs/components/useColorScheme.web.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.web.ts
@@ -2,12 +2,10 @@ import { useColorScheme as useRNColorScheme } from 'react-native'
 import { useState, useEffect } from 'react'
 
 export function useColorScheme() {
-  // NOTE: The default React Native styling doesn't support server rendering.
-  // Server rendered styles should not change between the first render of the HTML
-  // and the first render on the client. So, we need to ensure that the color scheme
-  // is only determined on the client side after hydration. This way, we avoid any
-  // mismatch in styles that could occur if the server-rendered styles were different
-  // from the client-rendered styles.
+  // Server rendered content and the content on first render on the clien must be same.
+  // So, we need to ensure that the color scheme is only determined on the client side
+  // after hydration in order to avoid style mismatches between server-rendered and
+  // client-rendered content.
   const hasHydrated = useHasHydrated()
 
   const colorScheme = useRNColorScheme()


### PR DESCRIPTION
# Why

Recently, I encountered an issue with a white background on the web platform, even though React Native's `useColorScheme` hook indicated it was in `dark` mode. So, I decided to investigate further.

<img width="1205" alt="image" src="https://github.com/user-attachments/assets/f50ce81e-653f-48e8-b724-e0a2afdfab72">


Then I found out that it was due to the following `useColorScheme.web.ts` hook

<img width="1336" alt="image" src="https://github.com/user-attachments/assets/6d094d32-dfd3-4794-9137-fb7da4ee1471">

I read the NOTE comment which said that `useColorScheme` is written like that because when doing SSR, our server rendered content must be the same as the first render on the client

So this PR fixes that issue and ensures that the **_React Native's `useColorScheme` hook_** is only  allowed to determine the color scheme after client side hydration completes

<details>
 <summary>I picked up this solution idea <a href="https://www.joshwcomeau.com/react/the-perils-of-rehydration/#the-solution-9" target="_blank">from a blog</a> written by joshwcomeau </summary>
 
 
<img width="857" alt="image" src="https://github.com/user-attachments/assets/6e4a90ed-ad83-4d67-ae9b-9b5d95082e1c">

</details>
 
# Test Plan

 Here's the demo in which I throttled down the network to `Fast 4G` to demonstrate that only initally the color scheme was "light" and after the first useEffect run, we are allowing the **_React Native's `useColorScheme` hook_** to determine the color scheme

https://github.com/user-attachments/assets/ac4d0c1c-f41c-4029-8102-06ed1e747092



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
