### PR TITLE
chore: remove jcenter mentions from test fixtures

### DIFF
--- a/packages/@expo/cli/src/prebuild/__tests__/fixtures/react-native-project.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/fixtures/react-native-project.ts
@@ -1069,7 +1069,6 @@ export default {
           }
           repositories {
               google()
-              jcenter()
           }
           dependencies {
               classpath("com.android.tools.build:gradle:3.5.3")
@@ -1092,7 +1091,6 @@ export default {
               }
       
               google()
-              jcenter()
               maven { url 'https://www.jitpack.io' }
           }
       }`,

--- a/packages/@expo/config-plugins/src/android/__tests__/GoogleServices-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/GoogleServices-test.ts
@@ -95,7 +95,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -111,7 +110,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.4.1'

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -223,15 +223,9 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
-platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
-
-prepare_react_native_project!
-
-target 'HelloWorld' do
-  use_expo_modules!
-
+use_autolinking_method_symbol = ('use' + '_native' + '_modules!').to_sym
+origin_autolinking_method = self.method(use_autolinking_method_symbol)
+self.define_singleton_method(use_autolinking_method_symbol) do |*args|
   if ENV['EXPO_UNSTABLE_CORE_AUTOLINKING'] == '1'
     Pod::UI.puts('Using expo-modules-autolinking as core autolinking source'.green)
     config_command = [
@@ -244,13 +238,25 @@ target 'HelloWorld' do
       '--platform',
       'ios'
     ]
+    origin_autolinking_method.call(config_command)
+  else
+    origin_autolinking_method.call()
+  end
+end
+
+platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+install! 'cocoapods',
+  :deterministic_uuids => false
+
+prepare_react_native_project!
+
+target 'HelloWorld' do
+  use_expo_modules!
+
 # @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-e9cc66c360abe50bc66d89fffb3c55b034d7d369
   pod 'react-native-google-maps', path: File.dirname(\`node --print "require.resolve('react-native-maps/package.json')"\`)
 # @generated end react-native-maps
-    config = use_native_modules!(config_command)
-  else
-    config = use_native_modules!
-  end
+  config = use_native_modules!
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']


### PR DESCRIPTION
# Why

closes #12226. JCenter isn't used any more, and I removed it also from test fixtures for completeness

# How

removed JCenter from test fixtures for completeness. Also one snapshot test for a podspec was updated but that's unrelated.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
