### PR TITLE
[font]: clarify font family name when using config plugin

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -94,13 +94,20 @@ Add the config plugin to your [app config](/versions/latest/config/app/#plugins)
 
 After embedding the font with the config plugin, create a [new development build](/develop/development-builds/create-a-build/) and install it on your device or Android Emulator or iOS Simulator.
 
-You can use that font on `<Text>` by using `fontFamily` style prop. For example, the `<Text>` uses the `Inter-Black` as the font family:
+You can use the font with `<Text>` by specifying the `fontFamily` style prop. [Read below](#how-to-determine-which-font-family-name-to-use) on how to determine the font family. For example:
 
 ```tsx
 <Text style={{ fontFamily: 'Inter-Black' }}>Inter Black.</Text>
 ```
 
 </Step>
+
+<ConfigReactNative title="Using this method in a bare React Native project?">
+
+- **Android:** Copy font files to **android/app/src/main/assets/fonts**.
+- **iOS:** See [Adding a Custom Font to Your App](https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app) in the Apple Developer documentation.
+
+</ConfigReactNative>
 
 #### How to determine which font family name to use
 
@@ -117,13 +124,6 @@ For example, Inter Black font file's PostScript name is `Inter-Black`.
 <ContentSpotlight src="/static/images/postscript-name.png" />
 
 </Collapsible>
-
-<ConfigReactNative title="Using this method in a bare React Native project?">
-
-- **Android:** Copy font files to **android/app/src/main/assets/fonts**.
-- **iOS:** See [Adding a Custom Font to Your App](https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app) in the Apple Developer documentation.
-
-</ConfigReactNative>
 
 ### With `useFonts` hook
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -94,7 +94,9 @@ Add the config plugin to your [app config](/versions/latest/config/app/#plugins)
 
 After embedding the font with the config plugin, create a [new development build](/develop/development-builds/create-a-build/) and install it on your device or Android Emulator or iOS Simulator.
 
-You can use the font with `<Text>` by specifying the `fontFamily` style prop. [Read below](#how-to-determine-which-font-family-name-to-use) on how to determine the font family. For example:
+You can use the font with `<Text>` by specifying the `fontFamily` style prop. See the [next section](#how-to-determine-which-font-family-name-to-use) on how to determine the font family name.
+
+In the example below, the `<Text>` uses the `Inter-Black` as the font family name:
 
 ```tsx
 <Text style={{ fontFamily: 'Inter-Black' }}>Inter Black.</Text>

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -50,7 +50,7 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
     {
       name: 'fonts',
       description:
-        'An array of font files to link to the native project. The paths should be relative to the project root, and the file names will become the font family names.',
+        'An array of font files to link to the native project. The paths should be relative to the project root. The file names will become the font family names on Android. On iOS, the font family name may not be the same as the file name - use [`getLoadedFonts`](#getloadedfonts) to see what fonts are available.',
       default: '[]',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -50,7 +50,7 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
     {
       name: 'fonts',
       description:
-        'An array of font files to link to the native project. The paths should be relative to the project root. The file names will become the font family names on Android. On iOS, the font family name may not be the same as the file name - use [`getLoadedFonts`](#getloadedfonts) to see what fonts are available.',
+        'An array of font files to link to the native project. The paths should be relative to the project root. The file names will become the font family names on Android. On iOS, the font family name may not be the same as the file name &mdash; use [`getLoadedFonts`](#getloadedfonts) to see what fonts are available.',
       default: '[]',
     },
   ]}


### PR DESCRIPTION
# Why

The config plugin docs are not 100% correct: https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app#2939906

# How

change docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
