### PR TITLE
[docs][guides] Add keyboard handling guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -423,6 +423,7 @@ const general = [
         makePage('guides/editing-richtext.mdx'),
         makePage('guides/store-assets.mdx'),
         makePage('guides/local-first.mdx'),
+        makePage('guides/keyboard-handling.mdx'),
       ]),
       makeSection('Integrations', [
         makePage('guides/using-analytics.mdx'),

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -142,9 +142,66 @@ export default function RootLayout() {
 }
 ```
 
+### Handling multiple inputs
+
+For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
+
+```tsx FormScreen.tsx
+import { TextInput, View, StyleSheet } from 'react-native';
+import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
+
+export default function FormScreen() {
+  return (
+    <>
+      <KeyboardAwareScrollView bottomOffset={62} contentContainerStyle={styles.container}>
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+      </KeyboardAwareScrollView>
+      <KeyboardToolbar />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    padding: 16,
+  },
+  listStyle: {
+    padding: 16,
+    gap: 16,
+  },
+  textInput: {
+    width: 'auto',
+    flexGrow: 1,
+    flexShrink: 1,
+    height: 45,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderColor: '#d8d8d8',
+    backgroundColor: '#fff',
+    padding: 8,
+    marginBottom: 8,
+  },
+});
+```
+
+The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
+
 ### Animating views in sync with keyboard height
 
-The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`useKeyboardHandler`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/hooks/keyboard/use-keyboard-handler) from Keyboard Controller. It provides access to keyboard lifecycle events and allows us to determine when the keyboard starts animating and its position in every frame of the animation.
+The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view), which automatically scrolls to focused `TextInput` and provides a native-like performance, we recommend using `KeyboardAwareScrollView` for simple screens with not many elements.
+
+For a more advanced and customizable approach, you can use [`useKeyboardHandler`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/hooks/keyboard/use-keyboard-handler). It provides access to keyboard lifecycle events. It allows us to determine when the keyboard starts animating and its position in every frame of the animation.
 
 Using the `useKeyboardHandler` hook, you can create a custom hook to access the height of the keyboard at each frame. It uses `useSharedValue` from reanimated to return the height, as shown below.
 
@@ -230,61 +287,6 @@ const styles = StyleSheet.create({
   },
 });
 ```
-
-### Handling multiple inputs
-
-For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
-
-```tsx FormScreen.tsx
-import { TextInput, View, StyleSheet } from 'react-native';
-import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
-
-export default function FormScreen() {
-  return (
-    <>
-      <KeyboardAwareScrollView bottomOffset={62} contentContainerStyle={styles.container}>
-        <View>
-          <TextInput placeholder="Type a message..." style={styles.textInput} />
-          <TextInput placeholder="Type a message..." style={styles.textInput} />
-        </View>
-        <TextInput placeholder="Type a message..." style={styles.textInput} />
-        <View>
-          <TextInput placeholder="Type a message..." style={styles.textInput} />
-          <TextInput placeholder="Type a message..." style={styles.textInput} />
-          <TextInput placeholder="Type a message..." style={styles.textInput} />
-        </View>
-        <TextInput placeholder="Type a message..." style={styles.textInput} />
-      </KeyboardAwareScrollView>
-      <KeyboardToolbar />
-    </>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    gap: 16,
-    padding: 16,
-  },
-  listStyle: {
-    padding: 16,
-    gap: 16,
-  },
-  textInput: {
-    width: 'auto',
-    flexGrow: 1,
-    flexShrink: 1,
-    height: 45,
-    borderWidth: 1,
-    borderRadius: 8,
-    borderColor: '#d8d8d8',
-    backgroundColor: '#fff',
-    padding: 8,
-    marginBottom: 8,
-  },
-});
-```
-
-The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
 
 ## Additional resources
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -84,11 +84,11 @@ export default function HomeScreen() {
     };
   }, []);
 
-  const handleKeyboardShow = (event) => {
+  const handleKeyboardShow = event => {
     setIsKeyboardVisible(true);
   };
 
-  const handleKeyboardHide = (event) => {
+  const handleKeyboardHide = event => {
     setIsKeyboardVisible(false);
   };
 
@@ -152,7 +152,7 @@ const useGradualAnimation = () => {
 
   useKeyboardHandler(
     {
-      onMove: (event) => {
+      onMove: event => {
         'worklet';
         height.value = Math.max(event.height, 0);
       },

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -1,5 +1,4 @@
 ---
-modificationDate:
 title: Keyboard handling
 sidebar_title: Keyboard handling
 description: A guide to handling common keyboard interactions.
@@ -113,9 +112,9 @@ export default function RootLayout() {
 
 ### Using keyboard controller
 
-Let's explore how we can achieve the `KeyboardAvoidingView` functionality using the `useKeyboardHandler` hook.
+Let's explore how you can achieve the `KeyboardAvoidingView` functionality using the `useKeyboardHandler` hook.
 
-The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. We'll use the `onMove` handler to get the keyboard height and use it to push our content above the keyboard when an input is active:
+The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. You'll use the `onMove` handler to get the keyboard height and use it to push our content above the keyboard when an input is active:
 
 ```js
 const useGradualAnimation = () => {
@@ -134,7 +133,7 @@ const useGradualAnimation = () => {
 };
 ```
 
-In this example, we use the `useSharedValue` hook from Reanimated to store the keyboard's height. The value changes from 0 when the keyboard is dismissed to the maximum height when it's active.
+The above example uses the `useSharedValue` hook from Reanimated to store the keyboard's height. The value changes from 0 when the keyboard is dismissed to the maximum height when it's active.
 
 Now, let's use our `useGradualAnimation` hook inside a component:
 
@@ -163,7 +162,7 @@ export default function TabTwoScreen() {
 }
 ```
 
-In this example, we use the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
+This example uses the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
 
 ### Handling multiple inputs
 
@@ -194,7 +193,7 @@ export default function AdvancedToolbar() {
 }
 ```
 
-In this example, we wrap the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
+The example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
 
 Keyboard Controller provides consistency across Android and iOS with minimal configuration, offering the native feel users expect.
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -6,13 +6,13 @@ description: A guide to handling common keyboard interactions.
 
 Keyboard handling is crucial for creating an excellent user experience in your Expo app. This guide covers common keyboard interactions and how to manage them effectively.
 
-React Native provides several keyboard-related APIs, with [Keybaord](https://reactnative.dev/docs/keyboard) and [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keybaord Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), a library that offers advanced keyboard handling capabilities.
+React Native provides several keyboard-related APIs, with [Keyboard](https://reactnative.dev/docs/keyboard) and [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), a library that offers advanced keyboard handling capabilities.
 
 ## The basics
 
-### Keybaord events
+### Keyboard events
 
-The Keybaord module allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
+The Keyboard module allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
 
 To listen for keyboard events, use the `Keyboard.addListener` method. This method takes an event name and a callback function as arguments. The callback function will be called with the event data when the keyboard is shown or hidden.
 
@@ -76,7 +76,7 @@ After adding this property, restart your app so that the changes take effect.
 
 For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs.
 
-### Installing keybaord controller
+### Installing keyboard controller
 
 To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), install it in your Expo project:
 
@@ -200,4 +200,4 @@ Keyboard Controller provides consistency across Android and iOS with minimal con
 ## Additional resources
 
 - [Keyboard Guide Source Code](https://github.com/betomoedano/keyboard-guide.git)
-- [Keybaord Controller Docs](https://kirillzyusko.github.io/react-native-keyboard-controller)
+- [Keyboard Controller Docs](https://kirillzyusko.github.io/react-native-keyboard-controller)

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -149,6 +149,8 @@ export default function RootLayout() {
 
 ### Handling multiple inputs
 
+The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view), which automatically scrolls to focused `TextInput` and provides a native-like performance, we recommend using `KeyboardAwareScrollView` for simple screens with not many elements.
+
 For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
 
 ```tsx FormScreen.tsx
@@ -203,8 +205,6 @@ const styles = StyleSheet.create({
 The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
 
 ### Animating views in sync with keyboard height
-
-The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view), which automatically scrolls to focused `TextInput` and provides a native-like performance, we recommend using `KeyboardAwareScrollView` for simple screens with not many elements.
 
 For a more advanced and customizable approach, you can use [`useKeyboardHandler`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/hooks/keyboard/use-keyboard-handler). It provides access to keyboard lifecycle events. It allows us to determine when the keyboard starts animating and its position in every frame of the animation.
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -1,9 +1,14 @@
 ---
 title: Keyboard handling
-description: A guide for handling common keyboard interactions.
+description: A guide for handling common keyboard interactions on an Android or iOS device.
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
+import { CODE } from '~/ui/components/Text';
 
 Keyboard handling is crucial for creating an excellent user experience in your Expo app. React Native provides [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview), which are commonly used to handle keyboard events. For more complex or custom keyboard interactions, you can consider using [`react-native-keyboard-controller`](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
 
@@ -283,5 +288,16 @@ The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the
 
 ## Additional resources
 
-- [Example project based on this guide](https://github.com/betomoedano/keyboard-guide)
-- [`react-native-keyboard-controller` documentation](https://kirillzyusko.github.io/react-native-keyboard-controller)
+<BoxLink
+  title="Example"
+  description="See the source code for the example project on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/betomoedano/keyboard-guide"
+/>
+
+<BoxLink
+  title={<CODE>react-native-keyboard-controller</CODE>}
+  description="For more details on the Keyboard Controller library, see the documentation."
+  Icon={BookOpen02Icon}
+  href="https://kirillzyusko.github.io/react-native-keyboard-controller"
+/>

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -17,11 +17,11 @@ The `Keyboard` module from React Native allows you to listen for native events, 
 
 To listen for keyboard events, use the `Keyboard.addListener` method. This method accepts an event name and a callback function as arguments. The callback function is called with the event data when the keyboard is shown or hidden.
 
-```js
-import {useEffect } from 'react';
+```tsx HomeScreen.tsx
+import { useEffect } from 'react';
 import { Keyboard } from 'react-native';
 
-export default function App() {
+export default function HomeScreen() {
   useEffect(() => {
     const showSubscription = Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
 
@@ -38,20 +38,22 @@ export default function App() {
 
 To dismiss the keyboard, use the `dismiss` method.
 
-```js
-import { Keyboard } from 'react-native';
+```tsx DismissKeyboardButton.tsx
+import { Keyboard, Button } from 'react-native';
 
-Keyboard.dismiss();
+export default function DismissKeyboardButton() {
+  return <Button title="Dismiss keyboard" onPress={Keyboard.dismiss} />;
+}
 ```
 
 ### Keyboard avoiding view
 
 The `KeyboardAvoidingView` is a component that automatically adjusts its height, position, or bottom padding based on the keyboard height to remain visible while the keyboard is displayed.
 
-```js
-import { KeyboardAvoidingView } from 'react-native';
+```tsx HomeScreen.tsx
+import { KeyboardAvoidingView, TextInput } from 'react-native';
 
-export default function App() {
+export default function HomeScreen() {
   return (
     <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1 }}>
       <TextInput placeholder="Type here..." />
@@ -76,12 +78,11 @@ After adding this property, restart your app so that the changes take effect.
 
 ## Advanced keyboard handling
 
-For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs.
+For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
 
 ### Install keyboard controller
 
 To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), install it in your Expo project:
-
 
 <Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
 
@@ -95,7 +96,8 @@ Keyboard Controller library also requires `react-native-reanimated` to work prop
 
 To finalize the setup, add the `KeyboardProvider` to your app.
 
-```js
+```tsx _layout.tsx
+import { Stack } from 'expo-router';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 
 export default function RootLayout() {
@@ -117,7 +119,10 @@ Let's explore how to use the `useKeyboardHandler` hook to achieve the same funct
 
 The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. You'll use the `onMove` handler to get the keyboard height and use it to push the screen's content above the keyboard when an input is active:
 
-```js
+```tsx ChatScreen.tsx
+import { useKeyboardHandler } from 'react-native-keyboard-controller';
+import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+
 const useGradualAnimation = () => {
   const height = useSharedValue(0);
 
@@ -138,8 +143,17 @@ The above example uses the `useSharedValue` hook from Reanimated to store the ke
 
 Now, let's use the `useGradualAnimation` hook inside a screen component:
 
-```js
-export default function TabTwoScreen() {
+```tsx ChatScreen.tsx
+import { StyleSheet, Platform, FlatList, View, StatusBar, TextInput } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+import { useKeyboardHandler } from "react-native-keyboard-controller";
+
+import MessageItem from "@/components/MessageItem";
+import { messages } from "@/messages";
+
+const useGradualAnimation = () => {...};
+
+export default function ChatScreen() {
   const { height } = useGradualAnimation();
 
   const fakeView = useAnimatedStyle(() => {
@@ -161,6 +175,28 @@ export default function TabTwoScreen() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: Platform.OS === "android" ? StatusBar.currentHeight : 0,
+  },
+  listStyle: {
+    padding: 16,
+    gap: 16,
+  },
+  textInput: {
+    width: "95%",
+    height: 45,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderColor: "#d8d8d8",
+    backgroundColor: "#fff",
+    padding: 8,
+    alignSelf: "center",
+    marginBottom: 8,
+  },
+});
 ```
 
 The above uses the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
@@ -169,10 +205,11 @@ The above uses the keyboard's height to move the screen content above the keyboa
 
 For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
 
-```js
+```tsx FormScreen.tsx
+import { TextInput, View, StyleSheet } from 'react-native';
 import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
 
-export default function AdvancedToolbar() {
+export default function FormScreen() {
   return (
     <>
       <KeyboardAwareScrollView bottomOffset={62} contentContainerStyle={styles.container}>
@@ -192,11 +229,32 @@ export default function AdvancedToolbar() {
     </>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    padding: 16,
+  },
+  listStyle: {
+    padding: 16,
+    gap: 16,
+  },
+  textInput: {
+    width: 'auto',
+    flexGrow: 1,
+    flexShrink: 1,
+    height: 45,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderColor: '#d8d8d8',
+    backgroundColor: '#fff',
+    padding: 8,
+    marginBottom: 8,
+  },
+});
 ```
 
 The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
-
-Keyboard Controller provides consistency across Android and iOS with minimal configuration, offering the native feel users expect.
 
 ## Additional resources
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -11,44 +11,11 @@ React Native provides several keyboard-related APIs, with [`Keyboard`](https://r
 
 ## The basics
 
-### Keyboard events
-
-The `Keyboard` module from React Native allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
-
-To listen for keyboard events, use the `Keyboard.addListener` method. This method accepts an event name and a callback function as arguments. The callback function is called with the event data when the keyboard is shown or hidden.
-
-```tsx HomeScreen.tsx
-import { useEffect } from 'react';
-import { Keyboard } from 'react-native';
-
-export default function HomeScreen() {
-  useEffect(() => {
-    const showSubscription = Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
-
-    return () => {
-      showSubscription.remove();
-    };
-  }, []);
-
-  const handleKeyboardShow = event => {
-    // Handle keyboard show event here
-  };
-}
-```
-
-To dismiss the keyboard, use the `dismiss` method.
-
-```tsx DismissKeyboardButton.tsx
-import { Keyboard, Button } from 'react-native';
-
-export default function DismissKeyboardButton() {
-  return <Button title="Dismiss keyboard" onPress={Keyboard.dismiss} />;
-}
-```
-
 ### Keyboard avoiding view
 
 The `KeyboardAvoidingView` is a component that automatically adjusts its height, position, or bottom padding based on the keyboard height to remain visible while the keyboard is displayed.
+
+> **info** Android and iOS interact with the `behavior` property differently. On iOS, `padding` is usually what works best, and for Android, just having the `KeyboardAvoidingView` prevents covering the input. This is why the following example uses `undefined` for Android. Playing around with the `behavior` is a good practice since a different option could work best for your app.
 
 ```tsx HomeScreen.tsx
 import { KeyboardAvoidingView, TextInput } from 'react-native';
@@ -74,11 +41,75 @@ When using a Bottom Tab navigator on Android, you might notice that focusing on 
 }
 ```
 
-After adding this property, restart your app so that the changes take effect.
+After adding this property, restart the development server and reload your app to apply the changes.
+
+It's also possible to hide the bottom tab when the keyboard opens using [`tabBarHideOnKeyboard`](https://reactnavigation.org/docs/bottom-tab-navigator/#tabbarhideonkeyboard), an option with the Bottom Tab Navigator. If set to `true`, it will hide the bar when the keyboard opens. See the example below.
+
+```tsx _layout.tsx
+import { Tabs } from 'expo-router';
+
+export default function TabLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarHideOnKeyboard: true,
+      }}>
+      <Tabs.Screen name="index" />
+    </Tabs>
+  );
+}
+```
+
+### Keyboard events
+
+The `Keyboard` module from React Native allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
+
+To listen for keyboard events, use the `Keyboard.addListener` method. This method accepts an event name and a callback function as arguments. When the keyboard is shown or hidden, the callback function is called with the event data.
+
+The following example illustrates a use case for adding a keyboard listener. The state variable `isKeyboardVisible` is toggled each time the keyboard shows or hides. Based on this variable, a button that allows the user to dismiss the keyboard only if the keyboard is active is rendered. Also, notice that the button uses the `dismiss` method from the `Keyboard` module.
+
+```tsx HomeScreen.tsx
+import { useEffect, useState } from 'react';
+import { Keyboard, View, Button, TextInput } from 'react-native';
+
+export default function HomeScreen() {
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', handleKeyboardHide);
+
+    return () => {
+      showSubscription.remove();
+    };
+  }, []);
+
+  const handleKeyboardShow = event => {
+    setIsKeyboardVisible(true);
+  };
+
+  const handleKeyboardHide = event => {
+    setIsKeyboardVisible(false);
+  };
+
+  return (
+    <View>
+      {isKeyboardVisible && <Button title="Dismiss keyboard" onPress={Keyboard.dismiss} />}
+      <TextInput placeholder="Type here..." />
+    </View>
+  );
+}
+```
 
 ## Advanced keyboard handling
 
-For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
+For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
+
+### Prerequisites
+
+The following steps are described using a [development build](/develop/development-builds/introduction/) since this library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
+
+[Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) requires `react-native-reanimated` to work correctly. To install it, follow the [installation instructions](/versions/latest/sdk/reanimated/#installation).
 
 ### Install keyboard controller
 
@@ -86,11 +117,9 @@ To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-n
 
 <Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
 
-Keyboard Controller uses native code, so you need to prebuild your app:
+Then prebuild your app:
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
-
-Keyboard Controller library also requires `react-native-reanimated` to work properly. Follow the [installation instructions](/versions/latest/sdk/reanimated/#installation) to install it.
 
 ### Set up Keyboard Controller provider
 
@@ -104,20 +133,20 @@ export default function RootLayout() {
   return (
     <KeyboardProvider>
       <Stack>
-        <Stack.Screen name="basic" />
-        <Stack.Screen name="advanced" />
-        <Stack.Screen name="+not-found" />
+        <Stack.Screen name="home" />
+        <Stack.Screen name="chat" />
       </Stack>
     </KeyboardProvider>
   );
 }
 ```
 
-### Usage
+### Animating Views in Sync with Keyboard Height
 
-Let's explore how to use the `useKeyboardHandler` hook to achieve the same functionality that `KeyboardAvoidingView` provides.
+The `KeyboardAvoidingView` component is excellent for prototyping but requires platform-specific configuration and is not very customizable. Here's how to achieve the same functionality using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller).
 
-The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. You'll use the `onMove` handler to get the keyboard height and use it to push the screen's content above the keyboard when an input is active:
+Let's use the `useKeyboardHandler` hook from [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), which provides access to keyboard lifecycle events and allows us to determine when the keyboard starts animating and its position in every frame of the animation.
+The example below is a hook that leverages the `useKeyboardHandler` hook to access the height of the keyboard at each frame, using `useSharedValue` from reanimated returns the height.
 
 ```tsx ChatScreen.tsx
 import { useKeyboardHandler } from 'react-native-keyboard-controller';
@@ -139,9 +168,11 @@ const useGradualAnimation = () => {
 };
 ```
 
-The above example uses the `useSharedValue` hook from Reanimated to store the keyboard's height. The value changes from 0 when the keyboard is dismissed to the maximum height when it's active.
+The following example uses the `useGradualAnimation` hook to animate a view and give it a smooth animation when the keyboard is active or dismissed.
 
-Now, let's use the `useGradualAnimation` hook inside a screen component:
+The component gets the keyboard height using the `useGradualAnimation` hook. It then creates an animated style called `fakeView` using the `useAnimatedStyle` hook from reanimated. This style only contains one property, `height` which is set to the keyboard's height.
+
+The `fakeView` animated style is used in an animated view after the text input. This view height will animate based on the keyboard's height at each frame, effectively pushing the content above the keyboard with a smooth animation. It also decreases its height to zero when the keyboard is dismissed.
 
 ```tsx ChatScreen.tsx
 import { StyleSheet, Platform, FlatList, View, StatusBar, TextInput } from "react-native";
@@ -198,8 +229,6 @@ const styles = StyleSheet.create({
   },
 });
 ```
-
-The above uses the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
 
 ### Handling multiple inputs
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -84,11 +84,11 @@ export default function HomeScreen() {
     };
   }, []);
 
-  const handleKeyboardShow = event => {
+  const handleKeyboardShow = (event) => {
     setIsKeyboardVisible(true);
   };
 
-  const handleKeyboardHide = event => {
+  const handleKeyboardHide = (event) => {
     setIsKeyboardVisible(false);
   };
 
@@ -101,7 +101,7 @@ export default function HomeScreen() {
 }
 ```
 
-## Advanced keyboard handling
+## Advanced keyboard handling with Keyboard Controller
 
 For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [`react-native-keyboard-controller` (Keyboard Controller)](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
 
@@ -117,8 +117,7 @@ Start by installing the Keyboard Controller library in your Expo project:
 
 <Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
 
-
-### Set up Keyboard Controller provider
+### Set up provider
 
 To finalize the setup, add the `KeyboardProvider` to your app.
 
@@ -165,7 +164,6 @@ const useGradualAnimation = () => {
 ```
 
 You can use the `useGradualAnimation` hook to animate a view and give it a smooth animation when the keyboard is active or dismissed, for example, in a chat screen component (shown in the example below). This component gets the keyboard height from the hook. It then creates an animated style called `fakeView` using the `useAnimatedStyle` hook from reanimated. This style only contains one property: `height`, which is set to the keyboard's height.
-
 
 The `fakeView` animated style is used in an animated view after the `TextInput`. This view's height will animate based on the keyboard's height at each frame, which effectively pushes the content above the keyboard with a smooth animation. It also decreases its height to zero when the keyboard is dismissed.
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -1,0 +1,204 @@
+---
+modificationDate:
+title: Keyboard handling
+sidebar_title: Keyboard handling
+description: A guide to handling common keyboard interactions.
+---
+
+Keyboard handling is crucial for creating an excellent user experience in your Expo app. This guide covers common keyboard interactions and how to manage them effectively.
+
+React Native provides several keyboard-related APIs, with [Keybaord](https://reactnative.dev/docs/keyboard) and [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keybaord Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), a library that offers advanced keyboard handling capabilities.
+
+## The basics
+
+### Keybaord events
+
+The Keybaord module allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
+
+To listen for keyboard events, use the `Keyboard.addListener` method. This method takes an event name and a callback function as arguments. The callback function will be called with the event data when the keyboard is shown or hidden.
+
+```js
+import { Keyboard } from 'react-native';
+
+export default function App() {
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
+
+    return () => {
+      showSubscription.remove();
+    };
+  }, []);
+
+  const handleKeyboardShow = event => {
+    // Handle keyboard show event here
+  };
+}
+```
+
+To dismiss the keyboard, use the `dismiss` method.
+
+```js
+import { Keyboard } from 'react-native';
+
+Keyboard.dismiss();
+```
+
+### Keyboard avoiding view
+
+The `KeyboardAvoidingView` is a component that automatically adjusts its height, position, or bottom padding based on the keyboard height to remain visible while the keyboard is displayed.
+
+```js
+import { KeyboardAvoidingView } from 'react-native';
+
+export default function App() {
+  return (
+    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1 }}>
+      <TextInput placeholder="Type here..." />
+    </KeyboardAvoidingView>;
+  );
+}
+```
+
+This example will automatically adjust the height of the `KeyboardAvoidingView` based on the keyboard height, so that the input is always visible.
+
+> **info** When using BottomTabs for navigation in Android, you might notice that focusing on an input field causes the bottom tabs to be pushed above the keyboard. To address this issue add the `softwareKeyboardLayoutMode` property to your Android configuration in `app.json` and set it to `pan`.
+
+```js app.json
+"expo" {
+  "android": {
+    "softwareKeyboardLayoutMode": "pan"
+  }
+}
+```
+
+After adding this property, restart your app so that the changes take effect.
+
+## Advanced keyboard handling
+
+For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs.
+
+### Installing keybaord controller
+
+To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), install it in your Expo project:
+
+import { Terminal } from '~/ui/components/Snippet';
+
+<Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
+
+Keyboard Controller uses native code, so you need to prebuild your app:
+
+<Terminal cmd={['$ expo prebuild --clean']} />
+
+Keyboard controller also requires [`react-native-reanimated`](/versions/latest/sdk/reanimated) to work properly. Follow the [installation instructions](/versions/latest/sdk/reanimated/) to install it.
+
+### Setting up keyboard controller provider
+
+To finalize the setup, add the `KeyboardControllerProvider` to your app.
+
+```js
+import { KeyboardProvider } from 'react-native-keyboard-controller';
+
+export default function RootLayout() {
+  return (
+    <KeyboardProvider>
+      <Stack>
+        <Stack.Screen name="basic" />
+        <Stack.Screen name="advanced" />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+    </KeyboardProvider>
+  );
+}
+```
+
+### Using keyboard controller
+
+Let's explore how we can achieve the `KeyboardAvoidingView` functionality using the `useKeyboardHandler` hook.
+
+The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. We'll use the `onMove` handler to get the keyboard height and use it to push our content above the keyboard when an input is active:
+
+```js
+const useGradualAnimation = () => {
+  const height = useSharedValue(0);
+
+  useKeyboardHandler(
+    {
+      onMove: e => {
+        'worklet';
+        height.value = Math.max(e.height, 0);
+      },
+    },
+    []
+  );
+  return { height };
+};
+```
+
+In this example, we use the `useSharedValue` hook from Reanimated to store the keyboard's height. The value changes from 0 when the keyboard is dismissed to the maximum height when it's active.
+
+Now, let's use our `useGradualAnimation` hook inside a component:
+
+```js
+export default function TabTwoScreen() {
+  const { height } = useGradualAnimation();
+
+  const fakeView = useAnimatedStyle(() => {
+    return {
+      height: Math.abs(height.value),
+    };
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={messages}
+        renderItem={({ item }) => <MessageItem message={item} />}
+        keyExtractor={item => item.createdAt.toString()}
+        contentContainerStyle={styles.listStyle}
+      />
+      <TextInput placeholder="Type a message..." style={styles.textInput} />
+      <Animated.View style={fakeView} />
+    </View>
+  );
+}
+```
+
+In this example, we use the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
+
+### Handling multiple inputs
+
+For screens with multiple inputs, Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These handle input navigation and prevent the keyboard from covering the screen without custom configuration:
+
+```js
+import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
+
+export default function AdvancedToolbar() {
+  return (
+    <>
+      <KeyboardAwareScrollView bottomOffset={62} contentContainerStyle={styles.container}>
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+      </KeyboardAwareScrollView>
+      <KeyboardToolbar />
+    </>
+  );
+}
+```
+
+In this example, we wrap the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
+
+Keyboard Controller provides consistency across Android and iOS with minimal configuration, offering the native feel users expect.
+
+## Additional resources
+
+- [Keyboard Guide Source Code](https://github.com/betomoedano/keyboard-guide.git)
+- [Keybaord Controller Docs](https://kirillzyusko.github.io/react-native-keyboard-controller)

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -5,17 +5,17 @@ description: A guide for handling common keyboard interactions.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Keyboard handling is crucial for creating an excellent user experience in your Expo app. This guide covers common keyboard interactions and how to manage them effectively.
+Keyboard handling is crucial for creating an excellent user experience in your Expo app. React Native provides [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview), which are commonly used to handle keyboard events. For more complex or custom keyboard interactions, you can consider using [`react-native-keyboard-controller`](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
 
-React Native provides several keyboard-related APIs, with [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
+This guide covers common keyboard interactions and how to manage them effectively.
 
 ## The basics
 
 ### Keyboard avoiding view
 
-The `KeyboardAvoidingView` is a component that automatically adjusts its height, position, or bottom padding based on the keyboard height to remain visible while the keyboard is displayed.
+The `KeyboardAvoidingView` is a component that automatically adjusts a keyboard's height, position, or bottom padding based on the keyboard height to remain visible while it is displayed.
 
-> **info** Android and iOS interact with the `behavior` property differently. On iOS, `padding` is usually what works best, and for Android, just having the `KeyboardAvoidingView` prevents covering the input. This is why the following example uses `undefined` for Android. Playing around with the `behavior` is a good practice since a different option could work best for your app.
+Android and iOS interact with the `behavior` property differently. On iOS, `padding` is usually what works best, and for Android, just having the `KeyboardAvoidingView` prevents covering the input. This is why the following example uses `undefined` for Android. Playing around with the `behavior` is a good practice since a different option could work best for your app.
 
 ```tsx HomeScreen.tsx
 import { KeyboardAvoidingView, TextInput } from 'react-native';
@@ -43,9 +43,9 @@ When using a Bottom Tab navigator on Android, you might notice that focusing on 
 
 After adding this property, restart the development server and reload your app to apply the changes.
 
-It's also possible to hide the bottom tab when the keyboard opens using [`tabBarHideOnKeyboard`](https://reactnavigation.org/docs/bottom-tab-navigator/#tabbarhideonkeyboard), an option with the Bottom Tab Navigator. If set to `true`, it will hide the bar when the keyboard opens. See the example below.
+It's also possible to hide the bottom tab when the keyboard opens using [`tabBarHideOnKeyboard`](https://reactnavigation.org/docs/bottom-tab-navigator/#tabbarhideonkeyboard). It is an option with the Bottom Tab Navigator. If set to `true`, it will hide the bar when the keyboard opens.
 
-```tsx _layout.tsx
+```tsx app/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function TabLayout() {
@@ -66,7 +66,7 @@ The `Keyboard` module from React Native allows you to listen for native events, 
 
 To listen for keyboard events, use the `Keyboard.addListener` method. This method accepts an event name and a callback function as arguments. When the keyboard is shown or hidden, the callback function is called with the event data.
 
-The following example illustrates a use case for adding a keyboard listener. The state variable `isKeyboardVisible` is toggled each time the keyboard shows or hides. Based on this variable, a button that allows the user to dismiss the keyboard only if the keyboard is active is rendered. Also, notice that the button uses the `dismiss` method from the `Keyboard` module.
+The following example illustrates a use case for adding a keyboard listener. The state variable `isKeyboardVisible` is toggled each time the keyboard shows or hides. Based on this variable, a button allows the user to dismiss the keyboard only if the keyboard is active. Also, notice that the button uses the `Keyboard.dismiss` method.
 
 ```tsx HomeScreen.tsx
 import { useEffect, useState } from 'react';
@@ -103,29 +103,26 @@ export default function HomeScreen() {
 
 ## Advanced keyboard handling
 
-For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
+For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [`react-native-keyboard-controller` (Keyboard Controller)](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
 
 ### Prerequisites
 
-The following steps are described using a [development build](/develop/development-builds/introduction/) since this library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
+The following steps are described using a [development build](/develop/development-builds/introduction/) since the Keyboard Controller library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
 
-[Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) requires `react-native-reanimated` to work correctly. To install it, follow the [installation instructions](/versions/latest/sdk/reanimated/#installation).
+[Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) also requires `react-native-reanimated` to work correctly. To install it, follow these [installation instructions](/versions/latest/sdk/reanimated/#installation).
 
-### Install keyboard controller
+### Install
 
-To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), install it in your Expo project:
+Start by installing the Keyboard Controller library in your Expo project:
 
 <Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
 
-Then prebuild your app:
-
-<Terminal cmd={['$ npx expo prebuild --clean']} />
 
 ### Set up Keyboard Controller provider
 
 To finalize the setup, add the `KeyboardProvider` to your app.
 
-```tsx _layout.tsx
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 
@@ -141,12 +138,11 @@ export default function RootLayout() {
 }
 ```
 
-### Animating Views in Sync with Keyboard Height
+### Animating views in sync with keyboard height
 
-The `KeyboardAvoidingView` component is excellent for prototyping but requires platform-specific configuration and is not very customizable. Here's how to achieve the same functionality using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller).
+The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`useKeyboardHandler`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/hooks/keyboard/use-keyboard-handler) from Keyboard Controller. It provides access to keyboard lifecycle events and allows us to determine when the keyboard starts animating and its position in every frame of the animation.
 
-Let's use the `useKeyboardHandler` hook from [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), which provides access to keyboard lifecycle events and allows us to determine when the keyboard starts animating and its position in every frame of the animation.
-The example below is a hook that leverages the `useKeyboardHandler` hook to access the height of the keyboard at each frame, using `useSharedValue` from reanimated returns the height.
+Using the `useKeyboardHandler` hook, you can create a custom hook to access the height of the keyboard at each frame. It uses `useSharedValue` from reanimated to return the height, as shown below.
 
 ```tsx ChatScreen.tsx
 import { useKeyboardHandler } from 'react-native-keyboard-controller';
@@ -157,9 +153,9 @@ const useGradualAnimation = () => {
 
   useKeyboardHandler(
     {
-      onMove: e => {
+      onMove: (event) => {
         'worklet';
-        height.value = Math.max(e.height, 0);
+        height.value = Math.max(event.height, 0);
       },
     },
     []
@@ -168,21 +164,23 @@ const useGradualAnimation = () => {
 };
 ```
 
-The following example uses the `useGradualAnimation` hook to animate a view and give it a smooth animation when the keyboard is active or dismissed.
+You can use the `useGradualAnimation` hook to animate a view and give it a smooth animation when the keyboard is active or dismissed, for example, in a chat screen component (shown in the example below). This component gets the keyboard height from the hook. It then creates an animated style called `fakeView` using the `useAnimatedStyle` hook from reanimated. This style only contains one property: `height`, which is set to the keyboard's height.
 
-The component gets the keyboard height using the `useGradualAnimation` hook. It then creates an animated style called `fakeView` using the `useAnimatedStyle` hook from reanimated. This style only contains one property, `height` which is set to the keyboard's height.
 
-The `fakeView` animated style is used in an animated view after the text input. This view height will animate based on the keyboard's height at each frame, effectively pushing the content above the keyboard with a smooth animation. It also decreases its height to zero when the keyboard is dismissed.
+The `fakeView` animated style is used in an animated view after the `TextInput`. This view's height will animate based on the keyboard's height at each frame, which effectively pushes the content above the keyboard with a smooth animation. It also decreases its height to zero when the keyboard is dismissed.
 
 ```tsx ChatScreen.tsx
-import { StyleSheet, Platform, FlatList, View, StatusBar, TextInput } from "react-native";
-import Animated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
-import { useKeyboardHandler } from "react-native-keyboard-controller";
+import { StyleSheet, Platform, FlatList, View, StatusBar, TextInput } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+import { useKeyboardHandler } from 'react-native-keyboard-controller';
 
-import MessageItem from "@/components/MessageItem";
-import { messages } from "@/messages";
+import MessageItem from '@/components/MessageItem';
+import { messages } from '@/messages';
 
-const useGradualAnimation = () => {...};
+const useGradualAnimation = () => {
+  /* @hide // Code remains same from previous example */
+  /* @end */
+};
 
 export default function ChatScreen() {
   const { height } = useGradualAnimation();
@@ -210,21 +208,21 @@ export default function ChatScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: Platform.OS === "android" ? StatusBar.currentHeight : 0,
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
   },
   listStyle: {
     padding: 16,
     gap: 16,
   },
   textInput: {
-    width: "95%",
+    width: '95%',
     height: 45,
     borderWidth: 1,
     borderRadius: 8,
-    borderColor: "#d8d8d8",
-    backgroundColor: "#fff",
+    borderColor: '#d8d8d8',
+    backgroundColor: '#fff',
     padding: 8,
-    alignSelf: "center",
+    alignSelf: 'center',
     marginBottom: 8,
   },
 });
@@ -287,5 +285,5 @@ The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the
 
 ## Additional resources
 
-- [Keyboard guide source code](https://github.com/betomoedano/keyboard-guide)
-- [Keyboard Controller documentation](https://kirillzyusko.github.io/react-native-keyboard-controller)
+- [Example project based on this guide](https://github.com/betomoedano/keyboard-guide)
+- [`react-native-keyboard-controller` documentation](https://kirillzyusko.github.io/react-native-keyboard-controller)

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -7,12 +7,17 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
 Keyboard handling is crucial for creating an excellent user experience in your Expo app. React Native provides [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview), which are commonly used to handle keyboard events. For more complex or custom keyboard interactions, you can consider using [`react-native-keyboard-controller`](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
 
 This guide covers common keyboard interactions and how to manage them effectively.
+
+### Video walkthrough
+
+<ContentSpotlight url="https://www.youtube.com/embed/Y51mDfAhd4E" />
 
 ## The basics
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -1,22 +1,24 @@
 ---
 title: Keyboard handling
-sidebar_title: Keyboard handling
-description: A guide to handling common keyboard interactions.
+description: A guide for handling common keyboard interactions.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 Keyboard handling is crucial for creating an excellent user experience in your Expo app. This guide covers common keyboard interactions and how to manage them effectively.
 
-React Native provides several keyboard-related APIs, with [Keyboard](https://reactnative.dev/docs/keyboard) and [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), a library that offers advanced keyboard handling capabilities.
+React Native provides several keyboard-related APIs, with [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview) being the most frequently used. For more complex or custom keyboard interactions, you might consider using [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
 
 ## The basics
 
 ### Keyboard events
 
-The Keyboard module allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
+The `Keyboard` module from React Native allows you to listen for native events, react to them, and make changes to the keyboard, such as dismissing it.
 
-To listen for keyboard events, use the `Keyboard.addListener` method. This method takes an event name and a callback function as arguments. The callback function will be called with the event data when the keyboard is shown or hidden.
+To listen for keyboard events, use the `Keyboard.addListener` method. This method accepts an event name and a callback function as arguments. The callback function is called with the event data when the keyboard is shown or hidden.
 
 ```js
+import {useEffect } from 'react';
 import { Keyboard } from 'react-native';
 
 export default function App() {
@@ -58,11 +60,11 @@ export default function App() {
 }
 ```
 
-This example will automatically adjust the height of the `KeyboardAvoidingView` based on the keyboard height, so that the input is always visible.
+In the above example, the height of the `KeyboardAvoidingView` automatically adjusts based on the device's keyboard height, which ensures that the input is always visible.
 
-> **info** When using BottomTabs for navigation in Android, you might notice that focusing on an input field causes the bottom tabs to be pushed above the keyboard. To address this issue add the `softwareKeyboardLayoutMode` property to your Android configuration in `app.json` and set it to `pan`.
+When using a Bottom Tab navigator on Android, you might notice that focusing on an input field causes the bottom tabs to be pushed above the keyboard. To address this issue, add the `softwareKeyboardLayoutMode` property to your Android configuration in [app confg](/workflow/configuration/) and set it to `pan`.
 
-```js app.json
+```json app.json
 "expo" {
   "android": {
     "softwareKeyboardLayoutMode": "pan"
@@ -76,23 +78,22 @@ After adding this property, restart your app so that the changes take effect.
 
 For more complex keyboard interactions, consider using the [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs.
 
-### Installing keyboard controller
+### Install keyboard controller
 
 To get started with [Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller), install it in your Expo project:
 
-import { Terminal } from '~/ui/components/Snippet';
 
 <Terminal cmd={['$ npx expo install react-native-keyboard-controller']} />
 
 Keyboard Controller uses native code, so you need to prebuild your app:
 
-<Terminal cmd={['$ expo prebuild --clean']} />
+<Terminal cmd={['$ npx expo prebuild --clean']} />
 
-Keyboard controller also requires [`react-native-reanimated`](/versions/latest/sdk/reanimated) to work properly. Follow the [installation instructions](/versions/latest/sdk/reanimated/) to install it.
+Keyboard Controller library also requires `react-native-reanimated` to work properly. Follow the [installation instructions](/versions/latest/sdk/reanimated/#installation) to install it.
 
-### Setting up keyboard controller provider
+### Set up Keyboard Controller provider
 
-To finalize the setup, add the `KeyboardControllerProvider` to your app.
+To finalize the setup, add the `KeyboardProvider` to your app.
 
 ```js
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -110,11 +111,11 @@ export default function RootLayout() {
 }
 ```
 
-### Using keyboard controller
+### Usage
 
-Let's explore how you can achieve the `KeyboardAvoidingView` functionality using the `useKeyboardHandler` hook.
+Let's explore how to use the `useKeyboardHandler` hook to achieve the same functionality that `KeyboardAvoidingView` provides.
 
-The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. You'll use the `onMove` handler to get the keyboard height and use it to push our content above the keyboard when an input is active:
+The `useKeyboardHandler` hook takes two parameters: a handler and dependencies. The handler provides information about the current device's keyboard. You'll use the `onMove` handler to get the keyboard height and use it to push the screen's content above the keyboard when an input is active:
 
 ```js
 const useGradualAnimation = () => {
@@ -135,7 +136,7 @@ const useGradualAnimation = () => {
 
 The above example uses the `useSharedValue` hook from Reanimated to store the keyboard's height. The value changes from 0 when the keyboard is dismissed to the maximum height when it's active.
 
-Now, let's use our `useGradualAnimation` hook inside a component:
+Now, let's use the `useGradualAnimation` hook inside a screen component:
 
 ```js
 export default function TabTwoScreen() {
@@ -162,11 +163,11 @@ export default function TabTwoScreen() {
 }
 ```
 
-This example uses the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
+The above uses the keyboard's height to move the screen content above the keyboard. The view after the keyboard has an animated style that modifies its height based on the keyboard's height.
 
 ### Handling multiple inputs
 
-For screens with multiple inputs, Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These handle input navigation and prevent the keyboard from covering the screen without custom configuration:
+For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
 
 ```js
 import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
@@ -193,11 +194,11 @@ export default function AdvancedToolbar() {
 }
 ```
 
-The example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
+The above example wraps the inputs with `KeyboardAwareScrollView` to prevent the keyboard from covering them. The `KeyboardToolbar` component displays navigation controls and a dismiss button. While it works without configuration, you can customize the toolbar content if needed.
 
 Keyboard Controller provides consistency across Android and iOS with minimal configuration, offering the native feel users expect.
 
 ## Additional resources
 
-- [Keyboard Guide Source Code](https://github.com/betomoedano/keyboard-guide.git)
-- [Keyboard Controller Docs](https://kirillzyusko.github.io/react-native-keyboard-controller)
+- [Keyboard guide source code](https://github.com/betomoedano/keyboard-guide)
+- [Keyboard Controller documentation](https://kirillzyusko.github.io/react-native-keyboard-controller)


### PR DESCRIPTION
# Why

This fixes: [CX-261](https://linear.app/expo/issue/CX-261/[docs]-keyboard-handling-guide)

# How

Added a keyboard handling guide covering basic and some advanced topics using [Keybaord Controller Docs](https://kirillzyusko.github.io/react-native-keyboard-controller)

Created a video explaining more in detail (Will embed video once published)

Created an example app -> [Keyboard Guide Source Code](https://github.com/betomoedano/keyboard-guide.git) 

# Test Plan

Run docs locally and validate the guide displays correctly

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/0549a08e-cfdd-4263-89b1-a59a5b495425">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
