### PR TITLE
[cli] fix broken CorsMiddleware

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads. ([#30424](https://github.com/expo/expo/pull/30424) by [@byCedric](https://github.com/byCedric))
+- Fixed the `CorsMiddleware` is a not registered since react-native 0.75. ([#30752](https://github.com/expo/expo/pull/30752) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -220,9 +220,14 @@ export async function instantiateMetroAsync(
 
   if (!isExporting) {
     // The `securityHeadersMiddleware` does not support cross-origin requests, we replace with the enhanced version.
+    // From react-native 0.75, the exported `securityHeadersMiddleware` is a middleware factory that accepts single option parameter.
+    const securityHeadersMiddlewareHandler =
+      securityHeadersMiddleware.length === 1
+        ? securityHeadersMiddleware({})
+        : securityHeadersMiddleware;
     replaceMiddlewareWith(
       middleware as ConnectServer,
-      securityHeadersMiddleware,
+      securityHeadersMiddlewareHandler,
       createCorsMiddleware(exp)
     );
 

--- a/packages/@expo/cli/src/start/server/middleware/mutations.ts
+++ b/packages/@expo/cli/src/start/server/middleware/mutations.ts
@@ -23,7 +23,10 @@ export function replaceMiddlewareWith(
   sourceMiddleware: HandleFunction,
   targetMiddleware: HandleFunction
 ) {
-  const item = app.stack.find((middleware) => middleware.handle === sourceMiddleware);
+  const item = app.stack.find((middleware) => {
+    const handlerCode = middleware.handle.toString();
+    return !handlerCode.includes('[native code]') && handlerCode === sourceMiddleware.toString();
+  });
   if (item) {
     item.handle = targetMiddleware;
   }


### PR DESCRIPTION
# Why

CorsMiddleware has not been correctly replaced since react-native 0.75 upgrade.

# How

from https://github.com/react-native-community/cli/commit/9c813dcdf, the exported `securityHeadersMiddleware` is now a middleware factory. this pr tries to fix that with backward-compatible support.

# Test Plan

start dev server and run `curl -v http://localhost:8081/status -H 'Origin: https://chrome-devtools-frontend.appspot.com/' > /dev/null`. the response http code should be 200 rather than 500.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
