### PR TITLE
[Docs] Document expo doctor as a tool

### DIFF
--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -55,7 +55,7 @@ Expo Doctor is a command line tool used to diagnose issues in your Expo project.
 
 <Terminal cmd={['$ npx expo-doctor']} />
 
-This command performs checks and analyzes your project's codebase for common issues, dependency compatibility, configuration files, and the overall health of the project. Once the check is complete, Expo Doctor outputs the results.
+This command performs checks and analyzes your project's codebase for common issues in [app config](/workflow/configuration/) and **package.json** files, dependency compatibility, configuration files, and the overall health of the project. Once the check is complete, Expo Doctor outputs the results.
 
 If Expo Doctor finds an issue, it provides a description of the problem along with advice on how to fix it or where to find help.
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -49,17 +49,15 @@ To use EAS CLI, you need to install it globally on your local machine by running
 
 You can use `eas --help` in your terminal window to learn more about the available commands. For a complete reference, see [`eas-cli` npm page](https://www.npmjs.com/package/eas-cli).
 
-## Expo Doctor CLI
+## Expo Doctor
 
-Expo Doctor is a command line tool used to diagnose issues in your Expo project.
-
-To use Expo Doctor, run the following command in your project's root folder:
+Expo Doctor is a command line tool used to diagnose issues in your Expo project. To use it, run the following command in your project's root directory:
 
 <Terminal cmd={['$ npx expo-doctor']} />
 
-This command will perform checks and analyses on your codebase, looking for common issues, dependency compatibility, configuration files, and the overall health of your project. Once the check is complete, Expo Doctor will output the results.
+This command performs checks and analyzes your project's codebase for common issues, dependency compatibility, configuration files, and the overall health of the project. Once the check is complete, Expo Doctor outputs the results.
 
-If Expo Doctor finds an issue, it will provide a description of the problem along with advice on how to fix it or where to find help.
+If Expo Doctor finds an issue, it provides a description of the problem along with advice on how to fix it or where to find help.
 
 You can also use `npx expo-doctor --help` to display usage information.
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -49,6 +49,20 @@ To use EAS CLI, you need to install it globally on your local machine by running
 
 You can use `eas --help` in your terminal window to learn more about the available commands. For a complete reference, see [`eas-cli` npm page](https://www.npmjs.com/package/eas-cli).
 
+## Expo Doctor CLI
+
+Expo Doctor is a command line tool used to diagnose issues in your Expo project.
+
+To use Expo Doctor, run the following command in your project's root folder:
+
+<Terminal cmd={['$ npx expo-doctor']} />
+
+This command will perform checks and analyses on your codebase, looking for common issues, dependency compatibility, configuration files, and the overall health of your project. Once the check is complete, Expo Doctor will output the results.
+
+If Expo Doctor finds an issue, it will provide a description of the problem along with advice on how to fix it or where to find help.
+
+You can also use `npx expo-doctor --help` to display usage information.
+
 ## Orbit
 
 Orbit is a macOS and Windows app that enables


### PR DESCRIPTION
# Why

We currently don't have a reference to learn about Expo Doctor

# How

Added Expo Doctor section in [docs.expo.dev/develop/tools](https://docs.expo.dev/develop/tools) between EAS CLI and Orbit

# Test Plan

Run docs locally

![image](https://github.com/user-attachments/assets/3f81ccbc-d38f-4ec5-ab6a-448141941c60)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
