### PR TITLE
[docs] Improve DOM components guide

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -1,29 +1,29 @@
 ---
 title: Using React DOM in Expo native apps
-sidebar_title: DOM Components
+sidebar_title: DOM components
 description: Learn about rendering React DOM elements in Expo native apps.
 ---
 
-> **warning** **Warning:** DOM Components are an experimental feature, the public API (`expo/dom`, `dom` prop), prop transport system, asset handling, and export embedding system are subject to breaking changes. Use WebViews directly for a production-ready approach.
-
 import { Terminal } from '~/ui/components/Snippet';
 
-Expo offers a novel approach to working with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app, simply moving on a per-component basis.
+> **warning** **Warning:** DOM components are an experimental feature. The public API (`expo/dom`, `dom` prop), prop transport system, asset handling, and export embedding system are subject to breaking changes. Use `WebViews` directly for a production-ready approach.
 
-The Expo native runtime generally does not support using `<div>` or `<img>` tags, but you may find that you want to quickly drop in some web components. This is where DOM components come in.
+Expo offers a novel approach to work with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app by moving on a per-component basis.
+
+While the Expo native runtime generally does not support elements like `<div>` or `<img>`, there may be instances where you need to quickly incorporate web components. In such cases, DOM components provide a useful solution.
 
 ## Usage
 
-First, install `react-native-webview` in your project:
+Install `react-native-webview` in your project:
 
 <Terminal cmd={['$ npx expo install react-native-webview']} />
 
-To render a React component to the DOM, simply add the `'use dom'` directive to the top of a file:
+To render a React component to the DOM, add the `'use dom'` directive to the top of the web component file:
 
-```jsx my-component.js (web)
+```tsx my-component.tsx (web)
 'use dom';
 
-export default function MyComponent({ name }) {
+export default function DOMComponent({ name }: { name: string }) {
   return (
     <div>
       <h1>Hello, {name}</h1>
@@ -32,13 +32,15 @@ export default function MyComponent({ name }) {
 }
 ```
 
-```jsx App.js (native)
-import MyComponent from './my-component.js';
+Inside the native component file, import the web component to use it:
+
+```tsx App.tsx (native)
+import DOMComponent from './my-component.tsx';
 
 export default function App() {
   return (
-    // This is a DOM component, it re-exports a wrapped `react-native-webview` behind the scenes.
-    <MyComponent name="Europa" />
+    // This is a DOM component. It re-exports a wrapped `react-native-webview` behind the scenes.
+    <DOMComponent name="Europa" />
   );
 }
 ```
@@ -51,8 +53,8 @@ export default function App() {
 - Fast Refresh and HMR.
 - Embedded exports for offline support.
 - Assets are unified across web and native.
-- DOM Component bundles can be introspected in Expo Atlas for debugging.
-- Access to all web functionality without needing a native rebuild.
+- DOM Component bundles can be introspected in [Expo Atlas](/guides/analyzing-bundles/#analyzing-bundle-size-with-atlas) for debugging.
+- Access to all web functionality without needing a native r(ebuild.
 - Runtime error overlay in development.
 - Supports Expo Go.
 
@@ -60,10 +62,10 @@ export default function App() {
 
 To pass props to the underlying native **WebView**, add a `dom` object to the component:
 
-```tsx my-components.tsx (web)
+```tsx my-component.tsx (web)
 'use dom';
 
-export default function MyComponent({}: { dom: import('expo/dom').DOMProps }) {
+export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
   return (
     <div>
       <h1>Hello, world!</h1>
@@ -75,11 +77,11 @@ export default function MyComponent({}: { dom: import('expo/dom').DOMProps }) {
 Now you can pass [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) to the DOM component:
 
 ```tsx App.tsx (native)
-import MyComponent from './my-component';
+import DOMComponent from './my-component';
 
 export default function App() {
   return (
-    <MyComponent
+    <DOMComponent
       dom={{
         scrollEnabled: false,
       }}
@@ -90,31 +92,33 @@ export default function App() {
 
 ## Marshalled props
 
-You can send data to the DOM component through serializable props (`number`, `string`, `boolean`, `null`, `undefined`, `Array`, `Object`):
+You can send data to the DOM component through serializable props (`number`, `string`, `boolean`, `null`, `undefined`, `Array`, `Object`). For example, inside a native component file, you can pass a prop to the DOM component:
 
 ```tsx App.tsx (native)
+import DOMComponent from './my-component';
+
 export default function App() {
-  return <MyComponent hello={'world'} />;
+  return <DOMComponent hello={'world'} />;
 }
 ```
+
+Inside the web component file, you can receive the prop as shown in the example below:
 
 ```tsx my-component.tsx (web)
 'use dom';
 
-export default function MyComponent({ hello }: { hello: string }) {
+export default function DOMComponent({ hello }: { hello: string }) {
   return <p>Hello, {hello}</p>;
 }
 ```
 
-These props are sent over an async bridge so they won't be updated synchronously. They're passed as props to the React root component meaning they re-render the entire React tree.
+Props are sent over an asynchronous bridge so they are not updated synchronously. They are passed as props to the React root component, which means they re-render the entire React tree.
 
-## Native Actions
+## Native actions
 
-You can send type-safe native functions to DOM components by passing async functions as top-level props to the DOM component:
+You can send type-safe native functions to DOM components by passing asynchronous functions as top-level props to the DOM component:
 
 ```tsx App.tsx (native)
-'use dom';
-
 import DomComponent from './my-component';
 
 export default function App() {
@@ -138,9 +142,9 @@ export default function MyComponent({ hello }: { hello: (data: string) => Promis
 
 > You cannot pass functions as nested props to DOM components. They must be top-level props.
 
-Native actions are always asynchronous and only accept serializable arguments (i.e. no functions). This is because the data is sent over a bridge to the DOM Component's JavaScript engine.
+Native actions are always asynchronous and accept only serializable arguments (meaning no functions) because the data is sent over a bridge to the DOM component's JavaScript engine.
 
-Native actions can return serializable data to the DOM component, this is useful for getting data back from the native side.
+Native actions can return serializable data to the DOM component, which is useful for getting data back from the native side.
 
 ```tsx
 getDeviceName(): Promise<string> {
@@ -148,21 +152,21 @@ getDeviceName(): Promise<string> {
 }
 ```
 
-Think of these functions like React Server Actions, but instead of living on the server they live locally in the native app and communicate with the DOM component. This is a powerful way to add truly native functionality into your DOM Components.
+Think of these functions like React Server Actions, but instead of residing on the server, they live locally in the native app and communicate with the DOM component. This approach provides a powerful way to add truly native functionality to your DOM components.
 
 ## Feature detection
 
-Because DOM components run websites, you may find yourself needing extra qualifiers to better support libraries. You can detect if a component is running in a DOM component with the following:
+Since DOM components are used to run websites, you might need extra qualifiers to better support certain libraries. You can detect if a component is running in a DOM component with the following code:
 
-```js
+```ts
 const IS_DOM = typeof ReactNativeWebView !== 'undefined';
 ```
 
 ## Public assets
 
-The contents of the root `/public` directory will be copied to the native app's binary to support using public assets in the DOM components. Since the public assets will be served from the local filesystem, you can use the `process.env.EXPO_DOM_BASE_URL` prefix to reference the correct path. For example:
+The contents of the root **public** directory are copied to the native app's binary to support the use of public assets in DOM components. Since these public assets will be served from the local filesystem, use the `process.env.EXPO_DOM_BASE_URL` prefix to reference the correct path. For example:
 
-```jsx
+```tsx
 <img src={`${process.env.EXPO_DOM_BASE_URL}/img.png`} />
 ```
 
@@ -172,13 +176,13 @@ The contents of the root `/public` directory will be copied to the native app's 
 
 By default, all `console.log` methods are extended in WebViews to forward logs to the terminal. This makes it fast and easy to see what's happening in your DOM components.
 
-Expo also enables WebView inspection and debugging when bundling in development mode. This means you can open Safari > Develop > Simulator > `MyComponent.tsx` to see the webview's console and inspect elements.
+Expo also enables WebView inspection and debugging when bundling in development mode. You can open **Safari** > **Develop** > **Simulator** > **MyComponent.tsx** to see the webview's console and inspect elements.
 
 ## Manual WebViews
 
-You can still create a manual WebView using the `WebView` component from `react-native-webview`:
+You can create a manual WebView using the `WebView` component from `react-native-webview`. This can be useful for rendering websites from a remote server.
 
-```jsx App.js (native)
+```tsx App.tsx (native)
 import { WebView } from 'react-native-webview';
 
 export default function App() {
@@ -186,14 +190,12 @@ export default function App() {
 }
 ```
 
-This can be useful for rendering websites from a remote server.
+## Measuring DOM components
 
-## Measuring DOM Components
-
-You may want to measure the size of a DOM component and report it back to the native side (ex: for native scrolling). This can be done using a native action:
+You may want to measure the size of a DOM component and report it back to the native side (for example, native scrolling). This can be done using a native action:
 
 ```tsx App.tsx (native)
-import MyComponent from './my-component';
+import DOMComponent from './my-component';
 import { useState } from 'react';
 
 export default function Route() {
@@ -238,7 +240,7 @@ function useSize(callback: (size: [number, number]) => void) {
   }, [callback]);
 }
 
-export default function Route({
+export default function DOMComponent({
   onLayout,
 }: {
   dom: import('expo/dom').DOMProps;
@@ -252,37 +254,39 @@ export default function Route({
 
 ## Architecture
 
-Built-in DOM support only renders websites as single-page applications (e.g. no SSR or SSG). This is because you don't need search engine optimization and indexing techniques in your embedded JS code.
+Built-in DOM support only renders websites as single-page applications (no SSR or SSG). This is because search engine optimization and indexing are unnecessary for embedded JS code.
 
-When a module is marked with `'use dom'`, the module is replaced with a proxy reference which is imported at runtime. This feature is primarily just a number of bundler and CLI magic tricks. You can always use a WebView with the standard approach by passing raw HTML to a WebView component if you'd like.
+When a module is marked with `'use dom'`, it is replaced with a proxy reference imported at runtime. This feature is primarily achieved through a series of bundler and CLI techniques. You can always use WebView with standard approach by passing raw HTML to a `WebView` component.
 
-DOM components that are rendered in websites or other DOM components will render as regular components and the `dom` prop will be ignored. This is because web content is passed directly through and not wrapped in an `iframe`.
+If desired, you can use a WebView with the standard approach by passing raw HTML to a WebView component.
 
-Overall, this system shares a lot of similarities with Expo's React Server Components implementation.
+DOM components rendered within websites or other DOM components will behave as regular components, and the `dom` prop will be ignored. This is because web content is passed directly through and not wrapped in an `iframe`.
+
+Overall, this system shares many similarities with Expo's React Server Components implementation.
 
 ## Considerations
 
-We recommend always building truly native apps using universal primitives such as `View`, `Image`, and `Text`. DOM Components only support standard JavaScript which is slower to parse and startup than optimized Hermes bytecode.
+We recommend building truly native apps using universal primitives such as `View`, `Image`, and `Text`. DOM Components only support standard JavaScript, which is slower to parse and start up than optimized Hermes bytecode.
 
-Data can only be sent between DOM components and your native components via an async JSON transport system. Avoid depending on data across JS engines. Also avoid deep linking to nested URLs in DOM components as they currently do not support full reconciliation with Expo Router.
+Data can be sent between DOM components and native components only through an asynchronous JSON transport system. Avoid relying on data across JS engines and deep linking to nested URLs in DOM components, as they do not currently support full reconciliation with Expo Router.
 
-DOM Components are not exclusive to Expo Router but they are developed and tested against Expo Router apps, meaning you'll have the best experience using them with Expo Router.
+While DOM Components are not exclusive to Expo Router, they are developed and tested against Expo Router apps to provide the best experience when used with Expo Router.
 
-If you have a global state for sharing data this won't be available across JS engines.
+If you have a global state for sharing data, it will not be accessible across JS engines.
 
-While native modules in the Expo SDK can be optimized to support DOM Components, we haven't done this yet. Use native actions and props to share native functionality with DOM components.
+While native modules in the Expo SDK can be optimized to support DOM Components, this optimization has not been implemented yet. Use native actions and props to share native functionality with DOM components.
 
-DOM Components and websites in general are less optimal than native views but there are some reasonable uses for them. For example, the web is conceptually the best way to render rich-text and markdown. The web also has very good WebGL support, with the caveat that devices in low-power mode will often throttle web framerates to preserve battery.
+DOM Components and websites in general are less optimal than native views but there are some reasonable uses for them. For example, the web is conceptually the best way to render rich-text and markdown. The web also has very good WebGL support, with the caveat that devices in low-power mode will often throttle web frame rates to preserve battery.
 
-Many large apps also use some web content for auxiliary routes such as blog posts, rich-text (e.g. X long-form posts), settings pages, help pages, and other less frequently visited parts of the app.
+Many large apps also use some web content for auxiliary routes such as blog posts, rich-text (for example, long-form posts on X), settings pages, help pages, and other less frequently visited parts of the app.
 
 ## Limitations
 
 - Unlike server components, you cannot pass `children` to DOM components.
 - DOM components are standalone and do not automatically share data between different instances.
-- You cannot add native views to DOM components. You can try to float native views over the top of DOM components but it may feel a bit janky.
-- Function props cannot return values synchronously. They must be async.
-- DOM components can currently only be embedded and do not support OTA updates, this can be added in the future as part of React Server Components.
+- You cannot add native views to DOM components. While you can attempt to float native views over DOM components, this approach results in a suboptimal user experience.
+- Function props cannot return values synchronously. They must be asynchronous.
+- DOM components can currently only be embedded and do not support OTA updates. This functionality may be added in the future as part of React Server Components.
 
 Ultimately, universal architecture is the most exciting kind. Expo CLI's extensive universal tooling is the only reason we can even offer a feature as intricate and valuable as this one.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Do a sanity check on the DOM components guide. In the process, I've found some instances where we were using JS code blocks and not highlighting settings for browser app.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR applies formatting guidelines from our writing style guide, improve verbiage where necessary, and fix inconsistencies (such as DOM Component vs. DOM component).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/dom-components

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
