### PR TITLE
[web][camera] Fixed issue; Camera would not load on web at the Expo t…

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -87,6 +87,11 @@ function Gestures({ children }: { children: React.ReactNode }) {
         }),
     []
   );
+
+  if (Platform.OS === 'web') {
+    return children;
+  }
+
   return (
     <GestureDetector gesture={Gesture.Race(doubleTapGesture, longPressGesture)}>
       {children}


### PR DESCRIPTION
Fixed issue; Camera View would not load in web browser at the Expo test-suite

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Camera Screen on Expo Test Suite would not load in a web browser.
This simply needs to be fixed in order to resolve on other bugs related to the camera package on the web.
I noticed the bug when I was working to resolve another issue.

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/de311d23-0668-4fa1-ba97-b1c22c70576b">


# How

<!--
How did you build this feature or fix this bug and why?
-->


I noticed the bug was recently introduced in this PR #30338.
The CameraView is now wrapped in a component `Gestures`, utilizing GestureDetector which errors out if the screen is opened in a web browser.

```
return (
  <GestureDetector gesture={Gesture.Race(doubleTapGesture, longPressGesture)}>
    {children}
  </GestureDetector>
);
```

A simple fix was just returning the children in case it's run through a web browser.

```diff
if (Platform.OS === 'web') {
  return children;
}

return (
  <GestureDetector gesture={Gesture.Race(doubleTapGesture, longPressGesture)}>
    {children}
  </GestureDetector>
);
```

I could argue that if run on web it would not be necessary to wrap it in the `Gesture`-component at all. But I think this come off as a "lighter" change that easily could be reverted once the real underlying problem is fixed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- I spun the project up by running `yarn start` and then `w` to open the browser.
- Navigated to the camera
  - Result before fix: white page
  - Result after fix: working camera view

I was able to replicate the problem in:
- Chrome
- Brave
- Safari
- Firefox

(which were all the browsers I tested)
The proposed solution also worked as expected in all of them.

I also tried it on Safari on phone, and the fix worked as expected.
Without the fix it would show a white page.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
