### PR TITLE
[android][core] Fix runtimeExecutor

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
-- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled. ([#31042](https://github.com/expo/expo/pull/31042) by [@alanjhughes](https://github.com/alanjhughes))
+- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled. ([#31058](https://github.com/expo/expo/pull/31058) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -174,7 +174,8 @@ class AppContext(
             val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
             runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
           } catch (e: NoSuchFieldException) {
-            reactContext.runtimeExecutor as RuntimeExecutor
+            val method = reactContext.javaClass.getMethod("getRuntimeExecutor")
+            method.invoke(reactContext) as RuntimeExecutor
           }
 
           jsiInterop.installJSIForBridgeless(


### PR DESCRIPTION
# Why
#31042 did not fix the problem so it can work on both 0.75 and 0.74

# How
We still need reflection, just a different method from what was done originally

# Test Plan
Builds and runs on 0.75 and 0.74
