### PR TITLE
test(expo-localization): resolve test typing issue

### DIFF
--- a/packages/expo-localization/src/__tests__/Localization-test.native.ts
+++ b/packages/expo-localization/src/__tests__/Localization-test.native.ts
@@ -19,7 +19,7 @@ const pl = {
   morning: 'rano',
 };
 
-const fakeLocalization = {
+const fakeLocalization: Partial<typeof ExpoLocalization> = {
   locale: 'en-US',
   locales: ['en-US', 'fr'],
   timezone: 'Etc/UTC',
@@ -34,8 +34,12 @@ const fakeLocalization = {
 
 beforeEach(() => {
   for (const property of Object.keys(fakeLocalization)) {
-    mockProperty(ExpoLocalization, property, fakeLocalization[property]);
-    mockProperty(Localization, property, fakeLocalization[property]);
+    mockProperty(
+      ExpoLocalization,
+      property as keyof typeof ExpoLocalization,
+      fakeLocalization[property]
+    );
+    mockProperty(Localization, property as keyof typeof Localization, fakeLocalization[property]);
   }
   mockProperty(
     ExpoLocalization,


### PR DESCRIPTION
# Why

We now have typings for `jest-expo` and the utility functions, this typing was too loose in `expo-localization`, this fixes that.

# How

- Added missing types for fake location

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
