### PR TITLE
[docs] Update invalid Vale's core settings

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -4,16 +4,18 @@ MinAlertLevel = warning
 [formats]
 mdx = md
 
+# Ignore code on basis of certain HTML tags.
+IgnoredClasses= whitesapce-pre, prose-code
+SkippedScopes = script, style, pre, figure, code, tt, tr, td, span
+
 # Settings applied to md/mdx format.
 [*.md]
 
 # List of styles to load
 BasedOnStyles = expo-docs
 
-# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and certain HTML tags.
+# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
 BlockIgnores = (?s) <Terminal(\s|\n)[^/>]*?property
-IgnoredClasses= whitesapce-pre, prose-code
-SkippedScopes = script, style, pre, figure, code, tt, tr, td, span
 TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch,
 
 # Temporarily ignore the following rules

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -17,6 +17,3 @@ BasedOnStyles = expo-docs
 # Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
 BlockIgnores = (?s) <Terminal(\s|\n)[^/>]*?property
 TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch,
-
-# Temporarily ignore the following rules
-expo-docs.Ellipses = NO

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -174,7 +174,7 @@ If you're using a **.env** file for storing your secrets locally, you can use th
 <Terminal
   cmd={[
     '$ eas secret:push --scope project --env-file ./eas/.env',
-    '✔ Creating secrets on account johndoe…',
+    '✔ Creating secrets on account johndoe...',
     '✔ Created the following secrets on account johndoe:',
     '- ABC',
     '- DEF',

--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -83,7 +83,7 @@ build:
     - run:
         name: Run tests
         command: |
-          echo "Running tests…"
+          echo "Running tests..."
           npm test
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

With the latest Vale version (`3.7.0`), some of the core settings that are configured inside `.vale.ini` file do not work when running `vale .` command locally.

For example:

![CleanShot 2024-08-22 at 16 40 22@2x](https://github.com/user-attachments/assets/18bcc7b1-6c16-4333-add8-0c2a6d1670e1)

The `IgnoredClasses` and `SkippedScopes` break the configuration and hence running the command since they are defined after the syntax `[**.*]` (which is used to define the file extension for Vale to watch for lint).

# How

<!--
How did you build this feature or fix this bug and why?
-->

FIx the Vale configuration by re-arranging the configuration settings  (`IgnoredClasses` and `SkippedScopes`) before defining the file format in `.vale.ini` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After updating the configuration in `.vale.ini`, run `vale .` or `yarn run lint-prose` locally from a terminal and there should be no errors related to invalid configuration.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
