### PR TITLE
[sdk-51][core] Runtime executor 0.75

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,7 +20,7 @@ _This version does not introduce any user-facing changes._
 
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
 - [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled. ([#31058](https://github.com/expo/expo/pull/31058) by [@alanjhughes](https://github.com/alanjhughes))
-- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled on 0.75.2.
+- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled on 0.75.2. ([#31122](https://github.com/expo/expo/pull/31122) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@ _This version does not introduce any user-facing changes._
 
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
 - [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled. ([#31058](https://github.com/expo/expo/pull/31058) by [@alanjhughes](https://github.com/alanjhughes))
+- [android] Fix accessing the `runtimeExecutor` from kotlin when the new arch is enabled on 0.75.2.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -169,10 +169,10 @@ class AppContext(
         if (reactContext.isBridgeless) {
           val runtimeExecutor: RuntimeExecutor = try {
             // When react-native version >= 0.75.0 get runtimeExecutor from catalystInstance
-            val catalystInstanceField = reactContext.javaClass.getDeclaredField("catalystInstance")
-            val catalystInstance = catalystInstanceField.get(reactContext)
-            val runtimeExecutorField = catalystInstance.javaClass.getDeclaredField("runtimeExecutor")
-            runtimeExecutorField.get(catalystInstance) as RuntimeExecutor
+            val catalystInstanceGetter = reactContext.javaClass.getMethod("getCatalystInstance")
+            val catalystInstance = catalystInstanceGetter.invoke(reactContext)
+            val runtimeExecutorGetter = catalystInstance.javaClass.getMethod("getRuntimeExecutor")
+            runtimeExecutorGetter.invoke(catalystInstance) as RuntimeExecutor
           } catch (e: NoSuchFieldException) {
             val method = reactContext.javaClass.getMethod("getRuntimeExecutor")
             method.invoke(reactContext) as RuntimeExecutor


### PR DESCRIPTION
# Why
Closes #31018
Same problem I was fixing with #31042. Not sure why I didn't catch this when testing that PR. 

# How
`reactContext.javaClass.getDeclaredField("catalystInstance")` will fail as `BridgelessReactContext` is a Java class and Kotlins property accessors cannot be used with reflection. We instead need to use the getters to access these instances

# Test Plan
New project running the new arch on 0.75

