### PR TITLE
Removed the misplaced 'the' 

### DIFF
--- a/docs/pages/develop/dynamic-routes.mdx
+++ b/docs/pages/develop/dynamic-routes.mdx
@@ -33,7 +33,7 @@ Let's consider the following **app** directory structure:
 ]}
 />
 
-In the above file structure, the `[id]` is used to display information for the route the **details/[id].tsx**. The same route will display unique information based on the value of the `id`:
+In the above file structure, the `[id]` is used to display information for the route **details/[id].tsx**. The same route will display unique information based on the value of the `id`:
 
 | Route                | Matched URL  |
 | -------------------- | ------------ |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
