### PR TITLE
test(babel-preset-expo): add jsc regression test for preloaded modules and babel helpers

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/jsc-bundle.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/jsc-bundle.test.ts
@@ -1,0 +1,57 @@
+import * as babel from '@babel/core';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+
+import preset from '..';
+
+it('bundles `@react-native/js-polyfills/console.js` without imports', () => {
+  const sourceFile = require.resolve('@react-native/js-polyfills/console.js');
+  const result = babel.transformFileSync(
+    sourceFile,
+    getConfig({
+      ast: true,
+      caller: getCaller({
+        name: 'metro',
+        engine: 'default',
+        platform: 'ios',
+        isDev: false,
+      }),
+    })
+  );
+
+  // Ensure the AST is available
+  expect(result?.ast).toBeDefined();
+
+  // Collect all `import` or `require` statements from the AST
+  const importRefs: Set<any> = new Set();
+  traverse(result!.ast, {
+    ImportDeclaration(path) {
+      importRefs.add(path.node);
+    },
+    CallExpression(path) {
+      if (t.isIdentifier(path.node.callee, { name: 'require' })) {
+        importRefs.add(path.node);
+      }
+    },
+  });
+
+  // Ensure there are no `import` or `require` statements
+  expect([...importRefs]).toEqual([]);
+});
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+function getConfig(props: babel.TransformOptions): babel.TransformOptions {
+  return {
+    babelrc: false,
+    presets: [preset],
+    sourceMaps: true,
+    configFile: false,
+    compact: false,
+    comments: true,
+    retainLines: true,
+    ...props,
+  };
+}


### PR DESCRIPTION
# Why

The incorrectly added babel plugin caused preloaded modules to include external imports, which isn't possible in Metro as preloaded modules doesn't have access to the dependency map. This resulted in JSC builds failing with `require is not a function`.

# How

- Added regression test for `@react-native/js-polyfills/console.js` and JSC

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
