### PR TITLE
[android][core] Fix running new arch on 0.74

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
+- [android] Fix accessing the `runtimeExecutor` from kotlin when new arch is enabled.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
-- [android] Fix accessing the `runtimeExecutor` from kotlin when new arch is enabled.
+- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled. ([#31042](https://github.com/expo/expo/pull/31042) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -174,8 +174,7 @@ class AppContext(
             val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
             runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
           } catch (e: NoSuchFieldException) {
-            val runtimeExecutorField = reactContext.javaClass.getDeclaredField("runtimeExecutor")
-            runtimeExecutorField.get(reactContext) as RuntimeExecutor
+            reactContext.runtimeExecutor as RuntimeExecutor
           }
 
           jsiInterop.installJSIForBridgeless(


### PR DESCRIPTION
# Why
Closes #31018

# How
We don't need to access the `runtimeExecutor` through reflection as this will only exist on the reactContext from Kotlin. We can just use the instance and return it.

# Test Plan
Tested in a new blank project where I reproed the issue.
