### PR TITLE
[camera][android] Fix rendering order

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 - On `iOS`, correctly stop the session when the `CameraView` is removed. ([#30580](https://github.com/expo/expo/pull/30580) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
-- Fix rendering order of child views.
+- Fix rendering order of child views. ([#30759](https://github.com/expo/expo/pull/30759) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 - On `iOS`, correctly stop the session when the `CameraView` is removed. ([#30580](https://github.com/expo/expo/pull/30580) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
+- Fix rendering order of child views.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -128,7 +128,7 @@ class ExpoCameraView(
   private var barcodeFormats: List<BarcodeType> = emptyList()
 
   private var previewView = PreviewView(context).apply {
-    elevation = -1f
+    elevation = 0f
   }
   private val scope = CoroutineScope(Dispatchers.Main)
   private var shouldCreateCamera = false
@@ -227,6 +227,16 @@ class ExpoCameraView(
     val width = right - left
     val height = bottom - top
     previewView.layout(0, 0, width, height)
+  }
+
+  override fun onViewAdded(child: View?) {
+    super.onViewAdded(child)
+    if (child == previewView) {
+      return
+    }
+    child?.bringToFront()
+    removeView(previewView)
+    addView(previewView, 0)
   }
 
   fun takePicture(options: PictureOptions, promise: Promise, cacheDirectory: File) {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -18,6 +18,7 @@ import android.util.Size
 import android.view.OrientationEventListener
 import android.view.Surface
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
@@ -126,7 +127,9 @@ class ExpoCameraView(
   private var recorder: Recorder? = null
   private var barcodeFormats: List<BarcodeType> = emptyList()
 
-  private var previewView = PreviewView(context)
+  private var previewView = PreviewView(context).apply {
+    elevation = -1f
+  }
   private val scope = CoroutineScope(Dispatchers.Main)
   private var shouldCreateCamera = false
   private var previewPaused = false
@@ -208,20 +211,22 @@ class ExpoCameraView(
   // Scanning-related properties
   private var shouldScanBarcodes = false
 
-  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-    val width = right - left
-    val height = bottom - top
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    measureChild(previewView, widthMeasureSpec, heightMeasureSpec)
 
-    previewView.layout(0, 0, width, height)
-    postInvalidate(left, top, right, bottom)
+    setMeasuredDimension(
+      ViewGroup.resolveSize(previewView.measuredWidth, widthMeasureSpec),
+      ViewGroup.resolveSize(previewView.measuredHeight, heightMeasureSpec)
+    )
   }
 
-  override fun onViewAdded(child: View) {
-    if (previewView === child) {
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    if (!changed) {
       return
     }
-    removeView(previewView)
-    addView(previewView, 0)
+    val width = right - left
+    val height = bottom - top
+    previewView.layout(0, 0, width, height)
   }
 
   fun takePicture(options: PictureOptions, promise: Promise, cacheDirectory: File) {
@@ -339,6 +344,12 @@ class ExpoCameraView(
         val cameraProvider: ProcessCameraProvider = providerFuture.get()
 
         val preview = Preview.Builder()
+          .setResolutionSelector(
+            ResolutionSelector.Builder()
+              .setAspectRatioStrategy(ratio.mapToStrategy())
+              .setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
+              .build()
+          )
           .build()
           .also {
             it.surfaceProvider = previewView.surfaceProvider
@@ -420,7 +431,7 @@ class ExpoCameraView(
 
   private fun createVideoCapture(): VideoCapture<Recorder> {
     val preferredQuality = videoQuality.mapToQuality()
-    val fallbackStrategy = FallbackStrategy.lowerQualityOrHigherThan(preferredQuality)
+    val fallbackStrategy = FallbackStrategy.higherQualityOrLowerThan(preferredQuality)
     val qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
 
     val recorder = Recorder.Builder()
@@ -599,7 +610,13 @@ class ExpoCameraView(
         parent?.layout(0, 0, parent.measuredWidth, parent.measuredHeight)
       }
     })
-    addView(previewView)
+    addView(
+      previewView,
+      ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT
+      )
+    )
   }
 
   fun onPictureSaved(response: Bundle) {

--- a/packages/expo-image/src/utils.ts
+++ b/packages/expo-image/src/utils.ts
@@ -114,5 +114,5 @@ export function resolveTransition(
  * Checks whether the given value is an instance of the ImageRef class.
  */
 export function isImageRef(value: any): value is ImageRef {
-  return value instanceof ImageModule.Image;
+  return !!ImageModule.Image && value instanceof ImageModule.Image;
 }


### PR DESCRIPTION
# Why
Closes #30720
Views such as `ImageBackground` were not rendering their child views in the correct order. This is because we manually handled when child views were added and it appears the order was not consistent on each render. Ideally, we would not support children in this component as it is not a container and should not be treated as one.

I may just use a suggestion @aleqsio made and render children as siblings but a common use case seems to be rendering the camera inside of modals so I'll need to test that.

# How
~~Because we don't target below android 21, we can drop `onViewAdded` and set the elevation on the `PreviewView` directly. This ensures it will always appear behind everything else without directly changing the order.~~

Edit 1: 
Second attempt
We explicitly bring all children to the front as well as moving the PreviewView to the back. I'm still not completely happy with the results here. We should recommend against using children with this component. My feeling is the functionality should be deprecated. If there is no opposition, I will do that cc @brentvatne @tsapeta @lukmccall  The desired effects can be achieved with absolute positioning.

# Test Plan
Bare expo using the provided repro code. Child views now render in the correct order.
