### PR TITLE
[modules-core][android] Update FilteredReadableMap to work with react-native 0.75

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
@@ -41,14 +41,12 @@ class FilteredReadableMap(
   private val backingMap: ReadableMap,
   private val filteredKeys: List<String>
 ) : ReadableMap by backingMap {
-  @Suppress("NOTHING_TO_OVERRIDE")
-  override fun getEntryIterator(): Iterator<Map.Entry<String, Any>> =
-    FilteredIterator(backingMap.getEntryIterator()) {
-      !filteredKeys.contains(it.key)
-    }
+  @Suppress("NOTHING_TO_OVERRIDE", "INAPPLICABLE_JVM_NAME")
+  @JvmName("getEntryIteratorFromFunction")
+  override fun getEntryIterator(): Iterator<Map.Entry<String, Any>> = entryIterator
 
   // Fallback for react-native 0.75.0 compatibility
-  @Suppress("NOTHING_TO_OVERRIDE")
+  @Suppress("NOTHING_TO_OVERRIDE", "INAPPLICABLE_JVM_NAME")
   @get:JvmName("getEntryIteratorFromProperty")
   override val entryIterator: Iterator<Map.Entry<String, Any>> =
     FilteredIterator(backingMap.entryIterator) {


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/30902

# How

Fix Suppress annotation in FilteredReadableMap

# Test Plan

Run sandbox using react-native 0.74 and 0.75

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
