### PR TITLE
[guides] Update and clean up Docs Writing Style Guide

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -11,7 +11,7 @@ This page is divided into two main sections:
 
 # Writing General documentation
 
-The "General" documentation contains all mechanics and formatting guidelines that we follow to write Expo documentation.
+The "General" documentation contains all mechanics and formatting guidelines that we follow when writing Expo documentation.
 
 > All Expo documentation is written in [Markdown](https://en.wikipedia.org/wiki/Markdown).
 
@@ -21,23 +21,23 @@ Developers reading the Expo docs shouldn't find obvious mistakes and feel less c
 
 Always **show and don't tell**. Instead of explaining a concept to the reader, give them an example. Providing examples helps grab the reader's attention.
 
-Some words have multiple legitimate ways to spell them. One of the most notorious examples in the Expo codebase is "canceled" vs. "cancelled". We tend to write "cancellation" instead of "cancelation". Prefer, "canceled" and "canceling".
+Some words have multiple legitimate ways to spell them. One of the most notorious examples in the Expo codebase is "canceled" vs. "cancelled". We tend to write "cancellation" instead of "cancelation". Prefer "canceled" and "canceling".
 
 ### Voice and tone
 
-Developers read documentation to find answers to their problems. Documentation exists because it can translate complex information into easily digestible pieces. Voice and tone directly influence translation of complex information and remove any friction.
+Developers read documentation to find answers to their problems. Documentation exists because it can translate complex information into easily digestible pieces. Voice and tone directly influence the translation of complex information and remove any friction.
 
 Writing clearly and concisely using plain American English is the approach we take at Expo. We also use [curb-effect](https://ssir.org/articles/entry/the_curb_cut_effect) when approaching technical documentation. We aim for clarity for all English speakers.
 
 ### Write in the second person
 
-Generally, we prefer to write in the second rather than the first person. Use “you” instead of "we”.
+Generally, we prefer to write in the second rather than the first person. Use "you" instead of "we".
 
-The word “we” is reserved when “we” as the Expo team directly want to interact with the audience or convey an important message.
+The word "we" is reserved when "we" as the Expo team directly want to interact with the audience or convey an important message.
 
 ### Use present tense
 
-Writing in the present tense allows our audience to understand the current benefits of our offering. Developers already face complex tradeoffs in selecting their stack.
+Writing in the present tense allows our audience to understand the current benefits of our offering. Developers already face complex tradeoffs when selecting their stack.
 
 ### Use active voice
 
@@ -47,7 +47,7 @@ Avoid writing sentences in the passive voice. Common passive voice usage uses wo
 
 Write short sentences. One thought per sentence is punchier and pithier. When you try cramming multiple thoughts and ideas into a single sentence, your copy becomes painful to read.
 
-Use action verbs and subject verb-object construction, cut clunky phrases, and avoid jargon. Remove any adjectives or adverbs that don’t modify the meaning of a sentence.
+Use action verbs and subject verb-object construction, cut clunky phrases, and avoid jargon. Remove any adjectives or adverbs that don't modify the meaning of a sentence.
 
 If you have to write a long sentence, follow it up with a short one. This can snap the reader back to attention. Don't repeat the same word in the same sentence. Furthermore, don't start or end a sentence with the same word you used to start or end the previous sentence.
 
@@ -60,7 +60,7 @@ Use "they" that can be used as a singular pronoun. When necessary, address a gro
 When it is correct to use words instead of symbols:
 
 - **Ampersands (&)**: Don't use "&" instead of "and" in headings, text, navigation, or tables of contents. Spell out "and" instead of using the ampersand.
-- **Plus (+)**: Don't use "+" instead of "plus" in text, navigation, or tables of contents. Spell out "plus" instead of using plus sign.
+- **Plus (+)**: Don't use "+" instead of "plus" in text, navigation, or tables of contents. Spell out "plus" instead of using the plus sign.
   - An exception to this rule is when [referencing keyboard shortcuts](#referencing-keyboard-shortcuts).
 
 ### Referencing "app stores"
@@ -75,7 +75,7 @@ The words "app" or "application" are used interchangeably since we use both at d
 
 Use ".ipa" or ".apk" or ".aab" only when referring specifically to that extension.
 
-Before an app is built into an app archive, it is a project. For example: “EAS Build takes a project and produces an app”.
+Before an app is built into an app archive, it is a project. For example, "EAS Build takes a project and produces an app".
 
 ### Abbreviations
 
@@ -100,13 +100,13 @@ Always use a capital "B" for bytes. Write "bit" or a lowercase "b" for bits. For
 
 For an in-detail reference on Bytes and Bits, read the [Writing API documentation](#writing-api-documentation).
 
-### Referencing Android, iOS and Web
+### Platform order when referencing Android, iOS, and Web or multiple platforms
 
-In most cases, to refer to multiple platforms (Android, iOS and Web) in one sentence or order sections on a particular page, follow the pattern: **"Android, iOS, and Web"**.
+In most cases, to refer to multiple platforms (Android, iOS, and Web) in one sentence or to order sections on a particular page, follow the pattern: **"Android, iOS, and Web"**.
 
 ### Referencing Expo Go
 
-When referencing Expo Go, the supported text should avoid implying: "running an app", "developing an app" or "previewing an app". One alternative to avoid these constraints is: "testing your project".
+When referencing Expo Go, the supported text should avoid implying: "running an app", "developing an app", or "previewing an app". One alternative to avoid these constraints is: "testing your project".
 
 ## Punctuation
 
@@ -121,16 +121,16 @@ Generally, use Oxford commas. The need for an exception is often because it prol
 
 One exception to avoid them is in headings for sections or sub-sections.
 
-### Using possessive form
+### Using the possessive form
 
-The possessive of singular nouns is formed by adding an apostrophe **‘s**. This is true no matter the final consonant. The possessive of plural nouns that end in **s** is formed by adding just the apostrophe at the end.
+The possessive of singular nouns is formed by adding an apostrophe **'s**. This is true no matter the final consonant. The possessive of plural nouns that end in **s** is formed by adding just the apostrophe at the end.
 
 - Example: Expo's logo.
 
 Exceptions to this guideline are the following:
 
-- Pronoun possessives use no apostrophe (for example, its, hers, yours, theirs, ours), but indefinite pronouns do (for example, one’s own opinions are not somebody else’s problem). However, in technical writing, always consider whether using a pronoun adds too much work for the reader, who must find its antecedent.
-- Ancient names that end in "-es" and "-is" are simply peculiar and take just an apostrophe (for example, Osiris’ mummification, not Osiris’s mummification). Still, you are unlikely to come across this in your technical writing.
+- Pronoun possessives use no apostrophe (for example, its, hers, yours, theirs, ours), but indefinite pronouns do (for example, one's own opinions are not somebody else's problem). However, in technical writing, always consider whether using a pronoun adds too much work for the reader, who must find its antecedent.
+- Ancient names that end in "-es" and "-is" are simply peculiar and take just an apostrophe (for example, Osiris' mummification, not Osiris's mummification). Still, you are unlikely to come across this in your technical writing.
 
 ### Do not add a space between the words and "/"
 
@@ -177,12 +177,12 @@ We, sometimes, have buttons that lead to an Expo Snack. Use title case for these
 
 Filenames are used as bold text in the markdown files.
 
-- Correct: Your app’s configuration is located in **app.json/app.config.js**
-- Incorrect: Your app’s configuration is loaded in `app.json/app.config.js`
+- Correct: Your app's configuration is located in **app.json/app.config.js**
+- Incorrect: Your app's configuration is loaded in `app.json/app.config.js`
 
 ### Capitalization
 
-Do not use capitalized words for the sake of emphasizing them.
+Do not use capitalized words to emphasize them.
 
 Exception: Always capitalize product phrases:
 
@@ -239,9 +239,9 @@ A few points to remember:
 
 Do not use emojis in the documentation.
 
-### When to use npm or yarn
+### When to use npm or Yarn
 
-To avoid inconsistency when referencing to install global packages with a package manager like npm or yarn, use npm.
+To avoid inconsistency when referencing to install global packages with a package manager like npm or Yarn, use npm.
 
 - Correct: npm install expo-cli
 - Incorrect: yarn install expo-cli
@@ -252,11 +252,11 @@ When a collapsible component has a single item or a paragraph to represent text,
 
 ### Avoiding using outdated workflows
 
-Avoid mentioning or using the terms to represent outdated/archived workflows: managed or bare workflow.
+Avoid mentioning or using the terms to represent outdated/archived workflows, such as managed or bare workflow.
 
 To avoid using the term "managed workflow", use "using Expo" to represent the current state of the Expo ecosystem. This is now the default way of explaining things.
 
-When offering guidance for projects that require manually editing native code/directories, put those instructions in a dropdown saying "manual setup" or "usage in bare React Native projects".
+When offering guidance for projects that require manually editing native code/directories, put those instructions in a dropdown saying "manual setup", or "usage in bare React Native projects", or "usage in existing React Native projects".
 
 ### Numbered Lists
 
@@ -282,15 +282,15 @@ Terms referred in this section are meant to be used consistently throughout the 
   - A Swift module is a namespaced unit of code that can be distributed. It includes a module map and conforms to some other technical details.
 - Library
   - An overarching name for code that application developers call into as a part of their apps. Examples of libraries are Expo modules, npm packages, and iOS APIs.
-  - **"Expo libraries" is a synonym for Expo modules** and for consistency reasons, let’s use **Expo Libraries**.
+  - **"Expo libraries" is a synonym for Expo modules** and for consistency reasons, let's use **Expo Libraries**.
 - Package
   - **npm packages** are units of code that include a file named package.json and are typically installed with npm or Yarn. They almost always include JavaScript code.
   - Expo modules are distributed as npm packages.
   - Java and Kotlin packages are namespaced units of code — a Java package is a namespace, not a single distributable file. They are often distributed as JAR files.
-  - An Android package is an .apk (Android PacKage) file, which is a zip file containing the application class/DEX files, icons, fonts, and other app resources. With side-loading, it is possible to install and run a .apk file on an Android device directly.
+  - An Android package is a .apk (Android PacKage) file, which is a zip file containing the application class/DEX files, icons, fonts, and other app resources. With side-loading, it is possible to install and run a .apk file on an Android device directly.
 - Archive
   - A compressed set of files, like a zip or tar file.
-  - An iOS archive is an .ipa file that is a zip file containing the main application binary, icons, fonts, dynamically linked frameworks, etc...
+  - An iOS archive is a .ipa file that is a zip file containing the main application binary, icons, fonts, dynamically linked frameworks, etc.
 - Bundle
   - An Android bundle is an .aab (Android Application Bundle) file that is similar to an .apk file but is designed to be submitted to Google Play, which will generate and sign .apk files for distribution.
   - A JavaScript bundle is a conglomerate of JS application code and dependencies (typically from npm packages) generated by a bundler like Webpack.
@@ -303,7 +303,7 @@ _A complete list of [Expo related glossary terms](https://docs.expo.dev/more/glo
 
 # Writing API documentation
 
-Writing API documentation accurately and precisely helps developers use our APIs correctly. In the following sections, we discuss the guidelines on properly documenting comments and some formatting tips to take care of when writing API docs.
+Writing API documentation accurately and precisely helps developers use our APIs correctly. In the following sections, we discuss the guidelines for properly documenting comments and some formatting tips to take care of when writing API docs.
 
 ## General approach
 
@@ -318,24 +318,24 @@ Writing API documentation accurately and precisely helps developers use our APIs
   - `@platform`
     - Available platforms: `android` , `ios` , `web` and `expo` (Expo Go).
     - You can also specify the minimum platform version, range, or add any other comment to the label, for example, `@platform ios 11+`.
-    - Currently, specifying multiple platforms (or lists) per one tag is not possible, however, you can include multiple `@platform` tags in the doc block.
+    - Currently, specifying multiple platforms (or lists) per one tag is not possible. However, you can include multiple `@platform` tags in the doc block.
   - `@example`
-    - Add the “Example” header and puts content at the bottom of the description block.
+    - Adds the "Example" header and puts content at the bottom of the description block.
   - `@see`
-    - Wraps the message in a note/quote block and adds “See:” at the beginning of the message.
+    - Wraps the message in a note/quote block and adds "See:" at the beginning of the message.
     - See section is placed after the main comment content.
   - `@deprecated`
-    - Wraps the message in note/quote block and adds “Deprecated.” at the beginning of the message automatically, however, a message is not required.
-    - The deprecation note will always be placed at the top of generated doc comment, no matter where you put it in the doc block content.
+    - Wraps the message in note/quote block and adds "Deprecated" at the beginning of the message automatically. However, a message is not required.
+    - The deprecation note will always be placed at the top of the generated doc comment, no matter where you put it in the doc block content.
   - `@internal` / `@private` / `@hidden`
     - Any of those annotations will hide the code and comments from the autogenerated API docs output.
   - `@header`
-    - Allows to group methods by the custom headers, should be used with `headersMapping` prop for `APISection` component to control the actual header titles
+    - Allows grouping methods by the custom headers, which should be used with `headersMapping` prop for the `APISection` component to control the actual header titles
       and their order (see `expo-notifications` source and doc page for an example usage).
 - When linking other SDK packages in a comment, use `./` instead of `../` at the beginning of the URL
   - For more information, check out [detect broken internal links in generated doc comments](https://github.com/expo/expo/pull/16771) PR on GitHub.
-- To add a subscript or superscript in the comment content use the following custom syntax:
-  ```md
+- To add a subscript or superscript in the comment content, use the following custom syntax:
+  ```markdown
   21^st^ Century <!-- sup -->
   H~2~O <!-- sub -->
   ```
@@ -357,13 +357,13 @@ It is possible, and very common with JavaScript, to have concurrency without par
 - A promise that is fulfilled or rejected (that is, not pending) is settled.
 - On the creating side, promises can be resolved to either another promise or a non-promise value.
   - A promise can resolve to a promise: `new Promise(resolve => resolve(anotherPromise))`
-  - A promise is never fulfilled with a promise: `await aPromise` is never a promise.
+  - A promise is never fulfilled with a promise: `await Promise` is never a promise.
 - For API documentation, the developer typically wants to know the value with which the promise is fulfilled and does not care about how the promise is resolved.
 - Typically write:
-  > The returned promise is fulfilled with a CameraPhoto object.
+  > The returned promise is fulfilled with a `CameraPhoto` object.
   - The developer cares about the value of `await capturePhotoAsync()`.
 - Typically, don't write:
-  > The returned promise resolves to a CameraPhoto object.
+  > The returned promise resolves to a `CameraPhoto` object.
   - The developer does not care how the promise returned from `capturePhotoAsync()` is resolved.
 - Sometimes write:
   > The returned promise is resolved with the given promise if it settles before the specified timeout.
@@ -386,7 +386,7 @@ Standardize on the term URL. URI and IRI are just confusing. In practice, a sing
 - A kibibyte ("kilo binary byte") always refers to 1,024 bytes and is abbreviated as "KiB".
 - Most Expo APIs work with powers of two like kibibytes. Write "KiB", "MiB", and "GiB" to communicate clearly to developers. We do not need to explain that a KiB refers to 1,024 bytes.
 - Some APIs, especially those related to disk storage and transmission rates like baud rates, use powers of 10. Write "kB", "MB", and "GB" **and** be clear we're referring to 1,000 bytes, 1,000,000 bytes, and so on.
-- Typically write "kbit", "Mbit", and "Gbit" when referring to bits to remove ambiguity between bits and bytes. Both "kbit/s" and "kbps" are acceptable when describing rates.
+- Typically, write "kbit", "Mbit", and "Gbit" when referring to bits to remove ambiguity between bits and bytes. Both "kbit/s" and "kbps" are acceptable when describing rates.
   Always use a capital "B" for bytes. Write "bit" or a lowercase "b" for bits.
 - Insert a space between the number and unit, like "10 MiB".
 - Decimal byte units: kB, MB, GB, TB
@@ -441,7 +441,7 @@ Example:
  *
  * Upon capturing the photo, it is written to the device's temporary file storage. The file will be
  * accessible right after this method completes but may be cleared by the device OS at an arbitrary
- * time afterwards; do not assume the file is permanent.
+ * time afterward; do not assume the file is permanent.
  *
  * @param options configuration options that specify the file format, image quality, and more
  * @returns a promise fulfilled with information about the captured photo, including its location on
@@ -453,6 +453,6 @@ Example:
 
 # References and additional resources
 
-- Learn how to set up `expo/docs` repository locally and what the requirements are to contribute in the [expo/docs/README.md file](https://github.com/expo/expo/blob/main/docs/README.md).
-- **External references**: This guide is by no means exhaustive. It covers the most common things that come up as we write and is mostly focused on Expo-related things. We also refer to other style guides that are exhaustive, well maintained, and have become industry standards, such as the [Google developer documentation style guide](https://developers.google.com/style?hl=en).
+- Learn how to set up the `expo/docs` repository locally and what the requirements are for contributing to the [expo/docs/README.md file](https://github.com/expo/expo/blob/main/docs/README.md).
+- **External references**: This guide is by no means exhaustive. It covers the most common things that come up as we write and is mostly focused on Expo-related things. We also refer to other style guides that are exhaustive, well maintained and have become industry standards, such as the [Google developer documentation style guide](https://developers.google.com/style?hl=en).
 - General tips on [what words to avoid and during which situations](https://css-tricks.com/words-avoid-educational-writing/) when writing educational material or technical documentation.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Changes:
- Fix multiple grammatical mistakes.
- Expand section title for referencing Android, iOS, and web to mention "multiple platforms", in general.
- Remove the usage of smart quotes and replace them with straight quotes.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By going through the changes manually in the markdown file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
