### PR TITLE
Update next-steps.mdx

### DIFF
--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -43,5 +43,5 @@ import { BoxLink } from '~/ui/components/BoxLink';
   title="ESLint and Prettier"
   Icon={BookOpen02Icon}
   description="A guide on configuring ESLint and Prettier to format Expo projects."
-  href="/guides/icons/"
+  href="/guides/using-eslint/"
 />


### PR DESCRIPTION
Bug Fix: "ESlint and Prettier" BoxLink href changed from '/guides/icons' to '/guides/using-eslint'

# Why

DOCS: "ESlint and Prettier" BoxLink href is incorrect

# How

"ESlint and Prettier" BoxLink href changed from '/guides/icons' to '/guides/using-eslint'

# Test Plan

Upon clicking "ESlint and Prettier"  on [Next steps](https://docs.expo.dev/develop/user-interface/next-steps/) page user should be navigated to [Use ESLint and Prettier](https://docs.expo.dev/guides/using-eslint/) instead of Icons page

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
