### PR TITLE
[docs] Use "Type" column for tables and fix minor issues in Custom Build schema reference

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -740,10 +740,10 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 All-in-one function that installs Maestro, prepares a testing environment (Android Emulator or iOS Simulator), and tests the app.
 
-| Input       | Description                                                                                                                                                                                                                                 |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flow_path` | **string** Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                 |
-| `app_path`  | **string** Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/**/*.apk** for Android and to **ios/build/Build/Products/*simulator/\*.app\*\* for iOS. |
+| Input       | Type     | Description                                                                                                                                                                                                                      |
+| ----------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                 |
+| `app_path`  | `string` | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/simulator/\*.app** for iOS. |
 
 ```yaml build-and-test.yml
 build:
@@ -806,6 +806,7 @@ Behind the scenes, it uses:
 If you need to customize the Maestro version, run a specific Android Emulator or iOS Simulator, or upload multiple build artifacts you will need to write this series of steps yourself.
 
 <Collapsible summary={<>An example Android workflow with <code>eas/maestro_test</code> expanded</>}>
+
 ```yaml build-and-test-android-expanded.yml
 build:
   name: Build and test (Android, expanded)
@@ -847,8 +848,8 @@ build:
           type: build-artifact
           path: ${ eas.env.HOME }/.maestro/tests
     # @end #
+```
 
-````
 </Collapsible>
 
 <Collapsible summary={<>An example iOS workflow with <code>eas/maestro_test</code> expanded</>}>
@@ -857,40 +858,40 @@ build:
 build:
 name: Build and test (iOS, expanded)
 steps:
-- eas/build
-# @info #
-- eas/install_maestro
-- eas/start_ios_simulator
-- run:
-    command: |
-      # shopt -s nullglob is necessary not to try to install
-      # SEARCH_PATH literally if there are no matching files.
-      shopt -s nullglob
+  - eas/build
+  # @info #
+  - eas/install_maestro
+  - eas/start_ios_simulator
+  - run:
+      command: |
+        # shopt -s nullglob is necessary not to try to install
+        # SEARCH_PATH literally if there are no matching files.
+        shopt -s nullglob
 
-      SEARCH_PATH="ios/build/Build/Products/*simulator/*.app"
-      FILES_FOUND=false
+        SEARCH_PATH="ios/build/Build/Products/*simulator/*.app"
+        FILES_FOUND=false
 
-      for APP_PATH in $SEARCH_PATH; do
-        FILES_FOUND=true
-        echo "Installing \\"$APP_PATH\\""
-        xcrun simctl install booted "$APP_PATH"
-      done
+        for APP_PATH in $SEARCH_PATH; do
+          FILES_FOUND=true
+          echo "Installing \\"$APP_PATH\\""
+          xcrun simctl install booted "$APP_PATH"
+        done
 
-      if ! $FILES_FOUND; then
-        echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
-        exit 1
-      fi
-- run:
-    command: |
-      maestro test maestro/flow.yaml
-- eas/upload_artifact:
-    name: Upload test artifact
-    if: ${ always() }
-    inputs:
-      type: build-artifact
-      path: ${ eas.env.HOME }/.maestro/tests
+        if ! $FILES_FOUND; then
+          echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
+          exit 1
+        fi
+  - run:
+      command: |
+        maestro test maestro/flow.yaml
+  - eas/upload_artifact:
+      name: Upload test artifact
+      if: ${ always() }
+      inputs:
+        type: build-artifact
+        path: ${ eas.env.HOME }/.maestro/tests
 # @end #
-````
+```
 
 </Collapsible>
 
@@ -1008,10 +1009,10 @@ build:
           apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
 ```
 
-| Property             | Description                                                                                                                                                                                              |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                                                        |
-| `inputs.credentials` | **json** Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS. |
+| Property             | Type     | Description                                                                                                                                                                                     |
+| -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | `string` | The name of the step in the reusable function that shows in the build logs. Defaults to `Resolve Apple team ID from credentials`.                                                               |
+| `inputs.credentials` | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS. |
 
 <BoxLink
   title="eas/resolve_apple_team_id_from_credentials source code"
@@ -1051,11 +1052,11 @@ build:
     # @end #
 ```
 
-| Property               | Description                                                                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | The name of the step in the reusable function that shows in the build logs. Defaults to `Prebuild`.                                                  |
-| `inputs.clean`         | **boolean** Optional input defining whether the function should use `--clean` flag when running the command. Defaults to false                       |
-| `inputs.apple_team_id` | **boolean** Optional input defining Apple team ID which should be used when doing prebuild. It should be specified for iOS builds using credentials. |
+| Property               | Type      | Description                                                                                                                              |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | -         | The name of the step in the reusable function that shows in the build logs. Defaults to `Prebuild`.                                      |
+| `inputs.clean`         | `boolean` | Optional input defining whether the function should use `--clean` flag when running the command. Defaults to false                       |
+| `inputs.apple_team_id` | `boolean` | Optional input defining Apple team ID which should be used when doing prebuild. It should be specified for iOS builds using credentials. |
 
 <BoxLink
   title="eas/prebuild source code"
@@ -1097,11 +1098,11 @@ build:
     # @end #
 ```
 
-| Property                 | Description                                                                                                                                                                         |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                   | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                                                     |
-| `inputs.runtime_version` | **string** Optional input defining runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version. |
-| `inputs.channel`         | **string** Optional input defining channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                    |
+| Property                 | Type     | Description                                                                                                                                                              |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                   | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure EAS Update`.                                                          |
+| `inputs.runtime_version` | `string` | Optional input defining runtime version which should be configured for the build. Defaults to `${ eas.job.version.runtimeVersion }` or natively defined runtime version. |
+| `inputs.channel`         | `string` | Optional input defining channel which should be configured for the build. Defaults to `${ eas.job.updates.channel }`.                                                    |
 
 <BoxLink
   title="eas/configure_eas_update source code"
@@ -1128,10 +1129,10 @@ build:
     # @end #
 ```
 
-| Property             | Description                                                                                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                                                            |
-| `inputs.credentials` | **json** Optional input defining the app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android. |
+| Property             | Type   | Description                                                                                                                                                                                             |
+| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | -      | The name of the step in the reusable function that shows in the build logs. Defaults to `Inject Android credentials`.                                                                                   |
+| `inputs.credentials` | `json` | Optional input defining the app credentials for your Android build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for Android. |
 
 <BoxLink
   title="eas/inject_android_credentials source code"
@@ -1163,11 +1164,11 @@ build:
     # @end #
 ```
 
-| Property                     | Description                                                                                                                                                                                                                |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                                                       |
-| `inputs.build_configuration` | **string** Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
-| `inputs.credentials`         | **json** Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                   |
+| Property                     | Type     | Description                                                                                                                                                                                                     |
+| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS credentials`.                                                                                            |
+| `inputs.build_configuration` | `string` | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
+| `inputs.credentials`         | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
 
 <BoxLink
   title="eas/configure_ios_credentials source code"
@@ -1215,11 +1216,11 @@ build:
     # @end #
 ```
 
-| Property              | Description                                                                                                             |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `name`                | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure Android version`.    |
-| `inputs.version_code` | **string** Optional input defining `versionCode` of your Android build. Defaults to `${ eas.job.version.versionCode }`  |
-| `inputs.version_name` | **string** Optional input defining `versionName` of your Android build. Defaults to `${ eas.job.version.versionName }`. |
+| Property              | Type     | Description                                                                                                          |
+| --------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `name`                | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure Android version`. |
+| `inputs.version_code` | `string` | Optional input defining `versionCode` of your Android build. Defaults to `${ eas.job.version.versionCode }`          |
+| `inputs.version_name` | `string` | Optional input defining `versionName` of your Android build. Defaults to `${ eas.job.version.versionName }`.         |
 
 <BoxLink
   title="eas/configure_android_version source code"
@@ -1277,13 +1278,13 @@ build:
     # @end #
 ```
 
-| Property                     | Description                                                                                                                                                                                                                |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                                                           |
-| `inputs.build_number`        | **string** Optional input defining the build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`                                                                                  |
-| `inputs.app_version`         | **string** Optional input defining the app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                        |
-| `inputs.build_configuration` | **string** Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
-| `inputs.credentials`         | **json** Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                   |
+| Property                     | Type     | Description                                                                                                                                                                                                     |
+| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                       | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Configure iOS version`.                                                                                                |
+| `inputs.build_number`        | `string` | Optional input defining the build number (`CFBundleVersion`) of your iOS build. Defaults to `${ eas.job.version.buildNumber }`                                                                                  |
+| `inputs.app_version`         | `string` | Optional input defining the app version (`CFBundleShortVersionString`) of your iOS build. Defaults to `${ eas.job.version.appVersion }`.                                                                        |
+| `inputs.build_configuration` | `string` | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. |
+| `inputs.credentials`         | `json`   | Optional input defining the app credentials for your iOS build. Defaults to `${ eas.job.secrets.buildCredentials }`. Needs to comply to `${ eas.job.secrets.buildCredentials }` schema for iOS.                 |
 
 <BoxLink
   title="eas/configure_ios_version source code"
@@ -1328,10 +1329,10 @@ build:
     # @end #
 ```
 
-| Property         | Description                                                                                                                                                                                        |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`           | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                                                              |
-| `inputs.command` | **string** Optional input defining the Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object. |
+| Property         | Type     | Description                                                                                                                                                                             |
+| ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Run gradle`.                                                                                   |
+| `inputs.command` | `string` | Optional input defining the Gradle command to run to build the Android app. If not specified it is resolved based on the build configuration and contents of the `${ eas.job }` object. |
 
 <BoxLink
   title="eas/run_gradle source code"
@@ -1480,15 +1481,15 @@ build:
         # @end #
 ```
 
-| Property                     | Description                                                                                                                                                                                                                                                                         |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                       | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                                                           |
-| `inputs.template`            | **string** Optional input defining the Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                      |
-| `inputs.credentials`         | **json** Optional input defining the app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                     |
-| `inputs.build_configuration` | **string** Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value. |
-| `inputs.scheme`              | **string** Optional input defining the Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                     |
-| `inputs.clean`               | **boolean** Optional input defining whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                     |
-| `inputs.extra`               | **json** Optional input defining extra values which should be provided to the template.                                                                                                                                                                                             |
+| Property                     | Type      | Description                                                                                                                                                                                                                                                              |
+| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                       | -         | The name of the step in the reusable function that shows in the build logs. Defaults to `Generate Gymfile from template`.                                                                                                                                                |
+| `inputs.template`            | `string`  | Optional input defining the Gymfile template which should be used. If not specified one out of two default templates will be used depending on whether the `inputs.credentials` value is specified.                                                                      |
+| `inputs.credentials`         | `json`    | Optional input defining the app credentials for your iOS build. If specified `KEYCHAIN_PATH`, `EXPORT_METHOD`, and `PROFILES` values will be provided to the template.                                                                                                   |
+| `inputs.build_configuration` | `string`  | Optional input defining the Xcode project's Build Configuration. Defaults to `${ eas.job.buildConfiguration }` or if not specified is resolved to `Debug` for development client or `Release` for other builds. Corresponds to the `BUILD_CONFIGURATION` template value. |
+| `inputs.scheme`              | `string`  | Optional input defining the Xcode project's scheme which should be used for the build. Defaults to `${ eas.job.scheme }` or if not specified is resolved to the first scheme found in the Xcode project. Corresponds to the `SCHEME` template value.                     |
+| `inputs.clean`               | `boolean` | Optional input defining whether the Xcode project should be cleaned before the build. Defaults to `true`. Corresponds to `CLEAN` template variable.                                                                                                                      |
+| `inputs.extra`               | `json`    | Optional input defining extra values which should be provided to the template.                                                                                                                                                                                           |
 
 <BoxLink
   title="eas/generate_gymfile_from_template source code"
@@ -1637,10 +1638,10 @@ build:
             assets/*.png
 ```
 
-| Input  | Description                                                                                                                                                                                                                               |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path` | **string** Required. Path or newline-delimited list of paths to the artifacts to upload to EAS servers. You can use `*` wildcard and other [glob patterns that `fast-glob` supports](https://github.com/mrmlnc/fast-glob#pattern-syntax). |
-| `type` | **string** The type of artifact that is uploaded to the EAS servers. Allowed values are `application-archive` and `build-artifact`. Defaults to `application-archive`.                                                                    |
+| Input  | Type     | Description                                                                                                                                                                                                                    |
+| ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `path` | `string` | Required. Path or newline-delimited list of paths to the artifacts to upload to EAS servers. You can use `*` wildcard and other [glob patterns that `fast-glob` supports](https://github.com/mrmlnc/fast-glob#pattern-syntax). |
+| `type` | `string` | The type of artifact that is uploaded to the EAS servers. Allowed values are `application-archive` and `build-artifact`. Defaults to `application-archive`.                                                                    |
 
 <BoxLink
   title="eas/upload_artifact source code"
@@ -1675,9 +1676,9 @@ build:
           path: ${ eas.env.HOME }/.maestro/tests
 ```
 
-| Input             | Description                                                                                                                      |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `maestro_version` | **string** Maestro version to install (for example, 1.35.0). If not provided, `install_maestro` will install the latest version. |
+| Input             | Type     | Description                                                                                                           |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `maestro_version` | `string` | Maestro version to install (for example, 1.35.0). If not provided, `install_maestro` will install the latest version. |
 
 <BoxLink
   title="eas/install_maestro source code"
@@ -1703,10 +1704,10 @@ build:
     # ... Maestro setup and tests
 ```
 
-| Input                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `device_name`          | **string** Name for the created device. You can customize it if starting multiple emulators.                                                                                                                                                                                                                                                                                                                                                                       |
-| `system_image_package` | **string** Android package path to use for the emulator. For example, `system-images;android-30;default;x86_64`.<br />To get a list of available system images, run [`sdkmanager --list`](https://developer.android.com/tools/sdkmanager#list) on a local computer. VMs run on x86_64 architecture, so always choose `x86_64` package variants. The [`sdkmanager` tool](https://developer.android.com/tools/sdkmanager) comes from Android SDK command-line tools. |
+| Input                  | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device_name`          | `string` | Name for the created device. You can customize it if starting multiple emulators.                                                                                                                                                                                                                                                                                                                                                                       |
+| `system_image_package` | `string` | Android package path to use for the emulator. For example, `system-images;android-30;default;x86_64`.<br />To get a list of available system images, run [`sdkmanager --list`](https://developer.android.com/tools/sdkmanager#list) on a local computer. VMs run on x86_64 architecture, so always choose `x86_64` package variants. The [`sdkmanager` tool](https://developer.android.com/tools/sdkmanager) comes from Android SDK command-line tools. |
 
 <BoxLink
   title="eas/start_android_emulator source code"
@@ -1730,9 +1731,9 @@ build:
     # ... Maestro setup and tests
 ```
 
-| Input               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `device_identifier` | **string** Name or UDID of the Simulator you want to start. Examples include `iPhone [XY] Pro`, `AEF997BB-222C-4379-89BA-D21070B1D787`.<br />**Note:** Available Simulators are different for every image. If you change the image, the Simulator for a given name may become unavailable. For instance, an Xcode 14 image will have iPhone 14 Simulators, while an Xcode 15 image will have iPhone 15 simulators. In general, we encourage not providing this input. See [runner images](/build/eas-json/#selecting-a-base-image) for more information. |
+| Input               | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device_identifier` | `string` | Name or UDID of the Simulator you want to start. Examples include `iPhone [XY] Pro`, `AEF997BB-222C-4379-89BA-D21070B1D787`.<br />**Note:** Available Simulators are different for every image. If you change the image, the Simulator for a given name may become unavailable. For instance, an Xcode 14 image will have iPhone 14 Simulators, while an Xcode 15 image will have iPhone 15 simulators. In general, we encourage not providing this input. See [runner images](/build/eas-json/#selecting-a-base-image) for more information. |
 
 <BoxLink
   title="eas/start_ios_simulator source code"
@@ -1849,11 +1850,11 @@ build:
                     value: another_thing
 ```
 
-| Input            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message`        | **string** The text of the message you want to send. For example, `'This is the content of the message'`.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                                        |
-| `payload`        | **string** The contents of the message you want to send defined using [Slack Block Kit](https://api.slack.com/block-kit) layout.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                 |
-| `slack_hook_url` | **string** The URL of the previously configured Slack webhook URL, which will post your message to the specified channel. You can provide the plain URL like `slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'`, use EAS secrets like `slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }`, or set the `SLACK_HOOK_URL` secret, which will serve as a default webhook URL (in this last case, there is no need to provide `slack_hook_url` input). |
+| Input            | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message`        | `string` | The text of the message you want to send. For example, `'This is the content of the message'`.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                                        |
+| `payload`        | `string` | The contents of the message you want to send defined using [Slack Block Kit](https://api.slack.com/block-kit) layout.<br /> <br />**Note:** Either `message` or `payload` needs to be provided, but not both.                                                                                                                                                                                                                                                 |
+| `slack_hook_url` | `string` | The URL of the previously configured Slack webhook URL, which will post your message to the specified channel. You can provide the plain URL like `slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'`, use EAS secrets like `slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }`, or set the `SLACK_HOOK_URL` secret, which will serve as a default webhook URL (in this last case, there is no need to provide `slack_hook_url` input). |
 
 <BoxLink
   title="eas/send_slack_message source code"

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -732,7 +732,6 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 ##### Known limitations
 
-- This function doesn't configure legacy classic updates. If you are using classic updates, [migrate to EAS Update](/eas-update/migrate-from-classic-updates/) before using this function.
 - It doesn't accept any inputs, and the resolved build process will be configured based on your build profile from [**eas.json**](/eas/json/).
 - The build process produced by `eas/build` is not configurable and you can't customize it. If you need to customize the build process, use the subset of functions and steps that are executed behind the scenes by this function and configure them manually in the YAML configuration file, as shown in the examples above.
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -740,10 +740,10 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 All-in-one function that installs Maestro, prepares a testing environment (Android Emulator or iOS Simulator), and tests the app.
 
-| Input       | Type     | Description                                                                                                                                                                                                                      |
-| ----------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                 |
-| `app_path`  | `string` | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/simulator/\*.app** for iOS. |
+| Input       | Type     | Description                                                                                                                                                                                                                        |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                   |
+| `app_path`  | `string` | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/\*simulator/\*.app** for iOS. |
 
 ```yaml build-and-test.yml
 build:
@@ -990,7 +990,7 @@ This function is automatically executed by the [`eas/build`](#easbuild) function
 
 #### `eas/resolve_apple_team_id_from_credentials`
 
-> **Warning** This function is only available for iOS builds
+> **Warning** This function is only available for iOS builds.
 
 Resolves the Apple team ID value based on build credentials provided in the `inputs.credentials`. The resolved Apple team ID is stored in the `outputs.apple_team_id` output value.
 
@@ -1067,7 +1067,7 @@ build:
 
 #### `eas/configure_eas_update`
 
-> **Warning** To use this function you need to have EAS Update configured for your project
+> **Warning** To use this function you need to have EAS Update configured for your project.
 
 Configures runtime version and release channel for your build.
 
@@ -1113,7 +1113,7 @@ build:
 
 #### `eas/inject_android_credentials`
 
-> **Warning** This function is only available for Android builds
+> **Warning** This function is only available for Android builds.
 
 Configures Android keystore with credentials on the builder and injects app signing config using these credentials into gradle config.
 
@@ -1143,7 +1143,7 @@ build:
 
 #### `eas/configure_ios_credentials`
 
-> **Warning** This function is only available for iOS builds
+> **Warning** This function is only available for iOS builds.
 
 Configures iOS credentials on the builder. Modifies the configuration of the Xcode project by assigning provisioning profiles to the targets.
 
@@ -1179,7 +1179,7 @@ build:
 
 #### `eas/configure_android_version`
 
-> **Warning** This function is only available for Android builds
+> **Warning** This function is only available for Android builds.
 
 Configures the version of your Android app. It's used to set a version when using [remote app version management](/build-reference/app-versions/).
 
@@ -1231,7 +1231,7 @@ build:
 
 #### `eas/configure_ios_version`
 
-> **Warning** This function is only available for iOS builds
+> **Warning** This function is only available for iOS builds.
 
 Configures the version of your iOS app. It's used to set a version when using [remote app version management](/build-reference/app-versions/).
 
@@ -1295,7 +1295,7 @@ build:
 
 #### `eas/run_gradle`
 
-> **Warning** This function is only available for Android builds
+> **Warning** This function is only available for Android builds.
 
 Runs a Gradle command to build an Android app.
 
@@ -1343,7 +1343,7 @@ build:
 
 #### `eas/generate_gymfile_from_template`
 
-> **Warning** This function is only available for iOS builds
+> **Warning** This function is only available for iOS builds.
 
 Generates a [`Gymfile`](https://docs.fastlane.tools/actions/gym/#gymfile) used to build the iOS app using Fastlane from a template.
 
@@ -1500,7 +1500,7 @@ build:
 
 #### `eas/run_fastlane`
 
-> **Warning** This function is only available for iOS builds
+> **Warning** This function is only available for iOS builds.
 
 Runs [`fastlane gym`](https://docs.fastlane.tools/actions/gym/#gym) command against the [`Gymfile`](https://docs.fastlane.tools/actions/gym/#gymfile) located in the `ios` project directory to build the iOS app.
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -635,7 +635,7 @@ EAS provides a set of built-in reusable functions that you can use in a workflow
 
 The all-in-one function that encapsulates the entire EAS Build build process. It resolves the best build workflow configuration based on your build profile's settings from [**eas.json**](/eas/json/).
 
-It's ideal for people who just want to have the build done without worrying about altering and configuring the build process manually. It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
+It's ideal for people who want to have the build done without worrying about altering and configuring the build process manually. It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
 
 ```yaml example.yml
 build:
@@ -926,7 +926,7 @@ build:
 
 #### `eas/use_npm_token`
 
-Configures node package managers (npm, pnpm, or Yarn) for use with private packages, published either to npm or private registry.
+Configures node package managers (npm, pnpm, or Yarn) for use with private packages, published either to npm or a private registry.
 Set `NPM_TOKEN` in your project's secrets, and this function will configure the build environment by creating **.npmrc** with the token.
 
 ```yaml example.yml

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -24,7 +24,7 @@ Defined to describe a custom workflow. All config options to create a workflow a
 
 The name of your workflow that is used to identify the workflow in the build logs. EAS Build uses this property to display the name of your workflow in the dashboard.
 
-For example, the workflow's name is `Run tests`:
+For example, the workflow name is `Run tests`:
 
 ```yaml
 build:
@@ -40,7 +40,7 @@ build:
 
 ### `steps`
 
-Steps are used to describe a list of actions either in the form of commands or function calls. These actions are executed when a workflow runs on EAS Build. You can define single or multiple steps in a workflow. However, it is **required** to define at least one step per workflow.
+Steps are used to describe a list of actions, either in the form of commands or function calls. These actions are executed when a workflow runs on EAS Build. You can define single or multiple steps in a workflow. However, it is **required** to define at least one step per workflow.
 
 Each step is configured with the following properties:
 
@@ -173,7 +173,7 @@ build:
 
 #### `steps[].run.name`
 
-The name that is used in build logs to display the name of the step.
+The name used in build logs to display the name of the step.
 
 #### `steps[].run.command`
 
@@ -904,7 +904,7 @@ steps:
 
 #### `eas/checkout`
 
-Checks out you project source files.
+Checks out your project source files.
 
 For example, a workflow with the following `steps` will check out the project and list the files in the **assets** directory:
 
@@ -2037,7 +2037,7 @@ build:
 
 ## Override values in a `build`
 
-You can override values for following properties:
+You can override values for the following properties:
 
 - `working_directory`
 - `name`


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As mentioned previously, describe the **Type** of the properties in different columns when using table format on the Custom Build schema reference page.


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add **Type** as a column to separate the type of each property from its description. Follows the same pattern as we do inside API reference docs.
- Fix minor grammatical errors, style issues, and typos
- Remove reference to the classic updates under Built-in EAS functions > Known limitations section

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/custom-builds/schema

## Preview

An example of how types are separated from the description: 

![CleanShot 2024-08-12 at 00 06 22](https://github.com/user-attachments/assets/01b17b07-5405-4b75-ae27-867dcb27153b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
