### PR TITLE
Update build-a-screen.mdx

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -408,35 +408,34 @@ import { StyleSheet, View, Pressable, Text } from 'react-native';
 
 export default function Button({ label, /* @info The prop theme to detect the button variant. */theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */
-  if (theme === "primary") {
+    const primaryButtonStyle = theme === "primary"
+    ? { backgroundColor: "#fff", borderRadius: 18 }
+    : {};
+
+    const primaryTextStyle = theme === "primary"
+    ? { color: "#25292e" } 
+    : {};
+
+    const iconVisible = theme === "primary";
+
   /* @end */
     return (
-      <View style={[styles.buttonContainer, { borderWidth: 4, borderColor: "#ffd33d", borderRadius: 18 }]}>
-        <Pressable
-          style={[styles.button, { backgroundColor: "#fff" }]}
-          onPress={() => alert('You pressed a button.')}
-        >
+       <View style={styles.buttonContainer}>
+      <View style={[styles.button, primaryButtonStyle]}>
+        {iconVisible && (
           <FontAwesome
             name="picture-o"
             size={18}
             color="#25292e"
             style={styles.buttonIcon}
           />
-          <Text style={[styles.buttonLabel, { color: "#25292e" }]}>{label}</Text>
-        </Pressable>
+        )}
+        <Text style={[styles.buttonLabel, primaryTextStyle]}>{label}</Text>
       </View>
+    </View>
     );
   /* @info */
-  }
   /* @end */
-
-  return (
-    <View style={styles.buttonContainer}>
-        <Pressable style={styles.button} onPress={() => alert('You pressed a button.')}>
-          <Text style={styles.buttonLabel}>{label}</Text>
-        </Pressable>
-      </View>
-  );
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Add themed button component with FontAwesome icon and conditional styling

- Implement Button component with primary and default themes
- Conditionally render FontAwesome icon for the primary theme
- Apply dynamic styles based on the selected theme
- Ensure consistent styling and layout for button elements

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
