### PR TITLE
[docs] add information about our policy for supported Xcode versions

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -369,5 +369,6 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### Supported Xcode versions
 
-We aim to support all of the stable Xcode releases that when used during the build process allow you to submit your app to the App Store Connect.
+We aim to support all stable Xcode releases that allow you to submit your app to the App Store Connect when used during the build process.
+
 This usually means that we support the latest stable Xcode version and the previous one (until the new [minimal Xcode version requirement](https://developer.apple.com/news/upcoming-requirements/?id=04292024a) is introduced by Apple).

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -53,7 +53,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc
-  registry=http://npm-cache-service.worker-infra-production.svc.cluster.local:4873
+  registry=http://10.4.0.19:4873
   ```
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
@@ -61,7 +61,7 @@ Android builders run on virtual machines in an isolated environment. Every build
   ```yml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
-  npmRegistryServer: 'http://npm-cache-service.worker-infra-production.svc.cluster.local:4873'
+  npmRegistryServer: 'http://10.4.0.19:4873'
   enableImmutableInstalls: false
   ```
 
@@ -263,7 +263,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc
-  registry=http://10.254.24.9:4873
+  registry=http://10.94.183.70:4873
   ```
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
@@ -271,7 +271,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
   ```yml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
-  npmRegistryServer: 'registry=http://10.254.24.9:4873'
+  npmRegistryServer: 'http://10.94.183.70:4873'
   enableImmutableInstalls: false
   ```
 
@@ -366,3 +366,8 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - node-gyp 10.0.1
 
 </Collapsible>
+
+### Supported Xcode versions
+
+We aim to support all of the stable Xcode releases that when used during the build process allow you to submit your app to the App Store Connect.
+This usually means that we support the latest stable Xcode version and the previous one (until the new [minimal Xcode version requirement](https://developer.apple.com/news/upcoming-requirements/?id=04292024a) is introduced by Apple).

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: April 8th, 2024
+modificationDate: July 31st, 2024
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1722382300690139

# How

Add information about our policy for supported Xcode versions.

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
