### PR TITLE
chore: update e2e tests

### DIFF
--- a/apps/router-e2e/__e2e__/rsc/app/index.tsx
+++ b/apps/router-e2e/__e2e__/rsc/app/index.tsx
@@ -1,3 +1,4 @@
+import 'server-only';
 import { View, Image, Text, Button } from '../lib/react-native';
 
 export default function Page() {

--- a/apps/router-e2e/__e2e__/rsc/app/index.tsx
+++ b/apps/router-e2e/__e2e__/rsc/app/index.tsx
@@ -4,7 +4,7 @@ import { View, Image, Text, Button } from '../lib/react-native';
 export default function Page() {
   return (
     <View style={{ flex: 1, gap: 8, alignItems: 'center', justifyContent: 'center' }}>
-      <Text testID="main-text">Hey!</Text>
+      <Text testID="main-text">Hey RSC</Text>
       {/* local Metro asset */}
       <Image
         testID="main-image"

--- a/apps/router-e2e/index.js
+++ b/apps/router-e2e/index.js
@@ -1,5 +1,1 @@
-if (process.env.EXPO_PUBLIC_USE_RSC) {
-  require('expo-router/entry-rsc');
-} else {
-  require('expo-router/entry');
-}
+require('expo-router/entry');

--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -32,4 +32,13 @@ config.transformer.getTransformOptions = () => ({
   },
 });
 
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (process.env.E2E_RSC_ENABLED && moduleName === 'expo-router/entry') {
+    // Prevent loading the routes in client-first mode with the standard require.context module.
+    moduleName = 'expo-router/entry-rsc';
+  }
+
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = config;

--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -32,8 +32,10 @@ config.transformer.getTransformOptions = () => ({
   },
 });
 
+const isRSC = require('getenv').boolish('E2E_RSC_ENABLED', false);
+
 config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (process.env.E2E_RSC_ENABLED && moduleName === 'expo-router/entry') {
+  if (isRSC && moduleName === 'expo-router/entry') {
     // Prevent loading the routes in client-first mode with the standard require.context module.
     moduleName = 'expo-router/entry-rsc';
   }

--- a/apps/router-e2e/tailwind.config.js
+++ b/apps/router-e2e/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./__e2e__/tailwind-postcss/**/*.{js,tsx,ts,jsx}'],
+  content: ['./__e2e__/{tailwind-postcss,dom-components}/**/*.{js,tsx,ts,jsx}'],
   theme: {
     extend: {},
   },

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### 💡 Others
 
+- Enable experimental features for RSC when `experiments.reactServerComponents` is enabled.
 - Only enable RSC when `experiments.reactServerComponents` is true. ([#30875](https://github.com/expo/expo/pull/30875) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve logging. ([#30354](https://github.com/expo/expo/pull/30354) by [@EvanBacon](https://github.com/EvanBacon))
 - Decouple CLI from `@expo/metro-runtime`. ([#30300](https://github.com/expo/expo/pull/30300) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### 💡 Others
 
-- Enable experimental features for RSC when `experiments.reactServerComponents` is enabled.
+- Enable experimental features for RSC when `experiments.reactServerComponents` is enabled. ([#30967](https://github.com/expo/expo/pull/30967) by [@EvanBacon](https://github.com/EvanBacon))
 - Only enable RSC when `experiments.reactServerComponents` is true. ([#30875](https://github.com/expo/expo/pull/30875) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve logging. ([#30354](https://github.com/expo/expo/pull/30354) by [@EvanBacon](https://github.com/EvanBacon))
 - Decouple CLI from `@expo/metro-runtime`. ([#30300](https://github.com/expo/expo/pull/30300) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/playwright/dev/rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/rsc.test.ts
@@ -48,6 +48,10 @@ test.describe(inputDir, () => {
 
     console.time('Open page');
 
+    const serverResponsePromise = page.waitForResponse((response) => {
+      return new URL(response.url()).pathname.startsWith('/_flight/web/index.txt');
+    });
+
     // Listen for console errors
     const errorLogs: string[] = [];
     page.on('console', (msg) => {
@@ -66,8 +70,12 @@ test.describe(inputDir, () => {
     await page.goto(expo.url);
     console.timeEnd('Open page');
 
+    await serverResponsePromise;
+
+    await page.waitForSelector('[data-testid="main-text"]');
+
     // Ensure the initial state is correct
-    await expect(page.locator('[data-testid="main-text"]')).toHaveText('Hey!');
+    await expect(page.locator('[data-testid="main-text"]')).toHaveText('Hey RSC');
 
     expect(errorLogs).toEqual([]);
     expect(errors).toEqual([]);

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -89,6 +89,13 @@ export async function loadMetroConfigAsync(
   }: { exp: ExpoConfig; isExporting: boolean; getMetroBundler: () => Bundler }
 ) {
   let reportEvent: ((event: any) => void) | undefined;
+
+  // NOTE: Enable all the experimental Metro flags when RSC is enabled.
+  if (exp.experiments?.reactServerComponents) {
+    process.env.EXPO_USE_METRO_REQUIRE = '1';
+    process.env.EXPO_USE_FAST_RESOLVER = '1';
+  }
+
   const serverRoot = getMetroServerRoot(projectRoot);
   const terminalReporter = new MetroTerminalReporter(serverRoot, terminal);
 
@@ -159,7 +166,9 @@ export async function loadMetroConfigAsync(
     webOutput: exp.web?.output ?? 'single',
     isFastResolverEnabled: env.EXPO_USE_FAST_RESOLVER,
     isExporting,
-    isReactCanaryEnabled: exp.experiments?.reactCanary ?? false,
+    isReactCanaryEnabled:
+      (exp.experiments?.reactServerComponents || exp.experiments?.reactCanary) ?? false,
+    isNamedRequiresEnabled: env.EXPO_USE_METRO_REQUIRE,
     getMetroBundler,
   });
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -718,6 +718,7 @@ export async function withMetroMultiPlatformAsync(
     isFastResolverEnabled,
     isExporting,
     isReactCanaryEnabled,
+    isNamedRequiresEnabled,
     getMetroBundler,
   }: {
     config: ConfigT;
@@ -728,10 +729,11 @@ export async function withMetroMultiPlatformAsync(
     isFastResolverEnabled?: boolean;
     isExporting?: boolean;
     isReactCanaryEnabled: boolean;
+    isNamedRequiresEnabled: boolean;
     getMetroBundler: () => Bundler;
   }
 ) {
-  if (env.EXPO_USE_METRO_REQUIRE) {
+  if (isNamedRequiresEnabled) {
     debug('Using Expo metro require runtime.');
     // Change the default metro-runtime to a custom one that supports bundle splitting.
     require('metro-config/src/defaults/defaults').moduleSystem = require.resolve(


### PR DESCRIPTION
# Why

- Update tests to skip loading the default routes in client-only mode when RSC is enabled.
