### PR TITLE
[docs] update guide for aar autolinking

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -7,6 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
 Expo modules make it possible to easily use native, external libraries built for Android and iOS in React Native projects.
@@ -110,7 +111,34 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 
 <Collapsible summary={<>Are you trying to use a <CODE>.aar</CODE> dependency?</>}>
 
-Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the folder as a repository:
+<Tabs>
+  <Tab label="SDK 52 and above">
+    Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the file as a Gradle project from autolinking:
+
+```diff expo-module.config.json
+    "android": {
++     "gradleAarProjects": [
++       {
++         "name": "test-aar",
++         "aarFilePath": "android/libs/test.aar"
++       }
++     ],
+    "modules": [
+```
+
+    Finally, add the dependency to the `dependencies` list, using the specified name with `${project.name}$` prefix:
+
+```diff android/build.gradle
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
++ implementation project(":${project.name}\$test-aar")
+}
+```
+
+  </Tab>
+  <Tab label="SDK 51 and below">
+    Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the folder as a repository:
 
 ```diff android/build.gradle
   repositories {
@@ -130,6 +158,9 @@ dependencies {
 + implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0@aar'
 }
 ```
+
+  </Tab>
+</Tabs>
 
 </Collapsible>
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -126,7 +126,7 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
     "modules": [
 ```
 
-    Finally, add the dependency to the `dependencies` list, using the specified name with `${project.name}$` prefix:
+    Finally, add the dependency to the `dependencies` list in the **android/build.gradle** file, using the dependency's specified name with `${project.name}$` prefix:
 
 ```diff android/build.gradle
 dependencies {


### PR DESCRIPTION
# Why

update doc for aar autolinking
close ENG-12425

# How

![Screenshot 2024-07-30 at 7.32.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BhF1ySaozaWrX9KbwtqY/fa30a620-f2d7-4b51-b740-0dec0f353638.png)

# Test Plan

doc ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
