### PR TITLE
[docs] Remove `.mdx` extension references from internal links

### DIFF
--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -5,9 +5,9 @@ description: Learn about different options for supplying your app signing creden
 
 EAS Build gives you two options for how you can supply your build jobs with app signing credentials:
 
-1. [Automatically managed credentials](managed-credentials.mdx): EAS can host your app signing credentials and take care of sharing them with teammates that have the necessary permissions.
-2. [Local credentials](local-credentials.mdx): You create a **credentials.json** file in your project that points to your keystore (Android) and/or provisioning profile and distribution certificate (iOS), along with associated passwords. This is uploaded from your local machine at the time any given build job is run, and disposed of once that build job has completed.
+1. [Automatically managed credentials](/app-signing/managed-credentials/): EAS can host your app signing credentials and take care of sharing them with teammates that have the necessary permissions.
+2. [Local credentials](/app-signing/local-credentials/): You create a **credentials.json** file in your project that points to your keystore (Android) and/or provisioning profile and distribution certificate (iOS), along with associated passwords. This is uploaded from your local machine at the time any given build job is run, and disposed of once that build job has completed.
 
-Regardless of which option you choose, your first step for using your existing set of credentials is to set them up as local credentials in **credentials.json**. Refer to the [credentials.json section of the local credentials guide](local-credentials.mdx#credentialsjson) for more information on how to do this.
+Regardless of which option you choose, your first step for using your existing set of credentials is to set them up as local credentials in **credentials.json**. Refer to the [credentials.json section of the local credentials guide](/app-signing/local-credentials/#credentialsjson) for more information on how to do this.
 
-Once your **credentials.json** file is configured, you can run `eas credentials`, choose a platform, and then select `"Update credentials on Expo servers with values from credentials.json"` to upload them to be hosted and managed by EAS, if you would like. [Read more about syncing credentials](syncing-credentials.mdx).
+Once your **credentials.json** file is configured, you can run `eas credentials`, choose a platform, and then select `"Update credentials on Expo servers with values from credentials.json"` to upload them to be hosted and managed by EAS, if you would like. [Read more about syncing credentials](/app-signing/syncing-credentials/).

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -6,7 +6,7 @@ description: Learn how to configure and use local credentials when using EAS.
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-You can usually get away with not being a code signing expert by [letting EAS handle it for you](managed-credentials.mdx). However, there are cases where some users might want to manage their project keystore, certificates and profiles on their own.
+You can usually get away with not being a code signing expert by [letting EAS handle it for you](/app-signing/managed-credentials/). However, there are cases where some users might want to manage their project keystore, certificates and profiles on their own.
 
 If you would like to manage your own app signing credentials, you can use **credentials.json** to give EAS Build relative paths to the credentials on your local file system and their associated passwords to use them to sign your builds.
 
@@ -205,4 +205,4 @@ Consider the following steps:
 
 Similarly, you can encode your keystore, provisioning profile and distribution certificate so you can restore them later on the CI. To successfully trigger your build using local credentials from CI, you'll have to make sure all the credentials exist in the CI instance's file system (at the same locations as defined in **credentials.json**).
 
-Once the restoring steps are in place, you can use the same process described in the [Triggering builds from CI](/build/building-on-ci.mdx) guide to trigger the builds.
+Once the restoring steps are in place, you can use the same process described in the [Triggering builds from CI](/build/building-on-ci) guide to trigger the builds.

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -15,7 +15,7 @@ When you run `eas build`, you will be prompted to generate credentials if you ha
 
 Generating your iOS credentials (distribution certificate, provisioning profile, and push key) requires you to sign in with an [Apple Developer Program](https://developer.apple.com/programs) membership.
 
-> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, please refer to the ["Security"](/app-signing/security) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials.mdx) instead.
+> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, please refer to the ["Security"](/app-signing/security) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials/) instead.
 
 ### Push notification credentials
 
@@ -37,4 +37,4 @@ After you have generated your iOS credentials, it's no longer necessary to have 
 
 ## Inspecting credentials configuration
 
-You can view your currently configured app signing credentials by running `eas credentials`. This command also lets you remove and modify credentials, should you need to make any changes. Typically this is not necessary, but you may want to use it if you want to [sync your credentials to your local machine to run a build locally](syncing-credentials.mdx) or [migrate existing credentials to be automatically managed](existing-credentials.mdx).
+You can view your currently configured app signing credentials by running `eas credentials`. This command also lets you remove and modify credentials, should you need to make any changes. Typically this is not necessary, but you may want to use it if you want to [sync your credentials to your local machine to run a build locally](/app-signing/syncing-credentials/) or [migrate existing credentials to be automatically managed](/app-signing/existing-credentials/).

--- a/docs/pages/archive/classic-builds/turtle-cli.mdx
+++ b/docs/pages/archive/classic-builds/turtle-cli.mdx
@@ -2,13 +2,13 @@
 title: Building Standalone Apps on Your CI
 ---
 
-> This doc was archived in August 2022 and will not receive any further updates. SDK 46 is the last SDK supported by Classic Builds and the Classic Build service will stop running for all SDK versions after January 4, 2023. Check out [Running builds on your own infrastructure](/build-reference/local-builds.mdx) and [Triggering builds from CI](/build/building-on-ci.mdx).
+> This doc was archived in August 2022 and will not receive any further updates. SDK 46 is the last SDK supported by Classic Builds and the Classic Build service will stop running for all SDK versions after January 4, 2023. Check out [Running builds on your own infrastructure](/build-reference/local-builds) and [Triggering builds from CI](/build/building-on-ci).
 
 > **Note:** macOS is required to build standalone iOS apps.
 
 This guide describes an advanced feature of Expo. In most cases you can build
 standalone Expo apps using Expo's build services as described in the guide
-on [Building Standalone Apps](building-standalone-apps.mdx).
+on [Building Standalone Apps](/archive/classic-builds/building-standalone-apps/).
 
 If you prefer to not rely on our builders stability and you don't like waiting
 in the queue to get your standalone app build then you can build your Expo
@@ -67,8 +67,8 @@ Turtle CLI makes use of exactly the same codebase which is running on our server
 This means you're required to publish your app to Expo's servers or host it on your own server **before building it with Turtle CLI**.
 Whether you want Expo to host your app, or you'd like to do it yourself, all you need to do is follow the appropriate guide:
 
-- [Publishing an app to Expo's servers](/archive/classic-updates/publishing.mdx)
-- [Hosting an app on your own server](/distribution/custom-updates-server.mdx)
+- [Publishing an app to Expo's servers](/archive/classic-updates/publishing)
+- [Hosting an app on your own server](/versions/latest/sdk/updates/#manual-installation-configuration-and-custom-remote-update)
 
 ## Start the build
 
@@ -91,7 +91,7 @@ Before starting the build, prepare the following things:
 - Keystore alias
 - Keystore password and key password
 
-To learn how to generate those, see the guide on [Building Standalone Apps](building-standalone-apps.mdx)
+To learn how to generate those, see the guide on [Building Standalone Apps](/archive/classic-builds/building-standalone-apps/)
 first.
 
 Set the `EXPO_ANDROID_KEYSTORE_PASSWORD` and `EXPO_ANDROID_KEY_PASSWORD`
@@ -121,7 +121,7 @@ Prepare the following unless you're building only for the iOS Simulator:
 - Provisioning Profile
 
 To learn how to generate those, see the guide
-on [Building Standalone Apps](building-standalone-apps.mdx) first.
+on [Building Standalone Apps](/archive/classic-builds/building-standalone-apps/) first.
 
 Set the `EXPO_IOS_DIST_P12_PASSWORD` environment variable with the value of
 the Distribution Certificate password.

--- a/docs/pages/archive/classic-updates/advanced-release-channels.mdx
+++ b/docs/pages/archive/classic-updates/advanced-release-channels.mdx
@@ -6,7 +6,7 @@ title: Advanced release channels
 
 ## Introduction
 
-For a quick introduction to release channels, [read this](./release-channels.mdx).
+For a quick introduction to release channels, [read this](/archive/classic-updates/release-channels/).
 
 When you publish your app by running `expo publish --release-channel staging`, it creates:
 

--- a/docs/pages/archive/notification-channels.mdx
+++ b/docs/pages/archive/notification-channels.mdx
@@ -3,7 +3,7 @@ title: Notification Channels
 hideFromSearch: true
 ---
 
-> **warning** This page is archived. Please refer to the [Push Notifications guide](../../push-notifications/overview.mdx) for up-to-date information.
+> **warning** This page is archived. Please refer to the [Push Notifications guide](/push-notifications/overview/) for up-to-date information.
 
 Notification channels are a new feature in Android Oreo that give users more control over the notifications they receive. Starting in Android Oreo, every local and push notification must be assigned to a single channel. Users can see all notification channels in their OS Settings, and they can customize the behavior of alerts on a per-channel basis.
 

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -95,7 +95,7 @@ When using a remote app version source, the values in **app.json** will not be u
 
 The main goal of this feature is to avoid manual changes to the project every time you are uploading a new archive to run it on TestFlight/Play Store testing channels. When you are doing a production release, the user-facing version change should be explicit.
 
-We recommend updating `version` field after a new build goes live in the store, especially if you are using `expo-updates` with an automatic runtime version policy. This marks the beginning of a new development cycle for a new version of your app. [Learn more about deployment patterns](/eas-update/deployment-patterns.mdx).
+We recommend updating `version` field after a new build goes live in the store, especially if you are using `expo-updates` with an automatic runtime version policy. This marks the beginning of a new development cycle for a new version of your app. [Learn more about deployment patterns](/eas-update/deployment-patterns/).
 
 ## Local version source
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -130,7 +130,7 @@ You can verify that your project builds on your local machine with the `npx expo
   ]}
 />
 
-> If use [CNG](/workflow/continuous-native-generation.mdx), these commands will run `npx expo prebuild` to generate native projects to compile them.You likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting, unless you want to start managing these projects directly instead of generating them on demand.
+> If use [CNG](/workflow/continuous-native-generation/), these commands will run `npx expo prebuild` to generate native projects to compile them.You likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting, unless you want to start managing these projects directly instead of generating them on demand.
 >
 > <br />
 > You can alternatively run a local build with `eas build --local` &mdash; this command will run a

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -16,9 +16,9 @@ Before building with EAS on CI, we need to install and configure `eas-cli`. Then
 
 To trigger EAS builds from a CI environment, we first need to configure our app for EAS Build and successfully run a build from our local machine for each platform that we'd like to support on CI.
 
-If you have run `eas build -p [all|ios|android]` successfully before, then you can continue.
+If you have run `eas build -p [all|android|ios]` successfully before, then you can continue.
 
-If you haven't done this yet, see [Create your first build](setup.mdx) guide and return here when you're ready.
+If you haven't done this yet, see [Create your first build](/build/setup/) guide and return here when you're ready.
 
 ## Configure your app for CI
 

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -15,7 +15,7 @@ EAS Build can help you with this by providing shareable URLs for your builds wit
 
 ## Setting up internal distribution
 
-The following steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](setup.mdx). It will only take a few minutes in total to:
+The following steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](/build/setup/). It will only take a few minutes in total to:
 
 - Configure the project
 - Add a couple of test iOS devices to a provisioning profile

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -3,15 +3,15 @@ title: Use EAS Update
 description: Learn how to use EAS Update with EAS Build.
 ---
 
-EAS Build includes some special affordances for Expo's [`expo-updates`](/versions/latest/sdk/updates.mdx) library. In particular, you can configure the [`channel`](/eas-update/how-it-works/#distributing-builds) property in **eas.json** and EAS Build will take care of updating it in your native project at build time.
+EAS Build includes some special benefits for [`expo-updates`](/versions/latest/sdk/updates/) library. In particular, you can configure the [`channel`](/eas-update/how-it-works/#distributing-builds) property in **eas.json** and EAS Build will take care of updating it in your native project at build time.
 
-This document covers concerns specific to using `expo-updates` library with EAS Build. For more general information about configuring the library with EAS Update, see [Getting started with EAS Update ](/eas-update/getting-started).
+This document covers concerns specific to using `expo-updates` library with EAS Build. For more general information about configuring the library with EAS Update, see [Getting started with EAS Update ](/eas-update/getting-started/).
 
 ## Setting the channel for a build profile
 
-Each [build profile](./eas-json.mdx#build-profiles) can be assigned to a channel, so updates for builds produced for a given profile will pull only those releases that are published to its channel.
+Each [build profile](/build/eas-json/#build-profiles) can be assigned to a channel, so updates for builds produced for a given profile will pull only those releases that are published to its channel.
 
-The following example demonstrates how you might use the `"production"` channel for production builds, and the `"staging"` channel for test builds distributed with [internal distribution](internal-distribution.mdx).
+The following example demonstrates how you might use the `"production"` channel for production builds, and the `"staging"` channel for test builds distributed with [internal distribution](/build/internal-distribution/).
 
 ```json eas.json
 {
@@ -31,7 +31,7 @@ The following example demonstrates how you might use the `"production"` channel 
 
 Your native runtime may change on each build, depending on whether you modify the code in a way that changes the API contract with JavaScript. If you publish a JavaScript bundle to a binary with an incompatible native runtime (for example, a function that the JavaScript bundle expects to exist does not exist) then your app may not work as expected, or it may crash.
 
-We recommend using a different [runtime version](/distribution/runtime-versions.mdx) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
+We recommend using a different [runtime version](/distribution/runtime-versions/) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
 
 ## Previewing updates in development builds
 

--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -14,7 +14,7 @@ EAS Insights makes it easy to see the state of your app, providing information a
 
 ## Integration with EAS Update
 
-If you're already using [EAS Update](/eas-update/introduction.mdx), we provide certain high-level usage insights without any additional client-side changes. This is possible because by aggregating data from client requests to check for an update into a limited Insights view that shows usage over time, as well as usage broken down by platform.
+If you're already using [EAS Update](/eas-update/introduction/), we provide certain high-level usage insights without any additional client-side changes. This is possible because by aggregating data from client requests to check for an update into a limited Insights view that shows usage over time, as well as usage broken down by platform.
 
 ## Use the `expo-insights` library
 

--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -18,7 +18,7 @@ Besides the default JSON format, EAS Metadata also supports more dynamic config 
 The default store config type for EAS Metadata is a simple JSON file.
 The code snippet below shows an example store config with basic App Store information written in English (U.S.).
 
-You can find all configuration options in the [store config schema](./schema.mdx).
+You can find all configuration options in the [store config schema](/eas/metadata/schema/).
 
 > If you have the [VS Code Expo Tools extension](https://github.com/expo/vscode-expo#readme) installed, you get auto-complete, suggestions, and warnings for **store.config.json** files.
 
@@ -45,7 +45,7 @@ You can find all configuration options in the [store config schema](./schema.mdx
 
 At times, Metadata properties can benefit from dynamic values. For example, the Metadata **copyright notice** should contain the current year. This can be automated with EAS Metadata.
 
-To generate content dynamically, start by creating a JavaScript config file **store.config.js**. Then, use the [`metadataPath`](../../submit/eas-json.mdx#metadatapath) property in the **eas.json** file to pick the JS config file.
+To generate content dynamically, start by creating a JavaScript config file **store.config.js**. Then, use the [`metadataPath`](/eas/json/#metadatapath) property in the **eas.json** file to pick the JS config file.
 
 > `eas metadata:pull` can't update dynamic store config files. Instead, it creates a JSON file with the same name as the configured file. You can import the JSON file to reuse the data from `eas metadata:pull`.
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -50,11 +50,11 @@ If you don't have an app in the stores yet, EAS Metadata can't generate the stor
 
 ## Update the store config
 
-Now it's time to edit the **store.config.json** file and customize it to your app needs. You can find all available options in the [store config schema](./schema.mdx).
+Now it's time to edit the **store.config.json** file and customize it to your app needs. You can find all available options in the [store config schema](/eas/metadata/schema/).
 
 ## Upload a new app version
 
-Before pushing the **store.config.json** to the app stores, you must upload a new binary of your app. For more information, see [uploading new binaries to stores](../../submit/introduction.mdx).
+Before pushing the **store.config.json** to the app stores, you must upload a new binary of your app. For more information, see [uploading new binaries to stores](/submit/introduction/).
 
 After the binary is submitted and processed, we can push the store config to the app stores.
 

--- a/docs/pages/guides/sharing-preview-releases.mdx
+++ b/docs/pages/guides/sharing-preview-releases.mdx
@@ -27,7 +27,7 @@ You will need to know the UDID (Unique Device Identifier) of each device that wi
 with someone who is not a developer. Adding a new device will require a rebuild of your application.
 
 Setting up Ad Hoc certificates correctly can be intimidating if you haven't done it before, and tedious even if you have.
-If you're using [EAS Build](/build/internal-distribution.mdx), which is optimized for Expo and React Native projects, we'll handle the time-consuming parts
+If you're using [EAS Build](/build/internal-distribution/), which is optimized for Expo and React Native projects, we'll handle the time-consuming parts
 of setting up Ad Hoc credentials for you.
 
 ### iOS enterprise distribution
@@ -41,5 +41,5 @@ which requires your organization to be a legal entity and go through Apple's ver
 
 TestFlight is another option to distribute your application to iOS devices. TestFlight also requires a paid Apple Developer account,
 but allows you to share your application with up to 10,000 users that can be invited with their email or a public link.
-This method requires you to [upload your application](/submit/ios.mdx) to App Store Connect and wait for the automated review before you can share a build.
+This method requires you to [upload your application](/submit/ios) to App Store Connect and wait for the automated review before you can share a build.
 If you intend to ship new builds frequently, investing the time to set up Ad Hoc distribution will be worthwhile.

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -10,7 +10,7 @@ There are cases where you may want to integrate the Expo Modules API into an exi
 The following steps will set up your existing React Native library to access Expo Modules APIs.
 
 Create the [**expo-module.config.json**](/modules/module-config/) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
-The presence of the module config is enough for [Expo Autolinking](./autolinking.mdx) to recognize it as an Expo module and automatically link your native code.
+The presence of the module config is enough for [Expo Autolinking](/modules/autolinking/) to recognize it as an Expo module and automatically link your native code.
 
 ### Add the `expo-modules-core` native dependency
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -332,7 +332,7 @@ This command will be disabled if your project is configured to use `metro` for b
 
 <Terminal cmd={['$ npx expo prebuild']} />
 
-Native source code must be generated before a native app can compile. Expo CLI provides a unique and powerful system called _prebuild_, that generates the native code for your project. To learn more, read the [Expo Prebuild docs](/workflow/prebuild.mdx).
+Native source code must be generated before a native app can compile. Expo CLI provides a unique and powerful system called _prebuild_, that generates the native code for your project. To learn more, read the [Expo Prebuild docs](/workflow/prebuild/).
 
 ## Config
 

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -31,14 +31,14 @@ For more information, see [expo.fyi/first-android-submission](https://expo.fyi/f
 
 ## Build a standalone app
 
-You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction.mdx) or do it on your own.
+You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction/) or do it on your own.
 
 </Step>
 
 <Step label="2">
 ## Start the submission
 
-To submit the binary to the Play Store, run `eas submit -p android` from inside your project directory. The command will lead you step by step through the process of submitting the app. See the [Configuration with eas.json](./eas-json.mdx) page to learn how to pre-configure your submission.
+To submit the binary to the Play Store, run `eas submit -p android` from inside your project directory. The command will lead you step by step through the process of submitting the app. See the [Configuration with eas.json](/build/eas-json/) page to learn how to pre-configure your submission.
 
 > Although it's possible to upload any binary to the store, each submission is associated with an Expo project. That's why it's important to start a submission from inside your project's directory because [app config](/workflow/configuration) is defined inside that directory.
 
@@ -65,7 +65,7 @@ The command will perform the following steps:
 
 ## Submitting your app using CI
 
-The `eas submit` command can perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the Android package name is present in your [app config file](/workflow/configuration.mdx).
+The `eas submit` command can perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the Android package name is present in your [app config file](/workflow/configuration/).
 
 For Android submissions, you must provide the path to your Google Services JSON key using the `serviceAccountKeyPath` key in **eas.json**. You may also find the `track` and `releaseStatus` parameters useful.
 

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -19,7 +19,7 @@ This guide outlines how to submit your app to the Apple App Store from your own 
 <Step label="1">
 ## Build a standalone app
 
-You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction.mdx) or do it on your own.
+You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction/) or do it on your own.
 
 </Step>
 
@@ -27,7 +27,7 @@ You'll need a native app binary signed for store submission. You can either use 
 
 ## Start the submission
 
-To submit the binary to the App Store, run `eas submit -p ios` from inside your project directory. The command will lead you step by step through the process of submitting the app. See the [Configuration with eas.json](./eas-json.mdx) page to learn how to pre-configure your submission.
+To submit the binary to the App Store, run `eas submit -p ios` from inside your project directory. The command will lead you step by step through the process of submitting the app. See the [Configuration with eas.json](/build/eas-json/) page to learn how to pre-configure your submission.
 
 > Although it's possible to upload any binary to the store, each submission is associated with an Expo project. That's why it's important to start a submission from inside your project's directory because [app config](/workflow/configuration) is defined inside that directory.
 
@@ -79,7 +79,7 @@ The `eas submit` command is able to perform submissions from a CI environment. A
 You must do the following:
 
 - Provide the archive source (`--latest`, `--id`, `--path`, or `--url`).
-- Make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration.mdx).
+- Make sure that the iOS Bundle Identifier is present in your [app config file](/workflow/configuration/).
 - Set the ASC App ID (`ascAppId` in **eas.json**). The ASC App ID is required to skip the Apple Developer log-in process, which will likely not be possible on CI due to the 2FA prompt.
 - Set up your App Store Connect API Key with EAS Servers. You can check the state of your credentials by running `eas credentials` or by running `eas submit -p ios` interactively.
 

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -54,7 +54,7 @@ A conformant client library MUST make a GET request with the headers:
 
 A conformant client library MAY send one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` based on the [supported response structures](#response), though it SHOULD send `accept: application/expo+json, application/json, multipart/mixed`. A conformant client library MAY express preference using "q" parameters as specified in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1), which default to `1`.
 
-A conformant client library configured to perform [code signing](#code-signing) verification MUST send a `expo-expect-signature` header to indicate that it expects the conformant server to include the `expo-signature` header in the manifest response. `expo-expect-signature` is an [Expo SFV](expo-sfv-0.mdx) dictionary which MAY contain any of the following key value pairs:
+A conformant client library configured to perform [code signing](#code-signing) verification MUST send a `expo-expect-signature` header to indicate that it expects the conformant server to include the `expo-signature` header in the manifest response. `expo-expect-signature` is an [Expo SFV](/technical-specs/expo-sfv-0/) dictionary which MAY contain any of the following key value pairs:
 
 - `sig` SHOULD contain the boolean `true` to indicate that it requires a conformant server to respond with the signature in the `sig` key.
 - `keyid` SHOULD contain the keyId of the public key the client will use to verify the signature
@@ -93,8 +93,8 @@ content-type: *
 
 - `expo-protocol-version` describes the version of the protocol defined in this spec and MUST be `1`.
 - `expo-sfv-version` MUST be `0`.
-- `expo-manifest-filters` is an [Expo SFV](expo-sfv-0.mdx) dictionary. It is used to filter updates stored by the client library by the `metadata` attribute found in the [manifest](#manifest-body). If a field is mentioned in the filter, the corresponding field in the metadata must either be missing or equal for the update to be included. The client library MUST store the manifest filters until it is overwritten by a newer response.
-- `expo-server-defined-headers` is an [Expo SFV](expo-sfv-0.mdx) dictionary. It defines headers that a client library MUST store until overwritten by a newer dictionary, and they MUST be included in every subsequent [update request](#request).
+- `expo-manifest-filters` is an [Expo SFV](/technical-specs/expo-sfv-0/) dictionary. It is used to filter updates stored by the client library by the `metadata` attribute found in the [manifest](#manifest-body). If a field is mentioned in the filter, the corresponding field in the metadata must either be missing or equal for the update to be included. The client library MUST store the manifest filters until it is overwritten by a newer response.
+- `expo-server-defined-headers` is an [Expo SFV](/technical-specs/expo-sfv-0/) dictionary. It defines headers that a client library MUST store until overwritten by a newer dictionary, and they MUST be included in every subsequent [update request](#request).
 - `cache-control` MUST be set to an appropriately short period of time. A value of `cache-control: private, max-age=0` is recommended to ensure the newest manifest is returned. Setting longer cache ages could result in stale updates.
 - `content-type` MUST be determined by _proactive negotiation_ as defined in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.4.1). Since the client library is [required](#request) to send an `accept` header with each manifest request, this will always be either `application/expo+json`, `application/json`; otherwise the request would return a `406` error.
 
@@ -104,7 +104,7 @@ content-type: *
 expo-signature: *
 ```
 
-- `expo-signature` SHOULD contain the signature of the manifest to be used during the validation step of [code signing](#code-signing) if the request for the manifest contained the `expo-expect-signature` header. This is an [Expo SFV](expo-sfv-0.mdx) dictionary which MAY contain any of the following key value pairs:
+- `expo-signature` SHOULD contain the signature of the manifest to be used during the validation step of [code signing](#code-signing) if the request for the manifest contained the `expo-expect-signature` header. This is an [Expo SFV](/technical-specs/expo-sfv-0/) dictionary which MAY contain any of the following key value pairs:
   - `sig` MUST contain the signature of the manifest. The name of this field matches that of `expo-expect-signature`.
   - `keyid` MAY contain the keyId of the key the server used to sign the response. The client SHOULD use the certificate that matches this `keyid` to verify the signature.
   - `alg` MAY contain the algorithm the server used to sign the response. The client SHOULD use this field only if it matches the algorithm defined for the certificate matching `keyid`.

--- a/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
+++ b/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
@@ -5,7 +5,7 @@ description: Learn how to clear the bundler cache when using Yarn or npm with Ex
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> Need to clear development caches on Windows? [Find the relevant commands here.](clear-cache-windows.mdx)
+> Need to clear development caches on Windows? [Find the relevant commands here.](/troubleshooting/clear-cache-windows/)
 
 There are a number of different caches associated with your project that can prevent your project from running as intended. Clearing a cache sometimes can help you work around issues related to stale or corrupt data and is often useful when troubleshooting and debugging.
 

--- a/docs/pages/troubleshooting/clear-cache-windows.mdx
+++ b/docs/pages/troubleshooting/clear-cache-windows.mdx
@@ -5,7 +5,7 @@ description: Learn how to clear the bundler cache when using Yarn or npm with Ex
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> Need to clear development caches on macOS or Linux? [Find the relevant commands here.](clear-cache-macos-linux.mdx)
+> Need to clear development caches on macOS or Linux? [Find the relevant commands here.](/troubleshooting/clear-cache-macos-linux/)
 
 There are a number of different caches associated with your project that can prevent your project from running as intended. Clearing a cache sometimes can help you work around issues related to stale or corrupt data and is often useful when troubleshooting and debugging.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Many internal links are used with `.mdx` suffix in the URL path. This PR updates those links to use the actual URL path instead of referencing `.mdx`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and test internal links are working properly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
