### PR TITLE
[expo-video] feature: support onFullscreenChange callback

### DIFF
--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -187,6 +187,9 @@ export default function VideoScreen() {
           setIsInPictureInPicture(false);
           console.log('Exited Picture in Picture mode');
         }}
+        onFullscreenChange={({ nativeEvent: { isFullscreen } }) => {
+          console.log('Fullscreen changed to ' + isFullscreen);
+        }}
       />
       <ScrollView style={styles.controlsContainer}>
         <Text>PictureInPicture Active: {isInPictureInPicture ? 'Yes' : 'No'}</Text>

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for `onFullscreenChange` callback on all platforms ([#31083](https://github.com/expo/expo/pull/31083) by [@lucasrose](https://github.com/lucasrose))
+
 ### 🐛 Bug fixes
 
 - [Android] Fixed `resolvedLayoutDirection` building issues when using react-native 0.75.X. ([#31064](https://github.com/expo/expo/pull/31064) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -27,6 +27,7 @@ class FullscreenPlayerActivity : Activity() {
 
     videoView = VideoManager.getVideoView(videoViewId)
     videoView.videoPlayer?.changePlayerView(playerView)
+    videoView.onFullscreenChange(mapOf("isFullscreen" to true))
   }
 
   override fun onPostCreate(savedInstanceState: Bundle?) {
@@ -44,7 +45,7 @@ class FullscreenPlayerActivity : Activity() {
   override fun finish() {
     super.finish()
     VideoManager.getVideoView(videoViewId).exitFullscreen()
-
+    videoView.onFullscreenChange(mapOf("isFullscreen" to false))
     // Disable the exit transition
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
       overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -43,7 +43,8 @@ class VideoModule : Module() {
     View(VideoView::class) {
       Events(
         "onPictureInPictureStart",
-        "onPictureInPictureStop"
+        "onPictureInPictureStop",
+        "onFullscreenChange"
       )
 
       Prop("player") { view: VideoView, player: VideoPlayer ->

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -36,7 +36,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   val playerView: PlayerView = PlayerView(context.applicationContext)
   val onPictureInPictureStart by EventDispatcher<Unit>()
   val onPictureInPictureStop by EventDispatcher<Unit>()
-
+  val onFullscreenChange by EventDispatcher<Map<String, Boolean>>()
   var willEnterPiP: Boolean = false
   var isInFullscreen: Boolean = false
     private set

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -16,7 +16,8 @@ public final class VideoModule: Module {
     View(VideoView.self) {
       Events(
         "onPictureInPictureStart",
-        "onPictureInPictureStop"
+        "onPictureInPictureStop",
+        "onFullscreenChange"
       )
 
       Prop("player") { (view, player: VideoPlayer?) in

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -41,6 +41,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   let onPictureInPictureStart = EventDispatcher()
   let onPictureInPictureStop = EventDispatcher()
+  let onFullscreenChange = EventDispatcher()
 
   public override var bounds: CGRect {
     didSet {
@@ -94,6 +95,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       self.playerViewController.view.removeFromSuperview()
       self.reactViewController().present(self.playerViewController, animated: true)
       isFullscreen = true
+      self.onFullscreenChange(["isFullscreen": true])
       #endif
     }
   }
@@ -144,6 +146,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   public func playerViewControllerDidEndDismissalTransition(_ playerViewController: AVPlayerViewController) {
     self.isFullscreen = false
+    self.onFullscreenChange(["isFullscreen": false])
     // Reset the bounds of the view controller and add it back to our view
     self.playerViewController.view.frame = self.bounds
     addSubview(self.playerViewController.view)
@@ -164,6 +167,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
   ) {
     isFullscreen = true
+    self.onFullscreenChange(["isFullscreen": true])
   }
 
   public func playerViewController(
@@ -180,6 +184,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
           self.player?.pointer.play()
         }
         self.isFullscreen = false
+        self.onFullscreenChange(["isFullscreen": false])
       }
     }
   }

--- a/packages/expo-video/src/VideoView.types.ts
+++ b/packages/expo-video/src/VideoView.types.ts
@@ -10,6 +10,12 @@ import type { VideoPlayer } from './VideoPlayer.types';
  */
 export type VideoContentFit = 'contain' | 'cover' | 'fill';
 
+export type FullscreenChangeEvent = {
+  nativeEvent: {
+    isFullscreen: boolean;
+  };
+};
+
 export interface VideoViewProps extends ViewProps {
   /**
    * A player instance – use `useVideoPlayer()` to create one.
@@ -70,6 +76,13 @@ export interface VideoViewProps extends ViewProps {
    * @platform ios 14+
    */
   onPictureInPictureStop?: () => void;
+
+  /**
+   * A callback to call when the video player enters or exits full screen mode.
+   * @param isFullScreen
+   * @returns
+   */
+  onFullscreenChange?: (e: FullscreenChangeEvent) => void;
 
   /**
    * Determines whether the player allows Picture in Picture (PiP) mode.


### PR DESCRIPTION
# Why

There was a requested feature for my current role. We needed to show an inline video and show custom controls but show native controls when entering fullscreen.

# How

Used expo EventDispatcher pattern to support the new callback `onFullscreenChange`.

# Test Plan

Will link an example to reproduce

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
