### PR TITLE
[sqlite] add config plugin

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -8,6 +8,7 @@ platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
@@ -15,6 +16,60 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-sqlite` for advanced configurations using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-sqlite",
+        {
+          "enableFTS": true,
+          "useSQLCipher": true,
+          "android": {
+            // Override the shared configuration for Android
+            "enableFTS": false,
+            "useSQLCipher": false
+          },
+          "ios": {
+            // You can also override the shared configurations for iOS
+            "customBuildFlags": ["-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'customBuildFlags',
+      description: 'Custom build flags to be passed to the SQLite build process.',
+    },
+    {
+      name: 'enableFTS',
+      description:
+        'Whether to enable the [FTS3, FTS4](https://www.sqlite.org/fts3.html) and [FTS5](https://www.sqlite.org/fts5.html) extensions.',
+      default: 'true',
+    },
+    {
+      name: 'useSQLCipher',
+      description:
+        'Use the [SQLCipher](https://www.zetetic.net/sqlcipher/) implementations rather than the default SQLite.',
+      default: 'false',
+    },
+  ]}
+/>
 
 ## Usage
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Added SQLCipher support. ([#30824](https://github.com/expo/expo/pull/30824) by [@kudo](https://github.com/kudo))
+- Added SQLCipher support. ([#30824](https://github.com/expo/expo/pull/30824), [#30825](https://github.com/expo/expo/pull/30825) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-sqlite/app.plugin.js
+++ b/packages/expo-sqlite/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withSQLite');

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -6,6 +6,7 @@
   "types": "build/index.d.ts",
   "sideEffects": false,
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "default": "./build/index.js",
       "types": "./build/index.d.ts"

--- a/packages/expo-sqlite/plugin/babel.config.js
+++ b/packages/expo-sqlite/plugin/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/babel.config.plugin');

--- a/packages/expo-sqlite/plugin/build/withSQLite.d.ts
+++ b/packages/expo-sqlite/plugin/build/withSQLite.d.ts
@@ -1,0 +1,18 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+interface Props {
+    customBuildFlags?: string;
+    enableFTS?: boolean;
+    useSQLCipher?: boolean;
+    android: {
+        customBuildFlags?: string;
+        enableFTS?: boolean;
+        useSQLCipher?: boolean;
+    };
+    ios: {
+        customBuildFlags?: string;
+        enableFTS?: boolean;
+        useSQLCipher?: boolean;
+    };
+}
+declare const _default: ConfigPlugin<Props>;
+export default _default;

--- a/packages/expo-sqlite/plugin/build/withSQLite.js
+++ b/packages/expo-sqlite/plugin/build/withSQLite.js
@@ -1,0 +1,45 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const pkg = require('expo-sqlite/package.json');
+const withSQLite = (config, props) => {
+    config = withSQLiteAndroidProps(config, props);
+    config = withSQLiteIOSProps(config, props);
+    return config;
+};
+const withSQLiteAndroidProps = (config, props) => {
+    return (0, config_plugins_1.withGradleProperties)(config, (config) => {
+        const customBuildFlags = props.android?.customBuildFlags ?? props.customBuildFlags;
+        const enableFTS = props.android?.enableFTS ?? props.enableFTS;
+        const useSQLCipher = props.android?.useSQLCipher ?? props.useSQLCipher;
+        config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.customBuildFlags', customBuildFlags);
+        config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.enableFTS', enableFTS);
+        config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.useSQLCipher', useSQLCipher);
+        return config;
+    });
+};
+const withSQLiteIOSProps = (config, props) => {
+    return (0, config_plugins_1.withPodfileProperties)(config, (config) => {
+        const customBuildFlags = props.ios?.customBuildFlags ?? props.customBuildFlags;
+        const enableFTS = props.ios?.enableFTS ?? props.enableFTS;
+        const useSQLCipher = props.ios?.useSQLCipher ?? props.useSQLCipher;
+        config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.customBuildFlags', customBuildFlags);
+        config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.enableFTS', enableFTS);
+        config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.useSQLCipher', useSQLCipher);
+        return config;
+    });
+};
+function updateAndroidBuildPropertyIfNeeded(properties, name, value) {
+    if (value !== undefined) {
+        return config_plugins_1.AndroidConfig.BuildProperties.updateAndroidBuildProperty(properties, name, String(value));
+    }
+    return properties;
+}
+function updateIOSBuildPropertyIfNeeded(properties, name, value) {
+    if (value !== undefined) {
+        properties[name] = String(value);
+        return properties;
+    }
+    return properties;
+}
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withSQLite, pkg.name, pkg.version);

--- a/packages/expo-sqlite/plugin/src/withSQLite.ts
+++ b/packages/expo-sqlite/plugin/src/withSQLite.ts
@@ -1,0 +1,111 @@
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withGradleProperties,
+  withPodfileProperties,
+} from 'expo/config-plugins';
+
+const pkg = require('expo-sqlite/package.json');
+
+interface Props {
+  customBuildFlags?: string;
+  enableFTS?: boolean;
+  useSQLCipher?: boolean;
+  android: {
+    customBuildFlags?: string;
+    enableFTS?: boolean;
+    useSQLCipher?: boolean;
+  };
+  ios: {
+    customBuildFlags?: string;
+    enableFTS?: boolean;
+    useSQLCipher?: boolean;
+  };
+}
+
+const withSQLite: ConfigPlugin<Props> = (config, props) => {
+  config = withSQLiteAndroidProps(config, props);
+  config = withSQLiteIOSProps(config, props);
+  return config;
+};
+
+const withSQLiteAndroidProps: ConfigPlugin<Props> = (config, props) => {
+  return withGradleProperties(config, (config) => {
+    const customBuildFlags = props.android?.customBuildFlags ?? props.customBuildFlags;
+    const enableFTS = props.android?.enableFTS ?? props.enableFTS;
+    const useSQLCipher = props.android?.useSQLCipher ?? props.useSQLCipher;
+
+    config.modResults = updateAndroidBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.customBuildFlags',
+      customBuildFlags
+    );
+    config.modResults = updateAndroidBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.enableFTS',
+      enableFTS
+    );
+    config.modResults = updateAndroidBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.useSQLCipher',
+      useSQLCipher
+    );
+    return config;
+  });
+};
+
+const withSQLiteIOSProps: ConfigPlugin<Props> = (config, props) => {
+  return withPodfileProperties(config, (config) => {
+    const customBuildFlags = props.ios?.customBuildFlags ?? props.customBuildFlags;
+    const enableFTS = props.ios?.enableFTS ?? props.enableFTS;
+    const useSQLCipher = props.ios?.useSQLCipher ?? props.useSQLCipher;
+
+    config.modResults = updateIOSBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.customBuildFlags',
+      customBuildFlags
+    );
+    config.modResults = updateIOSBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.enableFTS',
+      enableFTS
+    );
+    config.modResults = updateIOSBuildPropertyIfNeeded(
+      config.modResults,
+      'expo.sqlite.useSQLCipher',
+      useSQLCipher
+    );
+
+    return config;
+  });
+};
+
+function updateAndroidBuildPropertyIfNeeded(
+  properties: AndroidConfig.Properties.PropertiesItem[],
+  name: string,
+  value: any
+): AndroidConfig.Properties.PropertiesItem[] {
+  if (value !== undefined) {
+    return AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+      properties,
+      name,
+      String(value)
+    );
+  }
+  return properties;
+}
+
+function updateIOSBuildPropertyIfNeeded(
+  properties: Record<string, string>,
+  name: string,
+  value: any
+): Record<string, string> {
+  if (value !== undefined) {
+    properties[name] = String(value);
+    return properties;
+  }
+  return properties;
+}
+
+export default createRunOncePlugin(withSQLite, pkg.name, pkg.version);

--- a/packages/expo-sqlite/plugin/tsconfig.json
+++ b/packages/expo-sqlite/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

close ENG-12401

# How

- add config-plugin for expo-sqlite to support some build-time configurations
  - `customBuildFlags`
  - `enableFTS`
  - `useSQLCipher`
- update doc for expo-sqlite's config-plugin

# Test Plan

adding these config to **apps/bare-expo/app.json**, running prebuild and check the content in **ios/Podfile.properties.json** and **android/gradle.properties**
```
    plugins: [
      [
        "expo-sqlite",
        {
          "enableFTS": true,
          "useSQLCipher": true,
          "android": {
            "useSQLCipher": false,
            "customBuildFlags": ["-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"]
          },
          "ios": {
            "enableFTS": true,
            "customBuildFlags": ["-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"]
          }
        }
      ]
    ]
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
