### PR TITLE
refactor(config): simplify `modifyConfigAsync` and return `ExpoConfig` instead of `AppJSONConfig`

### DIFF
--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Change the `config` return type from `AppJSONConfig` to `ExpoConfig` in `modifyConfigAsync`. ([#30783](https://github.com/expo/expo/pull/30783) by [@byCedric](https://github.com/byCedric))
+
 ### 🎉 New features
 
 - Automatically write an `app.json` when attempting to modify a config and no file exists. ([#30026](https://github.com/expo/expo/pull/30026) by [@EvanBacon](https://github.com/EvanBacon))


### PR DESCRIPTION
# Why

This PR contains two changes:

1. Change the `config` return type on `modifyConfigAsync` (`AppJSONConfig` → `ExpoConfig`)
2. Simplify the `modifyConfigAsync` function, dropping previously required helpers to merge the dynamic config as `AppJSONConfig`.

# How

See #30782

# Test Plan

See #30782

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
