### PR TITLE
Enable dark mode in bare-expo

### DIFF
--- a/apps/bare-expo/android/app/src/main/res/values/strings.xml
+++ b/apps/bare-expo/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
   <string name="expo_splash_screen_resize_mode" translatable="false">cover</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_runtime_version">1.0.0</string>
+  <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
 </resources>

--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -15,6 +15,7 @@
     "privacy": "unlisted",
     "version": "1.0.0",
     "platforms": ["ios", "android", "web"],
+    "userInterfaceStyle": "automatic",
     "android": {
       "scheme": ["com.googleusercontent.apps.29635966244-knmlpr1upnv6rs4bumqea7hpit4o7kg2"],
       "adaptiveIcon": {

--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -117,7 +117,7 @@
       <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
+    <string>Automatic</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
   </dict>


### PR DESCRIPTION
# Why

I noticed that bare-expo declares support only for the light mode 😅

# How

- set `userInterfaceStyle` to `true` in `app.json`
- ran `npx expo prebuild` in `apps/bare-expo` and commit changes made by the plugin

# Test Plan

The Appearance example in NCL (run inside bare-expo) now works as expected (detects light and dark mode)