### PR TITLE
[create-expo] Update cli instructions for npm to use npx

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Update `tar` dependency. ([#29663](https://github.com/expo/expo/pull/29663) by [@Simek](https://github.com/Simek))
+- Use `npx` for npm examples. ([#31012](https://github.com/expo/expo/pull/31012) by [](@kadikraman)(https://github.com/kadikraman))
 
 ## 3.0.0 — 2024-06-10
 

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -47,17 +47,17 @@ async function run() {
       chalk`
     {gray To choose a template pass in the {bold --template} arg:}
 
-    {gray $} npm create ${nameWithoutCreate} {cyan --template}
+    {gray $} npx ${CLI_NAME} {cyan --template}
 
     {gray To choose an Expo example pass in the {bold --example} arg:}
 
-    {gray $} npm create ${nameWithoutCreate} {cyan --example}
-    {gray $} npm create ${nameWithoutCreate} {cyan --example with-router}
+    {gray $} npx ${CLI_NAME} {cyan --example}
+    {gray $} npx ${CLI_NAME} {cyan --example with-router}
 
     {gray The package manager used for installing}
     {gray node modules is based on how you invoke the CLI:}
 
-    {bold  npm:} {cyan npm create ${nameWithoutCreate}}
+    {bold  npm:} {cyan npx ${CLI_NAME}}
     {bold yarn:} {cyan yarn create ${nameWithoutCreate}}
     {bold pnpm:} {cyan pnpm create ${nameWithoutCreate}}
     {bold  bun:} {cyan bun create ${nameWithoutCreate}}


### PR DESCRIPTION
# Why

The current instruction:

```sh
npm create expo-app --template
```

does not work. You actually need to pass in an additional `--` like

```sh
npm create expo-app -- --template
```

# How

To bypass npm weirdness, it would be safest to use `npx` commands in these examples instead.

# Test Plan

### Before:
<img width="1487" alt="Screenshot 2024-08-14 at 19 37 48" src="https://github.com/user-attachments/assets/d4c259f6-356e-4b98-b6c9-60db7ffcc926">


### After
<img width="1487" alt="Screenshot 2024-08-14 at 19 36 50" src="https://github.com/user-attachments/assets/9090794f-fccd-44ef-8f1e-93cd8c88e56b">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
