### PR TITLE
fix: use proper type version for React

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.79",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-expo": "~11.0.0",
     "expo-module-scripts": "^3.0.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -36,7 +36,6 @@
     "@shopify/flash-list": "1.6.4",
     "@shopify/react-native-skia": "1.2.3",
     "@stripe/stripe-react-native": "0.37.2",
-    "@types/react-native": "~0.70.6",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",
     "es6-error": "^4.1.1",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -92,7 +92,6 @@
     "@types/jest": "^29.2.1",
     "@types/lodash": "^4.14.161",
     "@types/react": "~18.2.79",
-    "@types/react-redux": "^7.1.16",
     "@types/semver": "^7.5.8",
     "expo-module-scripts": "^3.0.0"
   }

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -91,7 +91,7 @@
     "@types/dedent": "^0.7.0",
     "@types/jest": "^29.2.1",
     "@types/lodash": "^4.14.161",
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.79",
     "@types/react-redux": "^7.1.16",
     "@types/semver": "^7.5.8",
     "expo-module-scripts": "^3.0.0"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -158,7 +158,6 @@
     "@types/pixi.js": "^4.8.6",
     "@types/react": "~18.0.14",
     "@types/three": "^0.137.0",
-    "@types/victory": "^31.0.14",
     "babel-jest": "^29.2.1",
     "expo-module-scripts": "^3.0.0",
     "jest": "^29.2.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -156,7 +156,7 @@
     "@types/fbemitter": "^2.0.32",
     "@types/i18n-js": "^3.0.1",
     "@types/pixi.js": "^4.8.6",
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.79",
     "@types/three": "^0.137.0",
     "babel-jest": "^29.2.1",
     "expo-module-scripts": "^3.0.0",

--- a/packages/expo/build/environment/DevLoadingView.d.ts
+++ b/packages/expo/build/environment/DevLoadingView.d.ts
@@ -1,2 +1,3 @@
-export default function DevLoadingView(): JSX.Element | null;
+import React from 'react';
+export default function DevLoadingView(): React.JSX.Element | null;
 //# sourceMappingURL=DevLoadingView.d.ts.map

--- a/packages/expo/build/environment/DevLoadingView.d.ts.map
+++ b/packages/expo/build/environment/DevLoadingView.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"DevLoadingView.d.ts","sourceRoot":"","sources":["../../src/environment/DevLoadingView.tsx"],"names":[],"mappings":"AAQA,MAAM,CAAC,OAAO,UAAU,cAAc,uBAiFrC"}
+{"version":3,"file":"DevLoadingView.d.ts","sourceRoot":"","sources":["../../src/environment/DevLoadingView.tsx"],"names":[],"mappings":"AAEA,OAAO,KAA+C,MAAM,OAAO,CAAC;AAMpE,MAAM,CAAC,OAAO,UAAU,cAAc,6BAiFrC"}

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -81,7 +81,7 @@
     "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.79",
     "@types/react-test-renderer": "^18.0.0",
     "expo-module-scripts": "^3.5.1",
     "react": "19.0.0-rc-fb9a90fa48-20240614",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,7 +2594,7 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-"@jest/globals@^29.7.0":
+"@jest/globals@^29.2.1", "@jest/globals@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
   integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
@@ -4454,14 +4454,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@~0.70.6":
-  version "0.70.9"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.70.9.tgz#7d9d11960a4ab78c874e77af895f83d2817aac96"
-  integrity sha512-0C6sIo13ztzM2llaWdTq0Vpscx3VdU0T8F45kEurWv3l5n+BHm/Mkr8Z+N29eXDYGhTvCz5y2jegB8JyiVa5kw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-redux@^7.1.16", "@types/react-redux@^7.1.20":
+"@types/react-redux@^7.1.20":
   version "7.1.23"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.23.tgz#3c2bb1bcc698ae69d70735f33c5a8e95f41ac528"
   integrity sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==
@@ -4478,7 +4471,15 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@~18.0.14":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@~18.2.79":
+  version "18.2.79"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
+  integrity sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@~18.0.14":
   version "18.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
   integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
@@ -4596,13 +4597,6 @@
   integrity sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==
   dependencies:
     source-map "^0.6.1"
-
-"@types/victory@^31.0.14":
-  version "31.0.22"
-  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.22.tgz#b1c0f87261af7bc264207e3864acfe75d0abf605"
-  integrity sha512-6xwSLp6nefiN7/xXk3tscmz2C9JAGgT5z/WtPlHz2uAqstbnyC0EmUXzU/RScZT1odLmHyLhkDRzEezJOzxb5A==
-  dependencies:
-    "@types/react" "*"
 
 "@types/webgl2@^0.0.6":
   version "0.0.6"
@@ -10940,7 +10934,7 @@ jest-runtime@^29.7.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-jest-snapshot@^29.7.0:
+jest-snapshot@^29.2.1, jest-snapshot@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
   integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4479,15 +4479,6 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@~18.0.14":
-  version "18.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
-  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
 "@types/require-from-string@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/require-from-string/-/require-from-string-1.2.1.tgz#50292d824e2244628c0b961c6a1a583fdc494554"
@@ -4504,11 +4495,6 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/semver@^6.0.0":
   version "6.2.7"


### PR DESCRIPTION
# Why

This is a follow-up PR to fix our React types, found in #30710

# How

- Ran `$ yarn why @types/react`
- Updated all instances and dropped extraneous types that pulled in older React types.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
