### PR TITLE
fix(font): include postScript font names in getLoadedFonts

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- On iOS `loadAsync()` will reject if font loading fails.
 - Add `getLoadedFonts()` function ([#30431](https://github.com/expo/expo/pull/30431) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 ### 🎉 New features
 
-- On iOS `loadAsync()` will reject if font loading fails.
 - Add `getLoadedFonts()` function ([#30431](https://github.com/expo/expo/pull/30431) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes
 
+- On iOS `loadAsync()` will reject if font loading fails. ([#31053](https://github.com/expo/expo/pull/31053) by [@vonovak](https://github.com/vonovak))
 - Add missing `react` peer dependencies for isolated modules. ([#30467](https://github.com/expo/expo/pull/30467) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config` to follow proper dependency chains. ([#30501](https://github.com/expo/expo/pull/30501) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/expo-font/ios/FontExceptions.swift
+++ b/packages/expo-font/ios/FontExceptions.swift
@@ -12,6 +12,12 @@ internal final class FontCreationFailedException: GenericException<String> {
   }
 }
 
+internal final class FontNoPostScriptException: GenericException<String> {
+  override var reason: String {
+    "Could not create font from loaded data for '\(param)'. Could not obtain font's 'postScriptName'."
+  }
+}
+
 internal final class FontRegistrationFailedException: GenericException<CFError> {
   override var reason: String {
     "Registering '\(param)' font failed with message: '\(param.localizedDescription)'"

--- a/packages/expo-font/ios/FontExceptions.swift
+++ b/packages/expo-font/ios/FontExceptions.swift
@@ -14,7 +14,7 @@ internal final class FontCreationFailedException: GenericException<String> {
 
 internal final class FontNoPostScriptException: GenericException<String> {
   override var reason: String {
-    "Could not create font from loaded data for '\(param)'. Could not obtain font's 'postScriptName'."
+    "Could not create font '\(param)' from loaded data because it is missing the PostScript name"
   }
 }
 

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -40,9 +40,10 @@ public final class FontLoaderModule: Module {
 
       if let postScriptName = font.postScriptName as? String {
         FontFamilyAliasManager.setAlias(fontFamilyAlias, forFont: postScriptName)
+        registeredFonts = Array(Set(registeredFonts).union([postScriptName, fontFamilyAlias]))
+      } else {
+        throw FontNoPostScriptException(fontFamilyAlias)
       }
-
-      registeredFonts = Array(Set(registeredFonts).union([fontFamilyAlias]))
     }
   }
 }


### PR DESCRIPTION
# Why

When loading a font via config plugin and via `loadAsync`, `getLoadedFonts()` can return results which may be unexpected:

consider that you have a font called `SomeIconFont.ttf` and its postScript name is `some-icon-font`.

When you add the font via config plugin, and then call `getLoadedFonts()`, you'll get `["some-icon-font"]`.

When you load the font via `loadAsync('123', require('./SomeIconFont.ttf'))` and then call `getLoadedFonts()`, you'll get `["123"]`.

I believe the expected behavior is that font's postScript name should be taken into account along with the provided alias("123"), and the returned result should be `["some-icon-font", "123"]`.

Because postScript is required for our module to work properly, I went a step further and reject if it's not available.

# How

include the font's postScript name in `registeredFonts`

# Test Plan

bare expo+separate app for testing icons

# Checklist

docs will be addresses in https://github.com/expo/expo/pull/31032 as needed

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
