### PR TITLE
[core][Android] `EitherTypeConverter` now can work with the `Dynamic`class

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS. ([#30944](https://github.com/expo/expo/pull/30944) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add functions that are called before and after a shared object is removed from the registry. ([#30949](https://github.com/expo/expo/pull/30949) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Rewrite map converter to support a broader range of types that can be passed to the JS. ([#31016](https://github.com/expo/expo/pull/31016) by [@lukmccall](https://github.com/lukmccall))
-- [Android] `EitherTypeConverter` now can work with the `Dynamic` class.
+- [Android] `EitherTypeConverter` now can work with the `Dynamic` class. ([#31074](https://github.com/expo/expo/pull/31074) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Android] Introduced experimental converter to support a broader range of types that can be passed to the JS. ([#30944](https://github.com/expo/expo/pull/30944) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add functions that are called before and after a shared object is removed from the registry. ([#30949](https://github.com/expo/expo/pull/30949) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Rewrite map converter to support a broader range of types that can be passed to the JS. ([#31016](https://github.com/expo/expo/pull/31016) by [@lukmccall](https://github.com/lukmccall))
+- [Android] `EitherTypeConverter` now can work with the `Dynamic` class.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
@@ -2,11 +2,16 @@
 
 package expo.modules.kotlin.jni.types
 
+import com.facebook.react.bridge.DynamicFromObject
 import com.google.common.truth.Truth
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import expo.modules.kotlin.jni.SharedString
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
+import expo.modules.kotlin.jni.withSingleModule
+import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.Either
+import expo.modules.kotlin.types.convert
 import org.junit.Test
 import java.net.URL
 
@@ -51,4 +56,41 @@ class EitherTypeConversionTest {
       jsValue = "123",
       map = { false }
     )
+
+  @Test
+  fun should_convert_from_dynamic() {
+    val dynamicInt = DynamicFromObject(1.0)
+    val dynamicString = DynamicFromObject("second")
+
+    val convertedInt = convert<Either<Int, String>>(dynamicInt)
+    val convertedString = convert<Either<Int, String>>(dynamicString)
+
+    Truth.assertThat(convertedInt.`is`(Int::class)).isTrue()
+    Truth.assertThat(convertedInt.`is`(String::class)).isFalse()
+    Truth.assertThat(convertedInt.first()).isEqualTo(1)
+
+    Truth.assertThat(convertedString.`is`(Int::class)).isFalse()
+    Truth.assertThat(convertedString.`is`(String::class)).isTrue()
+    Truth.assertThat(convertedString.second()).isEqualTo("second")
+  }
+
+  @Test
+  fun should_convert_from_shared_ref() = withSingleModule({
+    Function("create") {
+      SharedString("shared string")
+    }
+
+    Function("unpack") { sharedString: Either<Int, SharedRef<String>> ->
+      sharedString.second().ref
+    }
+  }) {
+    val sharedString = evaluateScript(
+      """
+      const ref = $moduleRef.create();
+      $moduleRef.unpack(ref);
+      """.trimIndent()
+    ).getString()
+
+    Truth.assertThat(sharedString).isEqualTo("shared string")
+  }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
@@ -28,7 +28,7 @@ class DateTypeConverterTest {
     val date = convert<LocalDate>(1703718341639)
     Truth.assertThat(date.month).isEqualTo(Month.DECEMBER)
     Truth.assertThat(date.monthValue).isEqualTo(12)
-    Truth.assertThat(date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+    Truth.assertThat(date.dayOfWeek).isIn(listOf(DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY))
     Truth.assertThat(date.year).isEqualTo(2023)
   }
 }


### PR DESCRIPTION
# Why

Adds support for the `Dynamic` class in the `Either` type converter.

# How

I was against that for a long time because converting from dynamic already removes some information about the initial type. Although, we don't have any other way to support `Either<..., SharedRef>` as a prop in views. That is needed by `expo-image`. So, I've added dynamic conversion. It's pretty limited but should be enough for our use case.  

# Test Plan

- unit tests ✅ 