### PR TITLE
[sqlite] fix disk IO error on Android

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Fixed `<SQLiteProvider assetSource={{ assetId: require(...) }}>` database always being overwrite on iOS 16 and lower. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30483](https://github.com/expo/expo/pull/30483) by [@byCedric](https://github.com/byCedric))
 - Fixed invalid characters for prepared statements on iOS. ([#30579](https://github.com/expo/expo/pull/30579) by [@kudo](https://github.com/kudo))
+- Fixed the "disk I/O error" on older Android devices. ([#30718](https://github.com/expo/expo/pull/30718) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -27,9 +27,9 @@ def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File(
 def SQLITE3_SRC_DIR = new File("$buildDir/sqlite3_src")
 
 def getSQLiteBuildFlags() {
-  def buildFlags = '-DSQLITE_ENABLE_BYTECODE_VTAB=1'
+  def buildFlags = '-DSQLITE_ENABLE_BYTECODE_VTAB=1 -DSQLITE_TEMP_STORE=2'
   if (findProperty('expo.sqlite.enableFTS') !== 'false') {
-    buildFlags <<= '-DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
+    buildFlags <<= ' -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
   }
   def customBuildFlags = findProperty('expo.sqlite.customBuildFlags') ?: ''
   if (customBuildFlags != '') {


### PR DESCRIPTION
# Why

fixes #30600
close ENG-12952

# How

sqlite by default uses temp files when there's large operation. on older android, the temp files are in system paths that are not accessible. this pr tries to use memory as temp store. people can still use `PRAGMA temp_store` to override the setting. the memory temp_store behavior aligns with android system sqlite build as well as the room lib.

# Test Plan

test https://github.com/david98/expo-sqlite-bug on android 11 emulator

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
