### PR TITLE
[docs]: Fix typos

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "yarn generate-static-resoures && next dev -p 3002",
+    "dev": "yarn generate-static-resources && next dev -p 3002",
     "build": "next build",
-    "export": "yarn generate-static-resoures production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
-    "export-preview": "yarn generate-static-resoures preview && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
+    "export": "yarn generate-static-resources production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
+    "export-preview": "yarn generate-static-resources preview && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
@@ -15,13 +15,13 @@
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "vale .",
     "watch": "tsc --noEmit -w",
-    "test": "yarn generate-static-resoures && yarn node --experimental-vm-modules $(yarn bin jest)",
+    "test": "yarn generate-static-resources && yarn node --experimental-vm-modules $(yarn bin jest)",
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.cjs",
     "permissions-sync-android": "npx scrape-permissions-json@latest components/plugins/permissions/data --android",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
-    "generate-static-resoures": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
+    "generate-static-resources": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",
-    "postinstall": "node --async-stack-traces --unhandled-rejections=strict ./scripts/copy-latest.js && yarn generate-static-resoures"
+    "postinstall": "node --async-stack-traces --unhandled-rejections=strict ./scripts/copy-latest.js && yarn generate-static-resources"
   },
   "resolutions": {
     "string-width": "^4",

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -772,7 +772,7 @@ Behind the scenes, it uses:
 
 If you need to customize the Maestro version, run a specific Android Emulator or iOS Simulator, or upload multiple build artifacts you will need to write this series of steps yourself.
 
-<Collapsible summary={<>An example Android workflow with <code>eas/mastro_test</code> expanded</>}>
+<Collapsible summary={<>An example Android workflow with <code>eas/maestro_test</code> expanded</>}>
 ```yaml build-and-test-android-expanded.yml
 build:
   name: Build and test (Android, expanded)
@@ -818,7 +818,7 @@ build:
 ````
 </Collapsible>
 
-<Collapsible summary={<>An example iOS workflow with <code>eas/mastro_test</code> expanded</>}>
+<Collapsible summary={<>An example iOS workflow with <code>eas/maestro_test</code> expanded</>}>
 
 ```yaml build-and-test-ios-expanded.yml
 build:

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -80,7 +80,7 @@ You can enable the **JavaScript Profiler tab** within Chrome DevTools to record 
 <Collapsible summary="Screenshot of the Chrome DevTools command palette">
 
 <ContentSpotlight
-  alt="Chrome DevTools showing the command paletter."
+  alt="Chrome DevTools showing the command palette."
   src="/static/images/debugging/profiling-enable.png"
 />
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -101,7 +101,7 @@ You do not have to install other plugins or configurations to use Firebase JS SD
 
 Firebase version 9 and above provide a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
 
-> **info** **Troubleshooting tip:** If you encounter issues related to authentication persistance with Firebase JS SDK, see the guide for [setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
+> **info** **Troubleshooting tip:** If you encounter issues related to authentication persistence with Firebase JS SDK, see the guide for [setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
 
 </Step>
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -330,7 +330,7 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI compansion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI companion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -363,7 +363,7 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI compansion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI companion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 

--- a/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
@@ -331,7 +331,7 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI compansion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI companion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 

--- a/docs/ui/components/Text/withAnchor.test.tsx
+++ b/docs/ui/components/Text/withAnchor.test.tsx
@@ -11,7 +11,7 @@ describe(getTextFromChildren, () => {
     expect(getTextFromChildren(<span>Hello</span>)).toBe('Hello');
   });
 
-  it('returns text from miltiple child elements', () => {
+  it('returns text from multiple child elements', () => {
     expect(
       getTextFromChildren(
         <>


### PR DESCRIPTION
# Why

To have accurate and reliable documentation.

# How

By fixing typos.

# Test Plan

By running docs locally.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
