### PR TITLE
[docs] Add info about enabling Developer options iOS Physical Device in local dev build

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -30,7 +30,7 @@ Run the following command in your project's root directory:
 
 Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
-Make sure you have enabled Developer Mode on your device. Not sure how? Visit [Apple's official documentation](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device) for guidance.
+Make sure you have enabled Developer Mode on your device. See [Enable iOS developer mode with a Mac](https://docs.expo.dev/guides/ios-developer-mode/#connect-an-ios-device-with-a-mac) for instructions.
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -30,7 +30,7 @@ Run the following command in your project's root directory:
 
 Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
-Make sure you have enabled Developer Mode on your device. Not sure how? Visit https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device
+Make sure you have enabled Developer Mode on your device. Not sure how? Visit [Apple's official documentation](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device) for guidance.
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -30,6 +30,8 @@ Run the following command in your project's root directory:
 
 Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
+Make sure you have enabled Developer Mode on your device. Not sure how? Visit https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device
+
 </Step>
 
 <Step label="3">


### PR DESCRIPTION

# Why

Following the instructions in the ReadMe will not enable the user to successfully run the app on their device if they have not previously enabled Developer Mode on their device.

# How

I have added a line to make sure that is clearly explained with a link to Apple's official documentation.

# Test Plan

N/A, just text. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
