### PR TITLE
[docs] Add info about `eas build:version:set` to set app versions in EAS Tutorial

### DIFF
--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -85,7 +85,7 @@ If your app is already published in the app stores, the developer facing app ver
 - Select **yes** when asked **Do you want to set app version source to remote now?**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
 - When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
 
-After running the above commands, the app versions will be synced to EAS Build remotely, and you can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.
+After running the above command, the app versions will be synced to EAS Build remotely. You can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.
 
 </Collapsible>
 

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -82,7 +82,7 @@ If your app is already published in the app stores, the developer-facing app ver
 <Terminal cmd={['eas build:version:set']} />
 
 - Select the platform (Android or iOS) when prompted.
-- When asked **Do you want to set app version source to remote now?**, select **yes**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
+- When prompted **Do you want to set app version source to remote now?**, select **yes**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
 - When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
 
 After these steps, the app versions will be synced to EAS Build remotely. You can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -4,7 +4,9 @@ sidebar_title: Manage app versions
 description: Learn about developer-facing and user-facing app versions and how to manage them automatically.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
+import { Terminal } from '~/ui/components/Snippet';
 
 In this chapter, we'll configure our example app to auto-increment the developer-facing app version. Learning about it will be useful before we dive into production build in the next two chapters.
 
@@ -70,6 +72,22 @@ In **eas.json**:
 ```
 
 When we create a new production build in the next two chapters, the `versionCode` for Android and `buildNumber` for iOS will increment automatically.
+
+<Collapsible summary="Syncing developer facing app versions for already published apps to EAS">
+
+If your app is already published in the app stores, the developer facing app versions are already set. When migrating this app to use EAS, follow the steps below to sync those app versions:
+
+- In the terminal window, run the `eas build:version:set` command:
+
+<Terminal cmd={['eas build:version:set']} />
+
+- Select the platform (Android or iOS) when prompted.
+- Select **yes** when asked **Do you want to set app version source to remote now?**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
+- When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
+
+After running the above commands, the app versions will be synced to EAS Build remotely, and you can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.
+
+</Collapsible>
 
 ## Summary
 

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -73,9 +73,9 @@ In **eas.json**:
 
 When we create a new production build in the next two chapters, the `versionCode` for Android and `buildNumber` for iOS will increment automatically.
 
-<Collapsible summary="Syncing developer facing app versions for already published apps to EAS">
+<Collapsible summary="Syncing developer-facing app versions for already published apps to EAS">
 
-If your app is already published in the app stores, the developer facing app versions are already set. When migrating this app to use EAS Build, follow the steps below to sync those app versions:
+If your app is already published in the app stores, the developer-facing app versions are already set. When migrating this app to use EAS Build, follow the steps below to sync those app versions:
 
 - In the terminal window, run the `eas build:version:set` command:
 
@@ -85,7 +85,7 @@ If your app is already published in the app stores, the developer facing app ver
 - Select **yes** when asked **Do you want to set app version source to remote now?**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
 - When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
 
-After running the above command, the app versions will be synced to EAS Build remotely. You can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.
+After these steps, the app versions will be synced to EAS Build remotely. You can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.
 
 </Collapsible>
 

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -75,7 +75,7 @@ When we create a new production build in the next two chapters, the `versionCode
 
 <Collapsible summary="Syncing developer facing app versions for already published apps to EAS">
 
-If your app is already published in the app stores, the developer facing app versions are already set. When migrating this app to use EAS, follow the steps below to sync those app versions:
+If your app is already published in the app stores, the developer facing app versions are already set. When migrating this app to use EAS Build, follow the steps below to sync those app versions:
 
 - In the terminal window, run the `eas build:version:set` command:
 

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -82,7 +82,7 @@ If your app is already published in the app stores, the developer-facing app ver
 <Terminal cmd={['eas build:version:set']} />
 
 - Select the platform (Android or iOS) when prompted.
-- Select **yes** when asked **Do you want to set app version source to remote now?**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
+- When asked **Do you want to set app version source to remote now?**, select **yes**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
 - When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
 
 After these steps, the app versions will be synced to EAS Build remotely. You can set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented from now on.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on user feedback shared by @brentvatne about the user not being able to set the autoincrement property in **eas.json** for a build profile for an already deployed app to app stores. To use autoincrement functionality this way, the last version from any app store has to be set manually first by running the `eas build:version:set` before setting the `autoincrement` property for a build profile in **eas.json**.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds steps inside a collapsible to explain instructions required when running the `eas build:version:set` command and how to interact with this command to select the platform, enable `appSourceVersion` to use remotely, and provide an initial developer-facing app version value.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The steps demonstrated have been tested on a project by creating a production build and then going through the steps for `eas build:version:set` command.

The doc changes have been tested by visiting: http://localhost:3002/tutorial/eas/manage-app-versions/#syncing-developer-facing-app-versions-for-already.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
