### PR TITLE
[CI] Fix base ref for incremental SDK checks

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
-        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        run: git fetch origin ${{ github.base_ref || github.event.before || 'main' }}:${{ github.base_ref || github.event.before || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       - uses: actions/setup-node@v4
         with:
@@ -59,7 +59,7 @@ jobs:
           else
             # On push event check packages changed since previous remote head.
             # In pull requests and workflow_dispatch events check all packages changed in the entire PR.
-            bin/expotools check-packages --since ${{ github.event.before || github.base_ref || 'main' }}
+            bin/expotools check-packages --since ${{ github.base_ref || github.event.before || 'main' }}
           fi
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
# Why

This tries to fix the problem when SDK checks are checking too many packages on PRs, including packages that were not touched in the PR.

# How

Switched the precedence of `github.event.before` and `github.base_ref`.

As far as I understand, `github.event.before` points to a commit from which the PR originated (so basically every commit that was added to the target branch after creating the PR was taken into account in incremental checks). This ref makes more sense for `push` events as we can check only packages modified since the previous `push` event.
`github.base_ref` is a head of the target branch at the time of an event that triggered a workflow. This value is not available on events other than `pull_request` and `pull_request_target`, so for `push` events `github.event.before` will be used.

Giving `github.base_ref` more precedence should solve the problem for pull request events and keep using `github.event.before` for push events.

# Test Plan

I tried that out in one of my very old PR where the SDK checks go through all packages. After this change, only modified packages were checked.