### PR TITLE
[expo-notifications][Android] Eliminate unsupported types when processing notification intents from onCreate/onNewIntent

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -54,23 +54,6 @@ object JSTypeConverter {
     }
   }
 
-  /**
-   * Tests that a converted value can be added to a map for inclusion in the payload of a JS event
-   * without throwing
-   */
-  @JvmStatic
-  fun valueIsConvertibleToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Boolean {
-    val testMap = containerProvider.createMap()
-    try {
-      val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
-      testMap.putGeneric("testKey", convertedValue)
-    } catch (e: Throwable) {
-      return false
-    }
-    return true
-  }
-
-  @JvmStatic
   fun convertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
     return when (value) {
       null, is Unit -> null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -54,6 +54,23 @@ object JSTypeConverter {
     }
   }
 
+  /**
+   * Tests that a converted value can be added to a map for inclusion in the payload of a JS event
+   * without throwing
+   */
+  @JvmStatic
+  fun valueIsConvertibleToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Boolean {
+    val testMap = containerProvider.createMap()
+    try {
+      val convertedValue = JSTypeConverter.convertToJSValue(value, containerProvider)
+      testMap.putGeneric("testKey", convertedValue)
+    } catch (e: Throwable) {
+      return false
+    }
+    return true
+  }
+
+  @JvmStatic
   fun convertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
     return when (value) {
       null, is Unit -> null

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30478](https://github.com/expo/expo/pull/30478) by [@byCedric](https://github.com/byCedric))
+- [Android] Eliminate unsupported types when processing notification intents from onCreate/onNewIntent. ([#30750](https://github.com/expo/expo/pull/30750) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
@@ -1,8 +1,17 @@
 package expo.modules.notifications
 
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.ResultReceiver
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.typedarray.RawTypedArrayHolder
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
+import java.net.URI
+import java.net.URL
 
 typealias ResultReceiverBody = (resultCode: Int, resultData: Bundle?) -> Unit
 
@@ -14,6 +23,80 @@ internal fun createDefaultResultReceiver(
     override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
       super.onReceiveResult(resultCode, resultData)
       body(resultCode, resultData)
+    }
+  }
+}
+
+/**
+ * Returns true if object is convertible to a WritableMap element
+ */
+internal fun isWritableMapConvertible(value: Any?): Boolean {
+  return when (value) {
+    null, is Unit -> true
+    is Bundle -> true
+    is Array<*> -> true
+    is IntArray -> true
+    is FloatArray -> true
+    is DoubleArray -> true
+    is BooleanArray -> true
+    is ByteArray -> true
+    is Map<*, *> -> true
+    is Enum<*> -> true
+    is Record -> true
+    is URI -> true
+    is URL -> true
+    is Uri -> true
+    is File -> true
+    is Pair<*, *> -> true
+    is Long -> true
+    is Int -> true
+    is String -> true
+    is Float -> true
+    is Double -> true
+    is Boolean -> true
+    is RawTypedArrayHolder -> true
+    is Iterable<*> -> true
+    else -> false
+  }
+}
+
+/**
+ * Given an input bundle, creates a new bundle with non-WritableMap-convertible objects removed
+ */
+fun filteredBundleForWritableMap(bundle: Bundle): Bundle? {
+  val result = Bundle()
+  result.putAll(bundle)
+  bundle.keySet().forEach { key: String ->
+    val value = bundle[key]
+    if (!isWritableMapConvertible(value)) {
+      result.remove(key)
+    } else if (value is Bundle) {
+      result.putBundle(key, filteredBundleForWritableMap(value))
+    }
+  }
+  return result
+}
+
+/**
+ * Returns true if the argument is a valid JSON string, false otherwise
+ */
+fun isValidJSONString(test: Any?): Boolean {
+  when (test is String) {
+    true -> {
+      try {
+        JSONObject(test as String)
+        return true
+      } catch (objectEx: JSONException) {
+        try {
+          JSONArray(test as String)
+          return true
+        } catch (arrayEx: JSONException) {
+          return false
+        }
+      }
+    }
+    else -> {
+      return false
     }
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
@@ -1,17 +1,12 @@
 package expo.modules.notifications
 
-import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.ResultReceiver
-import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.typedarray.RawTypedArrayHolder
+import expo.modules.kotlin.types.JSTypeConverter
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import java.io.File
-import java.net.URI
-import java.net.URL
 
 typealias ResultReceiverBody = (resultCode: Int, resultData: Bundle?) -> Unit
 
@@ -28,50 +23,20 @@ internal fun createDefaultResultReceiver(
 }
 
 /**
- * Returns true if object is convertible to a WritableMap element
+ * Given an input bundle, creates a new bundle with non-convertible objects removed
  */
-internal fun isWritableMapConvertible(value: Any?): Boolean {
-  return when (value) {
-    null, is Unit -> true
-    is Bundle -> true
-    is Array<*> -> true
-    is IntArray -> true
-    is FloatArray -> true
-    is DoubleArray -> true
-    is BooleanArray -> true
-    is ByteArray -> true
-    is Map<*, *> -> true
-    is Enum<*> -> true
-    is Record -> true
-    is URI -> true
-    is URL -> true
-    is Uri -> true
-    is File -> true
-    is Pair<*, *> -> true
-    is Long -> true
-    is Int -> true
-    is String -> true
-    is Float -> true
-    is Double -> true
-    is Boolean -> true
-    is RawTypedArrayHolder -> true
-    is Iterable<*> -> true
-    else -> false
-  }
-}
-
-/**
- * Given an input bundle, creates a new bundle with non-WritableMap-convertible objects removed
- */
-fun filteredBundleForWritableMap(bundle: Bundle): Bundle? {
+internal fun filteredBundleForJSTypeConverter(bundle: Bundle): Bundle? {
   val result = Bundle()
   result.putAll(bundle)
   bundle.keySet().forEach { key: String ->
     val value = bundle[key]
-    if (!isWritableMapConvertible(value)) {
-      result.remove(key)
-    } else if (value is Bundle) {
-      result.putBundle(key, filteredBundleForWritableMap(value))
+    when (value is Bundle) {
+      true -> result.putBundle(key, filteredBundleForJSTypeConverter(value))
+      else -> {
+        if (!JSTypeConverter.valueIsConvertibleToJSValue(value)) {
+          result.remove(key)
+        }
+      }
     }
   }
   return result
@@ -80,7 +45,7 @@ fun filteredBundleForWritableMap(bundle: Bundle): Bundle? {
 /**
  * Returns true if the argument is a valid JSON string, false otherwise
  */
-fun isValidJSONString(test: Any?): Boolean {
+internal fun isValidJSONString(test: Any?): Boolean {
   when (test is String) {
     true -> {
       try {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Utils.kt
@@ -25,7 +25,7 @@ internal fun createDefaultResultReceiver(
 /**
  * Given an input bundle, creates a new bundle with non-convertible objects removed
  */
-internal fun filteredBundleForJSTypeConverter(bundle: Bundle): Bundle? {
+internal fun filteredBundleForJSTypeConverter(bundle: Bundle): Bundle {
   val result = Bundle()
   result.putAll(bundle)
   bundle.keySet().forEach { key: String ->

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -1,6 +1,6 @@
 package expo.modules.notifications.notifications;
 
-import static expo.modules.notifications.UtilsKt.filteredBundleForWritableMap;
+import static expo.modules.notifications.UtilsKt.filteredBundleForJSTypeConverter;
 import static expo.modules.notifications.UtilsKt.isValidJSONString;
 
 import android.os.Build;
@@ -228,9 +228,8 @@ public class NotificationSerializer {
     Bundle serializedContent = new Bundle();
     serializedContent.putString("title", extras.getString("title"));
     String body = extras.getString("body");
-    String projectId = extras.getString("projectId");
-    if (projectId != null && isValidJSONString(body) ) {
-      // If projectId is set in the bundle, and the body is a JSON string,
+    if (isValidJSONString(body) ) {
+      // If the body is a JSON string,
       // the notification was sent by the Expo notification service,
       // so we do the expected remapping of fields
       serializedContent.putString("dataString", body);
@@ -238,8 +237,8 @@ public class NotificationSerializer {
     } else {
       // The notification came directly from Firebase or some other service,
       // so we copy the data as is from the extras bundle, after
-      // ensuring it can be converted to a WritableMap
-      serializedContent.putBundle("data", filteredBundleForWritableMap(extras));
+      // ensuring it can be converted for emitting to JS
+      serializedContent.putBundle("data", filteredBundleForJSTypeConverter(extras));
     }
 
     Bundle serializedTrigger = new Bundle();

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -1,5 +1,8 @@
 package expo.modules.notifications.notifications;
 
+import static expo.modules.notifications.UtilsKt.filteredBundleForWritableMap;
+import static expo.modules.notifications.UtilsKt.isValidJSONString;
+
 import android.os.Build;
 import android.os.Bundle;
 
@@ -9,7 +12,6 @@ import com.google.firebase.messaging.RemoteMessage;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import expo.modules.core.arguments.MapArguments;
 
@@ -235,8 +237,9 @@ public class NotificationSerializer {
       serializedContent.putString("body", extras.getString("message"));
     } else {
       // The notification came directly from Firebase or some other service,
-      // so we copy the data as is from the extras bundle
-      serializedContent.putBundle("data", extras);
+      // so we copy the data as is from the extras bundle, after
+      // ensuring it can be converted to a WritableMap
+      serializedContent.putBundle("data", filteredBundleForWritableMap(extras));
     }
 
     Bundle serializedTrigger = new Bundle();
@@ -257,19 +260,6 @@ public class NotificationSerializer {
     serializedResponse.putBundle("notification", serializedNotification);
 
     return serializedResponse;
-  }
-
-  public static boolean isValidJSONString(String test) {
-    try {
-      new JSONObject(test);
-    } catch (JSONException objectEx) {
-      try {
-        new JSONArray(test);
-      } catch (JSONException arrayEx) {
-        return false;
-      }
-    }
-    return true;
   }
 
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -60,8 +60,7 @@ public class NotificationSerializer {
     serializedRequest.putBundle("trigger", toBundle(request.getTrigger()));
     Bundle content = toBundle(request.getContent());
     Bundle existingContentData = content.getBundle("data");
-    if (existingContentData == null) {
-      FirebaseNotificationTrigger trigger = (FirebaseNotificationTrigger) request.getTrigger();
+    if (existingContentData == null && request.getTrigger() instanceof FirebaseNotificationTrigger trigger) {
       RemoteMessage message = trigger.getRemoteMessage();
       RemoteMessage.Notification notification = message.getNotification();
       Map<String, String> data = message.getData();


### PR DESCRIPTION
# Why

On Android, when a notification is tapped to open the app, the intent passed into the Android lifecycle listeners may have properties in the `extras` bundle that are not supported in converting to `WritableMap` for sending events to JS. This potentially leads to a crash.

This PR fixes #30738.

# How

- New methods in `Utils` to filter out bundle properties that are not convertible.
- `NotificationSerializer` is modified to use the above new methods to filter out unconvertible values when processing the intent extras in `onCreate()` and `onNewIntent()` from `ExpoNotificationLifecycleListener`.

# Test Plan

- CI should pass
- The test app should not crash when this condition is encountered

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
