### PR TITLE
[android][dev-menu] Fix crash calling `setSystemGestureExclusionRects`

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
 - [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
 - [iOS] Fix build error on `0.75` because of missing headers. ([#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix a crash on android when calling `setSystemGestureExclusionRects` on apis below 29.
+- [Android] Fix a crash on android when calling `setSystemGestureExclusionRects` on apis below 29. ([#31114](https://github.com/expo/expo/pull/31114) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
 - [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
 - [iOS] Fix build error on `0.75` because of missing headers. ([#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix a crash on android when calling `setSystemGestureExclusionRects` on apis below 29.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.RequiresApi
+import androidx.core.view.ViewCompat
 import androidx.core.view.doOnLayout
 import com.facebook.react.ReactRootView
 import expo.modules.devmenu.fab.MovableFloatingActionButton
@@ -18,7 +19,6 @@ import expo.modules.devmenu.fab.MovableFloatingActionButton
 private const val enableFAB = false
 
 class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
-  @RequiresApi(Build.VERSION_CODES.Q)
   private val updateSystemGestureExclusionRects: () -> Unit = {
     val marginLayoutParams = fab.layoutParams as MarginLayoutParams
 
@@ -32,7 +32,7 @@ class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
 
     // For some reason, updating the system gesture exclusion rects has to be called on that view
     // instead of calling it on the fab view itself. Probably, because we want to extend the react by view margins.
-    setSystemGestureExclusionRects(listOf(rect))
+    ViewCompat.setSystemGestureExclusionRects(this, listOf(rect))
   }
 
   private val fab by lazy {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -31,7 +31,7 @@ class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
     )
 
     // For some reason, updating the system gesture exclusion rects has to be called on that view
-    // instead of calling it on the fab view itself. Probably, because we want to extend the react by view margins.
+    // instead of calling it on the fab view itself. Probably, because we want to extend the rect by view margins.
     ViewCompat.setSystemGestureExclusionRects(this, listOf(rect))
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -37,10 +37,6 @@ class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
 
   private val fab by lazy {
     MovableFloatingActionButton(context) {
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-        return@MovableFloatingActionButton
-      }
-
       // `setSystemGestureExclusionRects` should be call after the view is laid out
       doOnLayout {
         updateSystemGestureExclusionRects()


### PR DESCRIPTION
# Why
Closes #31112

# How
`@RequiresApi` is not a guard. It just produces a lint warning for callers. This function can still be called on devices below this version and will crash at runtime. `setSystemGestureExclusionRects` shouldn't be called on devices below api 29. We can use the `ViewCompat` class to drop the `@RequiresApi` annotation and safely call `setSystemGestureExclusionRects`

# Test Plan
Bare expo on an emulator running api 28. 

