### PR TITLE
fix(babel-preset-expo): make babel-plugin-react-compiler an optional peer dep

### DIFF
--- a/docs/pages/preview/react-compiler.mdx
+++ b/docs/pages/preview/react-compiler.mdx
@@ -24,6 +24,14 @@ This will generally verify if your app is following the [**rules of React**](htt
 
 <Step label="2">
 
+Install **babel-plugin-react-compiler** in your project:
+
+<Terminal cmd={['$ npx expo install babel-plugin-react-compiler']} />
+
+</Step>
+
+<Step label="3">
+
 Toggle on the React Compiler experiment in your app config file:
 
 ```json app.json

--- a/docs/pages/preview/react-compiler.mdx
+++ b/docs/pages/preview/react-compiler.mdx
@@ -24,7 +24,7 @@ This will generally verify if your app is following the [**rules of React**](htt
 
 <Step label="2">
 
-Install **babel-plugin-react-compiler** in your project:
+Install `babel-plugin-react-compiler` in your project:
 
 <Terminal cmd={['$ npx expo install babel-plugin-react-compiler']} />
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Make `babel-plugin-react-compiler` an optional peer dependency.
 - Changed the react client reference collection property to be a string. ([#29646](https://github.com/expo/expo/pull/29646) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### ⚠️ Notices

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Make `babel-plugin-react-compiler` an optional peer dependency.
+- Make `babel-plugin-react-compiler` an optional peer dependency. ([#30960](https://github.com/expo/expo/pull/30960) by [@EvanBacon](https://github.com/EvanBacon))
 - Changed the react client reference collection property to be a string. ([#29646](https://github.com/expo/expo/pull/29646) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### ⚠️ Notices

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -68,6 +68,9 @@ function babelPresetExpo(api, options = {}) {
         !isServerEnv &&
         // Give users the ability to opt-out of the feature, per-platform.
         platformOptions['react-compiler'] !== false) {
+        if (!(0, common_1.hasModule)('babel-plugin-react-compiler')) {
+            throw new Error('The `babel-plugin-react-compiler` must be installed before you can use React Compiler.');
+        }
         extraPlugins.push([
             require('babel-plugin-react-compiler'),
             {

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -49,9 +49,16 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
     "@react-native/babel-preset": "0.75.0-rc.7",
-    "babel-plugin-react-compiler": "^0.0.0-experimental-938cd9a-20240601",
     "babel-plugin-react-native-web": "~0.19.10",
     "react-refresh": "^0.14.2"
+  },
+  "peerDependencies": {
+    "babel-plugin-react-compiler": "0.0.0-experimental-334f00b-20240725"
+  },
+  "peerDependenciesMeta": {
+    "babel-plugin-react-compiler": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "babel-plugin-react-compiler": "0.0.0-experimental-334f00b-20240725",
     "expo-module-scripts": "^3.3.0",
     "jest": "^29.2.1"
   }

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -183,6 +183,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // Give users the ability to opt-out of the feature, per-platform.
     platformOptions['react-compiler'] !== false
   ) {
+    if (!hasModule('babel-plugin-react-compiler')) {
+      throw new Error(
+        'The `babel-plugin-react-compiler` must be installed before you can use React Compiler.'
+      );
+    }
     extraPlugins.push([
       require('babel-plugin-react-compiler'),
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,10 +5663,10 @@ babel-plugin-polyfill-regenerator@^0.5.4:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.5.0"
 
-babel-plugin-react-compiler@^0.0.0-experimental-938cd9a-20240601:
-  version "0.0.0-experimental-938cd9a-20240601"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-938cd9a-20240601.tgz#7e922f8c579564a42b2c3b7d1719f6a5bec5d554"
-  integrity sha512-t+uBHxbfxq2z4j83ZYgOsV0dlSaRgPfhrYB5+CMv6ByXUAv5wm7m7YLFx67fWKrG3eDhq3+KH1OMeFypuDLkUA==
+babel-plugin-react-compiler@0.0.0-experimental-334f00b-20240725:
+  version "0.0.0-experimental-334f00b-20240725"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-334f00b-20240725.tgz#d5fb88a286bb14c958b62f27fcfded9b436e1574"
+  integrity sha512-ktVKfOtJdHqrLib7IriUe00hnrs585He/n8uzs2yJT9pnH2eyrmMG21aRGBJKxt/P5mdizGLxgyFk0HSMrekhA==
   dependencies:
     "@babel/generator" "7.2.0"
     "@babel/types" "^7.19.0"


### PR DESCRIPTION
# Why

- Since React compiler is still experimental, the version is changing often. We should make it something that users must install first before they can use.
- However we were installing was leading to issues where the shim version v0 was being installed and leading to issues.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- Tested by packing the babel preset and installing in a template to ensure this works better.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
