### PR TITLE
[template] Stub com.facebook.react.settings when react-native <= 0.74.3

### DIFF
--- a/templates/expo-template-bare-minimum/android/react-settings-plugin/build.gradle.kts
+++ b/templates/expo-template-bare-minimum/android/react-settings-plugin/build.gradle.kts
@@ -1,0 +1,19 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "1.9.24"
+    id("java-gradle-plugin")
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        create("reactSettingsPlugin") {
+            id = "com.facebook.react.settings"
+            implementationClass = "expo.plugins.ReactSettingsPlugin"
+        }
+    }
+}

--- a/templates/expo-template-bare-minimum/android/react-settings-plugin/src/main/kotlin/expo/plugins/ReactSettingsPlugin.kt
+++ b/templates/expo-template-bare-minimum/android/react-settings-plugin/src/main/kotlin/expo/plugins/ReactSettingsPlugin.kt
@@ -1,0 +1,10 @@
+package expo.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
+class ReactSettingsPlugin : Plugin<Settings> {
+  override fun apply(settings: Settings) {
+    // Do nothing, just register the plugin.
+  }
+}

--- a/templates/expo-template-bare-minimum/android/settings.gradle
+++ b/templates/expo-template-bare-minimum/android/settings.gradle
@@ -1,9 +1,16 @@
 pluginManagement {
+  def version = providers.exec {
+    commandLine("node", "-e", "console.log(require('react-native/package.json').version);")
+  }.standardOutput.asText.get().trim()
+  def (_, reactNativeMinor, reactNativePatch) = version.split("-")[0].tokenize('.').collect { it.toInteger() }
+
   includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+  if(reactNativeMinor == 74 && reactNativePatch <= 3){
+    includeBuild("react-settings-plugin")
+  }
 }
 
-// Uncomment this to use React Native 0.75
-// plugins { id("com.facebook.react.settings") }
+plugins { id("com.facebook.react.settings") }
 
 def getRNMinorVersion() {
   def version = providers.exec {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/31005

# How

This PR adds a local gradle plugin to stub `com.facebook.react.settings` when react-native <= 0.74.3

# Test Plan

Using react-native 0.74.3, 0.74.5 and 0.75.1
`npx expo prebuild  --clean --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-bare-minimum.tar.gz -p android`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
