### PR TITLE
[docs] update scripts.mdx [npx run reset-project] incorrect command changed

### DIFF
--- a/docs/scenes/get-started/start-developing/ProjectStructure/files/scripts.mdx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/files/scripts.mdx
@@ -2,4 +2,4 @@ import { RawH3 } from '~/ui/components/Text';
 
 <RawH3>scripts</RawH3>
 
-Contains **reset-project.js**, which can be run with `npx run reset-project`. This script will move the **app** directory to **app-example**, and create a new **app** directory with an **index.tsx** file.
+Contains **reset-project.js**, which can be run with `npm run reset-project`. This script will move the **app** directory to **app-example**, and create a new **app** directory with an **index.tsx** file.


### PR DESCRIPTION
Script is defined in the scripts section inside the package.json file, so npm run or yarn should be used instead of npx.

# Checklist
- [ x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
