### PR TITLE
[docs] Table: refactor to Tailwind, small appearance tweaks

### DIFF
--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -1,3 +1,4 @@
+import { createSerializer } from '@emotion/jest';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { render, RenderOptions } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
@@ -27,4 +28,8 @@ export function renderWithTestRouter(element: ReactElement, router: Partial<Next
   return render(
     <RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>
   );
+}
+
+export function attachEmotionSerializer(expect: any) {
+  expect.addSnapshotSerializer(createSerializer({ includeStyles: false }));
 }

--- a/docs/components/DocumentationSidebarRight.test.tsx
+++ b/docs/components/DocumentationSidebarRight.test.tsx
@@ -3,8 +3,10 @@ import GithubSlugger from 'github-slugger';
 import DocumentationSidebarRight from './DocumentationSidebarRight';
 
 import { HeadingManager, HeadingType } from '~/common/headingManager';
-import { renderWithHeadings } from '~/common/test-utilities';
+import { attachEmotionSerializer, renderWithHeadings } from '~/common/test-utilities';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
+
+attachEmotionSerializer(expect);
 
 const prepareHeadingManager = () => {
   const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <p
-      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
+      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 emotion-0"
       data-text="true"
     >
       <svg
@@ -67,7 +67,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#base-level-heading"
     >
       <p
-        class="w-full !text-secondary hocus:!text-link css-1yjys1n-TextComponent"
+        class="w-full !text-secondary hocus:!text-link emotion-1"
         data-text="true"
       >
         Base level heading
@@ -80,7 +80,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       style="padding-left: 12px;"
     >
       <p
-        class="w-full !text-secondary hocus:!text-link css-1yjys1n-TextComponent"
+        class="w-full !text-secondary hocus:!text-link emotion-1"
         data-text="true"
       >
         Level 3 subheading
@@ -93,7 +93,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       style="padding-left: 12px;"
     >
       <code
-        class="w-full !text-secondary hocus:!text-link truncate !text-2xs css-yszm2s-TextComponent"
+        class="w-full !text-secondary hocus:!text-link truncate !text-2xs emotion-3"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -4,9 +4,11 @@ import { createRequire } from 'node:module';
 
 import APISection from './APISection';
 
-import { renderWithHeadings } from '~/common/test-utilities';
+import { attachEmotionSerializer, renderWithHeadings } from '~/common/test-utilities';
 
 const require = createRequire(import.meta.url);
+
+attachEmotionSerializer(expect);
 
 describe('APISection', () => {
   test('no data', () => {

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -43,10 +43,10 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-18kpoqz-APISectionComponents"
+    class="!shadow-none emotion-1"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -58,7 +58,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -91,24 +91,24 @@ exports[`APISection expo-apple-authentication 1`] = `
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       <span
-        class="css-1ibdfwu-TextComponent"
+        class="emotion-5"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="css-ite7ne-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         React.Element
         &lt;
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationbuttonprops"
         >
           AppleAuthenticationButtonProps
@@ -117,7 +117,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -128,16 +128,16 @@ available via the provided properties.
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       You should only attempt to render this if 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationisavailableasync"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -146,7 +146,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         true
@@ -154,7 +154,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         __DEV__ === true
@@ -164,12 +164,12 @@ a warning in development mode (
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         View
@@ -177,21 +177,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         style
@@ -199,7 +199,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         buttonStyle
@@ -207,7 +207,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         cornerRadius
@@ -218,14 +218,14 @@ button.
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -251,20 +251,20 @@ not appear on the screen.
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             See:
           </strong>
            
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
             rel="noopener noreferrer"
             target="_blank"
@@ -279,11 +279,11 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="!text-secondary !font-medium css-19qci8h-BoxSectionHeader"
+        class="!text-secondary !font-medium emotion-27"
         data-text="true"
       >
         <span
-          class="group css-11zd19b-TextComponent"
+          class="group emotion-28"
           data-text="true"
         >
           <a
@@ -328,10 +328,10 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-29"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-2"
           data-heading="true"
         >
           <a
@@ -343,7 +343,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-31"
                 data-text="true"
               >
                 buttonStyle
@@ -376,7 +376,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -386,11 +386,11 @@ for more details.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationbuttonstyle"
             >
               AppleAuthenticationButtonStyle
@@ -398,17 +398,17 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-29"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-2"
           data-heading="true"
         >
           <a
@@ -420,7 +420,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-31"
                 data-text="true"
               >
                 buttonType
@@ -453,7 +453,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -463,11 +463,11 @@ for more details.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationbuttontype"
             >
               AppleAuthenticationButtonType
@@ -475,17 +475,17 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-29"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-2"
           data-heading="true"
         >
           <a
@@ -497,7 +497,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-31"
                 data-text="true"
               >
                 cornerRadius
@@ -530,7 +530,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -545,20 +545,20 @@ for more details.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             number
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             style.borderRadius
@@ -567,10 +567,10 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-29"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-2"
           data-heading="true"
         >
           <a
@@ -582,7 +582,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-31"
                 data-text="true"
               >
                 onPress
@@ -615,7 +615,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -625,7 +625,7 @@ for more details.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             <span
@@ -643,16 +643,16 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="#appleauthenticationisavailableasync"
           >
             <code
-              class="css-qyuze8-TextComponent"
+              class="emotion-11"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -663,10 +663,10 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-29"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-2"
           data-heading="true"
         >
           <a
@@ -678,7 +678,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-31"
                 data-text="true"
               >
                 style
@@ -711,7 +711,7 @@ in here.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -726,7 +726,7 @@ in here.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             StyleProp
@@ -737,7 +737,7 @@ in here.
             </span>
             <span>
               <a
-                class="css-1na8e0o-A"
+                class="emotion-7"
                 href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -751,7 +751,7 @@ in here.
               </span>
               <span>
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="https://reactnative.dev/docs/view-style-props"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -791,19 +791,19 @@ in here.
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             borderRadius
@@ -813,7 +813,7 @@ properties.
         </p>
       </div>
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -853,18 +853,18 @@ properties.
         </a>
       </h4>
       <ul
-        class="css-118jp6n-TextComponent"
+        class="emotion-69"
       >
         <li
-          class="css-1hxzfrf-TextComponent"
+          class="emotion-70"
           data-text="true"
         >
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://reactnative.dev/docs/view#props"
               rel="noopener noreferrer"
               target="_blank"
@@ -877,7 +877,7 @@ properties.
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -917,10 +917,10 @@ properties.
     </a>
   </h2>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -932,7 +932,7 @@ properties.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -1001,7 +1001,7 @@ properties.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 user
               </strong>
@@ -1010,7 +1010,7 @@ properties.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -1020,17 +1020,17 @@ properties.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
 This should come from the user field of an 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="css-qyuze8-TextComponent"
+                    class="emotion-11"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1045,7 +1045,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1053,7 +1053,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -1079,16 +1079,16 @@ This should come from the user field of an
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         
 
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             Note:
           </strong>
@@ -1125,22 +1125,22 @@ This should come from the user field of an
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1154,7 +1154,7 @@ This should come from the user field of an
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationcredentialstate"
             >
               AppleAuthenticationCredentialState
@@ -1172,16 +1172,16 @@ This should come from the user field of an
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationcredentialstate"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -1193,10 +1193,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -1208,7 +1208,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             isAvailableAsync()
@@ -1241,7 +1241,7 @@ value depending on the state of the credential.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
@@ -1273,22 +1273,22 @@ value depending on the state of the credential.
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1315,19 +1315,19 @@ value depending on the state of the credential.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A promise that fulfills with 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           false
@@ -1337,10 +1337,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -1352,7 +1352,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             refreshAsync(options)
@@ -1421,7 +1421,7 @@ value depending on the state of the credential.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 options
               </strong>
@@ -1430,11 +1430,11 @@ value depending on the state of the credential.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationrefreshoptions"
                 >
                   AppleAuthenticationRefreshOptions
@@ -1445,16 +1445,16 @@ value depending on the state of the credential.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="css-qyuze8-TextComponent"
+                    class="emotion-11"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1469,7 +1469,7 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1502,22 +1502,22 @@ Calling this method will show the sign in modal before actually refreshing the u
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1531,7 +1531,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1549,16 +1549,16 @@ Calling this method will show the sign in modal before actually refreshing the u
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationcredential"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1567,7 +1567,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1578,10 +1578,10 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -1593,7 +1593,7 @@ refresh operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             signInAsync(options)
@@ -1662,7 +1662,7 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 options
               </strong>
@@ -1677,11 +1677,11 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationsigninoptions"
                 >
                   AppleAuthenticationSignInOptions
@@ -1692,16 +1692,16 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An optional 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="css-qyuze8-TextComponent"
+                    class="emotion-11"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1716,7 +1716,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1725,7 +1725,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1735,14 +1735,14 @@ of these options at runtime.
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
 into your app, so you must store it for later use. It's best to store this information either
 server-side, or using 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="./securestore"
       >
         SecureStore
@@ -1750,11 +1750,11 @@ server-side, or using
       , so that the data persists across app installs.
 You can use 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -1790,22 +1790,22 @@ the user, since this remains the same for apps released by the same developer.
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1819,7 +1819,7 @@ the user, since this remains the same for apps released by the same developer.
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1837,16 +1837,16 @@ the user, since this remains the same for apps released by the same developer.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationcredential"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1855,7 +1855,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1866,10 +1866,10 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -1881,7 +1881,7 @@ sign-in operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             signOutAsync(options)
@@ -1950,7 +1950,7 @@ sign-in operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 options
               </strong>
@@ -1959,11 +1959,11 @@ sign-in operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationsignoutoptions"
                 >
                   AppleAuthenticationSignOutOptions
@@ -1974,16 +1974,16 @@ sign-in operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="css-qyuze8-TextComponent"
+                    class="emotion-11"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -1998,7 +1998,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -2007,18 +2007,18 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
 Instead of using this method it is recommended to simply clear all the user's data collected
 from using 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="./#signinasync"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           signInAsync
@@ -2026,11 +2026,11 @@ from using
       </a>
        or 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="./#refreshasync"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           refreshAsync
@@ -2065,22 +2065,22 @@ from using
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -2094,7 +2094,7 @@ from using
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -2112,16 +2112,16 @@ from using
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationcredential"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2130,7 +2130,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2141,7 +2141,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -2181,10 +2181,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-74"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -2196,7 +2196,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-76"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2260,7 +2260,7 @@ sign-out operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 listener
               </strong>
@@ -2269,7 +2269,7 @@ sign-out operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span
@@ -2313,18 +2313,18 @@ sign-out operation.
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-87"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-88"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-6"
           data-text="true"
         >
           EventSubscription
@@ -2333,7 +2333,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -2373,10 +2373,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -2388,7 +2388,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2421,16 +2421,16 @@ sign-out operation.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       The object type returned from a successful call to 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2439,11 +2439,11 @@ sign-out operation.
       ,
 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2451,11 +2451,11 @@ sign-out operation.
       </a>
       , or 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2465,7 +2465,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -2491,20 +2491,20 @@ which contains all of the pertinent user and credential information.
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             See:
           </strong>
            
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
             rel="noopener noreferrer"
             target="_blank"
@@ -2554,7 +2554,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 authorizationCode
               </strong>
@@ -2563,7 +2563,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -2583,13 +2583,13 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   user
@@ -2605,7 +2605,7 @@ the app's server counterpart. Unlike
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 email
               </strong>
@@ -2614,7 +2614,7 @@ the app's server counterpart. Unlike
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -2634,12 +2634,12 @@ the app's server counterpart. Unlike
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   EMAIL
@@ -2658,7 +2658,7 @@ an Apple domain.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 fullName
               </strong>
@@ -2667,12 +2667,12 @@ an Apple domain.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
                   <a
-                    class="css-1na8e0o-A"
+                    class="emotion-7"
                     href="#appleauthenticationfullname"
                   >
                     AppleAuthenticationFullName
@@ -2692,26 +2692,26 @@ an Apple domain.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The user's name. May be 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   FULL_NAME
@@ -2729,7 +2729,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 identityToken
               </strong>
@@ -2738,7 +2738,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -2758,7 +2758,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -2772,7 +2772,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 realUserStatus
               </strong>
@@ -2781,11 +2781,11 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationuserdetectionstatus"
                 >
                   AppleAuthenticationUserDetectionStatus
@@ -2796,7 +2796,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -2810,7 +2810,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 state
               </strong>
@@ -2819,7 +2819,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -2839,12 +2839,12 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   state
@@ -2853,7 +2853,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   state
@@ -2861,7 +2861,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
@@ -2877,7 +2877,7 @@ will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 user
               </strong>
@@ -2886,7 +2886,7 @@ will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -2896,7 +2896,7 @@ will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -2911,10 +2911,10 @@ developers.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -2926,7 +2926,7 @@ developers.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -2959,13 +2959,13 @@ developers.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-11"
         data-text="true"
       >
         null
@@ -3009,7 +3009,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 familyName
               </strong>
@@ -3018,7 +3018,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3051,7 +3051,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 givenName
               </strong>
@@ -3060,7 +3060,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3093,7 +3093,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 middleName
               </strong>
@@ -3102,7 +3102,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3135,7 +3135,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 namePrefix
               </strong>
@@ -3144,7 +3144,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3177,7 +3177,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 nameSuffix
               </strong>
@@ -3186,7 +3186,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3219,7 +3219,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 nickname
               </strong>
@@ -3228,7 +3228,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <span>
@@ -3259,10 +3259,10 @@ may be
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -3274,7 +3274,7 @@ may be
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3307,16 +3307,16 @@ may be
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3326,7 +3326,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -3352,20 +3352,20 @@ You must include the ID string of the user whose credentials you'd like to refre
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             See:
           </strong>
            
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3415,7 +3415,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 requestedScopes
               </strong>
@@ -3430,11 +3430,11 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3446,14 +3446,14 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
@@ -3462,14 +3462,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   []
@@ -3485,7 +3485,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 state
               </strong>
@@ -3500,7 +3500,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -3510,7 +3510,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3518,7 +3518,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3536,7 +3536,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 user
               </strong>
@@ -3545,7 +3545,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -3566,10 +3566,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -3581,7 +3581,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3614,16 +3614,16 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -3633,7 +3633,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -3659,20 +3659,20 @@ None of these options are required.
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             See:
           </strong>
            
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3722,7 +3722,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 nonce
               </strong>
@@ -3737,7 +3737,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -3747,13 +3747,13 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3771,7 +3771,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 requestedScopes
               </strong>
@@ -3786,11 +3786,11 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3802,14 +3802,14 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
@@ -3818,14 +3818,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-11"
                   data-text="true"
                 >
                   []
@@ -3841,7 +3841,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 state
               </strong>
@@ -3856,7 +3856,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -3866,7 +3866,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3874,7 +3874,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3890,10 +3890,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -3905,7 +3905,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -3938,16 +3938,16 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="css-1na8e0o-A"
+        class="emotion-7"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-11"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -3957,7 +3957,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
       data-testid="callout-container"
     >
       <div
@@ -3983,20 +3983,20 @@ You must include the ID string of the user to sign out.
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 css-mt3buo-Callout"
+        class="text-default w-full last:mb-0 emotion-23"
       >
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <strong
-            class="css-bvflvn-TextComponent"
+            class="emotion-25"
           >
             See:
           </strong>
            
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -4046,7 +4046,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 state
               </strong>
@@ -4061,7 +4061,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -4071,7 +4071,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4079,7 +4079,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -4097,7 +4097,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 user
               </strong>
@@ -4106,7 +4106,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-6"
                 data-text="true"
               >
                 string
@@ -4127,10 +4127,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-183"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -4142,7 +4142,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-3"
             data-text="true"
           >
             Subscription
@@ -4175,7 +4175,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -4217,7 +4217,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-25"
               >
                 remove
               </strong>
@@ -4226,7 +4226,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="emotion-6"
                 data-text="true"
               >
                 <span
@@ -4247,7 +4247,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -4260,7 +4260,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -4300,13 +4300,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -4318,7 +4318,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationButtonStyle
@@ -4351,16 +4351,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationbutton"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4369,11 +4369,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationButtonStyle Values
@@ -4384,7 +4384,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4396,7 +4396,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               WHITE
@@ -4429,13 +4429,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         White button with black text.
@@ -4445,7 +4445,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4457,7 +4457,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               WHITE_OUTLINE
@@ -4490,13 +4490,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4506,7 +4506,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4518,7 +4518,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               BLACK
@@ -4551,13 +4551,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Black button with white text.
@@ -4565,13 +4565,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -4583,7 +4583,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationButtonType
@@ -4616,16 +4616,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationbutton"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4634,11 +4634,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationButtonType Values
@@ -4649,7 +4649,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4661,7 +4661,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               SIGN_IN
@@ -4694,13 +4694,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4710,7 +4710,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4722,7 +4722,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               CONTINUE
@@ -4755,13 +4755,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         "Continue with Apple"
@@ -4774,18 +4774,18 @@ After calling this function, the listener will no longer receive any events from
         class="flex flex-row items-center mb-2"
       >
         <span
-          class="inline-flex items-center css-1yjys1n-TextComponent"
+          class="inline-flex items-center emotion-88"
           data-text="true"
         >
           <span
-            class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
+            class="!text-inherit !font-medium emotion-5"
             data-text="true"
           >
             Only for:
              
           </span>
           <div
-            class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none css-1e5tu91-PlatformTag"
+            class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-359"
           >
             <svg
               class="opacity-80 icon-xs text-palette-blue12"
@@ -4805,7 +4805,7 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="css-103dp5g-PlatformTag"
+              class="emotion-360"
             >
               iOS 13.2+
             </span>
@@ -4814,7 +4814,7 @@ After calling this function, the listener will no longer receive any events from
         </span>
       </div>
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -4826,7 +4826,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               SIGN_UP
@@ -4859,13 +4859,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         "Sign up with Apple"
@@ -4873,13 +4873,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -4891,7 +4891,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationCredentialState
@@ -4924,16 +4924,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -4942,7 +4942,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
         data-testid="callout-container"
       >
         <div
@@ -4968,20 +4968,20 @@ After calling this function, the listener will no longer receive any events from
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-23"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             <strong
-              class="css-bvflvn-TextComponent"
+              class="emotion-25"
             >
               See:
             </strong>
              
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
               rel="noopener noreferrer"
               target="_blank"
@@ -4995,11 +4995,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationCredentialState Values
@@ -5010,7 +5010,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5022,7 +5022,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               REVOKED
@@ -5055,7 +5055,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5065,7 +5065,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5077,7 +5077,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               AUTHORIZED
@@ -5110,7 +5110,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5120,7 +5120,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5132,7 +5132,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               NOT_FOUND
@@ -5165,7 +5165,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5175,7 +5175,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5187,7 +5187,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               TRANSFERRED
@@ -5220,7 +5220,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5228,13 +5228,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -5246,7 +5246,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationOperation
@@ -5279,11 +5279,11 @@ for more details.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationOperation Values
@@ -5294,7 +5294,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5306,7 +5306,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               IMPLICIT
@@ -5339,13 +5339,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5355,7 +5355,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5367,7 +5367,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               LOGIN
@@ -5400,7 +5400,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5410,7 +5410,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5422,7 +5422,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               REFRESH
@@ -5455,7 +5455,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5465,7 +5465,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5477,7 +5477,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               LOGOUT
@@ -5510,7 +5510,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5518,13 +5518,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -5536,7 +5536,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationScope
@@ -5569,16 +5569,16 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -5589,7 +5589,7 @@ for more details.
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-22"
         data-testid="callout-container"
       >
         <div
@@ -5615,12 +5615,12 @@ for more details.
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-23"
         >
           
 
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -5631,7 +5631,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
         data-testid="callout-container"
       >
         <div
@@ -5657,20 +5657,20 @@ You will still need to handle null values for any fields you request.
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-23"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             <strong
-              class="css-bvflvn-TextComponent"
+              class="emotion-25"
             >
               See:
             </strong>
              
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
               rel="noopener noreferrer"
               target="_blank"
@@ -5684,11 +5684,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationScope Values
@@ -5699,7 +5699,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5711,7 +5711,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               FULL_NAME
@@ -5744,7 +5744,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -5754,7 +5754,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5766,7 +5766,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               EMAIL
@@ -5799,7 +5799,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -5807,13 +5807,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-321"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -5825,7 +5825,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-3"
               data-text="true"
             >
               AppleAuthenticationUserDetectionStatus
@@ -5858,13 +5858,13 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 emotion-22"
         data-testid="callout-container"
       >
         <div
@@ -5890,20 +5890,20 @@ for more details.
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-23"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             <strong
-              class="css-bvflvn-TextComponent"
+              class="emotion-25"
             >
               See:
             </strong>
              
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
               rel="noopener noreferrer"
               target="_blank"
@@ -5917,11 +5917,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-27"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-87"
           data-text="true"
         >
           AppleAuthenticationUserDetectionStatus Values
@@ -5932,7 +5932,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -5944,7 +5944,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               UNSUPPORTED
@@ -5977,13 +5977,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -5993,7 +5993,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -6005,7 +6005,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               UNKNOWN
@@ -6038,13 +6038,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6054,7 +6054,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-68"
         data-heading="true"
       >
         <a
@@ -6066,7 +6066,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-330"
               data-text="true"
             >
               LIKELY_REAL
@@ -6099,13 +6099,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-331"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6118,7 +6118,7 @@ for more details.
 exports[`APISection expo-barcode-scanner 1`] = `
 <div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -6158,13 +6158,13 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-18kpoqz-APISectionComponents"
+    class="!shadow-none emotion-1"
   >
     <div
       class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
     >
       <blockquote
-        class="flex gap-2 rounded-md py-3 px-4 mb-4 [&_p]:!mb-0 [table_&]:last-of-type:mb-2.5 pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4 css-16xozm6-Callout"
+        class="flex gap-2 rounded-md py-3 px-4 mb-4 [&_p]:!mb-0 [table_&]:last-of-type:mb-2.5 pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4 emotion-2"
         data-testid="callout-container"
       >
         <div
@@ -6190,20 +6190,20 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-3"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             <strong
-              class="css-bvflvn-TextComponent"
+              class="emotion-5"
             >
               Deprecated
             </strong>
              BarCodeScanner has been deprecated and will be removed in a future SDK version. Use 
             <code
-              class="css-qyuze8-TextComponent"
+              class="emotion-6"
               data-text="true"
             >
               expo-camera
@@ -6211,21 +6211,21 @@ exports[`APISection expo-barcode-scanner 1`] = `
              instead.
 See 
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://expo.fyi/barcode-scanner-to-expo-camera"
               rel="noopener noreferrer"
               target="_blank"
             >
               How to migrate from 
               <code
-                class="css-qyuze8-TextComponent"
+                class="emotion-6"
                 data-text="true"
               >
                 expo-barcode-scanner
               </code>
                to 
               <code
-                class="css-qyuze8-TextComponent"
+                class="emotion-6"
                 data-text="true"
               >
                 expo-camera
@@ -6238,7 +6238,7 @@ for more details.
       </blockquote>
     </div>
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -6250,7 +6250,7 @@ for more details.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-11"
             data-text="true"
           >
             BarCodeScanner
@@ -6283,18 +6283,18 @@ for more details.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       <span
-        class="css-1ibdfwu-TextComponent"
+        class="emotion-13"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="css-ite7ne-TextComponent"
+        class="emotion-14"
         data-text="true"
       >
         React.
@@ -6306,7 +6306,7 @@ for more details.
         </span>
         <span>
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="#barcodescannerprops"
           >
             BarCodeScannerProps
@@ -6321,11 +6321,11 @@ for more details.
     </p>
     <div>
       <p
-        class="!text-secondary !font-medium css-19qci8h-BoxSectionHeader"
+        class="!text-secondary !font-medium emotion-16"
         data-text="true"
       >
         <span
-          class="group css-11zd19b-TextComponent"
+          class="group emotion-17"
           data-text="true"
         >
           <a
@@ -6370,10 +6370,10 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-18"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-10"
           data-heading="true"
         >
           <a
@@ -6385,7 +6385,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-20"
                 data-text="true"
               >
                 barCodeTypes
@@ -6418,7 +6418,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -6433,19 +6433,19 @@ for more details.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-14"
             data-text="true"
           >
             string[]
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           An array of bar code types. Usage: 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
@@ -6453,14 +6453,14 @@ for more details.
            where
 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             codeType
           </code>
            is one of these 
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="#supported-formats"
           >
             listed above
@@ -6472,12 +6472,12 @@ minimize battery usage.
         
 
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           For example: 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
@@ -6486,10 +6486,10 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-18"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-10"
           data-heading="true"
         >
           <a
@@ -6501,7 +6501,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-20"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6534,7 +6534,7 @@ minimize battery usage.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -6549,11 +6549,11 @@ minimize battery usage.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-14"
             data-text="true"
           >
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#barcodescannedcallback"
             >
               BarCodeScannedCallback
@@ -6561,13 +6561,13 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
 provided with an 
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="#barcodescannerresult"
           >
             BarCodeScannerResult
@@ -6577,7 +6577,7 @@ provided with an
         
 
         <blockquote
-          class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+          class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-37"
           data-testid="callout-container"
         >
           <div
@@ -6603,29 +6603,29 @@ provided with an
             </svg>
           </div>
           <div
-            class="text-default w-full last:mb-0 css-mt3buo-Callout"
+            class="text-default w-full last:mb-0 emotion-3"
           >
             
 
             <p
-              class="mb-3.5 css-1kfqm4n-TextComponent"
+              class="mb-3.5 emotion-4"
               data-text="true"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 Note:
               </strong>
                Passing 
               <code
-                class="css-qyuze8-TextComponent"
+                class="emotion-6"
                 data-text="true"
               >
                 undefined
               </code>
                to the 
               <code
-                class="css-qyuze8-TextComponent"
+                class="emotion-6"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6640,10 +6640,10 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-18"
       >
         <h3
-          class="group css-eynke-TextComponent"
+          class="group emotion-10"
           data-heading="true"
         >
           <a
@@ -6655,7 +6655,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-831ndn-APISectionProps"
+                class="wrap-anywhere emotion-20"
                 data-text="true"
               >
                 type
@@ -6688,7 +6688,7 @@ data has been retrieved.
           </a>
         </h3>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           <span
@@ -6703,7 +6703,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-14"
             data-text="true"
           >
             <span>
@@ -6734,7 +6734,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="css-ite7ne-TextComponent"
+              class="emotion-14"
               data-text="true"
             >
               Type.back
@@ -6742,26 +6742,26 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-4"
           data-text="true"
         >
           Camera facing. Use one of 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             Type.front
           </code>
            or 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             Type.back
@@ -6769,7 +6769,7 @@ data has been retrieved.
           .
 Same as 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             Camera.Constants.Type
@@ -6778,7 +6778,7 @@ Same as
         </p>
       </div>
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-54"
         data-heading="true"
       >
         <a
@@ -6818,18 +6818,18 @@ Same as
         </a>
       </h4>
       <ul
-        class="css-118jp6n-TextComponent"
+        class="emotion-55"
       >
         <li
-          class="css-1hxzfrf-TextComponent"
+          class="emotion-56"
           data-text="true"
         >
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-14"
             data-text="true"
           >
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="https://reactnative.dev/docs/view#props"
               rel="noopener noreferrer"
               target="_blank"
@@ -6842,7 +6842,7 @@ Same as
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -6882,10 +6882,10 @@ Same as
     </a>
   </h2>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-60"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -6897,7 +6897,7 @@ Same as
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-62"
             data-text="true"
           >
             usePermissions(options)
@@ -6961,7 +6961,7 @@ Same as
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 options
               </strong>
@@ -6976,11 +6976,11 @@ Same as
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#permissionhookoptions"
                 >
                   PermissionHookOptions
@@ -7006,20 +7006,20 @@ Same as
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Check or request permissions for the barcode scanner.
 This uses both 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         requestPermissionAsync
       </code>
        and 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         getPermissionsAsync
@@ -7053,18 +7053,18 @@ This uses both
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-69"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-70"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-14"
           data-text="true"
         >
           [
@@ -7079,7 +7079,7 @@ This uses both
             </span>
             <span>
               <a
-                class="css-1na8e0o-A"
+                class="emotion-7"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7096,7 +7096,7 @@ This uses both
             </span>
             <span>
               <a
-                class="css-1na8e0o-A"
+                class="emotion-7"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7118,7 +7118,7 @@ This uses both
             </span>
             <span>
               <a
-                class="css-1na8e0o-A"
+                class="emotion-7"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7138,11 +7138,11 @@ This uses both
       class="mb-3.5 last:[&>*]:mb-0"
     >
       <p
-        class="!mt-1 css-19qci8h-BoxSectionHeader"
+        class="!mt-1 emotion-16"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-69"
           data-text="true"
         >
           <svg
@@ -7169,11 +7169,11 @@ This uses both
         </span>
       </p>
       <pre
-        class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+        class="relative max-h-[unset] last:mb-0 emotion-77"
         data-text="true"
       >
         <code
-          class="css-19nqa8l-Code"
+          class="emotion-78"
         >
           <span
             class="token keyword"
@@ -7237,7 +7237,7 @@ This uses both
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -7277,10 +7277,10 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-60"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -7292,7 +7292,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-62"
             data-text="true"
           >
             BarCodeScanner.getPermissionsAsync()
@@ -7325,7 +7325,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
@@ -7357,22 +7357,22 @@ This uses both
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-69"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-70"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-14"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7386,7 +7386,7 @@ This uses both
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -7404,16 +7404,16 @@ This uses both
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#permissionresponse"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             PermissionResponse
@@ -7424,10 +7424,10 @@ This uses both
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-60"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -7439,7 +7439,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-62"
             data-text="true"
           >
             BarCodeScanner.requestPermissionsAsync()
@@ -7472,7 +7472,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
@@ -7480,19 +7480,19 @@ This uses both
     
 
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         Info.plist
@@ -7526,22 +7526,22 @@ This uses both
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-69"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-70"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-14"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7555,7 +7555,7 @@ This uses both
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -7573,16 +7573,16 @@ This uses both
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#permissionresponse"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-6"
             data-text="true"
           >
             PermissionResponse
@@ -7593,10 +7593,10 @@ This uses both
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-60"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -7608,7 +7608,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-62"
             data-text="true"
           >
             BarCodeScanner.scanFromURLAsync(url, barCodeTypes)
@@ -7677,7 +7677,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 url
               </strong>
@@ -7686,7 +7686,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 string
@@ -7696,7 +7696,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 URL to get the image from.
@@ -7710,7 +7710,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 barCodeTypes
               </strong>
@@ -7725,7 +7725,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 string[]
@@ -7735,7 +7735,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 An array of bar code types. Defaults to all supported bar code types on
@@ -7744,7 +7744,7 @@ the platform.
               
 
               <blockquote
-                class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+                class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-37"
                 data-testid="callout-container"
               >
                 <div
@@ -7770,16 +7770,16 @@ the platform.
                   </svg>
                 </div>
                 <div
-                  class="text-default w-full last:mb-0 css-mt3buo-Callout"
+                  class="text-default w-full last:mb-0 emotion-3"
                 >
                   
 
                   <p
-                    class="mb-3.5 css-1kfqm4n-TextComponent"
+                    class="mb-3.5 emotion-4"
                     data-text="true"
                   >
                     <strong
-                      class="css-bvflvn-TextComponent"
+                      class="emotion-5"
                     >
                       Note:
                     </strong>
@@ -7796,7 +7796,7 @@ the platform.
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
@@ -7828,22 +7828,22 @@ the platform.
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-69"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-70"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-14"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-7"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7857,7 +7857,7 @@ the platform.
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-7"
               href="#barcodescannerresult"
             >
               BarCodeScannerResult
@@ -7876,12 +7876,12 @@ the platform.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         A possibly empty array of objects of the 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-6"
           data-text="true"
         >
           BarCodeScannerResult
@@ -7893,7 +7893,7 @@ code.
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -7933,10 +7933,10 @@ code.
     </a>
   </h2>
   <div
-    class="css-ztgmkf-APISectionInterfaces"
+    class="emotion-129"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -7948,7 +7948,7 @@ code.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-11"
             data-text="true"
           >
             PermissionResponse
@@ -7981,17 +7981,17 @@ code.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-19qci8h-BoxSectionHeader"
+      class="emotion-16"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        class="text-inherit flex flex-row gap-2 items-center emotion-69"
         data-text="true"
       >
         PermissionResponse Properties
@@ -8034,7 +8034,7 @@ code.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 canAskAgain
               </strong>
@@ -8043,7 +8043,7 @@ code.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 boolean
@@ -8053,7 +8053,7 @@ code.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -8069,7 +8069,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 expires
               </strong>
@@ -8078,11 +8078,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#permissionexpiration"
                 >
                   PermissionExpiration
@@ -8093,7 +8093,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -8107,7 +8107,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 granted
               </strong>
@@ -8116,7 +8116,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 boolean
@@ -8126,7 +8126,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -8140,7 +8140,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 status
               </strong>
@@ -8149,11 +8149,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#permissionstatus"
                 >
                   PermissionStatus
@@ -8164,7 +8164,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -8177,7 +8177,7 @@ in order to enable/disable the permission.
     <br />
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -8217,10 +8217,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8232,7 +8232,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodeBounds
@@ -8301,7 +8301,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 origin
               </strong>
@@ -8310,11 +8310,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodepoint"
                 >
                   BarCodePoint
@@ -8325,7 +8325,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The origin point of the bounding box.
@@ -8339,7 +8339,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 size
               </strong>
@@ -8348,11 +8348,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodesize"
                 >
                   BarCodeSize
@@ -8363,7 +8363,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The size of the bounding box.
@@ -8375,10 +8375,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8390,7 +8390,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-11"
             data-text="true"
           >
             BarCodeEvent
@@ -8423,22 +8423,22 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-1yjys1n-TextComponent"
+      class="emotion-70"
       data-text="true"
     >
       <span
-        class="css-1mm9j88-TextComponent"
+        class="emotion-69"
         data-text="true"
       >
         Type:
          
       </span>
       <code
-        class="text-default css-ite7ne-TextComponent"
+        class="text-default emotion-14"
         data-text="true"
       >
         <a
-          class="css-1na8e0o-A"
+          class="emotion-7"
           href="#barcodescannerresult"
         >
           BarCodeScannerResult
@@ -8446,7 +8446,7 @@ in order to enable/disable the permission.
       </code>
        
       <span
-        class="css-1ac5bb0-TextComponent"
+        class="emotion-168"
         data-text="true"
       >
         extended by
@@ -8491,7 +8491,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 target
               </strong>
@@ -8506,7 +8506,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 number
@@ -8527,10 +8527,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8542,7 +8542,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -8611,7 +8611,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 nativeEvent
               </strong>
@@ -8620,11 +8620,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodeevent"
                 >
                   BarCodeEvent
@@ -8646,10 +8646,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8661,7 +8661,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodePoint
@@ -8694,7 +8694,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -8737,7 +8737,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 x
               </strong>
@@ -8746,7 +8746,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 number
@@ -8756,12 +8756,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   x
@@ -8777,7 +8777,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 y
               </strong>
@@ -8786,7 +8786,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 number
@@ -8796,12 +8796,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   y
@@ -8815,10 +8815,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8830,7 +8830,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -8896,7 +8896,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <strong
-                  class="css-bvflvn-TextComponent"
+                  class="emotion-5"
                 >
                   params
                 </strong>
@@ -8905,11 +8905,11 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
-                  class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                  class="[&>span]:!text-inherit emotion-14"
                   data-text="true"
                 >
                   <a
-                    class="css-1na8e0o-A"
+                    class="emotion-7"
                     href="#barcodeevent"
                   >
                     BarCodeEvent
@@ -8923,10 +8923,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -8938,7 +8938,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodeScannerResult
@@ -9007,7 +9007,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 bounds
               </strong>
@@ -9016,11 +9016,11 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodebounds"
                 >
                   BarCodeBounds
@@ -9031,12 +9031,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodebounds"
                 >
                   BarCodeBounds
@@ -9044,7 +9044,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  object.
 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   bounds
@@ -9052,7 +9052,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  in some case will be representing an empty rectangle.
 Moreover, 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   bounds
@@ -9069,7 +9069,7 @@ For some types, they will represent the area used by the scanner.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 cornerPoints
               </strong>
@@ -9078,11 +9078,11 @@ For some types, they will represent the area used by the scanner.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-7"
                   href="#barcodepoint"
                 >
                   BarCodePoint
@@ -9094,27 +9094,27 @@ For some types, they will represent the area used by the scanner.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Corner points of the bounding box.
 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   cornerPoints
                 </code>
                  is not always available and may be empty. On iOS, for 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   code39
                 </code>
                  and 
                 <code
-                  class="css-qyuze8-TextComponent"
+                  class="emotion-6"
                   data-text="true"
                 >
                   pdf417
@@ -9131,7 +9131,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 data
               </strong>
@@ -9140,7 +9140,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 string
@@ -9150,7 +9150,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The parsed information encoded in the bar code.
@@ -9164,7 +9164,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 type
               </strong>
@@ -9173,7 +9173,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 string
@@ -9183,7 +9183,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The barcode type.
@@ -9195,10 +9195,10 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -9210,7 +9210,7 @@ you don't get this value.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-11"
             data-text="true"
           >
             BarCodeSize
@@ -9279,7 +9279,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 height
               </strong>
@@ -9288,7 +9288,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 number
@@ -9298,7 +9298,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The height value.
@@ -9312,7 +9312,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-5"
               >
                 width
               </strong>
@@ -9321,7 +9321,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-14"
                 data-text="true"
               >
                 number
@@ -9331,7 +9331,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 The width value.
@@ -9343,10 +9343,10 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-150"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-10"
       data-heading="true"
     >
       <a
@@ -9358,7 +9358,7 @@ you don't get this value.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-11"
             data-text="true"
           >
             PermissionHookOptions
@@ -9391,11 +9391,11 @@ you don't get this value.
       </a>
     </h3>
     <p
-      class="mb-3 css-1yjys1n-TextComponent"
+      class="mb-3 emotion-70"
       data-text="true"
     >
       <span
-        class="css-1mm9j88-TextComponent"
+        class="emotion-69"
         data-text="true"
       >
         Literal Type:
@@ -9404,11 +9404,11 @@ you don't get this value.
       multiple types
     </p>
     <p
-      class="css-1yjys1n-TextComponent"
+      class="emotion-70"
       data-text="true"
     >
       <span
-        class="css-1mm9j88-TextComponent"
+        class="emotion-69"
         data-text="true"
       >
         Acceptable values are:
@@ -9416,13 +9416,13 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-14"
           data-text="true"
         >
           PermissionHookBehavior
         </code>
         <span
-          class="css-1hmnf1v-TextComponent"
+          class="emotion-235"
           data-text="true"
         >
            | 
@@ -9430,7 +9430,7 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-14"
           data-text="true"
         >
           Options
@@ -9439,7 +9439,7 @@ you don't get this value.
     </p>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -9479,13 +9479,13 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-238"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-10"
         data-heading="true"
       >
         <a
@@ -9497,7 +9497,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-11"
               data-text="true"
             >
               PermissionStatus
@@ -9530,11 +9530,11 @@ you don't get this value.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-16"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-69"
           data-text="true"
         >
           PermissionStatus Values
@@ -9545,7 +9545,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-54"
         data-heading="true"
       >
         <a
@@ -9557,7 +9557,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-244"
               data-text="true"
             >
               DENIED
@@ -9590,13 +9590,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-245"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User has denied the permission.
@@ -9606,7 +9606,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-54"
         data-heading="true"
       >
         <a
@@ -9618,7 +9618,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-244"
               data-text="true"
             >
               GRANTED
@@ -9651,13 +9651,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-245"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User has granted the permission.
@@ -9667,7 +9667,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-54"
         data-heading="true"
       >
         <a
@@ -9679,7 +9679,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-244"
               data-text="true"
             >
               UNDETERMINED
@@ -9712,13 +9712,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-245"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -9731,7 +9731,7 @@ you don't get this value.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -9771,10 +9771,10 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-1"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -9786,7 +9786,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             getPermissionsAsync()
@@ -9819,7 +9819,7 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
@@ -9851,22 +9851,22 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-5"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-7"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-8"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -9880,7 +9880,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-8"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -9896,24 +9896,24 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-1"
   >
     <div
       class="flex flex-row items-center mb-2"
     >
       <span
-        class="inline-flex items-center css-1yjys1n-TextComponent"
+        class="inline-flex items-center emotion-6"
         data-text="true"
       >
         <span
-          class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
+          class="!text-inherit !font-medium emotion-12"
           data-text="true"
         >
           Only for:
            
         </span>
         <div
-          class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none css-1e5tu91-PlatformTag"
+          class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-13"
         >
           <svg
             class="opacity-80 icon-xs text-palette-blue12"
@@ -9933,7 +9933,7 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="css-103dp5g-PlatformTag"
+            class="emotion-14"
           >
             iOS
           </span>
@@ -9942,7 +9942,7 @@ exports[`APISection expo-pedometer 1`] = `
       </span>
     </div>
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -9954,7 +9954,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -10023,7 +10023,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 start
               </strong>
@@ -10032,11 +10032,11 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -10049,7 +10049,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -10063,7 +10063,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 end
               </strong>
@@ -10072,11 +10072,11 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -10089,7 +10089,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -10101,7 +10101,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Get the step count between two dates.
@@ -10133,22 +10133,22 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-5"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-7"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-8"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10162,7 +10162,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-8"
               href="#pedometerresult"
             >
               PedometerResult
@@ -10180,16 +10180,16 @@ exports[`APISection expo-pedometer 1`] = `
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-8"
           href="#pedometerresult"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-33"
             data-text="true"
           >
             PedometerResult
@@ -10200,12 +10200,12 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         As 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-8"
           href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
           rel="noopener noreferrer"
           target="_blank"
@@ -10217,7 +10217,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-36"
         data-testid="callout-container"
       >
         <div
@@ -10243,12 +10243,12 @@ exports[`APISection expo-pedometer 1`] = `
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-37"
         >
           
 
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -10261,10 +10261,10 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-1"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -10276,7 +10276,7 @@ a start date that is more than seven days in the past returns only the available
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             isAvailableAsync()
@@ -10309,7 +10309,7 @@ a start date that is more than seven days in the past returns only the available
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
@@ -10341,22 +10341,22 @@ a start date that is more than seven days in the past returns only the available
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-5"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-7"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-8"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10383,12 +10383,12 @@ a start date that is more than seven days in the past returns only the available
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-33"
           data-text="true"
         >
           boolean
@@ -10399,10 +10399,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-1"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -10414,7 +10414,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -10447,7 +10447,7 @@ available on this device.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
@@ -10479,22 +10479,22 @@ available on this device.
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-5"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-7"
           data-text="true"
         >
           <a
-            class="css-1na8e0o-A"
+            class="emotion-8"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10508,7 +10508,7 @@ available on this device.
           </span>
           <span>
             <a
-              class="css-1na8e0o-A"
+              class="emotion-8"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -10524,10 +10524,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-1q9cex2-APISectionMethods"
+    class="emotion-1"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -10539,7 +10539,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-s0csg4-TextComponent"
+            class="wrap-anywhere emotion-3"
             data-text="true"
           >
             watchStepCount(callback)
@@ -10608,7 +10608,7 @@ available on this device.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 callback
               </strong>
@@ -10617,11 +10617,11 @@ available on this device.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="#pedometerupdatecallback"
                 >
                   PedometerUpdateCallback
@@ -10632,17 +10632,17 @@ available on this device.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
 provided with a single argument that is 
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="#pedometerresult"
                 >
                   <code
-                    class="css-qyuze8-TextComponent"
+                    class="emotion-33"
                     data-text="true"
                   >
                     PedometerResult
@@ -10657,7 +10657,7 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Subscribe to pedometer updates.
@@ -10689,18 +10689,18 @@ provided with a single argument that is
           </g>
         </svg>
         <span
-          class="css-1mm9j88-TextComponent"
+          class="emotion-5"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="css-1yjys1n-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit emotion-7"
           data-text="true"
         >
           EventSubscription
@@ -10711,16 +10711,16 @@ provided with a single argument that is
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         Returns a 
         <a
-          class="css-1na8e0o-A"
+          class="emotion-8"
           href="#subscription"
         >
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-33"
             data-text="true"
           >
             Subscription
@@ -10729,7 +10729,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="css-qyuze8-TextComponent"
+          class="emotion-33"
           data-text="true"
         >
           remove()
@@ -10739,7 +10739,7 @@ provided with a single argument that is
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 emotion-36"
         data-testid="callout-container"
       >
         <div
@@ -10765,24 +10765,24 @@ provided with a single argument that is
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 css-mt3buo-Callout"
+          class="text-default w-full last:mb-0 emotion-37"
         >
           
 
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-4"
             data-text="true"
           >
             Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
 
             <a
-              class="css-1na8e0o-A"
+              class="emotion-8"
               href="https://developer.android.com/health-and-fitness/guides/health-connect"
               rel="noopener noreferrer"
               target="_blank"
             >
               <code
-                class="css-qyuze8-TextComponent"
+                class="emotion-33"
                 data-text="true"
               >
                 Health Connect API
@@ -10791,7 +10791,7 @@ provided with a single argument that is
             .
 On iOS, the 
             <code
-              class="css-qyuze8-TextComponent"
+              class="emotion-33"
               data-text="true"
             >
               getStepCountAsync
@@ -10805,7 +10805,7 @@ On iOS, the
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -10845,10 +10845,10 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-ztgmkf-APISectionInterfaces"
+    class="emotion-82"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -10860,7 +10860,7 @@ On iOS, the
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-84"
             data-text="true"
           >
             PermissionResponse
@@ -10893,17 +10893,17 @@ On iOS, the
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-19qci8h-BoxSectionHeader"
+      class="emotion-86"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        class="text-inherit flex flex-row gap-2 items-center emotion-5"
         data-text="true"
       >
         PermissionResponse Properties
@@ -10946,7 +10946,7 @@ On iOS, the
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 canAskAgain
               </strong>
@@ -10955,7 +10955,7 @@ On iOS, the
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 boolean
@@ -10965,7 +10965,7 @@ On iOS, the
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -10981,7 +10981,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 expires
               </strong>
@@ -10990,11 +10990,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="#permissionexpiration"
                 >
                   PermissionExpiration
@@ -11005,7 +11005,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -11019,7 +11019,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 granted
               </strong>
@@ -11028,7 +11028,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 boolean
@@ -11038,7 +11038,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -11052,7 +11052,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 status
               </strong>
@@ -11061,11 +11061,11 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 <a
-                  class="css-1na8e0o-A"
+                  class="emotion-8"
                   href="#permissionstatus"
                 >
                   PermissionStatus
@@ -11076,7 +11076,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -11089,7 +11089,7 @@ in order to enable/disable the permission.
     <br />
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -11129,10 +11129,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-176db5m"
+    class="emotion-103"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -11144,7 +11144,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-84"
             data-text="true"
           >
             PedometerResult
@@ -11213,7 +11213,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 steps
               </strong>
@@ -11222,7 +11222,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit emotion-7"
                 data-text="true"
               >
                 number
@@ -11232,7 +11232,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -11244,10 +11244,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-103"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -11259,7 +11259,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-84"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11293,7 +11293,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Callback function providing event result as an argument.
@@ -11331,7 +11331,7 @@ in order to enable/disable the permission.
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <strong
-                  class="css-bvflvn-TextComponent"
+                  class="emotion-17"
                 >
                   result
                 </strong>
@@ -11340,11 +11340,11 @@ in order to enable/disable the permission.
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
-                  class="[&>span]:!text-inherit css-ite7ne-TextComponent"
+                  class="[&>span]:!text-inherit emotion-7"
                   data-text="true"
                 >
                   <a
-                    class="css-1na8e0o-A"
+                    class="emotion-8"
                     href="#pedometerresult"
                   >
                     PedometerResult
@@ -11358,10 +11358,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-103"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -11373,7 +11373,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="wrap-anywhere emotion-84"
             data-text="true"
           >
             PermissionExpiration
@@ -11406,11 +11406,11 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3 css-1yjys1n-TextComponent"
+      class="mb-3 emotion-6"
       data-text="true"
     >
       <span
-        class="css-1mm9j88-TextComponent"
+        class="emotion-5"
         data-text="true"
       >
         Literal Type:
@@ -11419,17 +11419,17 @@ in order to enable/disable the permission.
       multiple types
     </p>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="css-1yjys1n-TextComponent"
+      class="emotion-6"
       data-text="true"
     >
       <span
-        class="css-1mm9j88-TextComponent"
+        class="emotion-5"
         data-text="true"
       >
         Acceptable values are:
@@ -11437,13 +11437,13 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-7"
           data-text="true"
         >
           'never'
         </code>
         <span
-          class="css-1hmnf1v-TextComponent"
+          class="emotion-125"
           data-text="true"
         >
            | 
@@ -11451,7 +11451,7 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-7"
           data-text="true"
         >
           number
@@ -11460,10 +11460,10 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-176db5m"
+    class="emotion-103"
   >
     <h3
-      class="group css-eynke-TextComponent"
+      class="group emotion-2"
       data-heading="true"
     >
       <a
@@ -11475,7 +11475,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="emotion-84"
             data-text="true"
           >
             Subscription
@@ -11508,7 +11508,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 css-1kfqm4n-TextComponent"
+      class="mb-3.5 emotion-4"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -11550,7 +11550,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
-                class="css-bvflvn-TextComponent"
+                class="emotion-17"
               >
                 remove
               </strong>
@@ -11559,7 +11559,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="emotion-7"
                 data-text="true"
               >
                 <span
@@ -11580,7 +11580,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 css-1kfqm4n-TextComponent"
+                class="mb-3.5 emotion-4"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -11593,7 +11593,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="group css-5ipfcq-TextComponent"
+    class="group emotion-0"
     data-heading="true"
   >
     <a
@@ -11633,13 +11633,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-e9fasf-APISectionEnum"
+    class="!p-0 emotion-135"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group css-eynke-TextComponent"
+        class="group emotion-2"
         data-heading="true"
       >
         <a
@@ -11651,7 +11651,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere css-yd3r23-TextComponent"
+              class="wrap-anywhere emotion-84"
               data-text="true"
             >
               PermissionStatus
@@ -11684,11 +11684,11 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
+        class="!mb-0 !border-b-0 emotion-86"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          class="text-inherit flex flex-row gap-2 items-center emotion-5"
           data-text="true"
         >
           PermissionStatus Values
@@ -11699,7 +11699,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-140"
         data-heading="true"
       >
         <a
@@ -11711,7 +11711,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-141"
               data-text="true"
             >
               DENIED
@@ -11744,13 +11744,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-142"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User has denied the permission.
@@ -11760,7 +11760,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-140"
         data-heading="true"
       >
         <a
@@ -11772,7 +11772,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-141"
               data-text="true"
             >
               GRANTED
@@ -11805,13 +11805,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-142"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User has granted the permission.
@@ -11821,7 +11821,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group css-iu1hy2-TextComponent"
+        class="group emotion-140"
         data-heading="true"
       >
         <a
@@ -11833,7 +11833,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit css-yszm2s-TextComponent"
+              class="!text-inherit emotion-141"
               data-text="true"
             >
               UNDETERMINED
@@ -11866,13 +11866,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 css-fmaglm-TextComponent"
+        class="mb-3 emotion-142"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-4"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -11885,7 +11885,7 @@ After calling this function, the listener will no longer receive any events from
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="css-1kfqm4n-TextComponent"
+    class="emotion-0"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="emotion-74"
+    class="emotion-29"
   >
     <h3
       class="group emotion-2"
@@ -2373,7 +2373,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -2911,7 +2911,7 @@ developers.
     </div>
   </div>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -3259,7 +3259,7 @@ may be
     </div>
   </div>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -3566,7 +3566,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -3890,7 +3890,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -4127,7 +4127,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-183"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -4300,7 +4300,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -4565,7 +4565,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -4873,7 +4873,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -5228,7 +5228,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -5518,7 +5518,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -5807,7 +5807,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-321"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="emotion-60"
+    class="emotion-18"
   >
     <h3
       class="group emotion-10"
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="emotion-60"
+    class="emotion-18"
   >
     <h3
       class="group emotion-10"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="emotion-60"
+    class="emotion-18"
   >
     <h3
       class="group emotion-10"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="emotion-60"
+    class="emotion-18"
   >
     <h3
       class="group emotion-10"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="emotion-129"
+    class="emotion-18"
   >
     <h3
       class="group emotion-10"
@@ -8217,7 +8217,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -8527,7 +8527,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -8646,7 +8646,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -8815,7 +8815,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -8923,7 +8923,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -9195,7 +9195,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="emotion-150"
+    class="emotion-1"
   >
     <h3
       class="group emotion-10"
@@ -9479,7 +9479,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 emotion-238"
+    class="!p-0 emotion-1"
   >
     <div
       class="px-5 pt-4"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="emotion-82"
+    class="emotion-1"
   >
     <h3
       class="group emotion-2"
@@ -11633,7 +11633,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 emotion-135"
+    class="!p-0 emotion-103"
   >
     <div
       class="px-5 pt-4"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-7sex76"
+    class="!shadow-none css-18kpoqz-APISectionComponents"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -328,7 +328,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -343,7 +343,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 buttonStyle
@@ -405,7 +405,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -420,7 +420,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 buttonType
@@ -482,7 +482,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -497,7 +497,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 cornerRadius
@@ -567,7 +567,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -582,7 +582,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 onPress
@@ -663,7 +663,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -678,7 +678,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 style
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -965,29 +965,29 @@ properties.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -995,10 +995,10 @@ properties.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -1007,7 +1007,7 @@ properties.
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -1017,7 +1017,7 @@ properties.
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1385,29 +1385,29 @@ value depending on the state of the credential.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -1415,10 +1415,10 @@ value depending on the state of the credential.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -1427,7 +1427,7 @@ value depending on the state of the credential.
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -1442,7 +1442,7 @@ value depending on the state of the credential.
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1626,29 +1626,29 @@ refresh operation.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -1656,10 +1656,10 @@ refresh operation.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -1674,7 +1674,7 @@ refresh operation.
               </span>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -1689,7 +1689,7 @@ refresh operation.
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1914,29 +1914,29 @@ sign-in operation.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -1944,10 +1944,10 @@ sign-in operation.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -1956,7 +1956,7 @@ sign-in operation.
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -1971,7 +1971,7 @@ sign-in operation.
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2229,24 +2229,24 @@ sign-out operation.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
@@ -2254,10 +2254,10 @@ sign-out operation.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2266,7 +2266,7 @@ sign-out operation.
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2373,14 +2373,14 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationcredential"
         id="appleauthenticationcredential"
       >
@@ -2388,7 +2388,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2518,29 +2518,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -2548,10 +2548,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2560,7 +2560,7 @@ for more details.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2580,7 +2580,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2599,10 +2599,10 @@ the app's server counterpart. Unlike
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2611,7 +2611,7 @@ the app's server counterpart. Unlike
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2631,7 +2631,7 @@ the app's server counterpart. Unlike
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2652,10 +2652,10 @@ an Apple domain.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2664,7 +2664,7 @@ an Apple domain.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2689,7 +2689,7 @@ an Apple domain.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2723,10 +2723,10 @@ your app.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2735,7 +2735,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2755,7 +2755,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2766,10 +2766,10 @@ your app.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2778,7 +2778,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2793,7 +2793,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2804,10 +2804,10 @@ your app.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2816,7 +2816,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2836,7 +2836,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2871,10 +2871,10 @@ will be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -2883,7 +2883,7 @@ will be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -2893,7 +2893,7 @@ will be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -2911,14 +2911,14 @@ developers.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationfullname"
         id="appleauthenticationfullname"
       >
@@ -2926,7 +2926,7 @@ developers.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -2973,29 +2973,29 @@ may be
       . Only applicable fields that the user has allowed your app to access will be nonnull.
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -3003,10 +3003,10 @@ may be
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3015,7 +3015,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3035,7 +3035,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3045,10 +3045,10 @@ may be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3057,7 +3057,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3077,7 +3077,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3087,10 +3087,10 @@ may be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3099,7 +3099,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3119,7 +3119,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3129,10 +3129,10 @@ may be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3141,7 +3141,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3161,7 +3161,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3171,10 +3171,10 @@ may be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3183,7 +3183,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3203,7 +3203,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3213,10 +3213,10 @@ may be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3225,7 +3225,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3245,7 +3245,7 @@ may be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3259,14 +3259,14 @@ may be
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationrefreshoptions"
         id="appleauthenticationrefreshoptions"
       >
@@ -3274,7 +3274,7 @@ may be
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3379,29 +3379,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -3409,10 +3409,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3427,7 +3427,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3443,7 +3443,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3479,10 +3479,10 @@ requests they will be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3497,7 +3497,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3507,7 +3507,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3530,10 +3530,10 @@ OAuth 2.0 protocol
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3542,7 +3542,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3552,7 +3552,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3566,14 +3566,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationsigninoptions"
         id="appleauthenticationsigninoptions"
       >
@@ -3581,7 +3581,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3686,29 +3686,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -3716,10 +3716,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3734,7 +3734,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3744,7 +3744,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3765,10 +3765,10 @@ for more details.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3783,7 +3783,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3799,7 +3799,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3835,10 +3835,10 @@ requests they will be
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -3853,7 +3853,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -3863,7 +3863,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3890,14 +3890,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationsignoutoptions"
         id="appleauthenticationsignoutoptions"
       >
@@ -3905,7 +3905,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -4010,29 +4010,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -4040,10 +4040,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -4058,7 +4058,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -4068,7 +4068,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -4091,10 +4091,10 @@ OAuth 2.0 protocol
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -4103,7 +4103,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -4113,7 +4113,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -4127,14 +4127,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -4142,7 +4142,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             Subscription
@@ -4181,29 +4181,29 @@ OAuth 2.0 protocol
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -4211,10 +4211,10 @@ OAuth 2.0 protocol
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -4223,7 +4223,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="css-ite7ne-TextComponent"
@@ -4244,7 +4244,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -4300,7 +4300,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4565,7 +4565,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4873,7 +4873,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5228,7 +5228,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5518,7 +5518,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5807,7 +5807,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -6158,7 +6158,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-7sex76"
+    class="!shadow-none css-18kpoqz-APISectionComponents"
   >
     <div
       class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
@@ -6370,7 +6370,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6385,7 +6385,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 barCodeTypes
@@ -6486,7 +6486,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6501,7 +6501,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6640,7 +6640,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qoy1vb-APISectionProps"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6655,7 +6655,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-1odgxmq-TextComponent"
+                class="wrap-anywhere css-831ndn-APISectionProps"
                 data-text="true"
               >
                 type
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -6930,24 +6930,24 @@ Same as
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
@@ -6955,10 +6955,10 @@ Same as
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -6973,7 +6973,7 @@ Same as
               </span>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7641,29 +7641,29 @@ This uses both
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -7671,10 +7671,10 @@ This uses both
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -7683,7 +7683,7 @@ This uses both
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -7693,7 +7693,7 @@ This uses both
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -7704,10 +7704,10 @@ This uses both
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -7722,7 +7722,7 @@ This uses both
               </span>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -7732,7 +7732,7 @@ This uses both
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-ztgmkf-APISectionInterfaces"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7998,29 +7998,29 @@ code.
       </span>
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -8028,10 +8028,10 @@ code.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8040,7 +8040,7 @@ code.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8050,7 +8050,7 @@ code.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8063,10 +8063,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8075,7 +8075,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8090,7 +8090,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8101,10 +8101,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8113,7 +8113,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8123,7 +8123,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8134,10 +8134,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8146,7 +8146,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8161,7 +8161,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8217,14 +8217,14 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodebounds"
         id="barcodebounds"
       >
@@ -8232,7 +8232,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeBounds
@@ -8265,29 +8265,29 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -8295,10 +8295,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8307,7 +8307,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8322,7 +8322,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8333,10 +8333,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8345,7 +8345,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8360,7 +8360,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8455,29 +8455,29 @@ in order to enable/disable the permission.
     </p>
     <br />
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -8485,10 +8485,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8503,7 +8503,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8513,7 +8513,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -8527,14 +8527,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodeeventcallbackarguments"
         id="barcodeeventcallbackarguments"
       >
@@ -8542,7 +8542,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -8575,29 +8575,29 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -8605,10 +8605,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8617,7 +8617,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8632,7 +8632,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -8646,14 +8646,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodepoint"
         id="barcodepoint"
       >
@@ -8661,7 +8661,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodePoint
@@ -8701,29 +8701,29 @@ in order to enable/disable the permission.
 are using the barcode scanner view, these values are adjusted to the dimensions of the view).
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -8731,10 +8731,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8743,7 +8743,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8753,7 +8753,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8771,10 +8771,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -8783,7 +8783,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8793,7 +8793,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -8815,14 +8815,14 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodescannedcallback"
         id="barcodescannedcallback"
       >
@@ -8830,7 +8830,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -8865,24 +8865,24 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </h3>
     <div>
       <div
-        class="table-wrapper css-1uyflf8-Table"
+        class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
       >
         <table
-          class="css-e41t9x-Table"
+          class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
-            class="bg-subtle border-b border-b-default border-solid"
+            class="bg-subtle border-b border-b-default"
           >
             <tr
-              class="css-190f936-Row"
+              class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <th
-                class="css-17s7rsv-HeaderCell"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
               >
                 Name
               </th>
               <th
-                class="css-17s7rsv-HeaderCell"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
               >
                 Type
               </th>
@@ -8890,10 +8890,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           </thead>
           <tbody>
             <tr
-              class="css-190f936-Row"
+              class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <td
-                class="css-zstkv9-Cell"
+                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <strong
                   class="css-bvflvn-TextComponent"
@@ -8902,7 +8902,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 </strong>
               </td>
               <td
-                class="css-zstkv9-Cell"
+                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
                   class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -8923,14 +8923,14 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodescannerresult"
         id="barcodescannerresult"
       >
@@ -8938,7 +8938,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeScannerResult
@@ -8971,29 +8971,29 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -9001,10 +9001,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9013,7 +9013,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9028,7 +9028,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9063,10 +9063,10 @@ For some types, they will represent the area used by the scanner.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9075,7 +9075,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9091,7 +9091,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9125,10 +9125,10 @@ you don't get this value.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9137,7 +9137,7 @@ you don't get this value.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9147,7 +9147,7 @@ you don't get this value.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9158,10 +9158,10 @@ you don't get this value.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9170,7 +9170,7 @@ you don't get this value.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9180,7 +9180,7 @@ you don't get this value.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9195,14 +9195,14 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#barcodesize"
         id="barcodesize"
       >
@@ -9210,7 +9210,7 @@ you don't get this value.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeSize
@@ -9243,29 +9243,29 @@ you don't get this value.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -9273,10 +9273,10 @@ you don't get this value.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9285,7 +9285,7 @@ you don't get this value.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9295,7 +9295,7 @@ you don't get this value.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9306,10 +9306,10 @@ you don't get this value.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -9318,7 +9318,7 @@ you don't get this value.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -9328,7 +9328,7 @@ you don't get this value.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9479,7 +9479,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -9771,7 +9771,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9896,7 +9896,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -9987,29 +9987,29 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -10017,10 +10017,10 @@ exports[`APISection expo-pedometer 1`] = `
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -10029,7 +10029,7 @@ exports[`APISection expo-pedometer 1`] = `
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -10046,7 +10046,7 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -10057,10 +10057,10 @@ exports[`APISection expo-pedometer 1`] = `
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -10069,7 +10069,7 @@ exports[`APISection expo-pedometer 1`] = `
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -10086,7 +10086,7 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -10261,7 +10261,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10399,7 +10399,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10524,7 +10524,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-17cktl8"
+    class="css-1q9cex2-APISectionMethods"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10572,29 +10572,29 @@ available on this device.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -10602,10 +10602,10 @@ available on this device.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -10614,7 +10614,7 @@ available on this device.
               </strong>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -10629,7 +10629,7 @@ available on this device.
               </code>
             </td>
             <td
-              class="css-zstkv9-Cell"
+              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-17cktl8"
+    class="css-ztgmkf-APISectionInterfaces"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10910,29 +10910,29 @@ On iOS, the
       </span>
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -10940,10 +10940,10 @@ On iOS, the
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -10952,7 +10952,7 @@ On iOS, the
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -10962,7 +10962,7 @@ On iOS, the
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -10975,10 +10975,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -10987,7 +10987,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -11002,7 +11002,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -11013,10 +11013,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -11025,7 +11025,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -11035,7 +11035,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -11046,10 +11046,10 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -11058,7 +11058,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -11073,7 +11073,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -11129,14 +11129,14 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#pedometerresult"
         id="pedometerresult"
       >
@@ -11144,7 +11144,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PedometerResult
@@ -11177,29 +11177,29 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -11207,10 +11207,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -11219,7 +11219,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -11229,7 +11229,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -11244,14 +11244,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#pedometerupdatecallback"
         id="pedometerupdatecallback"
       >
@@ -11259,7 +11259,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11300,24 +11300,24 @@ in order to enable/disable the permission.
     </p>
     <div>
       <div
-        class="table-wrapper css-1uyflf8-Table"
+        class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
       >
         <table
-          class="css-e41t9x-Table"
+          class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
-            class="bg-subtle border-b border-b-default border-solid"
+            class="bg-subtle border-b border-b-default"
           >
             <tr
-              class="css-190f936-Row"
+              class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <th
-                class="css-17s7rsv-HeaderCell"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
               >
                 Name
               </th>
               <th
-                class="css-17s7rsv-HeaderCell"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
               >
                 Type
               </th>
@@ -11325,10 +11325,10 @@ in order to enable/disable the permission.
           </thead>
           <tbody>
             <tr
-              class="css-190f936-Row"
+              class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <td
-                class="css-zstkv9-Cell"
+                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <strong
                   class="css-bvflvn-TextComponent"
@@ -11337,7 +11337,7 @@ in order to enable/disable the permission.
                 </strong>
               </td>
               <td
-                class="css-zstkv9-Cell"
+                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
                   class="[&>span]:!text-inherit css-ite7ne-TextComponent"
@@ -11358,7 +11358,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11460,14 +11460,14 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-7sex76"
+    class="css-176db5m"
   >
     <h3
       class="group css-eynke-TextComponent"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -11475,7 +11475,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere css-yd3r23-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             Subscription
@@ -11514,29 +11514,29 @@ in order to enable/disable the permission.
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="table-wrapper css-1uyflf8-Table"
+      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
     >
       <table
-        class="css-e41t9x-Table"
+        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default border-solid"
+          class="bg-subtle border-b border-b-default"
         >
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Name
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="css-17s7rsv-HeaderCell"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
             >
               Description
             </th>
@@ -11544,10 +11544,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="css-190f936-Row"
+            class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <strong
                 class="css-bvflvn-TextComponent"
@@ -11556,7 +11556,7 @@ in order to enable/disable the permission.
               </strong>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="css-ite7ne-TextComponent"
@@ -11577,7 +11577,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="css-18p3734-Cell"
+              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -11633,7 +11633,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-gz86c1-APISectionEnum"
+    class="!p-0 css-e9fasf-APISectionEnum"
   >
     <div
       class="px-5 pt-4"

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -107,8 +107,8 @@ const renderType = (
       <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
+        <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
+          <MONOSPACE weight="medium">
             {name}
             {type.declaration.signatures ? '()' : ''}
           </MONOSPACE>

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -3,6 +3,10 @@ import { render } from '@testing-library/react';
 import type { CommentData } from './APIDataTypes';
 import { CommentTextBlock, resolveTypeName } from './APISectionUtils';
 
+import { attachEmotionSerializer } from '~/common/test-utilities';
+
+attachEmotionSerializer(expect);
+
 describe('APISectionUtils.resolveTypeName', () => {
   test('void', () => {
     const { container } = render(

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -28,7 +28,6 @@ import {
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { Callout } from '~/ui/components/Callout';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
-import { tableWrapperStyle } from '~/ui/components/Table/Table';
 import { Tag } from '~/ui/components/Tag';
 import {
   A,
@@ -892,7 +891,7 @@ export const STYLES_APIBOX = css({
     marginBottom: 0,
   },
 
-  [`.css-${tableWrapperStyle.name}`]: {
+  [`.table-wrapper`]: {
     boxShadow: 'none',
     marginBottom: 0,
   },
@@ -916,7 +915,7 @@ export const STYLES_APIBOX_WRAPPER = css({
   marginBottom: spacing[3.5],
   padding: `${spacing[4]}px ${spacing[5]}px 0`,
 
-  [`.css-${tableWrapperStyle.name}:last-child`]: {
+  [`.table-wrapper:last-child`]: {
     marginBottom: spacing[4],
   },
 });

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="mb-3.5 css-1kfqm4n-TextComponent"
+    class="mb-3.5 emotion-0"
     data-text="true"
   >
     This is the basic comment.
@@ -17,18 +17,18 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     class="flex flex-row items-center mb-2"
   >
     <span
-      class="inline-flex items-center css-1yjys1n-TextComponent"
+      class="inline-flex items-center emotion-0"
       data-text="true"
     >
       <span
-        class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
+        class="!text-inherit !font-medium emotion-1"
         data-text="true"
       >
         Only for:
          
       </span>
       <div
-        class="!bg-palette-green3 !text-palette-green12 !border-palette-green4 select-none css-1e5tu91-PlatformTag"
+        class="!bg-palette-green3 !text-palette-green12 !border-palette-green4 select-none emotion-2"
       >
         <svg
           class="opacity-80 icon-xs text-palette-green12"
@@ -48,7 +48,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           </g>
         </svg>
         <span
-          class="css-103dp5g-PlatformTag"
+          class="emotion-3"
         >
           Android
         </span>
@@ -57,18 +57,18 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     </span>
   </div>
   <p
-    class="mb-3.5 css-1kfqm4n-TextComponent"
+    class="mb-3.5 emotion-4"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
     <a
-      class="css-1na8e0o-A"
+      class="emotion-5"
       href="https://developer.android.com/google/play/installreferrer"
       rel="noopener noreferrer"
       target="_blank"
     >
       <code
-        class="css-qyuze8-TextComponent"
+        class="emotion-6"
         data-text="true"
       >
         Install Referrer API
@@ -81,11 +81,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
     class="mb-3.5 last:[&>*]:mb-0"
   >
     <p
-      class="!mt-1 css-19qci8h-BoxSectionHeader"
+      class="!mt-1 emotion-7"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        class="text-inherit flex flex-row gap-2 items-center emotion-8"
         data-text="true"
       >
         <svg
@@ -112,11 +112,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       </span>
     </p>
     <pre
-      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+      class="relative max-h-[unset] last:mb-0 emotion-9"
       data-text="true"
     >
       <code
-        class="css-19nqa8l-Code"
+        class="emotion-10"
       >
         <span
           class="token keyword"
@@ -169,7 +169,7 @@ exports[`APISectionUtils.CommentTextBlock component no comment 1`] = `<div />`;
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -195,7 +195,7 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -209,7 +209,7 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#appleauthenticationcredential"
     >
       AppleAuthenticationCredential
@@ -304,7 +304,7 @@ exports[`APISectionUtils.resolveTypeName alternative generic object notation 1`]
 exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent"
     rel="noopener noreferrer"
     target="_blank"
@@ -317,7 +317,7 @@ exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type array 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="#appleauthenticationscope"
   >
     AppleAuthenticationScope
@@ -335,7 +335,7 @@ exports[`APISectionUtils.resolveTypeName custom type non-linkable array 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys"
     rel="noopener noreferrer"
     target="_blank"
@@ -349,7 +349,7 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#fontresource"
     >
       FontResource
@@ -389,7 +389,7 @@ exports[`APISectionUtils.resolveTypeName function 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -414,7 +414,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
     </span>
      
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -444,7 +444,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -469,7 +469,7 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
     </span>
      
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -502,7 +502,7 @@ exports[`APISectionUtils.resolveTypeName generic type 1`] = `
 exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="#pagedinfo"
   >
     PagedInfo
@@ -514,7 +514,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#asset"
     >
       Asset
@@ -531,7 +531,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
 <div>
   <a
-    class="css-1na8e0o-A"
+    class="emotion-0"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -545,7 +545,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#pagedinfo"
     >
       PagedInfo
@@ -557,7 +557,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
     </span>
     <span>
       <a
-        class="css-1na8e0o-A"
+        class="emotion-0"
         href="#asset"
       >
         Asset
@@ -618,7 +618,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
       rel="noopener noreferrer"
       target="_blank"
@@ -632,7 +632,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     </span>
     <span>
       <a
-        class="css-1na8e0o-A"
+        class="emotion-0"
         href="https://reactnative.dev/docs/view-style-props"
         rel="noopener noreferrer"
         target="_blank"
@@ -696,7 +696,7 @@ exports[`APISectionUtils.resolveTypeName tuple type 1`] = `
   [
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#sortbykey"
     >
       SortByKey
@@ -714,7 +714,7 @@ exports[`APISectionUtils.resolveTypeName union 1`] = `
 <div>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -736,7 +736,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   (
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#resultseterror"
     >
       ResultSetError
@@ -749,7 +749,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#resultset"
     >
       ResultSet
@@ -780,7 +780,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
 <div>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#assetref"
     >
       AssetRef
@@ -794,7 +794,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
   </span>
   <span>
     <a
-      class="css-1na8e0o-A"
+      class="emotion-0"
       href="#assetref"
     >
       AssetRef

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "wrap-ansi": "^7"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.4",
+    "@emotion/react": "^11.13.0",
     "@expo/styleguide": "^8.2.3",
     "@expo/styleguide-base": "^1.0.1",
     "@expo/styleguide-icons": "2.0.0-alpha.7",
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.6.4",
-    "@emotion/jest": "^11.11.0",
+    "@emotion/jest": "^11.13.0",
     "@expo/spawn-async": "^1.7.2",
     "@ocular-d/vale-bin": "^2.29.6",
     "@tailwindcss/typography": "^0.5.12",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -42,6 +42,7 @@
     "public/static/data",
     "public/static/diffs",
     "public/static/examples",
-    "public/static/libs"
+    "public/static/libs",
+    "out"
   ]
 }

--- a/docs/ui/components/AppConfigSchemaTable/AppConfigSchemaTable.test.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/AppConfigSchemaTable.test.tsx
@@ -4,7 +4,7 @@ import AppConfigSchemaTable from './';
 import { formatSchema, createDescription } from './helpers';
 import { Property } from './types';
 
-import { renderWithHeadings } from '~/common/test-utilities';
+import { attachEmotionSerializer, renderWithHeadings } from '~/common/test-utilities';
 
 const TEST_SCHEMA: Record<string, Property> = {
   name: {
@@ -92,6 +92,8 @@ const TEST_SCHEMA: Record<string, Property> = {
 };
 
 describe('AppConfigSchemaPropertiesTable', () => {
+  attachEmotionSerializer(expect);
+
   test('correctly matches snapshot', () => {
     const { container } = renderWithHeadings(<AppConfigSchemaTable schema={TEST_SCHEMA} />);
     expect(container).toMatchSnapshot();

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -149,7 +149,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -371,7 +371,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -524,7 +524,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
         >
           <p
             class="group css-1kfqm4n-TextComponent"
@@ -601,7 +601,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -692,7 +692,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -864,7 +864,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -940,7 +940,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -1009,7 +1009,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <div
-          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-qc2h9a-APIBox"
+          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
         >
           <p
             class="group css-1kfqm4n-TextComponent"

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group css-1kfqm4n-TextComponent"
+        class="group emotion-1"
         data-text="true"
       >
         <a
@@ -19,7 +19,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+              class="!px-1.5 !text-sm emotion-2"
               data-text="true"
             >
               name
@@ -52,35 +52,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 css-1ac5bb0-TextComponent"
+        class="my-3 emotion-3"
         data-text="true"
       >
         Type: 
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-2"
           data-text="true"
         >
           string
         </code>
       </p>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-1"
         data-text="true"
       >
         Name of your app.
       </p>
       <details
-        class="css-xpa10j"
+        class="emotion-6"
         id="bare-workflow"
       >
         <summary
-          class="group css-rdh8rz"
+          class="group emotion-7"
         >
           <div
-            class="css-qos8r6"
+            class="emotion-8"
           >
             <svg
-              class="icon-sm text-icon-default css-nlesit"
+              class="icon-sm text-icon-default emotion-9"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -101,7 +101,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="css-1n5kx9e-TextComponent"
+              class="emotion-10"
               data-text="true"
             >
               Bare Workflow
@@ -137,10 +137,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 css-qbaxbl"
+          class="last:[&>*]:!mb-1 emotion-11"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-1"
             data-text="true"
           >
             Edit the 'Display Name' field in Xcode
@@ -149,10 +149,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group css-1kfqm4n-TextComponent"
+        class="group emotion-1"
         data-text="true"
       >
         <a
@@ -164,7 +164,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+              class="!px-1.5 !text-sm emotion-2"
               data-text="true"
             >
               androidNavigationBar
@@ -197,35 +197,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 css-1ac5bb0-TextComponent"
+        class="my-3 emotion-3"
         data-text="true"
       >
         Type: 
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-2"
           data-text="true"
         >
           object
         </code>
       </p>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-1"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="css-xpa10j"
+        class="emotion-6"
         id="expokit"
       >
         <summary
-          class="group css-rdh8rz"
+          class="group emotion-7"
         >
           <div
-            class="css-qos8r6"
+            class="emotion-8"
           >
             <svg
-              class="icon-sm text-icon-default css-nlesit"
+              class="icon-sm text-icon-default emotion-9"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -246,7 +246,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="css-1n5kx9e-TextComponent"
+              class="emotion-10"
               data-text="true"
             >
               ExpoKit
@@ -282,10 +282,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 css-qbaxbl"
+          class="last:[&>*]:!mb-1 emotion-11"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-1"
             data-text="true"
           >
             Set this property using AppConstants.java.
@@ -293,17 +293,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <details
-        class="css-xpa10j"
+        class="emotion-6"
         id="bare-workflow-1"
       >
         <summary
-          class="group css-rdh8rz"
+          class="group emotion-7"
         >
           <div
-            class="css-qos8r6"
+            class="emotion-8"
           >
             <svg
-              class="icon-sm text-icon-default css-nlesit"
+              class="icon-sm text-icon-default emotion-9"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -324,7 +324,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="css-1n5kx9e-TextComponent"
+              class="emotion-10"
               data-text="true"
             >
               Bare Workflow
@@ -360,10 +360,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 css-qbaxbl"
+          class="last:[&>*]:!mb-1 emotion-11"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-1"
             data-text="true"
           >
             Set this property using just Xcode
@@ -371,10 +371,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group css-1kfqm4n-TextComponent"
+          class="group emotion-1"
           data-text="true"
         >
           <a
@@ -386,7 +386,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                class="!px-1.5 !text-sm emotion-2"
                 data-text="true"
               >
                 visible
@@ -419,12 +419,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 css-1ac5bb0-TextComponent"
+          class="my-3 emotion-3"
           data-text="true"
         >
           Type: 
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-2"
             data-text="true"
           >
             enum
@@ -440,23 +440,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-1"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="css-xpa10j"
+          class="emotion-6"
           id="expokit-1"
         >
           <summary
-            class="group css-rdh8rz"
+            class="group emotion-7"
           >
             <div
-              class="css-qos8r6"
+              class="emotion-8"
             >
               <svg
-                class="icon-sm text-icon-default css-nlesit"
+                class="icon-sm text-icon-default emotion-9"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -477,7 +477,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
             >
               <span
-                class="css-1n5kx9e-TextComponent"
+                class="emotion-10"
                 data-text="true"
               >
                 ExpoKit
@@ -513,10 +513,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </summary>
           <div
-            class="last:[&>*]:!mb-1 css-qbaxbl"
+            class="last:[&>*]:!mb-1 emotion-11"
           >
             <p
-              class="mb-3.5 css-1kfqm4n-TextComponent"
+              class="mb-3.5 emotion-1"
               data-text="true"
             >
               Set this property using Xcode.
@@ -524,10 +524,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
         >
           <p
-            class="group css-1kfqm4n-TextComponent"
+            class="group emotion-1"
             data-text="true"
           >
             <a
@@ -539,7 +539,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                  class="!px-1.5 !text-sm emotion-2"
                   data-text="true"
                 >
                   always
@@ -572,12 +572,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </p>
           <p
-            class="my-3 css-1ac5bb0-TextComponent"
+            class="my-3 emotion-3"
             data-text="true"
           >
             Type: 
             <code
-              class="css-ite7ne-TextComponent"
+              class="emotion-2"
               data-text="true"
             >
               boolean
@@ -593,7 +593,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </code>
           </p>
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-1"
             data-text="true"
           >
             Test sub-sub-property
@@ -601,10 +601,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group css-1kfqm4n-TextComponent"
+          class="group emotion-1"
           data-text="true"
         >
           <a
@@ -616,7 +616,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                class="!px-1.5 !text-sm emotion-2"
                 data-text="true"
               >
                 backgroundColor
@@ -649,12 +649,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 css-1ac5bb0-TextComponent"
+          class="my-3 emotion-3"
           data-text="true"
         >
           Type: 
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-2"
             data-text="true"
           >
             string
@@ -670,7 +670,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-1"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -678,12 +678,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-1"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="css-qyuze8-TextComponent"
+            class="emotion-59"
             data-text="true"
           >
             '#000000'
@@ -692,10 +692,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+      class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group css-1kfqm4n-TextComponent"
+        class="group emotion-1"
         data-text="true"
       >
         <a
@@ -707,7 +707,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+              class="!px-1.5 !text-sm emotion-2"
               data-text="true"
             >
               intentFilters
@@ -740,35 +740,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 css-1ac5bb0-TextComponent"
+        class="my-3 emotion-3"
         data-text="true"
       >
         Type: 
         <code
-          class="css-ite7ne-TextComponent"
+          class="emotion-2"
           data-text="true"
         >
           array
         </code>
       </p>
       <p
-        class="mb-3.5 css-1kfqm4n-TextComponent"
+        class="mb-3.5 emotion-1"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="css-xpa10j"
+        class="emotion-6"
         id="bare-workflow-2"
       >
         <summary
-          class="group css-rdh8rz"
+          class="group emotion-7"
         >
           <div
-            class="css-qos8r6"
+            class="emotion-8"
           >
             <svg
-              class="icon-sm text-icon-default css-nlesit"
+              class="icon-sm text-icon-default emotion-9"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -789,7 +789,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="css-1n5kx9e-TextComponent"
+              class="emotion-10"
               data-text="true"
             >
               Bare Workflow
@@ -825,10 +825,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 css-qbaxbl"
+          class="last:[&>*]:!mb-1 emotion-11"
         >
           <p
-            class="mb-3.5 css-1kfqm4n-TextComponent"
+            class="mb-3.5 emotion-1"
             data-text="true"
           >
             This is set in AndroidManifest.xml directly.
@@ -839,17 +839,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="grid grid-cols-1 gap-2 mb-6"
       >
         <p
-          class="font-bold css-1ac5bb0-TextComponent"
+          class="font-bold emotion-3"
           data-text="true"
         >
           Example
         </p>
         <span
-          class="[&_span]:!text-inherit css-1nzh6mw-CodeBlock"
+          class="[&_span]:!text-inherit emotion-74"
           data-text="true"
         >
           <code
-            class="css-fyy1wj-CodeBlock"
+            class="emotion-75"
             data-text="true"
           >
             [
@@ -864,10 +864,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group css-1kfqm4n-TextComponent"
+          class="group emotion-1"
           data-text="true"
         >
           <a
@@ -879,7 +879,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                class="!px-1.5 !text-sm emotion-2"
                 data-text="true"
               >
                 autoVerify
@@ -912,12 +912,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 css-1ac5bb0-TextComponent"
+          class="my-3 emotion-3"
           data-text="true"
         >
           Type: 
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-2"
             data-text="true"
           >
             boolean
@@ -933,17 +933,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 css-1kfqm4n-TextComponent"
+          class="mb-3.5 emotion-1"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
         </p>
       </div>
       <div
-        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+        class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group css-1kfqm4n-TextComponent"
+          class="group emotion-1"
           data-text="true"
         >
           <a
@@ -955,7 +955,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                class="!px-1.5 !text-sm emotion-2"
                 data-text="true"
               >
                 data
@@ -988,12 +988,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 css-1ac5bb0-TextComponent"
+          class="my-3 emotion-3"
           data-text="true"
         >
           Type: 
           <code
-            class="css-ite7ne-TextComponent"
+            class="emotion-2"
             data-text="true"
           >
             array || object
@@ -1009,10 +1009,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <div
-          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 css-1x1iwss-APIBox"
+          class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
         >
           <p
-            class="group css-1kfqm4n-TextComponent"
+            class="group emotion-1"
             data-text="true"
           >
             <a
@@ -1024,7 +1024,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="!px-1.5 !text-sm css-ite7ne-TextComponent"
+                  class="!px-1.5 !text-sm emotion-2"
                   data-text="true"
                 >
                   host
@@ -1057,12 +1057,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </p>
           <p
-            class="my-3 css-1ac5bb0-TextComponent"
+            class="my-3 emotion-3"
             data-text="true"
           >
             Type: 
             <code
-              class="css-ite7ne-TextComponent"
+              class="emotion-2"
               data-text="true"
             >
               string

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
 import { TextAlign } from './types';
-import { convertAlign } from './utils';
+import { convertAlignToClass } from './utils';
 
 type CellProps = PropsWithChildren<{
   fitContent?: boolean;
@@ -14,26 +12,14 @@ type CellProps = PropsWithChildren<{
 
 export const Cell = ({ children, colSpan, fitContent = false, align = 'left' }: CellProps) => (
   <td
-    css={[tableCellStyle, { textAlign: convertAlign(align) }, fitContent && fitContentStyle]}
+    className={mergeClasses(
+      'p-4 border-r border-secondary',
+      convertAlignToClass(align),
+      fitContent && 'w-fit',
+      'last:border-r-0',
+      '[&>*:last-child]:!mb-0'
+    )}
     colSpan={colSpan}>
     {children}
   </td>
 );
-
-const tableCellStyle = css({
-  padding: spacing[4],
-  verticalAlign: 'middle',
-  borderRight: `1px solid ${theme.border.default}`,
-
-  '&:last-child': {
-    borderRight: 0,
-  },
-
-  '> *:last-child': {
-    marginBottom: '0 !important',
-  },
-});
-
-const fitContentStyle = css({
-  width: 'fit-content',
-});

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
 import { TextAlign } from './types';
-import { convertAlign } from './utils';
+import { convertAlignToClass } from './utils';
 
 type HeaderCellProps = PropsWithChildren<{
   align?: TextAlign | 'char';
@@ -13,22 +11,13 @@ type HeaderCellProps = PropsWithChildren<{
 
 export const HeaderCell = ({ children, align = 'left', size = 'md' }: HeaderCellProps) => (
   <th
-    css={[
-      tableHeadersCellStyle,
-      { textAlign: convertAlign(align), fontSize: size === 'sm' ? '0.75rem' : '0.875rem' },
-    ]}>
+    className={mergeClasses(
+      'px-4 py-3.5 font-medium text-secondary border-r border-secondary',
+      convertAlignToClass(align),
+      size === 'sm' ? 'text-3xs' : 'text-2xs',
+      '[&_code]:text-3xs',
+      'last:border-r-0'
+    )}>
     {children}
   </th>
 );
-
-const tableHeadersCellStyle = css({
-  padding: spacing[4],
-  fontWeight: 500,
-  color: theme.text.secondary,
-  verticalAlign: 'middle',
-  borderRight: `1px solid ${theme.border.default}`,
-
-  '&:last-child': {
-    borderRight: 0,
-  },
-});

--- a/docs/ui/components/Table/Row.tsx
+++ b/docs/ui/components/Table/Row.tsx
@@ -1,25 +1,17 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import React, { PropsWithChildren } from 'react';
+import { mergeClasses } from '@expo/styleguide';
+import { PropsWithChildren } from 'react';
 
 type RowProps = PropsWithChildren<{
   subtle?: boolean;
 }>;
 
 export const Row = ({ children, subtle }: RowProps) => (
-  <tr css={[tableRowStyle, subtle && subtleStyle]}>{children}</tr>
+  <tr
+    className={mergeClasses(
+      'even:bg-subtle',
+      'even:[&_summary]:bg-element',
+      subtle && 'opacity-50'
+    )}>
+    {children}
+  </tr>
 );
-
-const tableRowStyle = css({
-  '&:nth-of-type(2n)': {
-    backgroundColor: theme.background.subtle,
-
-    summary: {
-      backgroundColor: theme.background.element,
-    },
-  },
-});
-
-const subtleStyle = css({
-  opacity: '0.5',
-});

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
-import { theme, typography, shadows } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
 import { TableHeaders } from './TableHeaders';
@@ -13,8 +11,18 @@ type TableProps = PropsWithChildren<{
 }>;
 
 export const Table = ({ children, headers = [], headersAlign, className }: TableProps) => (
-  <div css={tableWrapperStyle} className="table-wrapper">
-    <table css={tableStyle} className={className}>
+  <div className="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs">
+    <table
+      className={mergeClasses(
+        'w-full border-0 rounded-none text-xs text-default',
+        '[&_p]:text-xs',
+        '[&_li]:text-xs',
+        '[&_span]:text-xs',
+        '[&_strong]:text-xs',
+        '[&_blockquote_div]:text-xs',
+        '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',
+        className
+      )}>
       {headers.length ? (
         <>
           <TableHeaders headers={headers} headersAlign={headersAlign} />
@@ -26,49 +34,3 @@ export const Table = ({ children, headers = [], headersAlign, className }: Table
     </table>
   </div>
 );
-
-export const tableWrapperStyle = css({
-  border: `1px solid ${theme.border.default}`,
-  borderRadius: borderRadius.md,
-  overflowY: 'hidden',
-  overflowX: 'auto',
-  marginBottom: spacing[4],
-  boxShadow: shadows.xs,
-
-  '::-webkit-scrollbar': {
-    height: 6,
-  },
-
-  '::-webkit-scrollbar-track': {
-    background: theme.background.default,
-    borderBottomLeftRadius: borderRadius.md,
-    borderBottomRightRadius: borderRadius.md,
-  },
-
-  '::-webkit-scrollbar-thumb': {
-    background: theme.background.element,
-    borderRadius: borderRadius.md,
-
-    ':hover': {
-      background: theme.background.hover,
-    },
-  },
-});
-
-const tableStyle = css({
-  ...typography.fontSizes[14],
-  width: '100%',
-  border: 0,
-  borderRadius: 0,
-  marginBottom: 0,
-  borderCollapse: 'collapse',
-  color: theme.text.default,
-
-  'blockquote div, li, p, strong, span': {
-    ...typography.fontSizes[14],
-  },
-
-  'blockquote code': {
-    padding: `0 ${spacing[1]}px`,
-  },
-});

--- a/docs/ui/components/Table/TableHead.tsx
+++ b/docs/ui/components/Table/TableHead.tsx
@@ -3,5 +3,5 @@ import { PropsWithChildren } from 'react';
 type TableHeadProps = PropsWithChildren<object>;
 
 export const TableHead = ({ children }: TableHeadProps) => (
-  <thead className="bg-subtle border-b border-b-default border-solid">{children}</thead>
+  <thead className="bg-subtle border-b border-b-default">{children}</thead>
 );

--- a/docs/ui/components/Table/utils.ts
+++ b/docs/ui/components/Table/utils.ts
@@ -1,10 +1,15 @@
 import { TextAlign } from './types';
 
-export const convertAlign = (align: TextAlign | 'char'): TextAlign => {
+export function convertAlignToClass(align: TextAlign | 'char'): string {
   switch (align) {
+    case 'left':
     case 'char':
-      return 'left';
-    default:
-      return align;
+      return 'text-left';
+    case 'center':
+      return 'text-center';
+    case 'right':
+      return 'text-right';
+    case 'justify':
+      return 'text-justify';
   }
-};
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -329,16 +329,16 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@emotion/babel-plugin@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
-  integrity sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==
+"@emotion/babel-plugin@^11.12.0":
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz#7b43debb250c313101b3f885eba634f1d723fcc2"
+  integrity sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
     "@babel/runtime" "^7.18.3"
-    "@emotion/hash" "^0.9.1"
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/serialize" "^1.1.2"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.2.0"
     babel-plugin-macros "^3.1.0"
     convert-source-map "^1.5.0"
     escape-string-regexp "^4.0.0"
@@ -346,95 +346,95 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
-  integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
+"@emotion/cache@^11.13.0":
+  version "11.13.1"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.13.1.tgz#fecfc54d51810beebf05bf2a161271a1a91895d7"
+  integrity sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==
   dependencies:
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/sheet" "^1.2.2"
-    "@emotion/utils" "^1.2.1"
-    "@emotion/weak-memoize" "^0.3.1"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
     stylis "4.2.0"
 
-"@emotion/css-prettifier@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.1.3.tgz#014ff59a87a3be5f2ce555b70f096af66b2dc845"
-  integrity sha512-KNv23+VQ+pcw3ebd1vSEl11CQ6SKAG5EQkrinjVGsfw3ZTWe6/tpWQrsvFLqCtU2LRiLPi04KgFCE4A9+crfpQ==
+"@emotion/css-prettifier@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.1.4.tgz#3eea88addfd283d0ae58a5a048398710498a2819"
+  integrity sha512-lEjrAxtju83kkF2N7nPoFSPa00o+h1QujXM2F60kudDWuwBbuxJSG1dGKHVnr9tjxmLho2B0HGfmVThpR+scWw==
   dependencies:
-    "@emotion/memoize" "^0.8.1"
+    "@emotion/memoize" "^0.9.0"
     stylis "4.2.0"
 
-"@emotion/hash@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
-  integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
-"@emotion/jest@^11.11.0":
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.11.0.tgz#4d64b33052308739dcdd7396fd2bc902f7244f82"
-  integrity sha512-XZlnmdUZ32YjQnInsCFk/plKpkV/NXN1Ab4YoNvXN887MeR3Hr5ZsTyoblIW8AWwdfQiZHHphaPMb56lk6Ofdw==
+"@emotion/jest@^11.13.0":
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.13.0.tgz#c723fa8e3909a8ce4f5e8ffd17b0747bc973a479"
+  integrity sha512-XyoUbJ9fthKdlXjTvjzd6aQ8yVWe68InZawFdGTFkJQRW44rsLHK1qjKB/+L7RiGgdm0BYFv7+tz8znQzRQOBw==
   dependencies:
     "@babel/runtime" "^7.18.3"
-    "@emotion/css-prettifier" "^1.1.3"
+    "@emotion/css-prettifier" "^1.1.4"
     chalk "^4.1.0"
     specificity "^0.4.1"
     stylis "4.2.0"
 
-"@emotion/memoize@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
-  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.11.4":
-  version "11.11.4"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.4.tgz#3a829cac25c1f00e126408fab7f891f00ecc3c1d"
-  integrity sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==
+"@emotion/react@^11.13.0":
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.13.0.tgz#a9ebf827b98220255e5760dac89fa2d38ca7b43d"
+  integrity sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==
   dependencies:
     "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.11.0"
-    "@emotion/cache" "^11.11.0"
-    "@emotion/serialize" "^1.1.3"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
-    "@emotion/utils" "^1.2.1"
-    "@emotion/weak-memoize" "^0.3.1"
+    "@emotion/babel-plugin" "^11.12.0"
+    "@emotion/cache" "^11.13.0"
+    "@emotion/serialize" "^1.3.0"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.1.2", "@emotion/serialize@^1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.4.tgz#fc8f6d80c492cfa08801d544a05331d1cc7cd451"
-  integrity sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==
+"@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.0.tgz#e07cadfc967a4e7816e0c3ffaff4c6ce05cb598d"
+  integrity sha512-jACuBa9SlYajnpIVXB+XOXnfJHyckDfe6fOpORIM6yhBDlqGuExvDdZYHDQGoDf3bZXGv7tNr+LpLjJqiEQ6EA==
   dependencies:
-    "@emotion/hash" "^0.9.1"
-    "@emotion/memoize" "^0.8.1"
-    "@emotion/unitless" "^0.8.1"
-    "@emotion/utils" "^1.2.1"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.9.0"
+    "@emotion/utils" "^1.4.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
-  integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
-"@emotion/unitless@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
-  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+"@emotion/unitless@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.9.0.tgz#8e5548f072bd67b8271877e51c0f95c76a66cbe2"
+  integrity sha512-TP6GgNZtmtFaFcsOgExdnfxLLpRDla4Q66tnenA9CktvVSdNKDvMVuUah4QvWPIpNjrWsGg3qeGo9a43QooGZQ==
 
-"@emotion/use-insertion-effect-with-fallbacks@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
-  integrity sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==
+"@emotion/use-insertion-effect-with-fallbacks@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz#1a818a0b2c481efba0cf34e5ab1e0cb2dcb9dfaf"
+  integrity sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==
 
-"@emotion/utils@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
-  integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
+"@emotion/utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.0.tgz#262f1d02aaedb2ec91c83a0955dd47822ad5fbdd"
+  integrity sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ==
 
-"@emotion/weak-memoize@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
-  integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -8647,7 +8647,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2, string-width@^6.0.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2, string-width@^6.0.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8724,7 +8733,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9682,7 +9698,16 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# Why

Another chunk of rewrites leading to Emotion styling removal, this time it's Table component and relatives.

# How

Refactor `Table` and related component using Tailwind, tweak headings sizing, update utils.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-08-05 at 18 44 16](https://github.com/user-attachments/assets/dea5730a-1dcf-44e9-9af4-49a4ffca0aa4)
![Screenshot 2024-08-05 at 18 43 55](https://github.com/user-attachments/assets/80cf4f18-bbe5-4ce3-b728-d0ed94fa11df)
