### PR TITLE
Cherry pick filesystem fix to SDK51

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -494,5 +494,28 @@ export async function test({ describe, expect, it, ...t }) {
       expect(newDirInfo.exists).toBeTruthy();
       expect(newDirInfo.isDirectory).toBeTruthy();
     }, 30000);
+
+    it('delete(idempotent) -> !exists -> copy(from bundle) -> exists -> delete -> !exists', async () => {
+      const from = 'file://' + FS.bundleDirectory + 'Info.plist';
+      const to = FS.documentDirectory + 'Info.plist.copy';
+
+      const assertExists = async (expectedToExist) => {
+        const { exists } = await FS.getInfoAsync(to);
+        if (expectedToExist) {
+          expect(exists).toBeTruthy();
+        } else {
+          expect(exists).not.toBeTruthy();
+        }
+      };
+
+      await FS.deleteAsync(to, { idempotent: true });
+      await assertExists(false);
+
+      await FS.copyAsync({ from, to });
+      await assertExists(true);
+
+      await FS.deleteAsync(to);
+      await assertExists(false);
+    });
   });
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
@@ -110,10 +110,10 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
       return []
     }
     var filePermissions: EXFileSystemPermissionFlags = []
-    if FileManager.default.isReadableFile(atPath: url.absoluteString) {
+    if FileManager.default.isReadableFile(atPath: url.path) {
       filePermissions.insert(.read)
     }
-    if FileManager.default.isWritableFile(atPath: url.absoluteString) {
+    if FileManager.default.isWritableFile(atPath: url.path) {
       filePermissions.insert(.write)
     }
     return filePermissions


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/30108

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
