### PR TITLE
[docs] CodeBlockTable: refactor to Tailwind

### DIFF
--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -1,5 +1,4 @@
-import { css } from '@emotion/react';
-import { breakpoints, spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import { FileCode01Icon } from '@expo/styleguide-icons/outline/FileCode01Icon';
 import { PropsWithChildren } from 'react';
 
@@ -38,9 +37,19 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
     });
 
   return (
-    <div css={[codeBlocksWrapperStyle, connected && codeBlockConnectedWrapperStyle]} {...rest}>
+    <div
+      className={mergeClasses(
+        'grid grid-cols-2 gap-4',
+        connected && 'lg-gutters:gap-0 lg-gutters:mb-4',
+        connected &&
+          '[&>div:nth-child(odd)>div]:lg-gutters:border-r-0 [&>div:nth-child(odd)>div]:lg-gutters:!rounded-r-none',
+        connected && '[&>div:nth-child(even)>div]:lg-gutters:!rounded-l-none',
+        '[&_pre]:border-0 [&_pre]:m-0',
+        'max-lg-gutters:grid-cols-1'
+      )}
+      {...rest}>
       {codeBlocks.map((codeBlock, index) => (
-        <Snippet key={index} className="last:mb-4 max-xl:!mb-0">
+        <Snippet key={index} className="mb-0 last:max-lg-gutters:mb-4">
           <SnippetHeader title={tabNames[index]} Icon={FileCode01Icon}>
             <CopyAction text={cleanCopyValue(codeBlock.props.children.props.children)} />
           </SnippetHeader>
@@ -50,43 +59,3 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
     </div>
   );
 }
-
-const codeBlocksWrapperStyle = css({
-  display: 'grid',
-  gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
-  gap: spacing[4],
-  gridAutoRows: '1fr',
-
-  pre: {
-    border: 0,
-    margin: 0,
-    gridTemplateRows: 'minmax(100px, 1fr)',
-    height: '100%',
-  },
-
-  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
-    gridTemplateColumns: 'minmax(0, 1fr)',
-    gridAutoRows: 'auto',
-  },
-});
-
-const codeBlockConnectedWrapperStyle = css({
-  [`@media screen and (min-width: ${breakpoints.large}px)`]: {
-    gridGap: 0,
-
-    '> div:nth-of-type(odd)': {
-      '> div': {
-        borderRight: 0,
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-      },
-    },
-
-    '> div:nth-of-type(even)': {
-      '> div': {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-      },
-    },
-  },
-});

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-7sex76"
+    class="!shadow-none css-1vln2jt-APISectionComponents"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -328,7 +328,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -343,7 +343,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 buttonStyle
@@ -405,7 +405,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -420,7 +420,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 buttonType
@@ -482,7 +482,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -497,7 +497,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 cornerRadius
@@ -567,7 +567,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -582,7 +582,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 onPress
@@ -663,7 +663,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -678,7 +678,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 style
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2373,7 +2373,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2911,7 +2911,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3259,7 +3259,7 @@ may be
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3566,7 +3566,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3890,7 +3890,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4127,7 +4127,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -6158,7 +6158,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-7sex76"
+    class="!shadow-none css-1vln2jt-APISectionComponents"
   >
     <div
       class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
@@ -6370,7 +6370,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6385,7 +6385,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 barCodeTypes
@@ -6486,7 +6486,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6501,7 +6501,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6640,7 +6640,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6655,7 +6655,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 type
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7173,7 +7173,7 @@ This uses both
         data-text="true"
       >
         <code
-          class="css-dpez7n-Code"
+          class="css-19nqa8l-Code"
         >
           <span
             class="token keyword"
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1nl93gr-APISectionInterfaces"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8217,7 +8217,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8527,7 +8527,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8646,7 +8646,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8815,7 +8815,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8923,7 +8923,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9195,7 +9195,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9771,7 +9771,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9896,7 +9896,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -10261,7 +10261,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10399,7 +10399,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10524,7 +10524,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-7jozdd-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1nl93gr-APISectionInterfaces"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11129,7 +11129,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11244,7 +11244,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11358,7 +11358,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11460,7 +11460,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-7sex76"
+    class="css-1cty0bu-APISectionTypes"
   >
     <h3
       class="group css-eynke-TextComponent"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-1vln2jt-APISectionComponents"
+    class="!shadow-none css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -328,7 +328,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -343,7 +343,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 buttonStyle
@@ -405,7 +405,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -420,7 +420,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 buttonType
@@ -482,7 +482,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -497,7 +497,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 cornerRadius
@@ -567,7 +567,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -582,7 +582,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 onPress
@@ -663,7 +663,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -678,7 +678,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 style
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2373,7 +2373,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2911,7 +2911,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3259,7 +3259,7 @@ may be
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3566,7 +3566,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3890,7 +3890,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4127,7 +4127,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -6158,7 +6158,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-1vln2jt-APISectionComponents"
+    class="!shadow-none css-7sex76"
   >
     <div
       class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
@@ -6370,7 +6370,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6385,7 +6385,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 barCodeTypes
@@ -6486,7 +6486,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6501,7 +6501,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6640,7 +6640,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1yv1gn4-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6655,7 +6655,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 type
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-1nl93gr-APISectionInterfaces"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8217,7 +8217,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8527,7 +8527,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8646,7 +8646,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8815,7 +8815,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8923,7 +8923,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9195,7 +9195,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9771,7 +9771,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9896,7 +9896,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -10261,7 +10261,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10399,7 +10399,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10524,7 +10524,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-7jozdd-APISectionMethods"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-1nl93gr-APISectionInterfaces"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11129,7 +11129,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11244,7 +11244,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11358,7 +11358,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11460,7 +11460,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-1cty0bu-APISectionTypes"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -116,7 +116,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       data-text="true"
     >
       <code
-        class="css-dpez7n-Code"
+        class="css-19nqa8l-Code"
       >
         <span
           class="token keyword"

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -849,7 +849,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           data-text="true"
         >
           <code
-            class="css-1360qeq-CodeBlock"
+            class="css-fyy1wj-CodeBlock"
             data-text="true"
           >
             [


### PR DESCRIPTION
# Why

Chopping down on Emotion usage.

# How

Refactor `CodeBlockTable` to Tailwind classes.

# Test Plan

Changes have been reviewed locally.

# Preview

![Screenshot 2024-08-02 at 15 27 10](https://github.com/user-attachments/assets/24cb72cf-67f2-4bff-addc-dcfb7d98f585)

![Screenshot 2024-08-02 at 15 27 45](https://github.com/user-attachments/assets/c2c4036e-2c3a-48c0-b47a-144ebf2150c6)
