### PR TITLE
[video][android] Fix react-native 0.75 compatibility

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `resolvedLayoutDirection` building issues when using react-native 0.75.X. ([#31064](https://github.com/expo/expo/pull/31064) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 1.2.4 — 2024-07-30

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -292,14 +292,19 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
 
     // Draw borders on top of the video
     if (borderDrawableLazyHolder.isInitialized()) {
-      val layoutDirection = if (I18nUtil.getInstance().isRTL(context)) {
+      val newLayoutDirection = if (I18nUtil.getInstance().isRTL(context)) {
         LAYOUT_DIRECTION_RTL
       } else {
         LAYOUT_DIRECTION_LTR
       }
 
       borderDrawable.apply {
-        resolvedLayoutDirection = layoutDirection
+        val setLayoutDirectionMethod = try {
+          ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
+       } catch (e: NoSuchMethodException) {
+          ReactViewBackgroundDrawable ::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
+        }
+        setLayoutDirectionMethod.invoke(this, newLayoutDirection)
         setBounds(0, 0, width, height)
         draw(canvas)
       }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -300,8 +300,10 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
 
       borderDrawable.apply {
         val setLayoutDirectionMethod = try {
+          // React Native 0.74.0 and below
           ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
         } catch (e: NoSuchMethodException) {
+          // React Native 0.75.0 and above
           ReactViewBackgroundDrawable::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
         }
         setLayoutDirectionMethod.invoke(this, newLayoutDirection)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -301,8 +301,8 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
       borderDrawable.apply {
         val setLayoutDirectionMethod = try {
           ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
-       } catch (e: NoSuchMethodException) {
-          ReactViewBackgroundDrawable ::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
+        } catch (e: NoSuchMethodException) {
+          ReactViewBackgroundDrawable::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
         }
         setLayoutDirectionMethod.invoke(this, newLayoutDirection)
         setBounds(0, 0, width, height)


### PR DESCRIPTION
# Why

React-native 0.75 replaced the `get/set` `resolvedLayoutDirection` with `setLayoutDirectionOverride`, which prevents expo video from building on android
 

# How

Update `onDraw` to use reflection to access the appropriate `"setResolvedLayoutDirection"` method depending on the react-native version 

# Test Plan

- BareExpo using react-native 0.74 and 0.75

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
