### PR TITLE
[docs] Add Vale rule to detect and avoid using smart quotes

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/SmartQuotes.yml
+++ b/docs/.vale/writing-styles/expo-docs/SmartQuotes.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: Use straight quotes instead of smart quotes.
+level: warning
+nonword: true
+tokens:
+  - “
+  - ”
+  - ‘
+  - ’

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,7 +190,7 @@ Once you have made sure the development setup is ready, proceed to the next sect
 
 #### Step 1: Update the package's TypeDoc
 
-- After you have identified which package docs you want to update, open a terminal window and navigate to that package’s directory. For example:
+- After you have identified which package docs you want to update, open a terminal window and navigate to that packages directory. For example:
 
 ```shell
 # Navigate to expo-constants package directory inside expo/ repo
@@ -212,7 +212,7 @@ cd expo/packages/expo-constants
   expoConfig: ExpoConfig | null;
   ```
 
-- In the above example, let’s fix the typo by changing `confg` to `config`:
+- In the above example, let's fix the typo by changing `confg` to `config`:
 
 ```ts
 /**
@@ -258,7 +258,7 @@ Now, in the terminal window, navigate to **expo/docs** repo and run the command 
 
 After making changes, when you are opening the PR, consider adding `<!-- disable:changelog-checks -->` in the PR description if the changes you are making are docs-related changes (such as updating the field description or fixing a typo, and so on).
 
-This will make sure that the ExpoBot on GitHub will not complain about updating the package’s changelog (some of these changes, as described above, are not worth mentioning in the changelog).
+This will make sure that the ExpoBot on GitHub will not complain about updating the package's changelog (some of these changes, as described above, are not worth mentioning in the changelog).
 
 ##### Use the correct package name
 

--- a/docs/pages/archive/classic-updates/advanced-release-channels.mdx
+++ b/docs/pages/archive/classic-updates/advanced-release-channels.mdx
@@ -17,7 +17,7 @@ For simplicity, the rest of this article will refer to just the `ios` releases, 
 
 ## See past publishes
 
-You can see everything that you’ve published with `expo publish:history`.
+You can see everything that you've published with `expo publish:history`.
 
 #### Example command and output
 

--- a/docs/pages/archive/classic-updates/hosting-your-app.mdx
+++ b/docs/pages/archive/classic-updates/hosting-your-app.mdx
@@ -84,7 +84,7 @@ Here's an example of **firebase.json** configuration, with a [deploy target](htt
 
 ## Building the standalone app
 
-To configure your standalone binary to pull updates from your server, you’ll need to define the URL where you will host your **index.json** file. When using EAS Build, just set the [`updates.url` property in app.json](/versions/latest/config/app/#url) to point to that url.
+To configure your standalone binary to pull updates from your server, you'll need to define the URL where you will host your **index.json** file. When using EAS Build, just set the [`updates.url` property in app.json](/versions/latest/config/app/#url) to point to that url.
 
 ## Loading QR Code/URL in Development
 
@@ -92,7 +92,7 @@ You can also load an update hosted on your own servers as a QR code/URL into the
 
 ### QR code:
 
-The URI you’ll use to convert to QR code will be deeplinked using the `exps`/`exp` protocol. Both `exps` and `exp` deeplink into the mobile app and perform a request using HTTPS and HTTP respectively. You can create your own QR code using an online QR code generator from the input URI.
+The URI you'll use to convert to QR code will be deeplinked using the `exps`/`exp` protocol. Both `exps` and `exp` deeplink into the mobile app and perform a request using HTTPS and HTTP respectively. You can create your own QR code using an online QR code generator from the input URI.
 
 #### Here's an example of how you'd do this with a remote server:
 

--- a/docs/pages/archive/classic-updates/publishing.mdx
+++ b/docs/pages/archive/classic-updates/publishing.mdx
@@ -6,7 +6,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
 
-While you’re developing your project, you're writing code on your
+While you're developing your project, you're writing code on your
 computer, and when you use Expo CLI, a server and the Metro bundler run on your machine and bundle up all your source code and make
 it available from a URL. Your URL for a project you're working on
 probably looks something like this:
@@ -34,7 +34,7 @@ and publish it without any changes and you will see that it works.
 
 When you do this, the bundler will minify all your code and generate
 two versions of your code (one for iOS, one for Android) and then upload
-those to a free hosting service provided by Expo. You’ll get a link like [https://exp.host/@ccheever/an-example](https://exp.host/@ccheever/an-example)
+those to a free hosting service provided by Expo. You'll get a link like [https://exp.host/@ccheever/an-example](https://exp.host/@ccheever/an-example)
 that anyone can load your project from.
 
 If you haven't optimized your assets yet you will be prompted and asked
@@ -106,7 +106,7 @@ more widely.
 ## Privacy
 
 You can set the privacy of your project in your **app.json** configuration
-file by setting the key “privacy” to either `“public”` or `“unlisted”`.
+file by setting the key "privacy" to either `"public"` or `"unlisted"`.
 
 These options work similarly to the way they do on YouTube. Unlisted
 project URLs will be secret unless you tell people about them or share

--- a/docs/pages/archive/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/archive/technical-specs/expo-updates-0.mdx
@@ -17,7 +17,7 @@ This is the specification for Expo Updates, a protocol for delivering updates to
 
 Conforming servers and client libraries must fulfill all normative requirements. Conformance requirements are described in this document by both descriptive assertions and key words with clearly defined meanings.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.
 
 A conforming implementation of this protocol may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non-conformance.
 

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -208,8 +208,8 @@ export default createRunOncePlugin(
   If anything goes wrong with the plugin, users should still be able to manually add the package to their project.
   Doing this often helps you find ways to reduce the setup, which can lead to a simpler plugin.
   - Document the available properties for the plugin, and specify if the plugin works without props.
-  - If you can make your plugin work after running prebuild multiple times, that’s a big plus! It can improve the developer experience to be able to run `npx expo prebuild` without the `--clean` flag to sync changes.
-- **Naming conventions**: Use `withFeatureName` if cross-platform. If the plugin is platform specific, use a camel case naming with the platform right after “with”. For example, `withAndroidSplash`, `withIosSplash`.
+  - If you can make your plugin work after running prebuild multiple times, that's a big plus! It can improve the developer experience to be able to run `npx expo prebuild` without the `--clean` flag to sync changes.
+- **Naming conventions**: Use `withFeatureName` if cross-platform. If the plugin is platform specific, use a camel case naming with the platform right after "with". For example, `withAndroidSplash`, `withIosSplash`.
   There is no universally agreed upon casing for `iOS` in camel cased identifiers, we prefer this style and suggest using it for your config plugins too.
 - **Leverage built-in plugins**: Account for built-in plugins from the [prebuild config](https://github.com/expo/expo-cli/blob/master/packages/prebuild-config/src/plugins/withDefaultPlugins.ts).
   Some features are included for historical reasons, like the ability to automatically copy and link [Google services files](https://github.com/expo/expo-cli/blob/3a0ef962a27525a0fe4b7e5567fb7b3fb18ec786/packages/config-plugins/src/ios/Google.ts#L15) defined in the app config.

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -5,9 +5,9 @@ description: Learn about current approaches to preview and edit rich text in Rea
 
 A lot of applications need to allow users to type in text. For example, if you want to build a messaging or social media app, you will probably rely heavily on text inputs. React Native has a built-in `<TextInput>` component to implement this without much effort for many simple cases.
 
-However, sometimes you need to be more flexible. Think of long social media posts, note apps, or document editors. Ideally, you need to allow different text styles, lists, headings, embedded images, and more. This is called a rich text editor, and it’s a difficult problem to solve everywhere, including in React Native.
+However, sometimes you need to be more flexible. Think of long social media posts, note apps, or document editors. Ideally, you need to allow different text styles, lists, headings, embedded images, and more. This is called a rich text editor, and it's a difficult problem to solve everywhere, including in React Native.
 
-There’s currently no default solution for that in the React Native ecosystem. In this guide, we explore some options and promising approaches, each with its own tradeoffs.
+There's currently no default solution for that in the React Native ecosystem. In this guide, we explore some options and promising approaches, each with its own tradeoffs.
 
 # Render rich text
 
@@ -43,7 +43,7 @@ You will not be able to use native UI components inside the editor. Any implemen
 
 ### Existing webview-based React Native libraries
 
-There are a couple of existing React Native libraries to allow rich-text editing. These are the easiest options to get started if you need a basic rich text editor with limited configuration and don’t have strict performance or UX requirements:
+There are a couple of existing React Native libraries to allow rich-text editing. These are the easiest options to get started if you need a basic rich text editor with limited configuration and don't have strict performance or UX requirements:
 
 - [`react-native-rich-editor`](https://github.com/wxik/react-native-rich-editor)
 - [`react-native-cn-quill`](https://github.com/imnapo/react-native-cn-quill)
@@ -57,7 +57,7 @@ If you need more configurability, you can build a similar library with an existi
 - [lexical](https://github.com/facebook/lexical)
 - [slate](https://github.com/ianstormtaylor/slate)
 
-You will need to use message passing to pass text and `onChange` events to and from the webview. Since rich texts often end up long, it’s better to model it as an uncontrolled component to prevent lag on each keystroke. Also, if you can avoid serializing and sending the entire state on each keystroke that also improves performance.
+You will need to use message passing to pass text and `onChange` events to and from the webview. Since rich texts often end up long, it's better to model it as an uncontrolled component to prevent lag on each keystroke. Also, if you can avoid serializing and sending the entire state on each keystroke that also improves performance.
 
 ## Building on top of React Native TextInput
 

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -12,7 +12,7 @@ This is the specification for Expo Updates, a protocol for delivering updates to
 
 Conforming servers and client libraries must fulfill all normative requirements. Conformance requirements are described in this document by both descriptive assertions and key words with clearly defined meanings.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.
 
 A conforming implementation of this protocol MAY provide additional functionality, but MUST NOT where explicitly disallowed or would otherwise result in non-conformance. Where relevant, unknown fields should be allowed and ignored by conforming clients.
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -174,7 +174,7 @@ export default function App() {
 
 </SnackInline>
 
-Now, choose a photo and add a sticker. Then tap the “Save” button. We should see the following result:
+Now, choose a photo and add a sticker. Then tap the "Save" button. We should see the following result:
 
 <ContentSpotlight file="tutorial/saving-screenshot.mp4" />
 

--- a/docs/ui/components/Snippet/prism-bash.js
+++ b/docs/ui/components/Snippet/prism-bash.js
@@ -85,7 +85,7 @@ import { Prism } from 'prism-react-renderer';
       // a) function foo {
       // b) foo() {
       // c) function foo() {
-      // but not “foo {”
+      // but not "foo {"
       {
         // a) and c)
         pattern: /(\bfunction\s+)[\w-]+(?=(?:\s*\(?:\s*\))?\s*\{)/,
@@ -105,7 +105,7 @@ import { Prism } from 'prism-react-renderer';
       lookbehind: true,
     },
     // Highlight variable names as variables in the left-hand part
-    // of assignments (“=” and “+=”).
+    // of assignments ("=" and "+=").
     'assign-left': {
       pattern: /(^|[\s;|&]|[<>]\()\w+(?:\.\w+)*(?=\+?=)/,
       inside: {
@@ -133,7 +133,7 @@ import { Prism } from 'prism-react-renderer';
         inside: insideString,
       },
       // Here-document with quotes around the tag
-      // → No expansion (so no “inside”).
+      // → No expansion (so no "inside").
       {
         pattern: /((?:^|[^<])<<-?\s*)(["'])(\w+)\2\s[\s\S]*?(?:\r?\n|\r)\3/,
         lookbehind: true,
@@ -142,7 +142,7 @@ import { Prism } from 'prism-react-renderer';
           bash: commandAfterHeredoc,
         },
       },
-      // “Normal” string
+      // "Normal" string
       {
         // https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
         pattern: /(^|[^\\](?:\\\\)*)"(?:\\[\s\S]|\$\([^)]+\)|\$(?!\()|`[^`]+`|[^"\\`$])*"/,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Sometimes, when copy-pasting content of a page from another writing tool (such as Notion), the smart quotes are copy and pasted. We prefer using straight quotes (single or double) in all of our docs content.

This PR adds a Vale rule to keep our docs consistent by providing a warning any time a single or a double smart quote is introduced when running `yarn run lint-prose`. It also suggests to use straight quotes.

Existing usage of smart quotes is also fixed in various docs by running `yarn run lint-prose`. Also cleaned this up in some code comments and `docs/README.md`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Create a `SmartQuotes.yml` in `.vale/writing-styles/expo-docs` directory.
- Add the rule to warn about smart quotes usage.
- Run `yarn run lint-prose` to detect on which pages the smart quotes are used. Replace them by using straight quotes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
