### PR TITLE
fix(cli): fix support for web --port

### DIFF
--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -91,5 +91,5 @@ export const expoStart: Command = async (argv) => {
   }
 
   const { startAsync } = await import('./startAsync.js');
-  return startAsync(projectRoot, options, { webOnly: false }).catch(logCmdError);
+  return startAsync(projectRoot, options, { webOnly: options?.web ?? false }).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -154,6 +154,10 @@ export async function resolvePortsAsync(
 ) {
   const multiBundlerSettings: { webpackPort?: number; metroPort?: number } = {};
 
+  const fallbackPort = process.env.RCT_METRO_PORT
+      ? parseInt(process.env.RCT_METRO_PORT, 10)
+      : 8081;
+
   if (settings.webOnly) {
     const webpackPort = await resolvePortAsync(projectRoot, {
       defaultPort: options.port,
@@ -164,10 +168,8 @@ export async function resolvePortsAsync(
       throw new AbortCommandError();
     }
     multiBundlerSettings.webpackPort = webpackPort;
+    multiBundlerSettings.metroPort = fallbackPort;
   } else {
-    const fallbackPort = process.env.RCT_METRO_PORT
-      ? parseInt(process.env.RCT_METRO_PORT, 10)
-      : 8081;
     const metroPort = await resolvePortAsync(projectRoot, {
       defaultPort: options.port,
       fallbackPort,


### PR DESCRIPTION
# Why

Add support for --port in web mode
`startAsync` has a hardcoded settings value. In `resolvePortsAsync` never goes trough `settings.webOnly` if statement.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
https://github.com/expo/expo/issues/20629


# How

<!--
How did you build this feature or fix this bug and why?
-->
Use of options.web to set settings.webOnly in startAsync allowing to resolvePortAsync use --port in web.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
