### PR TITLE
[docs] Add info on how to enable Array syntax usage in Shared routes

### DIFF
--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -31,17 +31,4 @@ export default function Layout() {
 
 Now deep linking directly to `/other` or reloading the page will continue to show the back arrow.
 
-When using [array syntax](/router/advanced/shared-routes/#arrays) `(foo,bar)` you can specify the name of a group in the `unstable_settings` object to target a particular segment.
-
-```tsx other.tsx
-export const unstable_settings = {
-  // Used for `(foo)`
-  initialRouteName: 'first',
-  // Used for `(bar)`
-  bar: {
-    initialRouteName: 'second',
-  },
-};
-```
-
 </APIBox>

--- a/docs/pages/router/advanced/shared-routes.mdx
+++ b/docs/pages/router/advanced/shared-routes.mdx
@@ -43,3 +43,21 @@ export default function DynamicLayout({ segment }) {
   return <Stack />;
 }
 ```
+
+To enable the **array syntax**, specify the [`initialRouteName`](/router/advanced/router-settings/#initialroutename) for each group using `unstable_settings` object in the dynamic layout:
+
+{/* prettier-ignore */}
+```tsx app/(home,search)/_layout.tsx
+export const unstable_settings = {
+  intialRouteName: 'home',
+  search: {
+    initialRouteName: 'search',
+  },
+};
+
+export default function DynamicLayout({ segment }) {
+  /* @hide  ... */ /* @end */
+}
+```
+
+In the above example, the `home` route is the default route for the `home` group and the app, and the `search` route is the default route for the `search` group.

--- a/docs/pages/router/advanced/shared-routes.mdx
+++ b/docs/pages/router/advanced/shared-routes.mdx
@@ -1,7 +1,6 @@
 ---
 title: Shared routes
 description: Learn how to define shared routes or use arrays to use the same route multiple times with different layouts using Expo Router.
-hideTOC: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
@@ -60,4 +59,10 @@ export default function DynamicLayout({ segment }) {
 }
 ```
 
-In the above example, the `home` route is the default route for the `home` group and the app, and the `search` route is the default route for the `search` group.
+In the above example, the `home` route is the default route for the `home` group and the app. The `search` route is the default route for the `search` group.
+
+## Key points
+
+- You can only provide groups for the current navigator.
+- When using the array syntax, if there are two groups (for example, `(one)/(two)`), only the last group's segment is used for matching the route.
+- If there are at least two group `initialRouteNames`, but a default `initialRouteName` is not provided, the first group's `initialRouteName` is used.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes the issue on how to enable **Array syntax** in an app when using shared routes.

Refs [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1723151618462689)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Changes:
- On Shared routes page, add info on how to enable array syntax by using `initialRouteName` in the dynamic layout route file. It continues using the example defined in the Array syntax section. This will act as a source of truth on how to enable this setting.
- On Router Settings page, remove the info that explains the context about using `initialRouteName` for array syntax. This is because the **Array syntax** section can act as a source of truth in itself and we should provide the info on how to enable it within that section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and see: http://localhost:3002/router/advanced/shared-routes/#arrays.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
