### PR TITLE
[docs] First pass on a local-first guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -422,6 +422,7 @@ const general = [
         makePage('guides/using-bun.mdx'),
         makePage('guides/editing-richtext.mdx'),
         makePage('guides/store-assets.mdx'),
+        makePage('guides/local-first.mdx'),
       ]),
       makeSection('Integrations', [
         makePage('guides/using-analytics.mdx'),

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -6,12 +6,14 @@ description: An introduction to the emerging local-first software movement, incl
 
 > **info** This guide is a work in progress. If you have any feedback, please [open an issue](https://github.com/expo/expo/issues/new/choose).
 
-## What is local-first?
-
-> In local-first software, the availability of another computer should never prevent you from working.
-> - Martin Kleppmann in ["The past, present, and future of local-first"](https://www.youtube.com/watch?v=NMq0vncHJvU)
-
 The term "local-first" was first coined in the paper ["Local-first software"](https://www.inkandswitch.com/local-first/), written by the research lab [Ink & Switch](https://www.inkandswitch.com/), but the ideas behind it have been around for a long time. It's the architecture that powers some of our favorite apps, like [Linear](https://linear.app/), [Superhuman](https://superhuman.com/), [Excalidraw](https://excalidraw.com/), and even [Apple Notes](https://en.wikipedia.org/wiki/Notes_(Apple)).
+
+In local-first software, "the availability of another computer should never prevent you from working" ([via Martin Kleppmann](https://www.youtube.com/watch?v=NMq0vncHJvU)). When you are offline, you can still read and write directly from/to a database on your device. You can trust the software to work offline, and you know that when you are connected to the internet, your data will be seamlessly synced and available on any of your devices running the app. When you're online, this architecture is well suited for "multiplayer" apps, [as popularized by Figma](https://www.figma.com/blog/how-figmas-multiplayer-technology-works/).
+
+To dig deeper into what local-first is and how it works, refer to the [additional resources](#additional-resources) below.
+
+
+## Why use a local-first architecture?
 
 ### User experience benefits
 
@@ -27,53 +29,45 @@ You no longer have to manage various states of your app for each network request
 
 Your server availability may still be important, but in the event of an outage your users can still access the app and continue working. You may even provide a mechanism to sync the data without going through your server.
 
-### Challenges in building local-first apps
+## Challenges in building local-first apps
 
-The tools available today are still in their early stages, and so you may find yourself solving problems that you would expect to be solved by the tools you are using today. For example, you may need to implement a custom sync layer, or you may have to figure out how to handle permissions for multiple users operating on the same data. As the ecosystem evolves, we expect it to become easier to build local-first apps.a  If you're not prepared to be an early adopter, and everything that comes with that, you might want to wait for the tools to mature before you start building your app with local-first tools.
+The tools available today are still in their early stages, and so you may find yourself solving problems that you would expect to be solved by the tools you are using today. For example, you may need to implement a custom sync layer, or you may have to figure out how to handle permissions for multiple users operating on the same data. As the ecosystem evolves, we expect it to become easier to build local-first apps. If you're not prepared to be an early adopter, and everything that comes with that, you might want to wait for the tools to mature before you start building your app with local-first tools.
 
 ## Tools for building local-first apps
 
 A comprehensive list of tools is available on the ["Local-first software" community website](https://localfirstweb.dev/). The following is a shorter list of tools that we at Expo have had direct experience working with.
 
+One way to think of local-first tools is to group them by the following categories: persistence, state management, and syncing. Some tools will fit into multiple categories if they handle multiple aspects of the problem. Syncing can be further subdivided into syncable data structures and transport layers.
+
 ### SQLite
 
-..add expo-sqlite etc. notes here
+[Expo SQLite](/versions/latest/sdk/sqlite/) is a SQLite library that is a great choice for persistence for local-first apps. You can use SQLite with different state management and syncing layers in front of it, such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite) to persist [Yjs](#yjs) documents, and [TinyBase](#tinybase) as a state management layer. Using SQLite is flexible, but you will need to combine it with other tools or build your own tools to get a complete local-first solution. [Learn more](https://docs.expo.dev/versions/latest/sdk/sqlite/).
 
 ### TinyBase
 
-[TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps" - 
+[TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps". It is a state management library that plugs in to many of the most popular syncing and persistence layers, such as [Yjs](#yjs) and [SQLite](#sqlite). It's a great choice for building local-first apps that need to persist and sync data. Get started with it using the [TinyBase example](https://github.com/expo/examples/tree/master/with-tinybase): `npx create-expo-app --example with-tinybase`.
 
 ### Yjs
 
-[Yjs](https://github.com/yjs/yjs) 
-
-...add link to example repo and yjs expo-sqlite adapter
-
-### Automerge
-
-...add notes about this here, also try it out 
+[Yjs](https://github.com/yjs/yjs) is a [CRDT implementation](https://github.com/yjs/yjs?tab=readme-ov-file#yjs-crdt-algorithm) that provides data types that can be synced across multiple clients. When building an app with Yjs and working with data that you would like to be able to sync, then you would use `Y.Array` and `Y.Map` to represent your data, rather than `Array` and `Object`. You may use a library like [TinyBase](#tinybase) for state management on top of Yjs, and persistence can be handled by a variety of tools, from a JSON file on your filesystem to a full-fledged database (such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite)) and everything in between. [Learn more](https://github.com/yjs/yjs).
 
 ### Prisma
 
-[Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for Expo and React Native in early access. [Learn more](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo).
-
-...link to beto prisma example
-
-### LiveStore
-
-...
+[Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for Expo and React Native in early access. [Learn more](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo). Prisma aims to provide a complete local-first solution, with state management, syncing, and persistence all covered for you. While it's still early, [Beto Moedano](https://github.com/betomoedano) has put together full walkthrough of using Prisma with Expo to build a local-first Notion clone, [watch it on YouTube](https://www.youtube.com/watch?v=uTrPte0sCiw) and [check out the code on GitHub](https://github.com/betomoedano/React-Native-Notion-Clone).
 
 ### Other tools
 
-- ElectricSQL
-- Instant (https://www.instantdb.com/)
-- Drizzle ORM
-- PowerSync
+Far from a comprehensive list, the following iis a list of some other tools that have caught our attention and that you may find interesting to explore. For a more thorough list of tools on the ["Local-first software" community website](https://localfirstweb.dev/).
+
+- [LiveStore](https://github.com/livestorejs/livestore)
+- [Automerge](https://automerge.org/)
+- [ElectricSQL](https://electric-sql.com/)
+- [Instant](https://www.instantdb.com/)
+- [PowerSync](https://www.powersync.com/)
 
 ## Additional resources
 
-- https://localfirstweb.dev/
-- https://localfirst.fm/
-- local first conf 2024 playlist: https://www.youtube.com/watch?v=NMq0vncHJvU&list=PL4isNRKAwz2O9FxP97_EbOivIWWwSWt5j
-- a couple other talks
-- some blog posts?
+- ["The past, present, and future of local-first"](https://www.youtube.com/watch?v=NMq0vncHJvU) by Martin Kleppmann
+- ["Local-first software"](https://www.inkandswitch.com/local-first/) by Ink & Switch
+- ["Local-first software" community website](https://localfirstweb.dev/) and [meetup playlist on YouTube](https://www.youtube.com/playlist?list=PLTbD2QA-VMnXFsLbuPGz1H-Najv9MD2-H)
+- [localfirst.fm podcast](https://localfirst.fm/) by Johannes Schickling

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -6,12 +6,11 @@ description: An introduction to the emerging local-first software movement, incl
 
 > **info** This guide is a work in progress. If you have any feedback, please [open an issue](https://github.com/expo/expo/issues/new/choose).
 
-The term "local-first" was first coined in the paper ["Local-first software"](https://www.inkandswitch.com/local-first/), written by the research lab [Ink & Switch](https://www.inkandswitch.com/), but the ideas behind it have been around for a long time. It's the architecture that powers some of our favorite apps, like [Linear](https://linear.app/), [Superhuman](https://superhuman.com/), [Excalidraw](https://excalidraw.com/), and even [Apple Notes](https://en.wikipedia.org/wiki/Notes_(Apple)).
+The term "local-first" was first coined in the paper ["Local-first software"](https://www.inkandswitch.com/local-first/), written by the research lab [Ink & Switch](https://www.inkandswitch.com/), but the ideas behind it have been around for a long time. It's the architecture that powers some of our favorite apps, like [Linear](https://linear.app/), [Superhuman](https://superhuman.com/), [Excalidraw](https://excalidraw.com/), and even [Apple Notes](<https://en.wikipedia.org/wiki/Notes_(Apple)>).
 
 In local-first software, "the availability of another computer should never prevent you from working" ([via Martin Kleppmann](https://www.youtube.com/watch?v=NMq0vncHJvU)). When you are offline, you can still read and write directly from/to a database on your device. You can trust the software to work offline, and you know that when you are connected to the internet, your data will be seamlessly synced and available on any of your devices running the app. When you're online, this architecture is well suited for "multiplayer" apps, [as popularized by Figma](https://www.figma.com/blog/how-figmas-multiplayer-technology-works/).
 
 To dig deeper into what local-first is and how it works, refer to the [additional resources](#additional-resources) below.
-
 
 ## Why use local-first architecture?
 

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -1,0 +1,79 @@
+---
+title: Local-first architecture with Expo
+sidebar_title: Local-first
+description: An introduction to the emerging local-first software movement, including links to relevant learning resources and tools.
+---
+
+> **info** This guide is a work in progress. If you have any feedback, please [open an issue](https://github.com/expo/expo/issues/new/choose).
+
+## What is local-first?
+
+> In local-first software, the availability of another computer should never prevent you from working.
+> - Martin Kleppmann in ["The past, present, and future of local-first"](https://www.youtube.com/watch?v=NMq0vncHJvU)
+
+The term "local-first" was first coined in the paper ["Local-first software"](https://www.inkandswitch.com/local-first/), written by the research lab [Ink & Switch](https://www.inkandswitch.com/), but the ideas behind it have been around for a long time. It's the architecture that powers some of our favorite apps, like [Linear](https://linear.app/), [Superhuman](https://superhuman.com/), [Excalidraw](https://excalidraw.com/), and even [Apple Notes](https://en.wikipedia.org/wiki/Notes_(Apple)).
+
+### User experience benefits
+
+Local-first software feels **fast** because interactions are no longer network-bound, you can read and write directly from/to a database on your device.
+
+You can trust the software to work offline, and you know that when you are connected to the internet, your data will be seamlessly synced and available on any of your devices running the app.
+
+Another characteristic of local-first software is that it is collaborative - multiple devices can work on the same data, and changes are synced across all of them. This can happen in real-time, like when you collaborate on a design in [Figma](https://www.figma.com/), or asynchronously, like when you create a task while offline in Linear and it is synced when you are online again.
+
+### Developer experience benefits
+
+You no longer have to manage various states of your app for each network request - "loaded", "loading", "error", etc., with their corresponding UI states and other logic. Write to a local database, and the app will automatically sync the changes to the server. This means that you can focus on building the app, and not worry as much about the networking and offline states.
+
+Your server availability may still be important, but in the event of an outage your users can still access the app and continue working. You may even provide a mechanism to sync the data without going through your server.
+
+### Challenges in building local-first apps
+
+The tools available today are still in their early stages, and so you may find yourself solving problems that you would expect to be solved by the tools you are using today. For example, you may need to implement a custom sync layer, or you may have to figure out how to handle permissions for multiple users operating on the same data. As the ecosystem evolves, we expect it to become easier to build local-first apps.a  If you're not prepared to be an early adopter, and everything that comes with that, you might want to wait for the tools to mature before you start building your app with local-first tools.
+
+## Tools for building local-first apps
+
+A comprehensive list of tools is available on the ["Local-first software" community website](https://localfirstweb.dev/). The following is a shorter list of tools that we at Expo have had direct experience working with.
+
+### SQLite
+
+..add expo-sqlite etc. notes here
+
+### TinyBase
+
+[TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps" - 
+
+### Yjs
+
+[Yjs](https://github.com/yjs/yjs) 
+
+...add link to example repo and yjs expo-sqlite adapter
+
+### Automerge
+
+...add notes about this here, also try it out 
+
+### Prisma
+
+[Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for Expo and React Native in early access. [Learn more](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo).
+
+...link to beto prisma example
+
+### LiveStore
+
+...
+
+### Other tools
+
+- ElectricSQL
+- Instant (https://www.instantdb.com/)
+- Drizzle ORM
+- PowerSync
+
+## Additional resources
+
+- https://localfirstweb.dev/
+- https://localfirst.fm/
+- local first conf 2024 playlist: https://www.youtube.com/watch?v=NMq0vncHJvU&list=PL4isNRKAwz2O9FxP97_EbOivIWWwSWt5j
+- a couple other talks
+- some blog posts?

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -4,7 +4,7 @@ sidebar_title: Local-first
 description: An introduction to the emerging local-first software movement, including links to relevant learning resources and tools.
 ---
 
-> **info** This guide is a work in progress. If you have any feedback, please [open an issue](https://github.com/expo/expo/issues/new/choose).
+> **info** This guide is a work in progress. If you have any feedback, [open an issue](https://github.com/expo/expo/issues/new/choose) in our GitHub repository.
 
 The term "local-first" was first coined in the paper ["Local-first software"](https://www.inkandswitch.com/local-first/), written by the research lab [Ink & Switch](https://www.inkandswitch.com/), but the ideas behind it have been around for a long time. It's the architecture that powers some of our favorite apps, like [Linear](https://linear.app/), [Superhuman](https://superhuman.com/), [Excalidraw](https://excalidraw.com/), and even [Apple Notes](<https://en.wikipedia.org/wiki/Notes_(Apple)>).
 
@@ -20,11 +20,11 @@ Local-first software feels **fast** because interactions are no longer network-b
 
 You can trust the software to work offline, and you know that when you are connected to the internet, your data will be seamlessly synced and available on any of your devices running the app.
 
-Another characteristic of local-first software is that it is collaborative - multiple devices can work on the same data, and changes are synced across all of them. This can happen in real-time, like when you collaborate on a design in [Figma](https://www.figma.com/), or asynchronously, like when you create a task while offline in Linear and it is synced when you are online again.
+Another characteristic of local-first software is that it is collaborative &mdash; multiple devices can work on the same data, and changes are synced across all of them. This can happen in real-time when you collaborate on a design in [Figma](https://www.figma.com/) or asynchronously when you create a task while offline in Linear and it is synced when you are online again.
 
 ### Developer experience benefits
 
-You no longer have to manage various states of your app for each network request - "loaded", "loading", "error", etc., with their corresponding UI states and other logic. Write to a local database, and the app will automatically sync the changes to the server. This means that you can focus on building the app, and not worry as much about the networking and offline states.
+You no longer have to manage various states of your app for each network request &mdash; "loaded", "loading", "error", and so on, with their corresponding UI states and other logic. Write to a local database, and the app will automatically sync the changes to the server. This means that you can focus on building the app, and not worry as much about the networking and offline states.
 
 Your server availability may still be important, but in the event of an outage your users can still access the app and continue working. You may even provide a mechanism to sync the data without going through your server.
 
@@ -40,23 +40,23 @@ One way to think of local-first tools is to group them by the following categori
 
 ### TinyBase
 
-[TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps". It is a state management library that plugs in to many of the most popular syncing and persistence layers, such as [Yjs](#yjs) and [SQLite](#sqlite). It's a great choice for building local-first apps that need to persist and sync data. Get started with it using the [TinyBase example](https://github.com/expo/examples/tree/master/with-tinybase): `npx create-expo-app --example with-tinybase`.
+[TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps". It is a state management library that plugs in to many of the most popular syncing and persistence layers, such as [Yjs](#yjs) and [SQLite](#sqlite). It's a great choice for building local-first apps that need to persist and sync data. Get started by using the [TinyBase example](https://github.com/expo/examples/tree/master/with-tinybase): `npx create-expo-app --example with-tinybase`.
 
 ### SQLite
 
-[Expo SQLite](/versions/latest/sdk/sqlite/) is a SQLite library that is a great choice for persistence for local-first apps. You can use SQLite with different state management and syncing layers in front of it, such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite) to persist [Yjs](#yjs) documents, and [TinyBase](#tinybase) as a state management layer. Using SQLite is flexible, but you will need to combine it with other tools or build your own tools to get a complete local-first solution. [Learn more](https://docs.expo.dev/versions/latest/sdk/sqlite/).
+[Expo SQLite](/versions/latest/sdk/sqlite/) is a SQLite library that is a great choice for persistence for local-first apps. You can use SQLite with different state management and syncing layers in front of it, such as [`y-expo-sqlite`](https://github.com/brentvatne/y-expo-sqlite) to persist [Yjs](#yjs) documents, and [TinyBase](#tinybase) as a state management layer. Using SQLite is flexible, but you will need to combine it with other tools or build your own tools to get a complete local-first solution. See [Expo SQLite API reference](/versions/latest/sdk/sqlite/) for more information.
 
 ### Yjs
 
-[Yjs](https://github.com/yjs/yjs) is a [CRDT implementation](https://github.com/yjs/yjs?tab=readme-ov-file#yjs-crdt-algorithm) that provides data types that can be synced across multiple clients. When building an app with Yjs and working with data that you would like to be able to sync, then you would use `Y.Array` and `Y.Map` to represent your data, rather than `Array` and `Object`. You may use a library like [TinyBase](#tinybase) for state management on top of Yjs, and persistence can be handled by a variety of tools, from a JSON file on your filesystem to a full-fledged database (such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite)) and everything in between. [Learn more](https://github.com/yjs/yjs).
+[Yjs](https://github.com/yjs/yjs) is a [CRDT implementation](https://github.com/yjs/yjs?tab=readme-ov-file#yjs-crdt-algorithm) that provides data types that can be synced across multiple clients. When building an app with Yjs and working with data that you would like to be able to sync, then you would use `Y.Array` and `Y.Map` to represent your data rather than `Array` and `Object`. You may use a library like [TinyBase](#tinybase) for state management on top of Yjs, and persistence can be handled by a variety of tools, from a JSON file on your filesystem to a full-fledged database (such as [`y-expo-sqlite`](https://github.com/brentvatne/y-expo-sqlite)) and everything in between. See [Yjs's GitHub repository](https://github.com/yjs/yjs) for more information.
 
 ### Prisma
 
-[Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for Expo and React Native in early access. [Learn more](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo). Prisma aims to provide a complete local-first solution, with state management, syncing, and persistence all covered for you. While it's still early, [Beto Moedano](https://github.com/betomoedano) has put together full walkthrough of using Prisma with Expo to build a local-first Notion clone, [watch it on YouTube](https://www.youtube.com/watch?v=uTrPte0sCiw) and [check out the code on GitHub](https://github.com/betomoedano/React-Native-Notion-Clone).
+[Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for [Expo and React Native in early access](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo). Prisma aims to provide a complete local-first solution, with state management, syncing, and persistence all covered for you. While it's still early, [Beto Moedano](https://github.com/betomoedano) has put together full walkthrough of using Prisma with Expo to build a local-first Notion clone, [watch it on YouTube](https://www.youtube.com/watch?v=uTrPte0sCiw) and [check out the code on GitHub](https://github.com/betomoedano/React-Native-Notion-Clone).
 
 ### Other tools
 
-Far from a comprehensive list, the following iis a list of some other tools that have caught our attention and that you may find interesting to explore. For a more thorough list of tools on the ["Local-first software" community website](https://localfirstweb.dev/).
+The following list, far from being comprehensive, provides other tools that have caught our attention and that you may find interesting to explore. For a more thorough list of tools, see ["Local-first software" community website](https://localfirstweb.dev/).
 
 - [LiveStore](https://github.com/livestorejs/livestore)
 - [Automerge](https://automerge.org/)

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -13,7 +13,7 @@ In local-first software, "the availability of another computer should never prev
 To dig deeper into what local-first is and how it works, refer to the [additional resources](#additional-resources) below.
 
 
-## Why use a local-first architecture?
+## Why use local-first architecture?
 
 ### User experience benefits
 
@@ -39,13 +39,13 @@ A comprehensive list of tools is available on the ["Local-first software" commun
 
 One way to think of local-first tools is to group them by the following categories: persistence, state management, and syncing. Some tools will fit into multiple categories if they handle multiple aspects of the problem. Syncing can be further subdivided into syncable data structures and transport layers.
 
-### SQLite
-
-[Expo SQLite](/versions/latest/sdk/sqlite/) is a SQLite library that is a great choice for persistence for local-first apps. You can use SQLite with different state management and syncing layers in front of it, such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite) to persist [Yjs](#yjs) documents, and [TinyBase](#tinybase) as a state management layer. Using SQLite is flexible, but you will need to combine it with other tools or build your own tools to get a complete local-first solution. [Learn more](https://docs.expo.dev/versions/latest/sdk/sqlite/).
-
 ### TinyBase
 
 [TinyBase](https://tinybase.org/) calls itself "the reactive data store for local-first apps". It is a state management library that plugs in to many of the most popular syncing and persistence layers, such as [Yjs](#yjs) and [SQLite](#sqlite). It's a great choice for building local-first apps that need to persist and sync data. Get started with it using the [TinyBase example](https://github.com/expo/examples/tree/master/with-tinybase): `npx create-expo-app --example with-tinybase`.
+
+### SQLite
+
+[Expo SQLite](/versions/latest/sdk/sqlite/) is a SQLite library that is a great choice for persistence for local-first apps. You can use SQLite with different state management and syncing layers in front of it, such as [y-expo-sqlite](https://github.com/brentvatne/y-expo-sqlite) to persist [Yjs](#yjs) documents, and [TinyBase](#tinybase) as a state management layer. Using SQLite is flexible, but you will need to combine it with other tools or build your own tools to get a complete local-first solution. [Learn more](https://docs.expo.dev/versions/latest/sdk/sqlite/).
 
 ### Yjs
 


### PR DESCRIPTION
# Why

It's useful for us to have a dedicated place in our documentation to discuss local-first. I could see this expanding into its own section at some point, but for now I just put this within the guides section.

# How

Wrote what I had in my head about this topic, while trying to keep it relatively concise and focused on providing an overview rather than go into detail on any particular subtopic (this is covered better by other resources that I link to).

# Test Plan

Read it over :)

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
