### PR TITLE
font: provide CTFontManagerError code in native module rejections

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- More detailed error messages for `FontLoader` native module rejections
 - Add `getLoadedFonts()` function ([#30431](https://github.com/expo/expo/pull/30431) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- More detailed error messages for `FontLoader` native module rejections
+- More detailed error messages for `FontLoader` native module rejections ([#31104](https://github.com/expo/expo/pull/31104) by [@vonovak](https://github.com/vonovak))
 - Add `getLoadedFonts()` function ([#30431](https://github.com/expo/expo/pull/30431) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-font/ios/FontExceptions.swift
+++ b/packages/expo-font/ios/FontExceptions.swift
@@ -18,14 +18,21 @@ internal final class FontNoPostScriptException: GenericException<String> {
   }
 }
 
-internal final class FontRegistrationFailedException: GenericException<CFError> {
+internal struct FontRegistrationErrorInfo {
+  let fontFamilyAlias: String
+  let cfError: CFError
+  let ctFontManagerError: CTFontManagerError?
+}
+
+internal final class FontRegistrationFailedException: GenericException<FontRegistrationErrorInfo> {
   override var reason: String {
-    "Registering '\(param)' font failed with message: '\(param.localizedDescription)'"
+    let ctErrorDescription = "CTFontManagerError code: " + (param.ctFontManagerError.map { String($0.rawValue) } ?? "N/A")
+    return "Registering '\(param.fontFamilyAlias)' font failed with message: '\(param.cfError.localizedDescription)'. \(ctErrorDescription)"
   }
 }
 
 internal final class UnregisteringFontFailedException: GenericException<CFError> {
   override var reason: String {
-    "Unregistering '\(param)' font failed with message: '\(param.localizedDescription)'"
+    "Unregistering font failed with message: '\(param.localizedDescription)'"
   }
 }

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -33,7 +33,7 @@ public final class FontLoaderModule: Module {
       }
 
       // Register the font
-      try registerFont(fontUrl)
+      try registerFont(fontUrl: fontUrl, fontFamilyAlias: fontFamilyAlias)
 
       // Create a font object from the given URL
       let font = try loadFont(fromUrl: fontUrl, alias: fontFamilyAlias)

--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -45,7 +45,7 @@ internal func loadFont(fromUrl url: CFURL, alias: String) throws -> CGFont {
 /**
  Registers the given font to make it discoverable through font descriptor matching.
  */
-internal func registerFont(_ fontUrl: CFURL) throws {
+internal func registerFont(fontUrl: CFURL, fontFamilyAlias: String) throws {
   var error: Unmanaged<CFError>?
 
   if !CTFontManagerRegisterFontsForURL(fontUrl, .process, &error), let error = error?.takeRetainedValue() {
@@ -58,7 +58,7 @@ internal func registerFont(_ fontUrl: CFURL) throws {
       // - another instance already registered with the same name (assuming it's most likely the same font anyway)
       return
     default:
-      throw FontRegistrationFailedException(error)
+      throw FontRegistrationFailedException(FontRegistrationErrorInfo(fontFamilyAlias: fontFamilyAlias, cfError: error, ctFontManagerError: fontError))
     }
   }
 }


### PR DESCRIPTION
# Why

On Android, it seems error messages cannot be improved much, but while working on https://github.com/oblador/react-native-vector-icons/pull/1645 I noticed that iOS error message (now it's "Font registration was unsuccessful.") can be a little more helpful when font loading fails.

Giving the CTFontManagerError code can help anyone to Google the underlying error cause.

# How

Add `fontFamilyAlias` and `CTFontManagerError` into the error message.


# Test Plan

bare expo. Can be tested with `globalThis?.expo?.modules.ExpoFontLoader.loadAsync('sfdds', 'sfasfd');`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
