### PR TITLE
[config-plugins][prebuild-config] update tests snapshots

### DIFF
--- a/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Permissions-test.ts.snap
+++ b/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Permissions-test.ts.snap
@@ -12,7 +12,7 @@ exports[`Permissions can write with a pretty format 1`] = `
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -667,10 +667,10 @@ exports[`built-in plugins introspects mods 1`] = `
           },
           {
             "type": "comment",
-            "value": "Automatically convert third-party libraries to use AndroidX",
+            "value": "Enable AAPT2 PNG crunching",
           },
           {
-            "key": "android.enableJetifier",
+            "key": "android.enablePngCrunchInReleaseBuilds",
             "type": "property",
             "value": "true",
           },
@@ -814,6 +814,7 @@ exports[`built-in plugins introspects mods 1`] = `
                   "android:label": "@string/app_name",
                   "android:name": ".MainApplication",
                   "android:roundIcon": "@mipmap/ic_launcher_round",
+                  "android:supportsRtl": "true",
                   "android:theme": "@style/AppTheme",
                 },
                 "activity": [


### PR DESCRIPTION
# Why

Fixes part of failures caught in:
* https://github.com/expo/expo/actions/runs/10189296187/job/28187053372

# How

Regenerate test snapshots for `@expo/config-plugins` and `@expo/prebuild-config`.

# Test Plan

Running given test suit do not fail due to outdated snapshots.
