### PR TITLE
[updates] reexport fingerprint

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Upgrade dependencies and remove unused ones. Change multipart parser to okhttp. ([#29060](https://github.com/expo/expo/pull/29060) by [@wschurman](https://github.com/wschurman))
 - [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Re-exported `@expo/fingerprint` as `expo-updates/fingerprint`. ([#30757](https://github.com/expo/expo/pull/30757) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/fingerprint.d.ts
+++ b/packages/expo-updates/fingerprint.d.ts
@@ -1,0 +1,1 @@
+export * from '@expo/fingerprint';

--- a/packages/expo-updates/fingerprint.js
+++ b/packages/expo-updates/fingerprint.js
@@ -1,0 +1,1 @@
+module.exports = require('@expo/fingerprint');


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/30746#discussion_r1700018319

# How

re-export fingerprint from expo-updates so that people can easier import the transitive fingerprint in **fingerprint.config.js**

```js
/** @type {import('expo-updates/fingerprint').Config} */
const config = {
  // ...
};

module.exports = config;
```

# Test Plan

test fingerprint.config.js locally if i added these two files to node_modules/expo-updates/

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
