### PR TITLE
[dev-menu] Fix build error on 0.75

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
 - [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
+- [iOS] Fix build error on `0.75` because of missing headers. [#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
 - [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
-- [iOS] Fix build error on `0.75` because of missing headers. [#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix build error on `0.75` because of missing headers. ([#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -108,7 +108,7 @@ Pod::Spec.new do |s|
     main.pod_target_xcconfig = {}
 
     main.dependency 'React-Core'
-    if reactNativeTargetVersion >= 75
+    if ENV['USE_FRAMEWORKS'] && reactNativeTargetVersion >= 75
       add_dependency(main, "React-rendererconsistency")
     end
     add_dependency(main, "React-jsinspector", :framework_name => 'jsinspector_modern')

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -108,6 +108,9 @@ Pod::Spec.new do |s|
     main.pod_target_xcconfig = {}
 
     main.dependency 'React-Core'
+    if reactNativeTargetVersion >= 75
+      add_dependency(main, "React-rendererconsistency")
+    end
     add_dependency(main, "React-jsinspector", :framework_name => 'jsinspector_modern')
     main.dependency "EXManifests"
     main.dependency 'ExpoModulesCore'


### PR DESCRIPTION
# Why
Closes #31092

# How
`DevClientRootViewFactory` imports `RuntimeScheduler.h` which imports `ShadowTreeRevisionConsistencyManager.h` on 0.75. When using `useFrameworks: "static"`, this will fail because `React-rendererconsistency` is not included in dev menus podspec. 

# Test Plan
Tested in a project on 0.74 and 0.75. Both can build and run with or without setting `useFrameworks`
