### PR TITLE
test(prebuild-config): resolve testing issues due to changes in various packages

### DIFF
--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -814,6 +814,7 @@ exports[`built-in plugins introspects mods 1`] = `
                   "android:label": "@string/app_name",
                   "android:name": ".MainApplication",
                   "android:roundIcon": "@mipmap/ic_launcher_round",
+                  "android:supportsRtl": "true",
                   "android:theme": "@style/AppTheme",
                 },
                 "activity": [

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -666,6 +666,15 @@ exports[`built-in plugins introspects mods 1`] = `
             "type": "empty",
           },
           {
+            "type": "comment",
+            "value": "Enable AAPT2 PNG crunching",
+          },
+          {
+            "key": "android.enablePngCrunchInReleaseBuilds",
+            "type": "property",
+            "value": "true",
+          },
+          {
             "type": "empty",
           },
           {

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -666,15 +666,6 @@ exports[`built-in plugins introspects mods 1`] = `
             "type": "empty",
           },
           {
-            "type": "comment",
-            "value": "Automatically convert third-party libraries to use AndroidX",
-          },
-          {
-            "key": "android.enableJetifier",
-            "type": "property",
-            "value": "true",
-          },
-          {
             "type": "empty",
           },
           {

--- a/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
+++ b/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
@@ -125,19 +125,16 @@ it('compiles expo-camera', async () => {
     },
     { projectRoot, platforms: ['ios', 'android'] }
   );
-  expect(config).toHaveModHistory('expo-camera');
 
-  expect(config).toMatchAndroidProjectBuildGradle(
-    expect.stringContaining(
-      `def expoCameraMavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")`
-    )
-  );
+  // Ensure the camera plugin was applied
+  expect(config).toHaveModHistory('expo-camera');
+  // Ensure the iOS camera permission string is set
   expect(config).toMatchInfoPlist(
     expect.objectContaining({
       NSCameraUsageDescription: expect.stringMatching(/custom message/),
     })
   );
-
+  // Ensure the Android camera permission is added
   expect(getAndroidManifestStringLikePrebuild(config)).toMatch(
     /<uses-permission android:name="android.permission.CAMERA"\/>/
   );


### PR DESCRIPTION
# Why

`@expo/prebuild-config` is failing on `main` due to changes in various packages. I traced them all, and applied the update for prebuild config. 

If you are added as reviewer, please check the appropriate change to see if it was intentional:

- @Kudo - I think you dropped the custom Maven repository from the `expo-camera` plugin, I assume that was intentional as it seems to be autolinked properly now 😄
  → [expo-camera change](https://github.com/expo/expo/pull/30707/files/#diff-f1132e0399f54ea2dae2abcbc8999ad685473d3e276de460de4320e64d74b783L16-L44) - [prebuild change](https://github.com/expo/expo/commit/df89cf4037d753a2a4f150edb41d56fa1e392396)
- @brentvatne - I think you added support for "png crunching in release builds" 
  → [expo-build-properties change](https://github.com/expo/expo/pull/30699/files/#diff-460b5835a19a98808e715e562cd0653ea2b28cc0988f703ff334a8e1993f0419R67-R70) - [prebuild change](https://github.com/expo/expo/commit/91b215bebaa26d05b101412aa5f8f72c524b586a)
- @gabrieldonadel - I think you removed the `android.enableJetifier` from the bare minimum template
  → [bare-minimum-template change](https://github.com/expo/expo/pull/30034/files/#diff-c1abe9eea32a8e683dbea2f18a322cc0b8c5a4ce1a8da1719c6a9ddf29f79e3fL27-L28) - [prebuild change](https://github.com/expo/expo/commit/5186c84bc89bf145e4aa6f08dbcdaedd3a5653cc)
- @gabrieldonadel - I think you added `android:supportsRtl` to the bare minimum template 
  → [bare-minimum-template change](https://github.com/expo/expo/pull/30034/files/#diff-26005f11552a4f319c92e7b9dfc3dd8f3e5a7887f598a0599d1106c77d59ccc3R21) - [prebuild change](https://github.com/expo/expo/commit/1d00ee8d04a9d3da749a838357cd5985c0e4a6d9)

# How

- Traced the changes through git
- Updated individual changes on the snapshots/tests

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
