### PR TITLE
[fingerprint] update readme

### DIFF
--- a/packages/@expo/fingerprint/README.md
+++ b/packages/@expo/fingerprint/README.md
@@ -203,33 +203,28 @@ You can customize the fingerprinting behavior by creating a **fingerprint.config
 Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
 
 ```js
-const { SourceSkips } = require('@expo/fingerprint');
-
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
-  sourceSkips:
-    SourceSkips.ExpoConfigRuntimeVersionIfString |
-    SourceSkips.ExpoConfigVersions |
-    SourceSkips.PackageJsonAndroidAndIosScriptsIfNotContainRun,
+  sourceSkips: [
+    'ExpoConfigRuntimeVersionIfString',
+    'ExpoConfigVersions',
+    'PackageJsonAndroidAndIosScriptsIfNotContainRun',
+  ],
 };
-
 module.exports = config;
 ```
 
-If you are using `@expo/fingerprint` through `expo-updates` (where `@expo/fingerprint` is installed as a transitive dependency), you can use the following example **fingerprint.config.js** configuration with dynamic `require`:
+If you are using `@expo/fingerprint` through `expo-updates` (where `@expo/fingerprint` is installed as a transitive dependency), you can import fingerprint from `expo-updates/fingerprint`:
 
 ```js
-const { createRequire } = require('module');
-const requireFromUpdates = createRequire(require.resolve('expo-updates'));
-const { SourceSkips } = requireFromUpdates('@expo/fingerprint');
-
+/** @type {import('expo-updates/fingerprint').Config} */
 const config = {
-  sourceSkips:
-    SourceSkips.ExpoConfigRuntimeVersionIfString |
-    SourceSkips.ExpoConfigVersions |
-    SourceSkips.PackageJsonAndroidAndIosScriptsIfNotContainRun,
+  sourceSkips: [
+    'ExpoConfigRuntimeVersionIfString',
+    'ExpoConfigVersions',
+    'PackageJsonAndroidAndIosScriptsIfNotContainRun',
+  ],
 };
-
 module.exports = config;
 ```
 


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/30746#discussion_r1700018319

# How

update readme to reduce ambiguous `require('@expo/fingerpring')` and use `import('expo-update/fingerprint')` for updates 

# Test Plan

n/a

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
