### PR TITLE
fix(babel-preset-expo): fix jsc builds

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix JSC builds.
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix JSC builds.
+- Fix JSC builds. ([#30763](https://github.com/expo/expo/pull/30763) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -87,7 +87,11 @@ function babelPresetExpo(api, options = {}) {
         // `@react-native/babel-preset` configures this plugin with `{ loose: true }`, which breaks all
         // getters and setters in spread objects. We need to add this plugin ourself without that option.
         // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
-        extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
+        extraPlugins.push([
+            require('@babel/plugin-transform-object-rest-spread'),
+            // Assume no dependence on getters or evaluation order. See https://github.com/babel/babel/pull/11520
+            { loose: true, useBuiltIns: true },
+        ]);
     }
     else {
         if (platform !== 'web' && !isServerEnv) {

--- a/packages/babel-preset-expo/src/__tests__/jsc-bundle.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/jsc-bundle.test.ts
@@ -1,0 +1,57 @@
+import * as babel from '@babel/core';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+
+import preset from '..';
+
+it('bundles `@react-native/js-polyfills/console.js` without imports', () => {
+  const sourceFile = require.resolve('@react-native/js-polyfills/console.js');
+  const result = babel.transformFileSync(
+    sourceFile,
+    getConfig({
+      ast: true,
+      caller: getCaller({
+        name: 'metro',
+        engine: 'default',
+        platform: 'ios',
+        isDev: false,
+      }),
+    })
+  );
+
+  // Ensure the AST is available
+  expect(result?.ast).toBeDefined();
+
+  // Collect all `import` or `require` statements from the AST
+  const importRefs: Set<any> = new Set();
+  traverse(result!.ast, {
+    ImportDeclaration(path) {
+      importRefs.add(path.node);
+    },
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name: 'require' })) {
+        importRefs.add(path.node);
+      }
+    },
+  });
+
+  // Ensure there are no `import` or `require` statements
+  expect([...importRefs]).toEqual([]);
+});
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+function getConfig(props: babel.TransformOptions): babel.TransformOptions {
+  return {
+    babelrc: false,
+    presets: [preset],
+    sourceMaps: true,
+    configFile: false,
+    compact: false,
+    comments: true,
+    retainLines: true,
+    ...props,
+  };
+}

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -203,7 +203,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // `@react-native/babel-preset` configures this plugin with `{ loose: true }`, which breaks all
     // getters and setters in spread objects. We need to add this plugin ourself without that option.
     // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
-    extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
+    extraPlugins.push([
+      require('@babel/plugin-transform-object-rest-spread'),
+      // Assume no dependence on getters or evaluation order. See https://github.com/babel/babel/pull/11520
+      { loose: true, useBuiltIns: true },
+    ]);
   } else {
     if (platform !== 'web' && !isServerEnv) {
       // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when


### PR DESCRIPTION
# Why

- Add missing flag from the upstream plugin.  https://github.com/facebook/react-native/blame/54a6438eaab6358793b485fec3dffcb38973d21e/packages/react-native-babel-preset/src/configs/main.js#L127C8-L128C42
- This ensures that the polyfills don't add extra imports that cannot be bundled. This only runs in JSC and we default to hermes.

# Test Plan

- RN JSC builds work again.