### PR TITLE
[docs] Change page title for Learn more in Get started Tutorial

### DIFF
--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -1,6 +1,6 @@
 ---
-title: Learn more
-description: A list of resources to learn more about Expo and React Native.
+title: Learning resources
+description: Explore a curated list of resources to learn about Expo and React Native.
 ---
 
 import { A } from '~/ui/components/Text';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-12969

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change page title to "Learning resources" in the Get started tutorial. Update the page description.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit:  http://localhost:3002/tutorial/follow-up/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
