### PR TITLE
[android][image] Replace deprecated class

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -14,7 +14,7 @@ import androidx.core.graphics.transform
 import androidx.core.view.isVisible
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.views.view.ReactViewBackgroundDrawable
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
 import expo.modules.image.drawing.OutlineProvider
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.records.ContentPosition
@@ -45,19 +45,9 @@ class ExpoImageView(
   private var transformationMatrixChanged = false
 
   private val borderDrawableLazyHolder = lazy {
-    ReactViewBackgroundDrawable(context).apply {
+    CSSBackgroundDrawable(context).apply {
       callback = this@ExpoImageView
-
-      outlineProvider.borderRadiiConfig
-        .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
-        .withIndex()
-        .forEach { (i, radius) ->
-          if (i == 0) {
-            setRadius(radius)
-          } else {
-            setRadius(radius, i - 1)
-          }
-        }
+      applyBorderRadius(outlineProvider.borderRadiiConfig)
     }
   }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
@@ -1,6 +1,11 @@
 package expo.modules.image
 
 import android.graphics.RectF
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
+import com.facebook.react.uimanager.style.BorderRadiusProp
 
 fun calcXTranslation(
   value: Float,
@@ -40,3 +45,13 @@ fun calcTranslation(
 
   return value
 }
+
+fun CSSBackgroundDrawable.applyBorderRadius(config: FloatArray) = config
+  .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
+  .forEachIndexed { i, radius ->
+    if (i == 0) {
+      setBorderRadius(BorderRadiusProp.BORDER_RADIUS, LengthPercentage(radius, LengthPercentageType.POINT))
+    } else {
+      setBorderRadius(BorderRadiusProp.entries[i - 1], LengthPercentage(radius, LengthPercentageType.POINT))
+    }
+  }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -18,7 +18,7 @@ import androidx.media3.ui.PlayerView
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.Spacing
-import com.facebook.react.views.view.ReactViewBackgroundDrawable
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
 import com.facebook.yoga.YogaConstants
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
@@ -26,6 +26,7 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import expo.modules.video.drawing.OutlineProvider
 import expo.modules.video.enums.ContentFit
+import expo.modules.video.utils.applyBorderRadius
 import expo.modules.video.utils.ifYogaDefinedUse
 import java.util.UUID
 
@@ -58,19 +59,9 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   private val outlineProvider = OutlineProvider(context)
 
   private val borderDrawableLazyHolder = lazy {
-    ReactViewBackgroundDrawable(context).apply {
+    CSSBackgroundDrawable(context).apply {
       callback = this@VideoView
-
-      outlineProvider.borderRadiiConfig
-        .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
-        .withIndex()
-        .forEach { (i, radius) ->
-          if (i == 0) {
-            setRadius(radius)
-          } else {
-            setRadius(radius, i - 1)
-          }
-        }
+      applyBorderRadius(outlineProvider.borderRadiiConfig)
     }
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/VideoUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/VideoUtils.kt
@@ -1,0 +1,17 @@
+package expo.modules.video.utils
+
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
+import com.facebook.react.uimanager.style.BorderRadiusProp
+
+fun CSSBackgroundDrawable.applyBorderRadius(config: FloatArray) = config
+  .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
+  .forEachIndexed { i, radius ->
+    if (i == 0) {
+      setBorderRadius(BorderRadiusProp.BORDER_RADIUS, LengthPercentage(radius, LengthPercentageType.POINT))
+    } else {
+      setBorderRadius(BorderRadiusProp.entries[i - 1], LengthPercentage(radius, LengthPercentageType.POINT))
+    }
+  }


### PR DESCRIPTION
# Why
`ReactViewBackgroundDrawable` is deprecated

# How
Replaced it with `CSSBackgroundDrawable`

# Test Plan
bare-expo

| Before | After |
| ------ | -------- |
| ![before](https://github.com/user-attachments/assets/b3e78fc2-d997-4d6a-8261-61138854ced9) | ![after](https://github.com/user-attachments/assets/e22f3426-e1cd-481c-abf3-43e411757d88) |
