### PR TITLE
[create-expo] add a comment to sync the forbidden names list in WWW

### DIFF
--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -24,6 +24,7 @@ const debug = require('debug')('expo:init:template') as typeof console.log;
 
 const isMacOS = process.platform === 'darwin';
 
+// keep this list in sync with the validation helper in WWW: src/utils/experienceParser.ts
 const FORBIDDEN_NAMES = [
   'react-native',
   'react',


### PR DESCRIPTION
# Why

I copied over the forbidden names validation logic to WWW to prevent issues when creating a project from the website, so I wanted to add a comment here to tell authors to update that list in WWW after changing it here.

The WWW PR number for reference: #16354 

# How

I added a comment above the `FORBIDDEN_NAMES` list.

# Test Plan

Nothing should change. Inspect the diff to read the comment.
