### PR TITLE
[doctor] Warn if app is (about to be) incompatible with Play Store

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Warn if project is incompatible with upcoming Play Store Android API level requirements. ([#31067](https://github.com/expo/expo/pull/31067) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
+++ b/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { learnMore } from '../utils/TerminalLink';
-import { isFileIgnoredAsync } from '../utils/isFileIgnoredAsync';
+import { existsAndIsNotIgnoredAsync } from '../utils/files';
 
 const appConfigFieldsToSyncWithNative = [
   'ios',
@@ -73,8 +73,4 @@ export class AppConfigFieldsNotSyncedToNativeProjectsCheck implements DoctorChec
       advice,
     };
   }
-}
-
-async function existsAndIsNotIgnoredAsync(filePath: string): Promise<boolean> {
-  return fs.existsSync(filePath) && !(await isFileIgnoredAsync(filePath));
 }

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
-import { isFileIgnoredAsync } from '../utils/isFileIgnoredAsync';
+import { isFileIgnoredAsync } from '../utils/files';
 
 export class ProjectSetupCheck implements DoctorCheck {
   description = 'Check for common project setup issues';

--- a/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
+++ b/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
@@ -1,0 +1,84 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { learnMore } from '../utils/TerminalLink';
+
+export class StoreCompatibilityCheck implements DoctorCheck {
+  description = 'Check if the project meets version requirements for submission to app stores';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    let issue: string | undefined = undefined;
+
+    // *** non-CNG ***
+    if (await existsAndIsNotIgnoredAsync(path.join(projectRoot, 'android', 'build.gradle'))) {
+      const buildGradle = fs.readFileSync(
+        path.join(projectRoot, 'android', 'build.gradle'),
+        'utf8'
+      );
+      if (
+        buildGradle.includes(
+          `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`
+        )
+      ) {
+        issue = 'This project appears to be targeting Android API level 33 or lower. ';
+      }
+    } else {
+      // *** CNG ***
+
+      // check if build properties overrides to a lower target SDK
+      const buildPropertiesConfig = exp.plugins?.find(
+        (plugin) => plugin[0] === 'expo-build-properties'
+      );
+      if (
+        buildPropertiesConfig &&
+        buildPropertiesConfig.length > 1 &&
+        buildPropertiesConfig[1].android.targetSdkVersion < 34
+      ) {
+        issue =
+          'This project is using expo-build-properties to targe Android API level 33 or lower. ';
+      } else if (!semver.satisfies(exp.sdkVersion!, '>=50.0.0')) {
+        issue =
+          'This project is using an SDK version that by default targets Android API level 33 or lower. ';
+      }
+    }
+
+    if (issue) {
+      issue +=
+        'To submit your app to the Google Play Store, you must target Android API level 34 or higher. ';
+    }
+
+    return {
+      isSuccessful: !issue,
+      issues: issue ? [issue] : [],
+      advice: issue
+        ? `Upgrade to Expo SDK 50 or later, which by default supports Android API level 34 ${learnMore(
+            'https://docs.expo.dev/workflow/configuration'
+          )}`
+        : undefined,
+    };
+  }
+}
+
+async function existsAndIsNotIgnoredAsync(filePath: string): Promise<boolean> {
+  return fs.existsSync(filePath) && !(await isFileIgnoredAsync(filePath));
+}
+
+async function isFileIgnoredAsync(filePath: string): Promise<boolean> {
+  try {
+    await spawnAsync('git', ['check-ignore', '-q', filePath], {
+      cwd: path.normalize(await getRootPathAsync()),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getRootPathAsync(): Promise<string> {
+  return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
+}

--- a/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
+++ b/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
@@ -20,11 +20,12 @@ export class StoreCompatibilityCheck implements DoctorCheck {
         path.join(projectRoot, 'android', 'build.gradle'),
         'utf8'
       );
-      if (
-        buildGradle.includes(
-          `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`
-        )
-      ) {
+      // checks for exact string from SDK 49 bare template, will not work if it was changed
+      const targetSdkVersionRegex =
+        /^targetSdkVersion\s*=\s*(?:Integer\.parseInt\(findProperty\('android\.targetSdkVersion'\)\s*\?:\s*'(\d+)'\)|'(\d+)')/m;
+      const match = buildGradle.match(targetSdkVersionRegex);
+      const targetSdkVersion = match ? parseInt(match[1], 10) : undefined;
+      if (targetSdkVersion && targetSdkVersion < 34) {
         issue = 'This project appears to be targeting Android API level 33 or lower. ';
       }
     } else {

--- a/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
+++ b/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
@@ -1,10 +1,10 @@
-import spawnAsync from '@expo/spawn-async';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { learnMore } from '../utils/TerminalLink';
+import { existsAndIsNotIgnoredAsync } from '../utils/files';
 
 export class StoreCompatibilityCheck implements DoctorCheck {
   description = 'Check if the project meets version requirements for submission to app stores';
@@ -63,23 +63,4 @@ export class StoreCompatibilityCheck implements DoctorCheck {
         : undefined,
     };
   }
-}
-
-async function existsAndIsNotIgnoredAsync(filePath: string): Promise<boolean> {
-  return fs.existsSync(filePath) && !(await isFileIgnoredAsync(filePath));
-}
-
-async function isFileIgnoredAsync(filePath: string): Promise<boolean> {
-  try {
-    await spawnAsync('git', ['check-ignore', '-q', filePath], {
-      cwd: path.normalize(await getRootPathAsync()),
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function getRootPathAsync(): Promise<string> {
-  return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
 }

--- a/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
+++ b/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
@@ -22,7 +22,7 @@ export class StoreCompatibilityCheck implements DoctorCheck {
       );
       // checks for exact string from SDK 49 bare template, will not work if it was changed
       const targetSdkVersionRegex =
-        /^targetSdkVersion\s*=\s*(?:Integer\.parseInt\(findProperty\('android\.targetSdkVersion'\)\s*\?:\s*'(\d+)'\)|'(\d+)')/m;
+        /^\s*targetSdkVersion\s*=\s*(?:Integer\.parseInt\(findProperty\('android\.targetSdkVersion'\)\s*\?:\s*'(\d+)'\)|'(\d+)')/m;
       const match = buildGradle.match(targetSdkVersionRegex);
       const targetSdkVersion = match ? parseInt(match[1], 10) : undefined;
       if (targetSdkVersion && targetSdkVersion < 34) {
@@ -41,7 +41,7 @@ export class StoreCompatibilityCheck implements DoctorCheck {
         buildPropertiesConfig[1].android.targetSdkVersion < 34
       ) {
         issue =
-          'This project is using expo-build-properties to targe Android API level 33 or lower. ';
+          'This project is using expo-build-properties to target Android API level 33 or lower. ';
       } else if (!semver.satisfies(exp.sdkVersion!, '>=50.0.0')) {
         issue =
           'This project is using an SDK version that by default targets Android API level 33 or lower. ';
@@ -58,7 +58,7 @@ export class StoreCompatibilityCheck implements DoctorCheck {
       issues: issue ? [issue] : [],
       advice: issue
         ? `Upgrade to Expo SDK 50 or later, which by default supports Android API level 34 ${learnMore(
-            'https://docs.expo.dev/workflow/configuration'
+            'https://support.google.com/googleplay/android-developer/answer/11926878?hl=en'
           )}`
         : undefined,
     };

--- a/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
@@ -1,0 +1,148 @@
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+
+import { mockSpawnPromise } from '../../__tests__/spawn-utils';
+import { StoreCompatibilityCheck } from '../StoreCompatibilityCheck';
+
+jest.mock('fs');
+
+const projectRoot = '/tmp/project';
+
+const expProjectProps = {
+  name: 'name',
+  slug: 'slug',
+};
+
+// required by runAsync
+const additionalProjectProps = {
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+/**
+ * Helper to mock the results of git rev-parse and git check-ignore based on whether the file should be ignored or not.
+ * Only works when checking a single file.
+ */
+function mockIsGitIgnoredResult(isFileIgnored: boolean) {
+  jest
+    .mocked(spawnAsync)
+    .mockImplementationOnce(() =>
+      mockSpawnPromise(
+        Promise.resolve({
+          status: 0,
+          stdout: '',
+        })
+      )
+    )
+    .mockImplementationOnce(() => {
+      if (isFileIgnored) {
+        return mockSpawnPromise(Promise.resolve({ status: 0, stdout: '' }));
+      }
+      const error: any = new Error();
+      error.status = -1; // git check-ignore errors if file is not ignored
+      return mockSpawnPromise(Promise.reject(error));
+    });
+}
+
+describe('runAsync', () => {
+  beforeEach(() => {
+    mockIsGitIgnoredResult(false);
+  });
+  afterEach(() => {
+    vol.reset();
+    jest.resetAllMocks();
+  });
+  it('returns result with isSuccessful = true if SDK 50+ with default Android target API level', async () => {
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'expo', version: '1.0.0' },
+      exp: { ...expProjectProps, sdkVersion: '50.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level 34+', async () => {
+    vol.fromJSON({
+      [projectRoot + '/android/build.gradle']:
+        `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')`,
+    });
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level 34+ (direct assignment)', async () => {
+    vol.fromJSON({
+      [projectRoot + '/android/build.gradle']: `targetSdkVersion = '34'`,
+    });
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if ios/android folders but build.gradle indicates API level <34', async () => {
+    vol.fromJSON({
+      [projectRoot + '/android/build.gradle']:
+        `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`,
+    });
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if expo-build-properties is set to target API level <34', async () => {
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: {
+        ...expProjectProps,
+        sdkVersion: '50.0.0',
+        plugins: [['expo-build-properties', { android: { targetSdkVersion: 33 } }]],
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = true if expo-build-properties plugin added but does not include any props', async () => {
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: {
+        ...expProjectProps,
+        sdkVersion: '50.0.0',
+        plugins: ['expo-build-properties'],
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if SDK <50', async () => {
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: {
+        ...expProjectProps,
+        sdkVersion: '49.0.0',
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
@@ -1,7 +1,7 @@
 import { vol } from 'memfs';
 
 import { existsAndIsNotIgnoredAsync } from '../../utils/files';
-import { StoreCompatibilityCheck } from '../StoreCompatibilityCheck';
+import { StoreCompatibilityCheck, PLAY_STORE_MINIMUM_REQS } from '../StoreCompatibilityCheck';
 
 jest.mock('fs');
 jest.mock('../../utils/files');
@@ -26,70 +26,76 @@ describe('runAsync', () => {
     vol.reset();
     jest.resetAllMocks();
   });
-  it('returns result with isSuccessful = true if SDK 50+ with default Android target API level', async () => {
+  it(`returns result with isSuccessful = true if SDK ${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}+ with default Android target API level`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
       pkg: { name: 'expo', version: '1.0.0' },
-      exp: { ...expProjectProps, sdkVersion: '50.0.0' },
+      exp: { ...expProjectProps, sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0` },
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeTruthy();
   });
 
-  it('returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level 34+', async () => {
+  it(`returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level ${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}+`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
     vol.fromJSON({
       [projectRoot + '/android/build.gradle']:
-        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')`,
+        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}')`,
     });
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
       pkg: { name: 'name', version: '1.0.0' },
-      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
+      exp: { ...expProjectProps, sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0` },
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeTruthy();
   });
 
-  it('returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level 34+ (direct assignment)', async () => {
-    jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
-    vol.fromJSON({
-      [projectRoot + '/android/build.gradle']: `targetSdkVersion = '34'`,
-    });
-    const check = new StoreCompatibilityCheck();
-    const result = await check.runAsync({
-      pkg: { name: 'name', version: '1.0.0' },
-      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
-      ...additionalProjectProps,
-    });
-    expect(result.isSuccessful).toBeTruthy();
-  });
-
-  it('returns result with isSuccessful = false if ios/android folders but build.gradle indicates API level <34', async () => {
+  it(`returns result with isSuccessful = true if ios/android folders but build.gradle indicates API level ${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}+ (direct assignment)`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
     vol.fromJSON({
       [projectRoot + '/android/build.gradle']:
-        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`,
+        `targetSdkVersion = '${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}'`,
     });
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
       pkg: { name: 'name', version: '1.0.0' },
-      exp: { ...expProjectProps, sdkVersion: '49.0.0' },
+      exp: { ...expProjectProps, sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0` },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it(`returns result with isSuccessful = false if ios/android folders but build.gradle indicates API level <${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}`, async () => {
+    jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
+    vol.fromJSON({
+      [projectRoot + '/android/build.gradle']:
+        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion - 1}')`,
+    });
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: { ...expProjectProps, sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion - 1}.0.0` },
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
   });
 
-  it('returns result with isSuccessful = false if expo-build-properties is set to target API level <34', async () => {
+  it(`returns result with isSuccessful = false if expo-build-properties is set to target API level <${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion}`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
       pkg: { name: 'name', version: '1.0.0' },
       exp: {
         ...expProjectProps,
-        sdkVersion: '50.0.0',
-        plugins: [['expo-build-properties', { android: { targetSdkVersion: 33 } }]],
+        sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0`,
+        plugins: [
+          [
+            'expo-build-properties',
+            { android: { targetSdkVersion: PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion - 1 } },
+          ],
+        ],
       },
       ...additionalProjectProps,
     });
@@ -103,7 +109,7 @@ describe('runAsync', () => {
       pkg: { name: 'name', version: '1.0.0' },
       exp: {
         ...expProjectProps,
-        sdkVersion: '50.0.0',
+        sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0`,
         plugins: ['expo-build-properties'],
       },
       ...additionalProjectProps,
@@ -111,14 +117,14 @@ describe('runAsync', () => {
     expect(result.isSuccessful).toBeTruthy();
   });
 
-  it('returns result with isSuccessful = false if SDK <50', async () => {
+  it(`returns result with isSuccessful = false if SDK <${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
       pkg: { name: 'name', version: '1.0.0' },
       exp: {
         ...expProjectProps,
-        sdkVersion: '49.0.0',
+        sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion - 1}.0.0`,
       },
       ...additionalProjectProps,
     });

--- a/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
@@ -41,7 +41,7 @@ describe('runAsync', () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
     vol.fromJSON({
       [projectRoot + '/android/build.gradle']:
-        `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')`,
+        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')`,
     });
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({
@@ -70,7 +70,7 @@ describe('runAsync', () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(true);
     vol.fromJSON({
       [projectRoot + '/android/build.gradle']:
-        `targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`,
+        `  targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')`,
     });
     const check = new StoreCompatibilityCheck();
     const result = await check.runAsync({

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -15,6 +15,7 @@ import { PackageJsonCheck } from './checks/PackageJsonCheck';
 import { PackageManagerVersionCheck } from './checks/PackageManagerVersionCheck';
 import { ProjectSetupCheck } from './checks/ProjectSetupCheck';
 import { ReactNativeDirectoryCheck } from './checks/ReactNativeDirectoryCheck';
+import { StoreCompatibilityCheck } from './checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
 import { getReactNativeDirectoryCheckEnabled } from './utils/doctorConfig';
@@ -135,6 +136,7 @@ export function getChecksInScopeForProject(exp: ExpoConfig, pkg: PackageJSONConf
     new MetroConfigCheck(),
     new NativeToolingVersionCheck(),
     new AppConfigFieldsNotSyncedToNativeProjectsCheck(),
+    new StoreCompatibilityCheck(),
   ];
 
   if (getReactNativeDirectoryCheckEnabled(pkg)) {

--- a/packages/expo-doctor/src/utils/__tests__/files.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/files.test.ts
@@ -1,0 +1,72 @@
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+
+import { mockSpawnPromise } from '../../__tests__/spawn-utils';
+import { isFileIgnoredAsync, existsAndIsNotIgnoredAsync } from '../files';
+
+jest.mock('fs');
+
+describe(isFileIgnoredAsync, () => {
+  it(`returns true if git check-ignore succeeds`, async () => {
+    jest
+      .mocked(spawnAsync)
+      .mockImplementationOnce(() =>
+        mockSpawnPromise(
+          Promise.resolve({
+            status: 0,
+            stdout: '',
+          })
+        )
+      )
+      .mockImplementationOnce(() => {
+        return mockSpawnPromise(Promise.resolve({ status: 0, stdout: '' }));
+      });
+    const result = await isFileIgnoredAsync('file');
+    expect(result).toBe(true);
+  });
+
+  it(`returns false if git check-ignore fails`, async () => {
+    jest
+      .mocked(spawnAsync)
+      .mockImplementationOnce(() =>
+        mockSpawnPromise(
+          Promise.resolve({
+            status: 0,
+            stdout: '',
+          })
+        )
+      )
+      .mockImplementationOnce(() => {
+        const error: any = new Error();
+        error.status = -1; // git check-ignore errors if file is not ignored
+        return mockSpawnPromise(Promise.reject(error));
+      });
+    const result = await isFileIgnoredAsync('file');
+    expect(result).toBe(false);
+  });
+});
+
+describe(existsAndIsNotIgnoredAsync, () => {
+  it(`returns true if git check-ignore fails and file exists`, async () => {
+    vol.fromJSON({
+      '/test.txt': 'test',
+    });
+    jest
+      .mocked(spawnAsync)
+      .mockImplementationOnce(() =>
+        mockSpawnPromise(
+          Promise.resolve({
+            status: 0,
+            stdout: '',
+          })
+        )
+      )
+      .mockImplementationOnce(() => {
+        const error: any = new Error();
+        error.status = -1; // git check-ignore errors if file is not ignored
+        return mockSpawnPromise(Promise.reject(error));
+      });
+    const result = await existsAndIsNotIgnoredAsync('/test.txt');
+    expect(result).toBe(true);
+  });
+});

--- a/packages/expo-doctor/src/utils/files.ts
+++ b/packages/expo-doctor/src/utils/files.ts
@@ -1,5 +1,15 @@
 import spawnAsync from '@expo/spawn-async';
+import fs from 'fs';
 import path from 'path';
+
+/**
+ * Checks if a file exists and is not ignored by git.
+ * @param filePath The path to the file to check.
+ * @returns `true` if the file exists and is not ignored by git.
+ */
+export async function existsAndIsNotIgnoredAsync(filePath: string): Promise<boolean> {
+  return fs.existsSync(filePath) && !(await isFileIgnoredAsync(filePath));
+}
 
 /**
  * Checks if a file is ignored by git.


### PR DESCRIPTION
# Why
Warn folks if they need to upgrade soon/now in order to be compatible with Play Store. Encourage upgrading to stay on top of platform requirements.

Eventually, we could do the same check for iOS the next time there's a new minimum Xcode version requirement.

# How
- New check: `StoreCompatibilityCheck`, checks one of three ways:
  - if managing own native projects: tries to check for common build.gradle configurations to see if they indicate a pre-SDK 34 version (this is very imperfect...AFAIK, we can't really evaluate build.gradle)
  - if using `expo-build-properties`: check if an older target SDK version is specified.
  - SDK version: if the other two checks don't apply, check based on Expo SDK version (<=49 supported Android SDK 33)
- Refactored `existsAndIsNotIgnoredAsync` and updated related checks and unit tests accordingly.

# Test Plan
Based on SDK version:
<img width="722" alt="image" src="https://github.com/user-attachments/assets/e111f075-0a11-4e1d-87de-fe4487dbcfcf">

Based on expo-build-properties
<img width="721" alt="image" src="https://github.com/user-attachments/assets/7163d4cd-cc74-4f80-99f5-2053b3ea5e17">

Based on build.gradle:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/b405b734-adc2-4c83-bb26-3e9cd19a9c66">

