### PR TITLE
autolinking: update deprecated platform docs

### DIFF
--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -54,9 +54,9 @@ The above command returns an object in JSON format with modules that have been f
 
 Resolving is the second phase based on the results from the `search` command. It resolves each search result to an object with more (platform-specific) details, such as the path to the podspec or **build.gradle** files and module classes to link.
 
-<Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <ios|android>']} />
+<Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <apple|android>']} />
 
-For example, with the `--platform ios` option it returns an object in JSON format with an array of modules and resolved details for the iOS platform:
+For example, with the `--platform apple` option it returns an object in JSON format with an array of modules and resolved details for the platform:
 
 ```json
 {


### PR DESCRIPTION
# Why

because the `ios` option was replaced by `apple`

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
