### PR TITLE
[cli] Fix missing setupTestProjectWithOptionsAsync in e2e tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -5,7 +5,14 @@ import fs from 'fs-extra';
 import klawSync from 'klaw-sync';
 import path from 'path';
 
-import { execute, projectRoot, getLoadedModulesAsync, setupTestProjectAsync, bin } from './utils';
+import {
+  execute,
+  projectRoot,
+  getLoadedModulesAsync,
+  setupTestProjectAsync,
+  bin,
+  setupTestProjectWithOptionsAsync,
+} from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -179,6 +179,30 @@ export async function createFromFixtureAsync(
 // Set this to true to enable caching and prevent rerunning yarn installs
 const testingLocally = !process.env.CI;
 
+export async function setupTestProjectWithOptionsAsync(
+  name: string,
+  fixtureName: string,
+  {
+    reuseExisting = testingLocally,
+    sdkVersion = '51.0.0',
+  }: {
+    sdkVersion?: string;
+    reuseExisting?: boolean;
+  }
+): Promise<string> {
+  // If you're testing this locally, you can set the projectRoot to a local project (you created with expo init) to save time.
+  const projectRoot = await createFromFixtureAsync(os.tmpdir(), {
+    dirName: name,
+    reuseExisting,
+    fixtureName,
+  });
+
+  // Many of the factors in this test are based on the expected SDK version that we're testing against.
+  const { exp } = getConfig(projectRoot, { skipPlugins: true });
+  expect(exp.sdkVersion).toBe(sdkVersion);
+  return projectRoot;
+}
+
 export async function setupTestProjectAsync(
   name: string,
   fixtureName: string,


### PR DESCRIPTION
# Why

When cherry-picking https://github.com/expo/expo/pull/29612 we ended up [breaking the cli e2e tests](https://github.com/expo/expo/actions/runs/10253268736/job/28365522507?pr=30822) due to a missing import of `setupTestProjectWithOptionsAsync`

# How

Add missing `setupTestProjectWithOptionsAsync` function

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
