### PR TITLE
[fingerprint] update readme

### DIFF
--- a/packages/@expo/fingerprint/README.md
+++ b/packages/@expo/fingerprint/README.md
@@ -4,10 +4,12 @@ A library to generate a fingerprint from a React Native project
 
 ## Table of Contents
 
-  * [API Usage](#api-usage)
-  * [CLI Usage](#cli-usage)
-  * [Customizations](#customizations)
-  * [Limitations](#limitations)
+- [API Usage](#api-usage)
+- [CLI Usage](#cli-usage)
+- [Customizations](#customizations)
+  - [**.fingerprintignore** file](#include-or-exclude-extra-files-to-ignored-paths-in-the-fingerprintignore-file)
+  - [**fingerprint.config.js** file](#fingerprintconfigjs)
+- [Limitations](#limitations)
 
 ## API Usage
 
@@ -82,7 +84,11 @@ bf8a3b08935f056270b1688333b02f1ef5fa25bf
 Diff the given `fingerprint` with the current project fingerprint state
 
 ```ts
-function diffFingerprintChangesAsync(fingerprint: Fingerprint, projectRoot: string, options?: Options): Promise<FingerprintSource[]>;
+function diffFingerprintChangesAsync(
+  fingerprint: Fingerprint,
+  projectRoot: string,
+  options?: Options
+): Promise<FingerprintSource[]>;
 ```
 
 Example:
@@ -118,16 +124,32 @@ console.log(result);
 ```json
 [
   {
-    "filePath": "ios",
-    "hash": "e4190c0af9142fe4add4842777d9aec713213cd4",
-    "reasons": ["bareNativeDir"],
-    "type": "dir"
+    "op": "removed",
+    "source": {
+      "type": "file",
+      "filePath": "./assets/icon.png",
+      "reasons": ["expoConfigExternalFile"],
+      "hash": "3f71f5a8458c06b83424cc33e1f2481f601199ea"
+    }
   },
   {
-    "filePath": "app.json",
-    "hash": "9ff1b51ca9b9435e8b849bcc82e3900d70f0feee",
-    "reasons": ["expoConfig"],
-    "type": "file"
+    "op": "added",
+    "source": {
+      "type": "dir",
+      "filePath": "ios",
+      "reasons": ["bareNativeDir"],
+      "hash": "2420400e6140a4ccfc350fc483b26efdfc26ddac"
+    }
+  },
+  {
+    "op": "changed",
+    "source": {
+      "type": "contents",
+      "id": "expoConfig",
+      "contents": "{\"ios\":{\"bundleIdentifier\":\"com.test\",\"supportsTablet\":true},\"name\":\"test\",\"platforms\":[\"ios\"],\"slug\":\"test\"}",
+      "reasons": ["expoConfig"],
+      "hash": "dd2a3ebb872b097f9c1e33780fb8db8688848fa0"
+    }
   }
 ]
 ```
@@ -137,7 +159,10 @@ console.log(result);
 Find the diff between two fingerprints
 
 ```ts
-function diffFingerprints(fingerprint1: Fingerprint, fingerprint2: Fingerprint): FingerprintSource[];
+function diffFingerprints(
+  fingerprint1: Fingerprint,
+  fingerprint2: Fingerprint
+): FingerprintSource[];
 ```
 
 ## CLI Usage
@@ -156,9 +181,9 @@ function diffFingerprints(fingerprint1: Fingerprint, fingerprint2: Fingerprint):
 
 ## Customizations
 
-### Include or exclude extra files in the **.fingerprintignore** file
+### Include or exclude extra files to ignored paths in the **.fingerprintignore** file
 
-Our default ignore paths, found here [`DEFAULT_IGNORE_PATHS`](https://github.com/expo/expo/blob/main/packages/%40expo/fingerprint/src/Options.ts#L9), make hashing fast and keep hashing results stable. If the default setup does not fit your workflow, you can add a **.fingerprintignore** file in your project root. It works like [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format) but with some slight differences: We use `minimatch` for pattern matching with the [limitations](https://github.com/expo/expo/blob/9b9133c96f209b0616d1796aadae28913f8d012f/packages/%40expo/fingerprint/src/Fingerprint.types.ts#L46-L55).
+Our default ignore paths, found here [`DEFAULT_IGNORE_PATHS`](https://github.com/expo/expo/blob/main/packages/%40expo/fingerprint/src/Options.ts#L11), make hashing fast and keep hashing results stable. If the default setup does not fit your workflow, you can add a **.fingerprintignore** file in your project root. It works like [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format) but with some slight differences: We use `minimatch` for pattern matching with the [limitations](https://github.com/expo/expo/blob/9b9133c96f209b0616d1796aadae28913f8d012f/packages/%40expo/fingerprint/src/Fingerprint.types.ts#L46-L55).
 
 Here's how to use **.fingerprintignore**: To skip a whole folder but keep some files, you can do this:
 
@@ -170,6 +195,45 @@ Here's how to use **.fingerprintignore**: To skip a whole folder but keep some f
 !/app/ios/Podfile
 !/app/ios/Podfile.lock
 ```
+
+### **fingerprint.config.js**
+
+You can customize the fingerprinting behavior by creating a **fingerprint.config.js** file in your project root. This file allows you to specify custom configurations, such as skipping certain fingerprint sources, adding extra fingerprint sources, or enabling debug mode.
+
+Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
+
+```js
+const { SourceSkips } = require('@expo/fingerprint');
+
+/** @type {import('@expo/fingerprint').Config} */
+const config = {
+  sourceSkips:
+    SourceSkips.ExpoConfigRuntimeVersionIfString |
+    SourceSkips.ExpoConfigVersions |
+    SourceSkips.PackageJsonAndroidAndIosScriptsIfNotContainRun,
+};
+
+module.exports = config;
+```
+
+If you are using `@expo/fingerprint` through `expo-updates` (where `@expo/fingerprint` is installed as a transitive dependency), you can use the following example **fingerprint.config.js** configuration with dynamic `require`:
+
+```js
+const { createRequire } = require('module');
+const requireFromUpdates = createRequire(require.resolve('expo-updates'));
+const { SourceSkips } = requireFromUpdates('@expo/fingerprint');
+
+const config = {
+  sourceSkips:
+    SourceSkips.ExpoConfigRuntimeVersionIfString |
+    SourceSkips.ExpoConfigVersions |
+    SourceSkips.PackageJsonAndroidAndIosScriptsIfNotContainRun,
+};
+
+module.exports = config;
+```
+
+For supported configurations, you can refer to the [source code](https://github.com/expo/expo/blob/main/packages/%40expo/fingerprint/src/Config.ts#L38-L45) and [`SourceSkips.ts`](https://github.com/expo/expo/blob/main/packages/%40expo/fingerprint/src/sourcer/SourceSkips.ts) for supported `SourceSkips`.
 
 ## Limitations
 


### PR DESCRIPTION
# Why

add doc for `fingerprint.config.js` and fix outdated diff format.

# How

update readme. online readme at https://github.com/expo/expo/blob/%40kudo/fingerprint/update-readme/packages/%40expo/fingerprint/README.md

# Test Plan

n/a

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
