### PR TITLE
docs: support generating and rendering TypeOperator target types

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -71,6 +71,7 @@ export type TypeDefinitionData = {
   qualifiedName?: string;
   head?: string;
   tail?: (TypeDefinitionData | string)[][];
+  target?: TypeDefinitionData;
 };
 
 export type MethodParamData = {

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -334,6 +334,7 @@ export const resolveTypeName = (
     operator,
     objectType,
     indexType,
+    target,
   } = typeDefinition;
 
   try {
@@ -484,9 +485,18 @@ export const resolveTypeName = (
       }
       return `${objectType?.name}['${indexType?.value}']`;
     } else if (type === 'typeOperator') {
+      if (target && operator && ['readonly', 'keyof'].includes(operator)) {
+        return (
+          <>
+            {operator} {resolveTypeName(target, sdkVersion)}
+          </>
+        );
+      }
       return operator || 'undefined';
     } else if (type === 'intrinsic') {
       return name || 'undefined';
+    } else if (type === 'rest' && elementType) {
+      return `...${resolveTypeName(elementType, sdkVersion)}`;
     } else if (value === null) {
       return 'null';
     }

--- a/tools/src/commands/GenerateDocsAPIData.ts
+++ b/tools/src/commands/GenerateDocsAPIData.ts
@@ -167,12 +167,12 @@ const executeCommand = async (
     const { readme, symbolIdMap, ...trimmedOutput } = output;
 
     if (MINIFY_JSON) {
-      const minifiedJson = recursiveOmitBy(
-        trimmedOutput,
-        ({ key, node }) =>
-          ['id', 'groups', 'target', 'kindString', 'originalName'].includes(key) ||
+      const minifiedJson = recursiveOmitBy(trimmedOutput, ({ key, node }) => {
+        return (
+          ['id', 'groups', 'kindString', 'originalName'].includes(key) ||
           (key === 'flags' && !Object.keys(node).length)
-      );
+        );
+      });
       await fs.writeFile(jsonOutputPath, JSON.stringify(minifiedJson, null, 0));
     } else {
       await fs.writeFile(jsonOutputPath, JSON.stringify(trimmedOutput));


### PR DESCRIPTION
# Why

Some docs use types that use keywords like `readonly` or `keyof`. Our docs currently don't play well with these. This PR attempts to fix it.

The solution is (1) keep more data in `json` files generated by `et gdad` and (2) use that information in the renderer

# How

The json output that's of interest to us can look like this:

```json
{
    "type": "typeOperator",
    "operator": "keyof",
    "target":
    {
        "type": "reference",
        "name": "VideoPlayerEvents",
        "package": "expo-video"
    }
}
```

but `target` can also be a number. I'm not sure what all cases there are but I took an approach that should "filter" only those that are of interest to us.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
