### PR TITLE
[docs] Fix code example in implementing-a-checkbox.mdx

### DIFF
--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -153,7 +153,7 @@ const styles = StyleSheet.create({
   },
   checkboxLabel: {
     marginLeft: 8,
-    fontWeight: 500,
+    fontWeight: '500',
     fontSize: 18,
   },
 });
@@ -261,7 +261,7 @@ const styles = StyleSheet.create({
   },
   checkboxLabel: {
     marginLeft: 8,
-    fontWeight: 500,
+    fontWeight: '500',
     fontSize: 18,
   },
 });


### PR DESCRIPTION
Fix code - fontWeight must be a string (Like line 77 of the same document).

# Why

The code was wrong in the docs

# How

Updated the docs

# Test Plan

I copied the code into my expo project and checked that it ran.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
