### PR TITLE
[android][camera] Implement custom resolution filter

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -440,7 +440,7 @@ export default class CameraScreen extends React.Component<object, State> {
           mode={this.state.mode}
           mute={this.state.mute}
           zoom={this.state.zoom}
-          ratio="4:3"
+          ratio="1:1"
           videoQuality="2160p"
           onMountError={this.handleMountError}
           barcodeScannerSettings={{

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -14,6 +14,7 @@ import android.media.MediaActionSound
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.util.Rational
 import android.util.Size
 import android.view.OrientationEventListener
 import android.view.Surface
@@ -37,6 +38,8 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.core.MirrorMode
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCaseGroup
+import androidx.camera.core.ViewPort
+import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -359,12 +362,20 @@ class ExpoCameraView(
           PreviewView.ScaleType.FILL_CENTER
         }
 
-        val resolutionSelector = ResolutionSelector.Builder().apply {
-          if (ratio != CameraRatio.ONE_ONE) {
-            setAspectRatioStrategy(ratio.mapToStrategy())
-          }
-          setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
-        }.build()
+        val resolutionSelector = if (ratio == CameraRatio.ONE_ONE) {
+          ResolutionSelector.Builder().setResolutionFilter { supportedSizes, _ ->
+            return@setResolutionFilter supportedSizes.filter {
+              it.width == it.height
+            }
+          }.setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY).build()
+        } else {
+          ResolutionSelector.Builder().apply {
+            if (ratio != CameraRatio.ONE_ONE) {
+              setAspectRatioStrategy(ratio.mapToStrategy())
+            }
+            setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
+          }.build()
+        }
 
         val preview = Preview.Builder()
           .setResolutionSelector(resolutionSelector)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -98,7 +98,7 @@ class ExpoCameraView(
   CameraViewInterface {
   private val currentActivity
     get() = appContext.currentActivity as? AppCompatActivity
-      ?: throw Exceptions.MissingActivity()
+            ?: throw Exceptions.MissingActivity()
 
   val orientationEventListener by lazy {
     object : OrientationEventListener(currentActivity) {
@@ -335,7 +335,7 @@ class ExpoCameraView(
                 else -> promise.reject(
                   CameraExceptions.VideoRecordingFailed(
                     event.cause?.message
-                      ?: "Video recording Failed: ${event.cause?.message ?: "Unknown error"}"
+                    ?: "Video recording Failed: ${event.cause?.message ?: "Unknown error"}"
                   )
                 )
               }
@@ -343,7 +343,7 @@ class ExpoCameraView(
           }
         }
     }
-      ?: promise.reject("E_RECORDING_FAILED", "Starting video recording failed - could not create video file.", null)
+    ?: promise.reject("E_RECORDING_FAILED", "Starting video recording failed - could not create video file.", null)
   }
 
   @SuppressLint("UnsafeOptInUsageError")
@@ -362,21 +362,7 @@ class ExpoCameraView(
           PreviewView.ScaleType.FILL_CENTER
         }
 
-        val resolutionSelector = if (ratio == CameraRatio.ONE_ONE) {
-          ResolutionSelector.Builder().setResolutionFilter { supportedSizes, _ ->
-            return@setResolutionFilter supportedSizes.filter {
-              it.width == it.height
-            }
-          }.setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY).build()
-        } else {
-          ResolutionSelector.Builder().apply {
-            if (ratio != CameraRatio.ONE_ONE) {
-              setAspectRatioStrategy(ratio.mapToStrategy())
-            }
-            setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
-          }.build()
-        }
-
+        val resolutionSelector = buildResolutionSelector()
         val preview = Preview.Builder()
           .setResolutionSelector(resolutionSelector)
           .build()
@@ -452,6 +438,21 @@ class ExpoCameraView(
           )
         }
       }
+
+  private fun buildResolutionSelector(): ResolutionSelector = if (ratio == CameraRatio.ONE_ONE) {
+    ResolutionSelector.Builder().setResolutionFilter { supportedSizes, _ ->
+      return@setResolutionFilter supportedSizes.filter {
+        it.width == it.height
+      }
+    }.setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY).build()
+  } else {
+    ResolutionSelector.Builder().apply {
+      if (ratio != CameraRatio.ONE_ONE) {
+        setAspectRatioStrategy(ratio.mapToStrategy())
+      }
+      setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
+    }.build()
+  }
 
   private fun createVideoCapture(): VideoCapture<Recorder> {
     val preferredQuality = videoQuality.mapToQuality()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -14,7 +14,6 @@ import android.media.MediaActionSound
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import android.util.Rational
 import android.util.Size
 import android.view.OrientationEventListener
 import android.view.Surface
@@ -38,8 +37,6 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.core.MirrorMode
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCaseGroup
-import androidx.camera.core.ViewPort
-import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -98,7 +95,7 @@ class ExpoCameraView(
   CameraViewInterface {
   private val currentActivity
     get() = appContext.currentActivity as? AppCompatActivity
-            ?: throw Exceptions.MissingActivity()
+      ?: throw Exceptions.MissingActivity()
 
   val orientationEventListener by lazy {
     object : OrientationEventListener(currentActivity) {
@@ -335,7 +332,7 @@ class ExpoCameraView(
                 else -> promise.reject(
                   CameraExceptions.VideoRecordingFailed(
                     event.cause?.message
-                    ?: "Video recording Failed: ${event.cause?.message ?: "Unknown error"}"
+                      ?: "Video recording Failed: ${event.cause?.message ?: "Unknown error"}"
                   )
                 )
               }
@@ -343,7 +340,7 @@ class ExpoCameraView(
           }
         }
     }
-    ?: promise.reject("E_RECORDING_FAILED", "Starting video recording failed - could not create video file.", null)
+      ?: promise.reject("E_RECORDING_FAILED", "Starting video recording failed - could not create video file.", null)
   }
 
   @SuppressLint("UnsafeOptInUsageError")
@@ -447,9 +444,7 @@ class ExpoCameraView(
     }.setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY).build()
   } else {
     ResolutionSelector.Builder().apply {
-      if (ratio != CameraRatio.ONE_ONE) {
-        setAspectRatioStrategy(ratio.mapToStrategy())
-      }
+      setAspectRatioStrategy(ratio.mapToStrategy())
       setResolutionStrategy(ResolutionStrategy.HIGHEST_AVAILABLE_STRATEGY)
     }.build()
   }


### PR DESCRIPTION
# Why
Follow up of #30831. 
After further investigation with the repro provided in #30829, there are cases where the preview will still not have the correct ratio ie when inside a `Modal` component, the preview will exceed the modals bounds. This is because CameraX does not support `1:1` aspect ratio by default. 

# How
When using a `1:1` aspect ratio, we implement a custom resolutionFilter. This forces the camera to only select an option that fits this criteria.

# Test Plan
bare expo with the provided repro. The preview no longer exceeds the bounds of the modal
