### PR TITLE
[modules-core][android] Add react-native 0.75 support

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.75.x. ([#30902](https://github.com/expo/expo/pull/30902) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 1.12.20 — 2024-07-29
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -168,14 +168,14 @@ class AppContext(
         @Suppress("DEPRECATION")
         if (reactContext.isBridgeless) {
           val runtimeExecutor: RuntimeExecutor = try {
-              // When react-native version >= 0.75.0 get runtimeExecutor from catalystInstance
-              val catalystInstanceField = reactContext.javaClass.getDeclaredField("catalystInstance")
-              val catalystInstance = catalystInstanceField.get(reactContext)
-              val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
-              runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
+            // When react-native version >= 0.75.0 get runtimeExecutor from catalystInstance
+            val catalystInstanceField = reactContext.javaClass.getDeclaredField("catalystInstance")
+            val catalystInstance = catalystInstanceField.get(reactContext)
+            val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
+            runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
           } catch (e: NoSuchFieldException) {
-              val runtimeExecutorField = reactContext.javaClass.getDeclaredField("runtimeExecutor")
-              runtimeExecutorField.get(reactContext) as RuntimeExecutor
+            val runtimeExecutorField = reactContext.javaClass.getDeclaredField("runtimeExecutor")
+            runtimeExecutorField.get(reactContext) as RuntimeExecutor
           }
 
           jsiInterop.installJSIForBridgeless(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.react.uimanager.UIManagerHelper
@@ -166,11 +167,22 @@ class AppContext(
 
         @Suppress("DEPRECATION")
         if (reactContext.isBridgeless) {
+          val runtimeExecutor: RuntimeExecutor = try {
+              // When react-native version >= 0.75.0 get runtimeExecutor from catalystInstance
+              val catalystInstanceField = reactContext.javaClass.getDeclaredField("catalystInstance")
+              val catalystInstance = catalystInstanceField.get(reactContext)
+              val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
+              runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
+          } catch (e: NoSuchFieldException) {
+              val runtimeExecutorField = reactContext.javaClass.getDeclaredField("runtimeExecutor")
+              runtimeExecutorField.get(reactContext) as RuntimeExecutor
+          }
+
           jsiInterop.installJSIForBridgeless(
             this,
             jsRuntimePointer,
             jniDeallocator,
-            reactContext.runtimeExecutor!!
+            runtimeExecutor
           )
         } else {
           jsiInterop.installJSI(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -4,7 +4,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactDelegate
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.config.ReactFeatureFlags
-import com.facebook.react.devsupport.DisabledDevSupportManager
 import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -70,7 +69,15 @@ class CoreModule : Module() {
         ?: return@AsyncFunction
       if (!ReactFeatureFlags.enableBridgelessArchitecture) {
         val reactInstanceManager = reactDelegate.reactInstanceManager
-        if (reactInstanceManager.devSupportManager is DisabledDevSupportManager) {
+
+        var devSupportManagerClass: Class<*>
+        try {
+          // react-native version 0.75.0 renamed DisabledDevSupportManager to ReleaseDevSupportManager
+          devSupportManagerClass = Class.forName("com.facebook.react.devsupport.ReleaseDevSupportManager")
+        } catch (e: ClassNotFoundException) {
+          devSupportManagerClass = Class.forName("com.facebook.react.devsupport.DisabledDevSupportManager")
+        }
+        if (devSupportManagerClass.isInstance(reactInstanceManager.devSupportManager)) {
           UiThreadUtil.runOnUiThread {
             reactInstanceManager.recreateReactContextInBackground()
           }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
@@ -41,7 +41,16 @@ class FilteredReadableMap(
   private val backingMap: ReadableMap,
   private val filteredKeys: List<String>
 ) : ReadableMap by backingMap {
+  @Suppress("NOTHING_TO_OVERRIDE")
   override fun getEntryIterator(): Iterator<Map.Entry<String, Any>> =
+    FilteredIterator(backingMap.getEntryIterator()) {
+      !filteredKeys.contains(it.key)
+    }
+
+  // Fallback for react-native 0.75.0 compatibility
+  @Suppress("NOTHING_TO_OVERRIDE")
+  @get:JvmName("getEntryIteratorFromProperty")
+  override val entryIterator: Iterator<Map.Entry<String, Any>> =
     FilteredIterator(backingMap.entryIterator) {
       !filteredKeys.contains(it.key)
     }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.75.x. ([#30902](https://github.com/expo/expo/pull/30902) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 51.0.26 — 2024-08-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -102,40 +102,40 @@ object ExpoReactHostFactory {
 
       var reactHostImpl: ReactHostImpl
       try {
-          // react-native 0.75.0 removed the ReactJsExceptionHandler parameter
-          val constructorWithoutHandler = ReactHostImpl::class.java.getConstructor(
-              Context::class.java,
-              ReactHostDelegate::class.java,
-              ComponentFactory::class.java,
-              Boolean::class.javaPrimitiveType,
-              Boolean::class.javaPrimitiveType
-          )
+        // react-native 0.75.0 removed the ReactJsExceptionHandler parameter
+        val constructorWithoutHandler = ReactHostImpl::class.java.getConstructor(
+          Context::class.java,
+          ReactHostDelegate::class.java,
+          ComponentFactory::class.java,
+          Boolean::class.javaPrimitiveType,
+          Boolean::class.javaPrimitiveType
+        )
 
-          reactHostImpl = constructorWithoutHandler.newInstance(
-              context,
-              reactHostDelegate,
-              componentFactory,
-              true,
-              useDeveloperSupport
-          )
+        reactHostImpl = constructorWithoutHandler.newInstance(
+          context,
+          reactHostDelegate,
+          componentFactory,
+          true,
+          useDeveloperSupport
+        )
       } catch (e: NoSuchMethodException) {
-          val constructorWithHandler = ReactHostImpl::class.java.getConstructor(
-              Context::class.java,
-              ReactHostDelegate::class.java,
-              ComponentFactory::class.java,
-              Boolean::class.javaPrimitiveType,
-              ReactJsExceptionHandler::class.java,
-              Boolean::class.javaPrimitiveType
-          )
+        val constructorWithHandler = ReactHostImpl::class.java.getConstructor(
+          Context::class.java,
+          ReactHostDelegate::class.java,
+          ComponentFactory::class.java,
+          Boolean::class.javaPrimitiveType,
+          ReactJsExceptionHandler::class.java,
+          Boolean::class.javaPrimitiveType
+        )
 
-          reactHostImpl = constructorWithHandler.newInstance(
-              context,
-              reactHostDelegate,
-              componentFactory,
-              true,
-              reactJsExceptionHandler,
-              useDeveloperSupport
-          )
+        reactHostImpl = constructorWithHandler.newInstance(
+          context,
+          reactHostDelegate,
+          componentFactory,
+          true,
+          reactJsExceptionHandler,
+          useDeveloperSupport
+        )
       }
 
       reactHostImpl.apply {

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -100,18 +100,47 @@ object ExpoReactHostFactory {
         handler.onWillCreateReactInstance(useDeveloperSupport)
       }
 
-      val reactHostImpl =
-        ReactHostImpl(
-          context,
-          reactHostDelegate,
-          componentFactory,
-          true,
-          reactJsExceptionHandler,
-          useDeveloperSupport
-        )
-          .apply {
-            jsEngineResolutionAlgorithm = reactNativeHost.jsEngineResolutionAlgorithm
-          }
+      var reactHostImpl: ReactHostImpl
+      try {
+          // react-native 0.75.0 removed the ReactJsExceptionHandler parameter
+          val constructorWithoutHandler = ReactHostImpl::class.java.getConstructor(
+              Context::class.java,
+              ReactHostDelegate::class.java,
+              ComponentFactory::class.java,
+              Boolean::class.javaPrimitiveType,
+              Boolean::class.javaPrimitiveType
+          )
+
+          reactHostImpl = constructorWithoutHandler.newInstance(
+              context,
+              reactHostDelegate,
+              componentFactory,
+              true,
+              useDeveloperSupport
+          )
+      } catch (e: NoSuchMethodException) {
+          val constructorWithHandler = ReactHostImpl::class.java.getConstructor(
+              Context::class.java,
+              ReactHostDelegate::class.java,
+              ComponentFactory::class.java,
+              Boolean::class.javaPrimitiveType,
+              ReactJsExceptionHandler::class.java,
+              Boolean::class.javaPrimitiveType
+          )
+
+          reactHostImpl = constructorWithHandler.newInstance(
+              context,
+              reactHostDelegate,
+              componentFactory,
+              true,
+              reactJsExceptionHandler,
+              useDeveloperSupport
+          )
+      }
+
+      reactHostImpl.apply {
+        jsEngineResolutionAlgorithm = reactNativeHost.jsEngineResolutionAlgorithm
+      }
 
       reactNativeHost.reactNativeHostHandlers.forEach { handler ->
         handler.onDidCreateDevSupportManager(reactHostImpl.devSupportManager)


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/30034

Closes [ENG-12562](https://linear.app/expo/issue/ENG-12562)

# How

Update modules-core to be compatible with both react-native 0.74 and 0.75

# Test Plan

- Sandbox
- BareExpo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
