### PR TITLE
fix: update typescript module resolution from `node` to `node10`

### DIFF
--- a/apps/eas-expo-go/tsconfig.json
+++ b/apps/eas-expo-go/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react-native",
     "lib": ["dom", "esnext"],
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -17,7 +17,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/create-expo-module/tsconfig.json
+++ b/packages/create-expo-module/tsconfig.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "outDir": "./build",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "types": [],
     "typeRoots": ["./ts-declarations", "node_modules/@types"],
     "sourceMap": true,

--- a/packages/create-expo-nightly/tsconfig.json
+++ b/packages/create-expo-nightly/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "node10",
     "esModuleInterop": true,
     "declaration": true,
     "strictNullChecks": true,

--- a/packages/create-expo/tsconfig.json
+++ b/packages/create-expo/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "declaration": false,
     "composite": false,
   }

--- a/packages/expo-dev-launcher/bundle/tsconfig.json
+++ b/packages/expo-dev-launcher/bundle/tsconfig.json
@@ -4,11 +4,10 @@
     "esModuleInterop": true,
     "jsx": "react-native",
     "lib": ["DOM", "ESNext"],
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "target": "ESNext"
   }
 }
-

--- a/packages/expo-env-info/tsconfig.json
+++ b/packages/expo-env-info/tsconfig.json
@@ -9,7 +9,7 @@
     "declaration": false,
     "composite": false,
     "module": "es2020",
-    "moduleResolution": "node"
+    "moduleResolution": "node10"
   },
   "exclude": [
     "**/__mocks__/*",

--- a/packages/expo-module-scripts/tsconfig.json
+++ b/packages/expo-module-scripts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "strict": true,
     "types": []
   }

--- a/packages/expo-modules-autolinking/tsconfig.json
+++ b/packages/expo-modules-autolinking/tsconfig.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "outDir": "./build",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "types": [],
     "typeRoots": ["./ts-declarations", "node_modules/@types"],
     "sourceMap": true,

--- a/packages/expo-modules-test-core/tsconfig.json
+++ b/packages/expo-modules-test-core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "strict": true,
     "outDir": "./build",
     "types": ["node"],


### PR DESCRIPTION
# Why

We set the `moduleResolution` in typescript to `node` when we initially adopted typescript. This has been renamed to `node10` ([docs](https://www.typescriptlang.org/tsconfig/#moduleResolution)):

<img width="745" alt="image" src="https://github.com/user-attachments/assets/7cbb365d-cf75-4589-a984-3ff20677d7fa">

We might want to consider switching to `node16` even.

# How

- Updated `"moduleResolution": "node10"`

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
