### PR TITLE
[image][android] Fix react-native 0.75 compatibility

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `resolvedLayoutDirection` building issues when using react-native 0.75.X. ([#31062](https://github.com/expo/expo/pull/31062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 1.12.13 — 2024-07-16

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -211,14 +211,19 @@ class ExpoImageView(
     super.onDraw(canvas)
     // Draw borders on top of the background and image
     if (borderDrawableLazyHolder.isInitialized()) {
-      val layoutDirection = if (I18nUtil.getInstance().isRTL(context)) {
+      val newLayoutDirection = if  (I18nUtil.getInstance().isRTL(context)) {
         LAYOUT_DIRECTION_RTL
       } else {
         LAYOUT_DIRECTION_LTR
       }
 
       borderDrawable.apply {
-        resolvedLayoutDirection = layoutDirection
+        val setLayoutDirectionMethod = try {
+          ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
+       } catch (e: NoSuchMethodException) {
+          ReactViewBackgroundDrawable ::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
+        }
+        setLayoutDirectionMethod.invoke(this, newLayoutDirection)
         setBounds(0, 0, width, height)
         draw(canvas)
       }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -211,7 +211,7 @@ class ExpoImageView(
     super.onDraw(canvas)
     // Draw borders on top of the background and image
     if (borderDrawableLazyHolder.isInitialized()) {
-      val newLayoutDirection = if  (I18nUtil.getInstance().isRTL(context)) {
+      val newLayoutDirection = if (I18nUtil.getInstance().isRTL(context)) {
         LAYOUT_DIRECTION_RTL
       } else {
         LAYOUT_DIRECTION_LTR

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -220,8 +220,8 @@ class ExpoImageView(
       borderDrawable.apply {
         val setLayoutDirectionMethod = try {
           ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
-       } catch (e: NoSuchMethodException) {
-          ReactViewBackgroundDrawable ::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
+        } catch (e: NoSuchMethodException) {
+          ReactViewBackgroundDrawable::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
         }
         setLayoutDirectionMethod.invoke(this, newLayoutDirection)
         setBounds(0, 0, width, height)


### PR DESCRIPTION
# Why

React-native 0.75 replaced the `get/set` `resolvedLayoutDirection` with `setLayoutDirectionOverride`, which prevents expo image from building on android

Closes https://github.com/expo/expo/issues/31029

# How

Update `onDraw` to use reflection to access the appropriate `"setResolvedLayoutDirection"` method depending on the react-native version 

# Test Plan

- BareExpo using react-native 0.74 and 0.75

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
