### PR TITLE
[TV] update deployment target in TV compile CI

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -454,6 +454,7 @@ function transformAppJsonForE2E(
       '@react-native-tvos/config-tv',
       {
         isTV: true,
+        tvosDeploymentTarget: '15.1',
         showVerboseWarnings: true,
       },
     ]);


### PR DESCRIPTION
# Why

Fixing an issue where Expo's iOS/tvOS deployment target was updated to 15.1, but TV config plugin still defaults to 13.4, breaking the TV compile test.

# How

Pass in the new deployment target as a plugin property in the test setup.

# Test Plan

CI should pass

