### PR TITLE
[docs] Update Development Build video link in Introduction to development builds

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -45,9 +45,9 @@ The launcher UI makes it possible to switch between development servers without 
 />
 
 <BoxLink
-  title={`"What's an Expo Development Build?"`}
-  description="A YouTube video that explains what a development build is and how to use it."
-  href="https://www.youtube.com/watch?v=Iw8FAUftJFU"
+  title="Getting the most out of Expo Development Builds"
+  description="A YouTube video that explains what a development build is, why it is important, and how to use it."
+  href="https://www.youtube.com/watch?v=7J8LRpja9_o"
   Icon={VideoRecorderIcon}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR replaces the previous Development Build video link in the Introduction to Development Builds doc with Kadi's talk at Appjs conf 2024. This new video provides a complete introduction to the development builds, and dives into how to use them (covering all options) with up-to-date information and steps.

Changes applied to the already existing BoxLink that links to the YouTube video by updating the title, description, and link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
