### PR TITLE
[core][Android] Introduced experimental converter

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
 - Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added experimental support for rendering SwiftUI views. ([#19888](https://github.com/expo/expo/pull/19888) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
 - Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added experimental support for rendering SwiftUI views. ([#19888](https://github.com/expo/expo/pull/19888) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS.
+- [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS. ([#30944](https://github.com/expo/expo/pull/30944) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
@@ -1,0 +1,44 @@
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class ExperimentalConverterTest {
+
+  @Test
+  fun primitive_arguments_should_be_convertible() = withSingleModule({
+    Function("simpleList") { listOf(1, 2, 3, 4, 5, 6) }
+      .UseExperimentalConverter()
+    Function("listWithMixedData") { listOf(1, 2, 3, "string", "expo" to "modules") }
+      .UseExperimentalConverter()
+    Function("complexList") { listOf(listOf(1, 2, "string"), listOf("expo", "modules"), listOf(listOf(1, 2, 3))) }
+      .UseExperimentalConverter()
+  }) {
+    val simpleList = call("simpleList").getArray().map { it.getInt() }
+    val listWithMixedData = call("listWithMixedData").getArray()
+    val complexList = call("complexList").getArray()
+
+    Truth.assertThat(simpleList).containsExactly(1, 2, 3, 4, 5, 6)
+
+    Truth.assertThat(listWithMixedData[0].getInt()).isEqualTo(1)
+    Truth.assertThat(listWithMixedData[1].getInt()).isEqualTo(2)
+    Truth.assertThat(listWithMixedData[2].getInt()).isEqualTo(3)
+    Truth.assertThat(listWithMixedData[3].getString()).isEqualTo("string")
+
+    val (first, second) = listWithMixedData[4].getArray().map { it.getString() }
+    Truth.assertThat(first).isEqualTo("expo")
+    Truth.assertThat(second).isEqualTo("modules")
+
+    val (inner1, inner2, inner3) = complexList.map { it.getArray() }
+
+    Truth.assertThat(inner1[0].getInt()).isEqualTo(1)
+    Truth.assertThat(inner1[1].getInt()).isEqualTo(2)
+    Truth.assertThat(inner1[2].getString()).isEqualTo("string")
+
+    Truth.assertThat(inner2[0].getString()).isEqualTo("expo")
+    Truth.assertThat(inner2[1].getString()).isEqualTo("modules")
+
+    val nested = inner3[0].getArray().map { it.getInt() }
+    Truth.assertThat(nested).containsExactly(1, 2, 3)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -37,6 +37,8 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
   loadJClass(env, "[J", {});
   loadJClass(env, "[F", {});
 
+  loadJClass(env, "java/util/List", {});
+
   loadJClass(env, "com/facebook/react/bridge/PromiseImpl", {
     {"<init>", "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V"}
   });

--- a/packages/expo-modules-core/android/src/main/cpp/javaclasses/Collections.h
+++ b/packages/expo-modules-core/android/src/main/cpp/javaclasses/Collections.h
@@ -15,6 +15,12 @@ template<typename E = jobject>
 struct Collection : public jni::JavaClass<Collection<E>, Iterable<E>> {
   constexpr static auto kJavaDescriptor = "Ljava/util/Collection;";
 
+  [[nodiscard]] size_t size() const {
+    static auto sizeMethod =
+      Collection<E>::javaClassStatic()->template getMethod<jint()>("size");
+    return sizeMethod(this->self());
+  }
+
   bool add(jni::alias_ref<E> element) {
     static auto addMethod = Collection<E>::javaClassStatic()->
       template getMethod<jboolean(jni::alias_ref<jni::JObject>)>("add");
@@ -25,6 +31,12 @@ struct Collection : public jni::JavaClass<Collection<E>, Iterable<E>> {
 template<typename E = jobject>
 struct List : public jni::JavaClass<List<E>, Collection<E>> {
   constexpr static auto kJavaDescriptor = "Ljava/util/List;";
+
+  [[nodiscard]] jni::local_ref<E> get(int index) const {
+    static auto getMethod =
+      List<E>::javaClassStatic()->template getMethod<jni::local_ref<jobject>(int)>("get");
+    return jni::static_ref_cast<E>(getMethod(this->self(), index));
+  }
 };
 
 template<typename E = jobject>

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -44,7 +44,7 @@ std::optional<jsi::Value> convertStringToFollyDynamicIfNeeded(jsi::Runtime &rt, 
 jsi::Value convert(
   JNIEnv *env,
   jsi::Runtime &rt,
-  jni::local_ref<jobject> value
+  const jni::local_ref<jobject> &value
 ) {
   if (value == nullptr) {
     return jsi::Value::undefined();
@@ -68,6 +68,10 @@ jsi::Value convert(
   CAST_AND_RETURN(JavaScriptModuleObject::javaobject, expo/modules/kotlin/jni/JavaScriptModuleObject)
   CAST_AND_RETURN(JSharedObject::javaobject, expo/modules/kotlin/sharedobjects/SharedObject)
   CAST_AND_RETURN(JavaScriptTypedArray::javaobject, expo/modules/kotlin/jni/JavaScriptTypedArray)
+
+  if (env->IsInstanceOf(unpackedValue, cache->getJClass("java/util/List").clazz)) {
+    return convertToJS(rt, jni::static_ref_cast<jni::JList<jobject>>(value));
+  }
 
   // Primitives arrays
   CAST_AND_RETURN(jni::JArrayDouble, [D)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -15,6 +15,13 @@ class SyncFunctionComponent(
   desiredArgsTypes: Array<AnyType>,
   private val body: (args: Array<out Any?>) -> Any?
 ) : AnyFunction(name, desiredArgsTypes) {
+  private var shouldUseExperimentalConverter = false
+
+  @Suppress("FunctionName")
+  fun UseExperimentalConverter(shouldUse: Boolean = true) = apply {
+    shouldUseExperimentalConverter = shouldUse
+  }
+
   @Throws(CodedException::class)
   fun call(args: ReadableArray): Any? {
     return body(convertArgs(args))
@@ -30,7 +37,7 @@ class SyncFunctionComponent(
         FunctionCallException(name, moduleName, it)
       }) {
         val result = call(args, appContext)
-        return@exceptionDecorator JSTypeConverter.convertToJSValue(result)
+        return@exceptionDecorator JSTypeConverter.convertToJSValue(result, useExperimentalConverter = shouldUseExperimentalConverter)
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -54,7 +54,11 @@ object JSTypeConverter {
     }
   }
 
-  fun convertToJSValue(value: Any?, containerProvider: ContainerProvider = DefaultContainerProvider): Any? {
+  fun convertToJSValue(
+    value: Any?,
+    containerProvider: ContainerProvider = DefaultContainerProvider,
+    useExperimentalConverter: Boolean = false
+  ): Any? {
     return when (value) {
       null, is Unit -> null
       is Bundle -> value.toJSValue(containerProvider)
@@ -71,6 +75,11 @@ object JSTypeConverter {
       is Pair<*, *> -> value.toJSValue(containerProvider)
       is Long -> value.toDouble()
       is RawTypedArrayHolder -> value.rawArray
+      is List<*> -> if (useExperimentalConverter) {
+        value.toJSValue()
+      } else {
+        value.toJSValue(containerProvider)
+      }
       is Iterable<*> -> value.toJSValue(containerProvider)
       else -> value
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
@@ -60,6 +60,10 @@ fun <K, V> Map<K, V>.toJSValue(containerProvider: JSTypeConverter.ContainerProvi
   return result
 }
 
+fun <T> List<T>.toJSValue(): List<Any?> {
+  return this.map { JSTypeConverter.convertToJSValue(it, useExperimentalConverter = true) }
+}
+
 fun <T> Iterable<T>.toJSValue(containerProvider: JSTypeConverter.ContainerProvider): WritableArray {
   val result = containerProvider.createArray()
 


### PR DESCRIPTION
# Why

Introduces an experimental converter to support a broader range of types that can be passed to the JS. This PR only adds the converter to the list. 

# How

Stopped using `folly::dynamic`, when converting lists.
I've planned to rewrite the map converter too, but decided to split it into a separate PR. 

# Test Plan

- unit tests ✅ 

# Benchmarks

I've done some benchmarks. The results depend on the types and how nested the structure is. However, our new converter isn't slower than the one that uses `foll::dynamic`.