### PR TITLE
[docs] Fix title too long SEO issue for some page titles

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build APKs for Android Emulators and devices
-description: Learn how to configure and install an .apk for Android Emulators and devices when using EAS Build.
+description: Learn how to configure and install a .apk for Android Emulators and devices when using EAS Build.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -97,7 +97,7 @@ Rebuild the app or build a new development client and you should see your change
 
 </Step>
 
-> **Note**: There are also other flows for working on an Expo module in parallel with your application. For example, you can use a monorepo or publish to npm, as described in the [How to use a standalone Expo module in your project](/modules/use-standalone-expo-module-in-your-project) guide.
+> **Note**: There are also other flows for working on an Expo module in parallel with your application. For example, you can use a monorepo or publish to npm, as described in the [How to use a standalone Expo module](/modules/use-standalone-expo-module-in-your-project) guide.
 
 ## Creating a new module with an example project
 

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -1,6 +1,5 @@
 ---
-title: How to use a standalone Expo module in your project
-sidebar_title: Use a standalone Expo module
+title: How to use a standalone Expo module
 description: Learn how to use a standalone module created with create-expo-module in your project by using a monorepo or publishing the package to npm.
 ---
 

--- a/docs/pages/ui-programming/z-index.mdx
+++ b/docs/pages/ui-programming/z-index.mdx
@@ -1,7 +1,7 @@
 ---
-title: Stacking overlapping views with zIndex in Expo and React Native apps
+title: Stacking overlapping views with zIndex
 sidebar_title: Stack views with zIndex
-description: Learn how to stack overlapping views with zIndex.
+description: Learn how to stack overlapping views with zIndex in Expo and React Native apps.
 ---
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-10175 ENG-10169

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update long titles for some pages in this PR based on the SEO audit report (linked as a spreadsheet in the linear task).
Also, fix grammatical error in one of the page's description.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
