### PR TITLE
Remove illegal S3 characters from exported asset file paths.

### DIFF
--- a/apps/router-e2e/__e2e__/static-rendering/app/about.tsx
+++ b/apps/router-e2e/__e2e__/static-rendering/app/about.tsx
@@ -16,6 +16,7 @@ export default function Page() {
         <meta name="description" content="About page" />
       </Head>
       <Text testID="content">About</Text>
+      <EvilIcons name="bell" testID="icon" />
     </>
   );
 }

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 🐛 Bug fixes
 
-- Remove illegal S3 characters from exported asset file paths.
+- Remove illegal S3 characters from exported asset file paths. ([#30698](https://github.com/expo/expo/pull/30698) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix server closing in headless run commands. ([#30432](https://github.com/expo/expo/pull/30432) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- Remove illegal S3 characters from exported asset file paths.
 - Fix server closing in headless run commands. ([#30432](https://github.com/expo/expo/pull/30432) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
@@ -88,7 +88,7 @@ describe('exports static', () => {
     // Posix path formatting is used to make paths the same across OSes.
     const files = klawSync(outputDir)
       .map((entry) => {
-        if (entry.path.includes('node_modules') || !entry.stats.isFile()) {
+        if (!entry.stats.isFile()) {
           return null;
         }
         return path.posix.relative(outputDir, entry.path);
@@ -112,6 +112,11 @@ describe('exports static', () => {
     expect(files).toContain('[post].html');
     expect(files).toContain('welcome-to-the-universe.html');
     expect(files).toContain('other.html');
+
+    // Assets should not contain illegal characters
+    files.forEach((file) => {
+      expect(file).not.toMatch(/@/);
+    });
   });
 
   it('has source maps', async () => {

--- a/packages/@expo/cli/src/export/metroAssetLocalPath.ts
+++ b/packages/@expo/cli/src/export/metroAssetLocalPath.ts
@@ -50,7 +50,13 @@ function getAssetLocalPathDefault(
     // Assets can have relative paths outside of the project root.
     // Replace `../` with `_` to make sure they don't end up outside of
     // the expected assets directory.
-    adjustedHttpServerLocation.replace(/^\/+/g, '').replace(/\.\.\//g, '_'),
+    adjustedHttpServerLocation
+      .replace(/^\/+/g, '')
+      .replace(/\.\.\//g, '_')
+      // See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+      // Certain characters are URL-unsafe and should be avoided as part of output filenames
+      // .replace(/[\x00-\x1F\x7F&$@=;:+,?{}^%`[\]"'<>~|#]/g, '_'),
+      .replace(/[\0-\32\127&$@=;:+,?{}^%`[\]"'<>~|#]/g, '_'),
     fileName
   );
 }

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Remove illegal S3 characters from exported asset file paths.
+- Remove illegal S3 characters from exported asset file paths. ([#30698](https://github.com/expo/expo/pull/30698) by [@EvanBacon](https://github.com/EvanBacon))
 - Add missing dependencies and follow proper dependency chains. ([#30500](https://github.com/expo/expo/pull/30500) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Remove illegal S3 characters from exported asset file paths.
 - Add missing dependencies and follow proper dependency chains. ([#30500](https://github.com/expo/expo/pull/30500) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others

--- a/packages/expo-asset/tools/hashAssetFiles.js
+++ b/packages/expo-asset/tools/hashAssetFiles.js
@@ -12,7 +12,10 @@ module.exports = function hashAssetFiles(asset) {
     if (asset.httpServerLocation.includes('?export_path=')) {
       asset.httpServerLocation = asset.httpServerLocation
         .match(/\?export_path=(.*)/)[1]
-        .replace(/\.\.\//g, '_');
+        .replace(/\.\.\//g, '_')
+        // See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+        // Certain characters are URL-unsafe and should be avoided as part of output filenames
+        .replace(/[\0-\32\127&$@=;:+,?{}^%`[\]"'<>~|#]/g, '_');
     }
 
     // URL encode asset paths defined as `?export_path` or `?unstable_path` query parameters.


### PR DESCRIPTION
# Why

- Follow up to https://github.com/expo/expo/pull/29689
- Ensure assets are output without illegal characters when exporting for production. This doesn't need as many code mods as the `../../` since this transform is export-only and we can modify the paths before they go to runtime code.
- This isn't a perfect fix since React Native still manually adds `@2x` extensions to some images.

# Test Plan

- Ensure a font from `@expo/vector-icons` can be loaded in a production web export. The file path should not contain an `@` symbol in it.