### PR TITLE
[docs] Hardcode links to types from the expo package

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -134,7 +134,6 @@ const nonLinkableTypes = [
   'Parameters',
   'ParsedQs',
   'ServiceActionResult',
-  'SharedObject',
   'T',
   'TaskOptions',
   'TEventsMap',
@@ -226,6 +225,30 @@ const hardcodedTypeLinks: Record<string, string> = {
 const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string>> = {
   'v49.0.0': {
     Manifest: '/versions/v49.0.0/sdk/constants/#manifest',
+  },
+  'v52.0.0': {
+    EventEmitter: '/versions/v52.0.0/sdk/expo/#eventemitter',
+    NativeModule: '/versions/v52.0.0/sdk/expo/#nativemodule',
+    SharedObject: '/versions/v52.0.0/sdk/expo/#sharedobject',
+    SharedRef: '/versions/v52.0.0/sdk/expo/#sharedref',
+  },
+  'v53.0.0': {
+    EventEmitter: '/versions/v53.0.0/sdk/expo/#eventemitter',
+    NativeModule: '/versions/v53.0.0/sdk/expo/#nativemodule',
+    SharedObject: '/versions/v53.0.0/sdk/expo/#sharedobject',
+    SharedRef: '/versions/v53.0.0/sdk/expo/#sharedref',
+  },
+  latest: {
+    EventEmitter: '/versions/latest/sdk/expo/#eventemitter',
+    NativeModule: '/versions/latest/sdk/expo/#nativemodule',
+    SharedObject: '/versions/latest/sdk/expo/#sharedobject',
+    SharedRef: '/versions/latest/sdk/expo/#sharedref',
+  },
+  unversioned: {
+    EventEmitter: '/versions/unversioned/sdk/expo/#eventemitter',
+    NativeModule: '/versions/unversioned/sdk/expo/#nativemodule',
+    SharedObject: '/versions/unversioned/sdk/expo/#sharedobject',
+    SharedRef: '/versions/unversioned/sdk/expo/#sharedref',
   },
 };
 


### PR DESCRIPTION
# Why

Fix links to some classes provided by the `expo` package by hardcoding them. Right now there is no better way to achieve this.

# How

To reduce the maintenance cost, I hardcoded links for `latest`, SDK 52 and SDK 53 ahead so we don't need to update them in the next two releases.

To be honest I think the current way it works is not a good solution and we should come up with something better that doesn't involve updating these links on each release.

# Test Plan

See preview. You can go to [/versions/unversioned/sdk/imagemanipulator/#imageref](/versions/unversioned/sdk/imagemanipulator/#imageref) and see that `ImageRef` class extends `SharedObject` which correctly links to [/versions/unversioned/sdk/expo/#sharedobject](/versions/unversioned/sdk/expo/#sharedobject)