### PR TITLE
fix(metro-runtime): use Expo Metro version

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix web styling bug. ([#30438](https://github.com/expo/expo/pull/30438) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix exceptions native import. ([#30433](https://github.com/expo/expo/pull/30433) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve error message for `window.location` polyfill. ([#30331](https://github.com/expo/expo/pull/30331) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix Metro imports by using `@expo/metro-config`.
 
 ### 💡 Others
 

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Fix web styling bug. ([#30438](https://github.com/expo/expo/pull/30438) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix exceptions native import. ([#30433](https://github.com/expo/expo/pull/30433) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve error message for `window.location` polyfill. ([#30331](https://github.com/expo/expo/pull/30331) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix Metro imports by using `@expo/metro-config`.
+- Fix Metro imports by using `@expo/metro-config`. ([#30920](https://github.com/expo/expo/pull/30920) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "url": "https://github.com/expo/expo.git"
   },
+  "dependencies": {
+    "@expo/metro-config": "~0.18.11"
+  },
   "peerDependencies": {
     "react-native": "*"
   }

--- a/packages/@expo/metro-runtime/src/HMRClient.ts
+++ b/packages/@expo/metro-runtime/src/HMRClient.ts
@@ -8,27 +8,19 @@
  * Based on this but with web support:
  * https://github.com/facebook/react-native/blob/086714b02b0fb838dee5a66c5bcefe73b53cf3df/Libraries/Utilities/HMRClient.js
  */
+import { HMRClient as MetroHMRClient } from '@expo/metro-config/metro-runtime';
 import prettyFormat, { plugins } from 'pretty-format';
 
 import LoadingView from './LoadingView';
 import LogBox from './error-overlay/LogBox';
 import getDevServer from './getDevServer';
 
-const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const pendingEntryPoints: string[] = [];
 
 // @ts-expect-error: Account for multiple versions of pretty-format inside of a monorepo.
 const prettyFormatFunc = typeof prettyFormat === 'function' ? prettyFormat : prettyFormat.default;
 
-type HMRClientType = {
-  send: (msg: string) => void;
-  isEnabled: () => boolean;
-  disable: () => void;
-  enable: () => void;
-  hasPendingUpdates: () => boolean;
-};
-
-let hmrClient: HMRClientType | null = null;
+let hmrClient: InstanceType<typeof MetroHMRClient> | null = null;
 let hmrUnavailableReason: string | null = null;
 let currentCompileErrorMessage: string | null = null;
 let didConnect: boolean = false;
@@ -265,7 +257,7 @@ function setHMRUnavailableReason(reason: string) {
   }
 }
 
-function registerBundleEntryPoints(client: HMRClientType | null) {
+function registerBundleEntryPoints(client: InstanceType<typeof MetroHMRClient> | null) {
   if (hmrUnavailableReason != null) {
     // "Bundle Splitting – Metro disconnected"
     window.location.reload();


### PR DESCRIPTION
# Why

This adds an explicit Metro dependency reference to `@expo/metro-runtime`.

# How

See PR #30919

# Test Plan

See PR #30919

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
