### PR TITLE
[ios][core] Add shared object lifecycle methods

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added experimental support for rendering SwiftUI views. ([#19888](https://github.com/expo/expo/pull/19888) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS. ([#30944](https://github.com/expo/expo/pull/30944) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Add functions that are called before and after a shared object is removed from the registry.
+- [iOS] Add functions that are called before and after a shared object is removed from the registry. ([#30949](https://github.com/expo/expo/pull/30949) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added experimental support for rendering SwiftUI views. ([#19888](https://github.com/expo/expo/pull/19888) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS. ([#30944](https://github.com/expo/expo/pull/30944) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Add functions that are called before and after a shared object is removed from the registry.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -28,14 +28,14 @@ open class SharedObject: AnySharedObject {
   public init() {}
 
   /**
-    A function that will be called before the object is removed from the registry.
-    */
-   open func sharedObjectWillRelease() {}
+   A function that will be called before the object is removed from the registry.
+   */
+  open func sharedObjectWillRelease() {}
 
-   /**
-    A function that will be called after the object is removed from the registry.
-    */
-   open func sharedObjectDidRelease() {}
+  /**
+   A function that will be called after the object is removed from the registry.
+   */
+  open func sharedObjectDidRelease() {}
 
   /**
    Returns the JavaScript shared object associated with the native shared object.

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -28,6 +28,16 @@ open class SharedObject: AnySharedObject {
   public init() {}
 
   /**
+    A function that will be called before the object is removed from the registry.
+    */
+   open func sharedObjectWillRelease() {}
+
+   /**
+    A function that will be called after the object is removed from the registry.
+    */
+   open func sharedObjectDidRelease() {}
+
+  /**
    Returns the JavaScript shared object associated with the native shared object.
    */
   public func getJavaScriptObject() -> JavaScriptObject? {

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -121,11 +121,13 @@ public final class SharedObjectRegistry {
   internal func delete(_ id: SharedObjectId) {
     Self.lockQueue.async {
       if let pair = self.pairs[id] {
+        pair.native.sharedObjectWillRelease()
         // Reset an ID on the objects.
         pair.native.sharedObjectId = 0
 
         // Delete the pair from the dictionary.
         self.pairs[id] = nil
+        pair.native.sharedObjectDidRelease()
       }
     }
   }


### PR DESCRIPTION
# Why
It's useful to know when the object will be removed from memory so that resources can be cleaned up ie subscriptions cancelled, notification center observers removed etc.

# How
Added two functions that are called on the object before and after it has been removed from the registry. 

# Test Plan
I tested it while working on expo-audio, it solved the issues I was having there and I can remove the need for the user to do any manual cleanup. 
