### PR TITLE
feat(babel-preset-expo): Add basic support for using DOM Components in RSC projects

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -280,6 +280,10 @@ DOM Components and websites in general are less optimal than native views but th
 
 Many large apps also use some web content for auxiliary routes such as blog posts, rich-text (for example, long-form posts on X), settings pages, help pages, and other less frequently visited parts of the app.
 
+## Server Components
+
+DOM Components currently only render as single-page applications and don't support static rendering or React Server Components. When the project uses React Server Components "use dom" will work the same as "use client" regardless of the platform. RSC Payloads can technically be passed as properties to DOM Components but they cannot be hydrated correctly on native platforms as they'll be rendered for a native runtime.
+
 ## Limitations
 
 - Unlike server components, you cannot pass `children` to DOM components.

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -282,7 +282,7 @@ Many large apps also use some web content for auxiliary routes such as blog post
 
 ## Server Components
 
-DOM Components currently only render as single-page applications and don't support static rendering or React Server Components. When the project uses React Server Components "use dom" will work the same as "use client" regardless of the platform. RSC Payloads can technically be passed as properties to DOM Components but they cannot be hydrated correctly on native platforms as they'll be rendered for a native runtime.
+DOM Components currently only render as single-page applications and don't support static rendering or React Server Components (RSC). When the project uses React Server Components,`"use dom"` will work the same as `"use client"` regardless of the platform. RSC Payloads can be passed as properties to DOM Components. However, they cannot be hydrated correctly on native platforms as they'll be rendered for a native runtime.
 
 ## Limitations
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add basic support for using DOM Components in React Server Components projects.
 - Add initial version of DOM Components and expose `expoDomComponentReference` on metadata. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `hasCjsExports` metadata for tracking static exports. ([#30111](https://github.com/expo/expo/pull/30111) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `process.env.EXPO_SERVER` for detecting when the JS was bundled for a server or react server environment. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add basic support for using DOM Components in React Server Components projects.
+- Add basic support for using DOM Components in React Server Components projects. ([#31080](https://github.com/expo/expo/pull/31080) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and expose `expoDomComponentReference` on metadata. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `hasCjsExports` metadata for tracking static exports. ([#30111](https://github.com/expo/expo/pull/30111) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `process.env.EXPO_SERVER` for detecting when the JS was bundled for a server or react server environment. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -14,7 +14,9 @@ function reactClientReferencesPlugin() {
         name: 'expo-client-references',
         visitor: {
             Program(path, state) {
-                const isUseClient = path.node.directives.some((directive) => directive.value.value === 'use client');
+                const isUseClient = path.node.directives.some((directive) => directive.value.value === 'use client' ||
+                    // Convert DOM Components to client proxies in React Server environments.
+                    directive.value.value === 'use dom');
                 // TODO: use server can be added to scopes inside of the file. https://github.com/facebook/react/blob/29fbf6f62625c4262035f931681c7b7822ca9843/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js#L55
                 const isUseServer = path.node.directives.some((directive) => directive.value.value === 'use server');
                 if (isUseClient && isUseServer) {

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -125,7 +125,6 @@ function babelPresetExpo(api, options = {}) {
         inlines['process.env.EXPO_BASE_URL'] = baseUrl;
     }
     extraPlugins.push([require('./define-plugin'), inlines]);
-    extraPlugins.push(use_dom_directive_plugin_1.expoUseDomDirectivePlugin);
     if (isProduction) {
         // Metro applies a version of this plugin too but it does it after the Platform modules have been transformed to CJS, this breaks the transform.
         // Here, we'll apply it before the commonjs transform, in production only, to ensure `Platform.OS` is replaced with a string literal.
@@ -162,6 +161,10 @@ function babelPresetExpo(api, options = {}) {
     if (isReactServer) {
         extraPlugins.push(client_module_proxy_plugin_1.reactClientReferencesPlugin);
         extraPlugins.push(restricted_react_api_plugin_1.environmentRestrictedReactAPIsPlugin);
+    }
+    else {
+        // DOM components must run after "use client" and only in client environments.
+        extraPlugins.push(use_dom_directive_plugin_1.expoUseDomDirectivePlugin);
     }
     // This plugin is fine to run whenever as the server-only imports were introduced as part of RSC and shouldn't be used in any client code.
     extraPlugins.push(environment_restricted_imports_1.environmentRestrictedImportsPlugin);

--- a/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
@@ -227,4 +227,23 @@ export default Svg;
 
     expect(contents?.code).not.toMatch('react-server-dom-webpack');
   });
+
+  it(`converts "use dom" to client proxies`, () => {
+    const res = transformReactServer(`
+    "use dom";
+    import { Text } from 'react-native';
+    
+    export const foo = 'bar';
+    
+    module.exports = function App() {
+      return <Text>Hello World</Text>
+    }
+    `);
+    expect(res.metadata.proxyExports).toEqual(['foo']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export const foo = proxy["foo"];"
+    `);
+  });
 });

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -10,7 +10,10 @@ export function reactClientReferencesPlugin(): babel.PluginObj {
     visitor: {
       Program(path, state) {
         const isUseClient = path.node.directives.some(
-          (directive: any) => directive.value.value === 'use client'
+          (directive: any) =>
+            directive.value.value === 'use client' ||
+            // Convert DOM Components to client proxies in React Server environments.
+            directive.value.value === 'use dom'
         );
         // TODO: use server can be added to scopes inside of the file. https://github.com/facebook/react/blob/29fbf6f62625c4262035f931681c7b7822ca9843/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js#L55
         const isUseServer = path.node.directives.some(

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -250,8 +250,6 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
   extraPlugins.push([require('./define-plugin'), inlines]);
 
-  extraPlugins.push(expoUseDomDirectivePlugin);
-
   if (isProduction) {
     // Metro applies a version of this plugin too but it does it after the Platform modules have been transformed to CJS, this breaks the transform.
     // Here, we'll apply it before the commonjs transform, in production only, to ensure `Platform.OS` is replaced with a string literal.
@@ -297,6 +295,9 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     extraPlugins.push(reactClientReferencesPlugin);
 
     extraPlugins.push(environmentRestrictedReactAPIsPlugin);
+  } else {
+    // DOM components must run after "use client" and only in client environments.
+    extraPlugins.push(expoUseDomDirectivePlugin);
   }
 
   // This plugin is fine to run whenever as the server-only imports were introduced as part of RSC and shouldn't be used in any client code.


### PR DESCRIPTION
# Why

Projects bundled with RSC should be able to import and render DOM components in some basic capacity. The more advanced uses (passing server actions or RSC as props) will need to be explored further in the future.

# How

Treat `"use dom"` the same as `"use client"` when bundling for react-server envs. This will effectively opt the DOM component out of SSR and require the app to recurse back to the server for it.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added unit test for basic behavior