### PR TITLE
fix: TV compile E2E test

### DIFF
--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/tvos-compile-test.yml
+      - packages/expo-updates/e2e/setup/create-eas-project-tv.ts
+      - packages/expo-updates/e2e/setup/project.ts
   push:
     branches: [main, 'sdk-*']
     paths:

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -193,11 +193,13 @@ async function copyCommonFixturesToProject(
   await fs.copyFile(path.resolve(repoRoot, '.prettierrc'), path.join(projectRoot, '.prettierrc'));
 
   // Copy react-native patch
-  await fs.mkdir(path.join(projectRoot, 'patches'));
-  await fs.copyFile(
-    path.resolve(repoRoot, 'patches', 'react-native+0.75.0-rc.5.patch'),
-    path.join(projectRoot, 'patches', 'react-native+0.75.0-rc.5.patch')
-  );
+  if (!isTV) {
+    await fs.mkdir(path.join(projectRoot, 'patches'));
+    await fs.copyFile(
+      path.resolve(repoRoot, 'patches', 'react-native+0.75.0-rc.5.patch'),
+      path.join(projectRoot, 'patches', 'react-native+0.75.0-rc.5.patch')
+    );
+  }
 
   // Modify specific files for TV
   if (isTV) {
@@ -362,7 +364,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.74.2-0',
+        'react-native': 'npm:react-native-tvos@~0.74.3-0',
         '@react-native-tvos/config-tv': '^0.0.10',
       },
       expo: {


### PR DESCRIPTION
# Why

A patch for RN 0.75 was added to the E2E setup, but this patch does not apply to RNTV 0.74, breaking the TV compile test.

# How

- Disable adding the patch for the TV compile test
- Bump RNTV version
- Add the TV compile test scripts to the workflow PR dependencies to catch future breakages

# Test Plan

- Ran the TV compile test to completion locally
- CI should pass


