### PR TITLE
[docs] Improve App version management EAS Build page

### DIFF
--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -3,114 +3,141 @@ title: App version management
 description: Learn about different version types and how to manage them remotely or locally.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
-Android and iOS each expose two values that identify the version of an application; one that is visible in stores, and another that is visible only to developers.
+Android and iOS each expose two values to identify the version of an app: the version visible in stores (user-facing version) and the version visible only to developers (developer-facing build version). This guide explains how you can manage these versions them remotely or locally.
 
-In managed projects, we use fields `version`/`android.versionCode`/`ios.buildNumber` in **app.json** to define versions, where `android.versionCode`/`ios.buildNumber` represents the developer-facing build version and `version` is the user-facing value visible in stores. For bare projects, each of those values maps to specific parts of the native configuration:
+## App versions
 
-- [`version`][config-version] field in **app.json** on iOS represents `CFBundleShortVersionString` in **Info.plist**.
-- [`version`][config-version] field in **app.json** on Android represents `versionName` in **android/app/build.gradle**.
-- [`ios.buildNumber`][config-ios-buildnumber] field in **app.json** represents `CFBundleVersion` in **Info.plist**.
-- [`android.versionCode`][config-android-versioncode] field in **app.json** represents `versionCode` in **android/app/build.gradle**.
+In Expo projects, the following properties can be used to define app versions in the [app config](/workflow/configuration/) file.
 
-One of the most frequent causes of app store rejections is submitting a build with a duplicate version number. This happens when a developer forgets to increment the version number before running a build.
+| Property                                                          | Description                                                                                                                                                                                    |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`version` ](/versions/latest/config/app/#version)                | The user-facing version visible in stores. On Android, it represents `versionName` name in **android/app/build.gradle**. On iOS, it represents `CFBundleShortVersionString` in **Info.plist**. |
+| [`android.versionCode`](/versions/latest/config/app/#versioncode) | The developer-facing build version for Android. It represents `versionCode` in **android/app/build.gradle**.                                                                                   |
+| [`ios.buildNumber`](/versions/latest/config/app/#buildnumber)     | The developer-facing build version for iOS. It represents `CFBundleVersion` in **Info.plist**.                                                                                                 |
 
-EAS Build can manage automatically incrementing these versions for you if you opt into using the "remote" app version source. The default behavior is to use a "local" app version source, which means you control versions manually in their respective config files.
+### Using app versions in your app
 
-To simplify the descriptions, we will use **app.json** terminology (`version`/`versionCode`/`buildNumber`) for the rest of this page, but unless stated otherwise, the same applies to bare projects.
+To show the user-facing version inside your app, you can use [`Application.nativeApplicationVersion`](/versions/latest/sdk/application/#applicationnativeapplicationversion) from the `expo-application` library.
 
-<ContentSpotlight url="https://www.youtube.com/embed/Gk7RHDWsLsQ" />
+To show the developer-facing build version inside your app, you can use [`Application.nativeBuildVersion`](/versions/latest/sdk/application/#applicationnativebuildversion) from the `expo-application` library.
 
-## Examples
+## Recommended workflow
 
-<Collapsible summary="Remote version source">
+### User-facing version
 
-With this **eas.json**, the version for all builds will be based on the value stored on EAS servers, and the version will be incremented remotely and only when building with `production` profile.
+When you are doing a production release, the user-facing version should be explicitly set and updated by you. You can update the `version` property in app config when production build is submitted to the app stores. This also applies if your project uses `expo-updates` with an automatic runtime version policy. This marks the beginning of a new development cycle for a new version of your app. Learn more about [deployment patterns](/eas-update/deployment-patterns).
 
-```json
-{
-  "cli": {
-    "appVersionSource": "remote"
-  },
-  "build": {
-    "staging": {
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      }
-    },
-    "production": {
-      "autoIncrement": true
-    }
-  }
-}
-```
+### Developer-facing build version
 
-</Collapsible>
+For developer-facing build version, you can set them to autoincrement on every build. This will help you avoid making manual changes to the project every time you upload a new archive on Play Store testing channels or TestFlight. One common cause for app store rejections is submitting a build with a duplicate version number. It happens when a developer forgets to increment the developer-facing build version number before creating a new build.
 
-<Collapsible summary="Local version source">
-
-With this **eas.json**, the version for all builds will be based on the value from **app.json** or native code. When you build using `production` profile, the version will be incremented in the local code before the build.
-
-```json
-{
-  "cli": {
-    "appVersionSource": "local"
-  },
-  "build": {
-    "staging": {
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      }
-    },
-    "production": {
-      "autoIncrement": true
-    }
-  }
-}
-```
-
-</Collapsible>
+EAS Build can help manage developer-facing build versions automatically by incrementing these versions for you if you opt into using the [`remote` version source](#remote-version-source). The default behavior is to use a `local` version source, which means you control versions manually in their respective config files.
 
 ## Remote version source
 
-You can configure your project to rely on EAS servers to store and manage the version of your app. Add `{ "cli": { "appVersionSource": "remote" } }` in your **eas.json**. The remote version will be initialized with the value from the local project. If you would like to explicitly set the value directly, or EAS CLI is not able to detect what version the app is on, you can use the `eas build:version:set` command. EAS stores version information scoped by account, slug, platform, and application ID/bundle identifier — so, for example, if you are building variants with different application IDs or bundle identifiers, versioning will be independent for each of them.
+EAS servers can store and manage your app's developer-facing build version (`android.versionCode` and `ios.buildNumber`) remotely. You can achieve this by setting `cli.appVersionSource` to `remote` in **eas.json**. Then, under the `production` build profile, you can set the `autoIncrement` property to `true`.
 
-If you want to build your project locally in Android Studio or Xcode using the same version stored remotely on EAS, you can update your local project with the remote versions using `eas build:version:sync`.
+```json eas.json
+{
+  "cli": {
+    /* @info The app version source is set to <CODE>remote</CODE> to store and manage the version of your app. */
+    "appVersionSource": "remote"
+    /* @end */
+  },
+  "build": {
+    "development": {
+      /* @hide ... */
+      /* @end */
+    },
+    "preview": {
+      /* @hide ... */
+      /* @end */
+    },
+    "production": {
+      /* @info The <CODE>autoIncrement</CODE> property is set to <CODE>true</CODE> to automatically increment the <CODE>android.versionCode</CODE> and <CODE>ios.buildNumber</CODE> values. */
+      "autoIncrement": true
+      /* @end */
+    }
+  }
+  /* @hide ... */ /* @end */
+}
+```
 
-Enabling the `autoIncrement` option in the remote app version source mode is currently only available for `versionCode`/`buildNumber`.
+The remote version is initialized with the value from the local project. For example, if you have `android.versionCode` set to `1` in app config, when you create a new build using the remote version source, it will auto increment to `2`. However, if you do not have build versions set in your app config, the remote version will initialize with `1` when the first build is created.
 
-When using a remote app version source, the values in **app.json** will not be updated when the version is incremented remotely, and so the local and remote values will fall out of sync. The remote source values will be set on the native project when running a build, and they are the source of truth — however, the values specified in your **app.json** will be present in `Constants.expoConfig` exposed by `expo-constants`. Use `expo-application` to determine your application version at runtime instead, and remove `versionCode`/`buildNumber` from your **app.json**.
+When the `remote` version property is enabled inside **eas.json**, the build version values stored in app config are ignored and not updated when the version is incremented remotely. The remote version source values are set on the native project when running a build, which is considered the source of truth for these values. You can safely remove these values from your app config.
+
+### Video walkthrough
+
+<ContentSpotlight url="https://www.youtube.com/embed/Gk7RHDWsLsQ" />
+
+### Syncing already defined versions to remote
+
+There are different scenarios where you already have versions set up for your project and want to increment from those versions when you create a new EAS Build. However, these existing versions might not be synced remotely with EAS. Some of these scenarios are:
+
+- You have already published your app in the app stores and want to continue using the same version numbers.
+- EAS CLI is not able to detect what version the app is on.
+- For any other reason, you have versions explicitly set, such as inside your app config.
+
+In these scenarios, you can sync the current version to EAS Build using the EAS CLI using the following steps:
+
+- In the terminal window, run the following command:
+
+<Terminal cmd={['$ eas build:version:set']} />
+
+- Select the platform (Android or iOS) when prompted.
+- When prompted **Do you want to set app version source to remote now?**, select **yes**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.
+- When prompted **What version would you like to initialize it with?**, enter the last version number that you have set in the app stores.
+
+After these steps, the app versions will be synced to EAS Build remotely. You can now set `build.production.autoIncrement` to `true` in **eas.json**. When you create a new production build, the `versionCode` and `buildNumber` will be automatically incremented.
+
+### Syncing versions from remote to local
+
+To build your project locally in Android Studio or Xcode using the same version stored remotely on EAS, update your local project with the remote versions using the following command:
+
+<Terminal cmd={['$ eas build:version:sync']} />
 
 ### Limitations
 
-- `eas build:version:sync` command on Android does not support bare projects with multiple flavors, but the rest of the remote versioning functionality should work with all projects.
+- `eas build:version:sync` command on Android does not support bare projects with multiple flavors. However, the rest of the remote versioning functionality should work with all projects.
 - `autoIncrement` does not support the `version` option.
 - It's not supported if you are using EAS Update and runtime policy set to `"runtimeVersion": { "policy": "nativeVersion" }`. For similar behavior, use the `"appVersion"` policy instead.
 
-### Recommended workflow
-
-The main goal of this feature is to avoid manual changes to the project every time you are uploading a new archive to run it on TestFlight/Play Store testing channels. When you are doing a production release, the user-facing version change should be explicit.
-
-We recommend updating `version` field after a new build goes live in the store, especially if you are using `expo-updates` with an automatic runtime version policy. This marks the beginning of a new development cycle for a new version of your app. [Learn more about deployment patterns](/eas-update/deployment-patterns.mdx).
-
 ## Local version source
 
-By default, the source of truth for project versions is the local project source code itself. In this case, EAS does not write to the project, it reads the values and builds projects as they are.
+By default, the source of truth for project versions is the local project source code itself. In this case, EAS does not write to the project. It reads the app version values and builds projects as they are. You can opt in to auto incrementing versions locally by setting the `autoIncrement` option on a build profile.
 
-You may opt in to auto incrementing versions locally with the `autoIncrement` option on a build profile, but it comes with some limitations.
+```json eas.json
+{
+  "cli": {
+    /* @end */
+  },
+  "build": {
+    "development": {
+      /* @hide ... */
+      /* @end */
+    },
+    "preview": {
+      /* @hide ... */
+      /* @end */
+    },
+    "production": {
+      /* @info The <CODE>autoIncrement</CODE> property is set to <CODE>true</CODE> to automatically increment the <CODE>android.versionCode</CODE> and <CODE>ios.buildNumber</CODE> values. */
+      "autoIncrement": true
+      /* @end */
+    }
+  }
+  /* @hide ... */ /* @end */
+}
+```
 
-In the case of bare React Native projects, values in native code take precedence, and `expo-constants` and `expo-updates` read values from **app.json**. If you rely on version values from a manifest, you should keep them in sync with native code. Keeping these values in sync is especially important if you are using EAS Update with the runtime policy set to `"runtimeVersion": { "policy": "nativeVersion" }`, because mismatched versions may result in the delivery of updates to the wrong version of an application. We recommend using `expo-application` to read the version instead of depending on values from **app.json**.
+In the case of [existing React Native projects](/bare/overview/), the values in native code take precedence. The libraries `expo-constants` and `expo-updates` read values from the app config file. If you rely on version values from a manifest, you should keep them in sync with native code. Keeping these values in sync is especially important if you are using EAS Update with the runtime policy set to `"runtimeVersion": { "policy": "nativeVersion" }`, because mismatched versions may result in the delivery of updates to the wrong version of an application. We recommend using [`expo-application`](/versions/latest/sdk/application/#constants) to read the version instead of depending on values from app config.
 
 ### Limitations
 
 - With `autoIncrement`, you need to commit your changes on every build if you want the version change to persist. This can be difficult to coordinate when building on CI.
-- `autoIncrement` is not supported if you are using a dynamic config (**app.config.js**).
-- For bare React Native projects with Gradle configuration that supports multiple flavors, EAS CLI is not able to read or modify the version, so `autoIncrement` option is not supported and versions will not be listed in the build details page on [expo.dev](https://expo.dev).
-
-[config-version]: /versions/latest/config/app/#version
-[config-android-versioncode]: /versions/latest/config/app/#versioncode
-[config-ios-buildnumber]: /versions/latest/config/app/#buildnumber
+- `autoIncrement` is not supported if you are using a dynamic config file (such as **app.config.js**).
+- For existing React Native projects with Gradle configuration that supports multiple flavors, EAS CLI is not able to read or modify the version, so `autoIncrement` option is not supported, and versions will not be listed in the build details page on [expo.dev](https://expo.dev).

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -86,7 +86,7 @@ In these scenarios, you can sync the current version to EAS Build using the EAS 
 
 - In the terminal window, run the following command:
 
-<Terminal cmd={['$ eas build:version:set']} />
+  <Terminal cmd={['$ eas build:version:set']} />
 
 - Select the platform (Android or iOS) when prompted.
 - When prompted **Do you want to set app version source to remote now?**, select **yes**. This will set the `cli.appVersionSource` to `remote` in **eas.json**.

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -6,7 +6,7 @@ description: Learn about different version types and how to manage them remotely
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-Android and iOS each expose two values to identify the version of an app: the version visible in stores (user-facing version) and the version visible only to developers (developer-facing build version). This guide explains how you can manage these versions them remotely or locally.
+Android and iOS each expose two values to identify the version of an app: the version visible in stores (user-facing version) and the version visible only to developers (developer-facing build version). This guide explains how you can manage those versions remotely or locally.
 
 ## App versions
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-8777 ENG-8527

This guide's existing structure is outdated since it doesn't clearly define the distinction between user and developer-facing versions.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Changes:
- Re-structure the guide to explain what are "app versions", what properties to use to display app versions inside an app, and the recommended flow for each app version type and for sections: Remove version source and Local version source.
- Update examples for both Remote version source and Local version source
- Clearly define steps on how to sync versions from remote to local and already defined/existing versions (local) to remote
- Improve verbiage by providing an example on how autoincrement works with EAS Build
- Fix grammatical mistakes
- Use links to specific `Application.*` properties from `expo-application`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Manually tested remote version and local version sources by creating an EAS Build.

For docs changes, run docs locally and visit: http://localhost:3002/build-reference/app-versions or see the Preview: /build-reference/app-versions/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).