### PR TITLE
[av] fix build error on 0.75

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build error with React Native 0.75 on iOS. ([#31072](https://github.com/expo/expo/pull/31072) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 14.0.6 — 2024-06-27

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -20,7 +20,8 @@ Pod::Spec.new do |s|
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+    'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
   }
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')


### PR DESCRIPTION
# Why

fixes build error for expo-av on ios with react-native 0.75 
fixes #31057
close ENG-13214

# How

expo-av includes some c++ headers inside react-native that requires newer c++. this pr uses c++20 to build expo-av. this is also partially change as #30034

# Test Plan

tested building with expo-av on ios & react-native 0.75

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
