### PR TITLE
[docs] Fix unit testing example

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -178,14 +178,12 @@ describe('<HomeScreen />', () => {
   test('Text renders correctly on HomeScreen', () => {
     const { getByText } = render(<HomeScreen />);
 
-    const textLabel = getByText('Welcome!');
-
-    expect(textLabel).toBeTruthy();
+    getByText('Welcome!');
   });
 });
 ```
 
-In the above example, the `getByText` query helps your tests find relevant elements in your app's user interface. The React Native Testing Library provides this query. For more information, see [querying with React Native Testing Library](https://callstack.github.io/react-native-testing-library/docs/api/queries).
+In the above example, the `getByText` query helps your tests find relevant element in your app's user interface and make assertion whether or not the certain element exists. The React Native Testing Library provides this query. For more information, see [querying with React Native Testing Library](https://callstack.github.io/react-native-testing-library/docs/api/queries).
 
 This example also uses `expect,` a conditional matcher provided by Jest that helps you verify that the element you are querying matches the expected value. For more information, see [`expect` and conditional matchers](https://jestjs.io/docs/en/expect).
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -183,9 +183,7 @@ describe('<HomeScreen />', () => {
 });
 ```
 
-In the above example, the `getByText` query helps your tests find relevant element in your app's user interface and make assertion whether or not the certain element exists. The React Native Testing Library provides this query. For more information, see [querying with React Native Testing Library](https://callstack.github.io/react-native-testing-library/docs/api/queries).
-
-This example also uses `expect,` a conditional matcher provided by Jest that helps you verify that the element you are querying matches the expected value. For more information, see [`expect` and conditional matchers](https://jestjs.io/docs/en/expect).
+In the above example, the `getByText` query helps your tests find relevant element in your app's user interface and make assertion whether or not the certain element exists. The React Native Testing Library provides this query, and each [query variant](https://callstack.github.io/react-native-testing-library/docs/api/queries#query-variant) differs in its return type. For more examples and detailed API information, see the React Native Testing Library's [Queries API reference](https://callstack.github.io/react-native-testing-library/docs/api/queries).
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update unit testing example to remove `truthy` statement to assert an element based on [this feedback](https://x.com/nsfounder/status/1823658204607471727).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the Unit test example and also add the context about the assertion behavior

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
