### PR TITLE
Update build-a-screen.mdx

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -404,7 +404,7 @@ To load and display the icon on the button, let's use `FontAwesome` from the lib
 {/* prettier-ignore */}
 ```jsx Button.js
 import { StyleSheet, View, Pressable, Text } from 'react-native';
-/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */
+/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons";/* @end */
 
 export default function Button({ label, /* @info The prop theme to detect the button variant. */theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */


### PR DESCRIPTION
# Why

Documentation is wrong

# How

Fixed the incorrect import

# Test Plan

It's a doc. It just works

# Checklist

- [ X ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ X ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ X ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
