### PR TITLE
[docs] Fix Typo in DOM Components Documentation

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -54,7 +54,7 @@ export default function App() {
 - Embedded exports for offline support.
 - Assets are unified across web and native.
 - DOM Component bundles can be introspected in [Expo Atlas](/guides/analyzing-bundles/#analyzing-bundle-size-with-atlas) for debugging.
-- Access to all web functionality without needing a native r(ebuild.
+- Access to all web functionality without needing a native rebuild.
 - Runtime error overlay in development.
 - Supports Expo Go.
 


### PR DESCRIPTION
# Why

The commit #31003 introduced a typo in the documentation, which needs correction to maintain clarity and accuracy. The typo is located in the guide for DOM components.

https://github.com/expo/expo/pull/31003/files#diff-d687fee327d457c1a128a554739c9c1a4cb51b086f41ecefd2297f4e289f1728R57

# How

Correct the typo by changing `r(ebuild` to `rebuild` in the documentation file. This ensures the documentation is clear and free from errors.

# Test Plan

To verify the fix, run the documentation locally and navigate to the following URL to ensure the typo is corrected: http://localhost:3002/guides/dom-components.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
