### PR TITLE
[core] Implement JSON serializer for shared objects

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageSharedRefScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageSharedRefScreen.tsx
@@ -11,21 +11,6 @@ function getRandomImageUri(): string {
   return `https://picsum.photos/seed/${seed}/3000/2000`;
 }
 
-// Shared objects' properties are defined in the prototype, thus they're not picked by `JSON.stringify`.
-// In this screen we show the contents of the image object, so `toJSON` needs to be overridden to include prototype's properties.
-// TODO: We may want to override this globally for all shared objects. Keep it here for now until we decide what to do.
-// @ts-expect-error
-Image.Image.prototype.toJSON = function () {
-  const json: Record<string, any> = {};
-
-  for (const key in this) {
-    if (typeof (this as any)[key] !== 'function') {
-      json[key] = (this as any)[key];
-    }
-  }
-  return json;
-};
-
 export default function ImageSharedRefScreen() {
   const [imageRef, setImageRef] = useState<ImageRef | null>(null);
   const [sourceUri, setSourceUri] = useState<string>(getRandomImageUri());

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [Android] Supported returning of the `SharedObject` from functions. ([#30426](https://github.com/expo/expo/pull/30426) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Support implementing `customizeRootView` in `ExpoAppDelegateSubscriber`. ([#30550](https://github.com/expo/expo/pull/30550) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
-- Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain.
+- Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Supported returning of the `SharedObject` from functions. ([#30426](https://github.com/expo/expo/pull/30426) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Support implementing `customizeRootView` in `ExpoAppDelegateSubscriber`. ([#30550](https://github.com/expo/expo/pull/30550) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
+- Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain.
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

Shared objects' properties are defined in their prototype, not on its instance. Thus, `JSON.stringify` doesn't include those properties. The console should be printing these properties as well.

# How

Added `toJSON` function that `JSON.stringify` calls under the hood to get the JSON-representable object. Instead of including only object's own properties, our implementation also includes enumerable properties in the prototype chain.

# Test Plan

I removed the JS implementation that I previously mocked in one of the expo-image example and the object (image) is still correctly serialized to JSON.