### PR TITLE
[expo] fix update crash when R8 is enabled

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed fetch streaming error on iOS. ([#30604](https://github.com/expo/expo/pull/30604) by [@kudo](https://github.com/kudo))
 - Fixed fetch import on Web. ([#30605](https://github.com/expo/expo/pull/30605) by [@kudo](https://github.com/kudo))
 - Add support for server root in `expo/scripts/resolveAppEntry.js`. ([#30652](https://github.com/expo/expo/pull/30652) by [@byCedric](https://github.com/byCedric))
+- Fixed expo-updates crash when R8 is enabled on Android. ([#30765](https://github.com/expo/expo/pull/30765) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/proguard-rules.pro
+++ b/packages/expo/android/proguard-rules.pro
@@ -1,5 +1,6 @@
 # For ReactActivityDelegateWrapper
 -keepclassmembers public class com.facebook.react.ReactActivityDelegate {
+  public *;
   protected *;
   private ReactDelegate mReactDelegate;
 }


### PR DESCRIPTION
# Why

fix update e2e error recovery error: https://github.com/expo/expo/actions/runs/10189296201

```
Error recovery tests › downloads new update before launching, but launches the last non-crashing update
    DetoxRuntimeError: The app has crashed, see the details below:
    @Thread DefaultDispatcher-worker-2(42):
    java.lang.NoSuchMethodException: com.facebook.react.v.onResume []
    	at java.lang.Class.getMethod(Class.java:2103)
    	at java.lang.Class.getDeclaredMethod(Class.java:2081)
    	at k2.f.z(SourceFile:14)
    	at k2.f.q(SourceFile:8)
    	at k2.f.B(SourceFile:65)
    	at k2.f.t(SourceFile:1)
    	at k2.e.run(SourceFile:1)
    	at expo.modules.updates.UpdatesPackage$c$b.invokeSuspend(Unknown Source:12)
    	at kotlin.coroutines.jvm.internal.a.resumeWith(Unknown Source:11)
    	at V4.P.run(SourceFile:99)
    	at android.os.Handler.handleCallback(Handler.java:938)
    	at android.os.Handler.dispatchMessage(Handler.java:99)
    	at android.os.Looper.loopOnce(Looper.java:201)
    	at android.os.Looper.loop(Looper.java:288)
    	at android.app.ActivityThread.main(ActivityThread.java:7839)
    	at java.lang.reflect.Method.invoke(Native Method)
    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
    	Suppressed: Y4.h: [x0{Cancelling}@d8e4bff, Dispatchers.IO]
```

# How

since https://github.com/facebook/react-native/commit/5ed3057822dce98efe9ea7db731f3cf253fd8d56, `onResume` is public. to keep backward compatibility, this pr tries to add `public *` as keeping methods.

# Test Plan

updates e2e error recovery passed: https://github.com/expo/expo/actions/runs/10204632458/job/28233566273

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
