### PR TITLE
[docs] Add note about the project structure in default app 

### DIFF
--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -86,7 +86,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 ## File structure
 
-Below, you can get familiar with the default project's file structure. This is only one of many possible ways to structure your project, and the only enforced convention is usage of the **app** directory for routes with Expo Router. Feel free to rename directories and files and structure your project however you like.
+Below, you can get familiar with the default project's file structure. This is one of many possible ways to structure your project, and the only enforced convention is usage of the **app** directory for routes with Expo Router. Feel free to rename directories and files and structure your project however you like.
 
 <ProjectStructure />
 

--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -93,6 +93,7 @@ Below, you can get familiar with the project's default file structure. This is o
 <br />
 
 > Read more about why [non-route files don't belong in the **app** directory](/router/create-pages/#non-route-files) when using Expo Router.
+
 ## Features
 
 The default project template has the following features:

--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -86,7 +86,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 ## File structure
 
-Below, you can get familiar with the default project's file structure:
+Below, you can get familiar with the default project's file structure. This is only one of many possible ways to structure your project, and the only enforced convention is usage of the **app** directory for routes with Expo Router. Feel free to rename directories and files and structure your project however you like.
 
 <ProjectStructure />
 

--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -86,10 +86,13 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 ## File structure
 
-Below, you can get familiar with the default project's file structure. This is one of many possible ways to structure your project, and the only enforced convention is usage of the **app** directory for routes with Expo Router. Feel free to rename directories and files and structure your project however you like.
+Below, you can get familiar with the project's default file structure. This is one of many possible ways to structure your project. The only enforced convention is **app** directory for routes with Expo Router. Feel free to rename other directories and files to structure your project however you like.
 
 <ProjectStructure />
 
+<br />
+
+> Read more about why [non-route files don't belong in the **app** directory](/router/create-pages/#non-route-files) when using Expo Router.
 ## Features
 
 The default project template has the following features:


### PR DESCRIPTION
# Why

I was chatting with @douglowder about opinions that we express, and project structure (outside of the **app** directory) isn't really one of them. However, he pointed out that people might see this differently given the layout of a default project. So I wanted to add some clarification that people can feel free to do whatever they like. Maybe this is not the best place? Unsure.

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/d167ab01-4a47-4ebb-a23e-b9915fa962c3">

# How

Add clarification about flexibility of project structure

# Test Plan

Let me know what you think.