### PR TITLE
[docs] Fix `ResizeMode` internal link in Video (expo-av)

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -226,36 +226,43 @@ const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string | null>
   'v49.0.0': {
     Manifest: '/versions/v49.0.0/sdk/constants/#manifest',
     SharedObject: null,
+    ResizeMode: '/versions/v49.0.0/sdk/video/#resizemode-1',
   },
   'v50.0.0': {
     SharedObject: null,
+    ResizeMode: '/versions/v50.0.0/sdk/video/#resizemode-1',
   },
   '51.0.0': {
     SharedObject: null,
+    ResizeMode: '/versions/v51.0.0/sdk/video-av/#resizemode-1',
   },
   'v52.0.0': {
     EventEmitter: '/versions/v52.0.0/sdk/expo/#eventemitter',
     NativeModule: '/versions/v52.0.0/sdk/expo/#nativemodule',
     SharedObject: '/versions/v52.0.0/sdk/expo/#sharedobject',
     SharedRef: '/versions/v52.0.0/sdk/expo/#sharedref',
+    ResizeMode: '/versions/v52.0.0/sdk/video-av/#resizemode-1',
   },
   'v53.0.0': {
     EventEmitter: '/versions/v53.0.0/sdk/expo/#eventemitter',
     NativeModule: '/versions/v53.0.0/sdk/expo/#nativemodule',
     SharedObject: '/versions/v53.0.0/sdk/expo/#sharedobject',
     SharedRef: '/versions/v53.0.0/sdk/expo/#sharedref',
+    ResizeMode: '/versions/v53.0.0/sdk/video-av/#resizemode-1',
   },
   latest: {
     EventEmitter: '/versions/latest/sdk/expo/#eventemitter',
     NativeModule: '/versions/latest/sdk/expo/#nativemodule',
     SharedObject: '/versions/latest/sdk/expo/#sharedobject',
     SharedRef: '/versions/latest/sdk/expo/#sharedref',
+    ResizeMode: '/versions/latest/sdk/video-av/#resizemode-1',
   },
   unversioned: {
     EventEmitter: '/versions/unversioned/sdk/expo/#eventemitter',
     NativeModule: '/versions/unversioned/sdk/expo/#nativemodule',
     SharedObject: '/versions/unversioned/sdk/expo/#sharedobject',
     SharedRef: '/versions/unversioned/sdk/expo/#sharedref',
+    ResizeMode: '/versions/unversioned/sdk/video-av/#resizemode-1',
   },
 };
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up partially https://github.com/expo/expo/pull/30386

Currently the internal link for Type `ResizeMode` doesn't work since the prop is also called `resizeMode` in Video API reference (expo-av).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Changes:
- This PR adds a hard-coded internal link for each SDK version (existing and next two future versions) for `ResizeMode` enum type on the `resizeMode` prop.

![CleanShot 2024-07-30 at 02 00 18](https://github.com/user-attachments/assets/c1d7d2c2-fb2a-49ec-a33e-4bb54baf0362)



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally, visiting: http://localhost:3002/versions/unversioned/sdk/video-av/#resizemode and then by clicking the internal link for the type `ResizeMode`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
