### PR TITLE
[expo-video][android] Fix wrong event being sent when the volume is changed

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Android] Fix support for local file playback. ([#30472](https://github.com/expo/expo/pull/30472) by [@behenate](https://github.com/behenate))
 - Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
+- [Android] Fix wrong event being sent when the volume is changed. ([#30891](https://github.com/expo/expo/pull/30891) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/PlayerEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/PlayerEvent.kt
@@ -23,7 +23,7 @@ sealed class PlayerEvent {
   }
 
   data class VolumeChanged(val newValue: VolumeEvent, val oldValue: VolumeEvent?) : PlayerEvent() {
-    override val name = "playingChange"
+    override val name = "volumeChange"
     override val arguments = arrayOf(newValue, oldValue)
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -67,11 +67,12 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   var volume: Float by IgnoreSameSet(1f) { new: Float, old: Float ->
     player.volume = if (muted) 0f else new
+    userVolume = volume
     sendEvent(PlayerEvent.VolumeChanged(VolumeEvent(new, muted), VolumeEvent(old, muted)))
   }
 
   var muted: Boolean by IgnoreSameSet(false) { new: Boolean, old: Boolean ->
-    volume = if (new) 0f else userVolume
+    player.volume = if (new) 0f else userVolume
     sendEvent(PlayerEvent.VolumeChanged(VolumeEvent(volume, new), VolumeEvent(volume, old)))
   }
 
@@ -113,7 +114,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     }
 
     override fun onVolumeChanged(volume: Float) {
-      this@VideoPlayer.volume = volume
+      if (!muted) {
+        this@VideoPlayer.volume = volume
+      }
     }
 
     override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/30734

# How

During a recent refactor the wrong name has been set for the `VolumeChange` event, also noticed some bugs with behavior, which I fixed in this PR.

# Test Plan

Tested in BareExpo on Android and iOS
