### PR TITLE
fix(expo-video): NaN current time when source is not provided

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [iOS] Add live indicator in the now playing info. ([#30629](https://github.com/expo/expo/pull/30629) by [@justjoostnl](https://github.com/justjoostnl))
 - [iOS] Add 'allowsExternalPlayback' property to control the AirPlay to stream video or mirror the screen. ([#30436](https://github.com/expo/expo/pull/30436) by [@adsalihac](https://github.com/adsalihac))
-- [iOS] Fix 'player.currentTime' NaN when source is not provided. ([#31011](https://github.com/expo/expo/pull/31011) by [@AlirezaHadjar](https://github.com/AlirezaHadjar))
+- [iOS] Fixed `player.currentTime` being `NaN` when source is not provided and `player.duration` being `NaN` inside the hook callback when the source is updated. ([#31011](https://github.com/expo/expo/pull/31011) by [@AlirezaHadjar](https://github.com/AlirezaHadjar))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [iOS] Add live indicator in the now playing info. ([#30629](https://github.com/expo/expo/pull/30629) by [@justjoostnl](https://github.com/justjoostnl))
 - [iOS] Add 'allowsExternalPlayback' property to control the AirPlay to stream video or mirror the screen. ([#30436](https://github.com/expo/expo/pull/30436) by [@adsalihac](https://github.com/adsalihac))
+- [iOS] Fix 'player.currentTime' NaN when source is not provided. ([#31011](https://github.com/expo/expo/pull/31011) by [@AlirezaHadjar](https://github.com/AlirezaHadjar))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -137,7 +137,8 @@ public final class VideoModule: Module {
       }
 
       Property("currentTime") { player -> Double in
-        return player.pointer.currentTime().seconds
+        let currentTime = player.pointer.currentTime().seconds
+        return currentTime.isNaN ? 0 : currentTime
       }
 
       Property("staysActiveInBackground") { player -> Bool in
@@ -155,7 +156,8 @@ public final class VideoModule: Module {
       }
 
       Property("currentTime") { player -> Double in
-        return player.pointer.currentTime().seconds
+        let currentTime = player.pointer.currentTime().seconds
+        return currentTime.isNaN ? 0 : currentTime
       }
       .set { (player, time: Double) in
         // Only clamp the lower limit, AVPlayer automatically clamps the upper limit.

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -162,7 +162,8 @@ public final class VideoModule: Module {
       }
 
       Property("duration") { player -> Double in
-        return player.pointer.currentItem?.duration.seconds ?? 0
+        let duration = player.pointer.currentItem?.duration.seconds ?? 0
+        return duration.isNaN ? 0 : duration
       }
 
       Property("playbackRate") { player -> Float in

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -136,11 +136,6 @@ public final class VideoModule: Module {
         player.pointer.allowsExternalPlayback = allowsExternalPlayback
       }
 
-      Property("currentTime") { player -> Double in
-        let currentTime = player.pointer.currentTime().seconds
-        return currentTime.isNaN ? 0 : currentTime
-      }
-
       Property("staysActiveInBackground") { player -> Bool in
         return player.staysActiveInBackground
       }


### PR DESCRIPTION
# Why

When the video source is not provided, `player.currentTime` returns `NaN` which is not ideal (`player.duration` returns `0`). Android is working fine and returns `0` and only iOS is broken.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
I put an `if condition` and check if the value is `nan` then return `0`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Here is how this scenario can be replicated:
Update:
```ts
  const [currentSource, setCurrentSource] = React.useState(videoSources[0]);
```
to: 
```ts
  const [currentSource, setCurrentSource] = React.useState(null);
```

Now if you log the `player.currentTime`, it's `NaN`. The fix that I provided changes it to `0`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
