### PR TITLE
feat(expo): Polyfill Symbol.asyncIterator

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Polyfill `Symbol.asyncIterator` on native.
+- Polyfill `Symbol.asyncIterator` on native. ([#31127](https://github.com/expo/expo/pull/31127) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and `expo/dom` module. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))
 - Support `URL.canParse`. ([#30697](https://github.com/expo/expo/pull/30697) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minimal `TextDecoder` support to native client platforms. ([#29620](https://github.com/expo/expo/pull/29620) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Polyfill `Symbol.asyncIterator` on native.
 - Add initial version of DOM Components and `expo/dom` module. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))
 - Support `URL.canParse`. ([#30697](https://github.com/expo/expo/pull/30697) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minimal `TextDecoder` support to native client platforms. ([#29620](https://github.com/expo/expo/pull/29620) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -28,7 +28,5 @@ install('URL', () => require('./url').URL);
 install('URLSearchParams', () => require('./url').URLSearchParams);
 
 // Polyfill async iterator symbol for Hermes.
-if (!Symbol.asyncIterator) {
-  // @ts-expect-error: readonly property only applies when the engine supports it
-  Symbol.asyncIterator = Symbol.for('Symbol.asyncIterator');
-}
+// @ts-expect-error: readonly property only applies when the engine supports it
+Symbol.asyncIterator ??= Symbol.for('Symbol.asyncIterator');

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -26,3 +26,9 @@ install('TextDecoder', () => require('./TextDecoder').TextDecoder);
 install('URL', () => require('./url').URL);
 // https://url.spec.whatwg.org/#urlsearchparams
 install('URLSearchParams', () => require('./url').URLSearchParams);
+
+// Polyfill async iterator symbol for Hermes.
+if (!Symbol.asyncIterator) {
+  // @ts-expect-error: readonly property only applies when the engine supports it
+  Symbol.asyncIterator = Symbol.for('Symbol.asyncIterator');
+}


### PR DESCRIPTION
# Why

- Many AI libraries (used with React Server Components) expect async iteration to exist. 

```js
for await (const delta of streamAsAsyncIterator) {
}
```

# How

- Ensure the symbol `Symbol.asyncIterator` exists when it doesn't on native. 
