### PR TITLE
[cli] add /expo-dev-plugins/broadcast endpoint

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Update `npm-package-arg@^7` to `npm-package-arg@^11`. ([#30842](https://github.com/expo/expo/pull/30842) by [@kitten](https://github.com/kitten))
 - Fixed DOM components bundling issues for Android emulators and release builds. ([#30974](https://github.com/expo/expo/pull/30974) by [@kudo](https://github.com/kudo))
 - Added public assets support for DOM components. ([#30975](https://github.com/expo/expo/pull/30975) by [@kudo](https://github.com/kudo))
+- Added `/expo-dev-plugins/broadcast` WebSocket endpoint in dev server to support devtools plugins. ([#30934](https://github.com/expo/expo/pull/30934) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
+++ b/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
@@ -14,5 +14,5 @@ export function createDevToolsPluginWebsocketEndpoint(): Record<string, WebSocke
     });
   });
 
-  return { '/dev-plugins-broadcast': wss };
+  return { '/expo-dev-plugins/broadcast': wss };
 }

--- a/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
+++ b/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
@@ -1,0 +1,18 @@
+import { WebSocket, WebSocketServer } from 'ws';
+
+export function createDevToolsPluginWebsocketEndpoint(): Record<string, WebSocketServer> {
+  const wss = new WebSocketServer({ noServer: true });
+
+  wss.on('connection', (ws: WebSocket) => {
+    ws.on('message', (message: string) => {
+      // Broadcast the received message to all other connected clients
+      wss.clients.forEach((client) => {
+        if (client !== ws && client.readyState === WebSocket.OPEN) {
+          client.send(message);
+        }
+      });
+    });
+  });
+
+  return { '/dev-plugins-broadcast': wss };
+}

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -12,6 +12,7 @@ import util from 'node:util';
 import semver from 'semver';
 import { URL } from 'url';
 
+import { createDevToolsPluginWebsocketEndpoint } from './DevToolsPluginWebsocketEndpoint';
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { attachAtlasAsync } from './debugging/attachAtlas';
@@ -280,6 +281,7 @@ export async function instantiateMetroAsync(
       websocketEndpoints: {
         ...websocketEndpoints,
         ...debugWebsocketEndpoints,
+        ...createDevToolsPluginWebsocketEndpoint(),
       },
       watch: !isExporting && isWatchEnabled(),
     },


### PR DESCRIPTION
# Why

the rnc-cli's `/message` broadcast endpoint doesn't support binary payload because it serialize/deserialize JSON payload

# How

add our dedicated `/expo-dev-plugins/broadcast` websocket endpoint that will broadcast to all the other connected clients without any payload processing

# Test Plan

test in the upstream stacked prs

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
