### PR TITLE
[updates] rollback for system sqlite on ios

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix data race in `AppLauncherWithDatabaseMock.swift`. ([#28924](https://github.com/expo/expo/pull/28924) by [@hakonk](https://github.com/hakonk))
 - Add missing `react` peer dependencies for isolated modules. ([#30488](https://github.com/expo/expo/pull/30488) by [@byCedric](https://github.com/byCedric))
 - Use relative entry point from `@expo/config/paths` with support for server root. ([#30633](https://github.com/expo/expo/pull/30633) by [@byCedric](https://github.com/byCedric))
+- [iOS] Rollback to system SQLite3 and fix incompatible issue when any third-party library uses iOS system SQLite3. ([#30826](https://github.com/expo/expo/pull/30826) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
-  if podfile_properties['expo.updates.use3rdPartySQLitePod'] === 'true'
+  if podfile_properties['expo.updates.useThirdPartySQLitePod'] === 'true'
     s.dependency 'sqlite3'
   end
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
 use_dev_client = false
 begin
@@ -31,7 +32,9 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
-  s.dependency 'sqlite3', '~> 3.45.3+1'
+  if podfile_properties['expo.updates.use3rdPartySQLitePod'] === 'true'
+    s.dependency 'sqlite3'
+  end
 
   unless defined?(install_modules_dependencies)
     # `install_modules_dependencies` is defined from react_native_pods.rb.

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
@@ -1,7 +1,11 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal enum UpdatesDatabaseMigrationError: Error {
   case foreignKeysError

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
@@ -3,7 +3,11 @@
 // swiftlint:disable line_length
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration4To5: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v4.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
@@ -3,7 +3,11 @@
 // swiftlint:disable line_length
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration5To6: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v5.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
@@ -3,7 +3,11 @@
 // swiftlint:disable line_length
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration6To7: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v6.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration7To8.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration7To8.swift
@@ -1,7 +1,11 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration7To8: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v7.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration8To9.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration8To9.swift
@@ -1,7 +1,11 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration8To9: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v8.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
@@ -3,7 +3,11 @@
 // swiftlint:disable line_length
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal final class UpdatesDatabaseMigration9To10: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v9.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -10,7 +10,11 @@
 // swiftlint:disable file_length
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 import EXManifests
 
 internal enum UpdatesDatabaseError: Error {

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -6,7 +6,11 @@
 // swiftlint:disable force_unwrapping
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 enum UpdatesDatabaseInitializationError: Error {
   case migrateAndRemoveOldDatabaseFailure

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseUtils.swift
@@ -8,7 +8,11 @@
 // swiftlint:disable force_unwrapping
 
 import Foundation
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 internal struct UpdatesDatabaseUtilsErrorInfo {
   let code: Int

--- a/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
+++ b/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
@@ -1,7 +1,11 @@
 //  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
 
 import ExpoModulesTestCore
+#if canImport(sqlite3)
 import sqlite3
+#else
+import SQLite3
+#endif
 
 @testable import EXUpdates
 
@@ -289,7 +293,7 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
     beforeEach {
       let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
       testDatabaseDir = applicationSupportDir!.appendingPathComponent("UpdatesDatabaseTests")
-      
+
       try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
 
       if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
@@ -460,7 +464,7 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         expect(try! UpdatesDatabaseUtils.execute(sql:foreignKeySelectSql, withArgs:nil, onDatabase:migratedDb).count) == 1
 
         let foreignKeyInsertBadSql = "INSERT INTO `updates_assets` (`update_id`, `asset_id`) VALUES (X'594100ea066e4804b5c7c907c773f980', 13)"
-        
+
         expect {
           try UpdatesDatabaseUtils.execute(sql:foreignKeyInsertBadSql, withArgs:nil, onDatabase:migratedDb)
         }.to(throwError(errorType: UpdatesDatabaseUtilsError.self) { error in


### PR DESCRIPTION
# Why

we forced to use third-party sqlite in expo-updates because #24375. it caused ios build issue like #30546 if lib uses system sqlite. with #30824, the third-party sqlite is not necessary anymore.

close ENG-12866

# How

rollback to use system sqlite by default but still provides a configurable `expo.updates.use3rdPartySQLitePod` for **ios/Podfile.properties.json** to change it.

# Test Plan

- [x] ci passed
- [x] test sdk 51 updates with db created from third-party sqlite. makes sure the database is compatible when using system sqlite.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
