### PR TITLE
[image] Clean up code availability for iOS 15.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -373,7 +373,6 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.14.6)
   - ExpoImage/Tests (1.12.9):
     - ExpoModulesCore
     - ExpoModulesTestCore
@@ -381,7 +380,6 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.14.6)
   - ExpoImageManipulator (12.0.5):
     - EXImageLoader
     - ExpoModulesCore
@@ -2914,7 +2912,7 @@ SPEC CHECKSUMS:
   ExpoFont: 8052e556507ff9c37bbd3fd24a4d52e79d60892e
   ExpoGL: 538b9cfb79816799a06c6557571d08bf50654a7e
   ExpoHaptics: 0b0a0bbbf3eeda6d2101e8987a0530dd00f7e0d2
-  ExpoImage: 8bc89db2f2c7705064afe2083c450f4147c0ea7c
+  ExpoImage: 64e08fd55723edc561f8c9b031c66b0f3474e57b
   ExpoImageManipulator: b70951c53b638b8a2535a9533b730b63ccf7b051
   ExpoImagePicker: 645d49aff6a6c9592bdd16c9488b6b8717621348
   ExpoInsights: c0b88961438e12ed34dfcde7b45c5c0555415dec

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -90,7 +90,6 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.14.6)
   - ExpoImage/Tests (1.12.9):
     - ExpoModulesCore
     - ExpoModulesTestCore
@@ -98,7 +97,6 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.14.6)
   - ExpoImageManipulator (12.0.5):
     - EXImageLoader
     - ExpoModulesCore
@@ -2378,7 +2376,7 @@ SPEC CHECKSUMS:
   ExpoGL: 538b9cfb79816799a06c6557571d08bf50654a7e
   ExpoHaptics: 0b0a0bbbf3eeda6d2101e8987a0530dd00f7e0d2
   ExpoHead: ffaa3a54a24ab83b1f20460c107802ce5e7911ae
-  ExpoImage: 8bc89db2f2c7705064afe2083c450f4147c0ea7c
+  ExpoImage: 64e08fd55723edc561f8c9b031c66b0f3474e57b
   ExpoImageManipulator: b70951c53b638b8a2535a9533b730b63ccf7b051
   ExpoImagePicker: 645d49aff6a6c9592bdd16c9488b6b8717621348
   ExpoKeepAwake: a273e4ddd0ef6bfd967f088df97b4734729b93c3

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Bumped iOS and tvOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))
+- Bumped iOS and tvOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840), [#30871](https://github.com/expo/expo/pull/30871) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🎉 New features
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -20,7 +20,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'SDWebImage', '~> 5.19.1'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'
   s.dependency 'SDWebImageAVIFCoder', '~> 0.11.0'
   s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'
   s.dependency 'libavif/libdav1d'

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -2,7 +2,6 @@
 
 import ExpoModulesCore
 import SDWebImage
-import SDWebImageWebPCoder
 import SDWebImageAVIFCoder
 import SDWebImageSVGCoder
 
@@ -206,13 +205,8 @@ public final class ImageModule: Module {
   }
 
   static func registerCoders() {
-    if #available(iOS 14.0, tvOS 14.0, *) {
-      // By default Animated WebP is not supported
-      SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
-    } else {
-      // This coder is much slower, but it's the only one that works in iOS 13
-      SDImageCodersManager.shared.addCoder(SDImageWebPCoder.shared)
-    }
+    // By default Animated WebP is not supported
+    SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageAVIFCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageHEICCoder.shared)

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -77,11 +77,8 @@ private func assetLocalIdentifier(fromUrl url: URL) -> String? {
  Checks whether the app is authorized to read the Photo Library.
  */
 private func isPhotoLibraryStatusAuthorized() -> Bool {
-  if #available(iOS 14, tvOS 14, *) {
-    let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-    return status == .authorized || status == .limited
-  }
-  return PHPhotoLibrary.authorizationStatus() == .authorized
+  let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+  return status == .authorized || status == .limited
 }
 
 /**


### PR DESCRIPTION
# Why

Follow up #30840 

# How

Removed dead code after minimum iOS version bump
`SDImageWebPCoder` is no longer necessary as a dependency 🎉 
