### PR TITLE
[android][updates] Add proguard rules for 0.75

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error with React Native 0.75 on Android. ([#31084](https://github.com/expo/expo/pull/31084) by [@kudo](https://github.com/kudo))
-- Add different set of proguard rules when using React Native 0.75 on Android.
+- Add different set of proguard rules when using React Native 0.75 on Android. ([#31136](https://github.com/expo/expo/pull/31136) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.25.22 — 2024-08-07
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build error with React Native 0.75 on Android. ([#31084](https://github.com/expo/expo/pull/31084) by [@kudo](https://github.com/kudo))
+- Add different set of proguard rules when using React Native 0.75 on Android.
 
 ## 0.25.22 — 2024-08-07
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -41,6 +41,8 @@ def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROI
 def useDevClient = findProject(":expo-dev-client") != null
 
 android {
+  def rnVersion = getRNVersion()
+
   buildFeatures {
     buildConfig true
   }
@@ -72,12 +74,20 @@ android {
       pickFirst "**/libc++_shared.so"
     }
   }
+  buildTypes {
+    release {
+      if (rnVersion >= versionToNumber(0, 75, 0)) {
+        proguardFiles 'proguard-rules-75.pro'
+      } else {
+        proguardFiles 'proguard-rules.pro'
+      }
+    }
+  }
   sourceSets {
     main.assets.srcDirs += files("$projectDir/src/main/certificates".toString())
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/schemas".toString())
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/certificates".toString())
 
-    def rnVersion = getRNVersion()
     if (rnVersion >= versionToNumber(0, 75, 0)) {
       main.java.srcDirs += "src/react-native-75/main"
     } else {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -41,8 +41,6 @@ def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROI
 def useDevClient = findProject(":expo-dev-client") != null
 
 android {
-  def rnVersion = getRNVersion()
-
   buildFeatures {
     buildConfig true
   }
@@ -51,7 +49,7 @@ android {
   defaultConfig {
     versionCode 31
     versionName '0.25.23'
-    consumerProguardFiles("proguard-rules.pro")
+    consumerProguardFiles(rnVersion >= versionToNumber(0, 75, 0) ? 'proguard-rules-75.pro' : 'proguard-rules.pro')
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", exUpdatesNativeDebug)
@@ -74,20 +72,12 @@ android {
       pickFirst "**/libc++_shared.so"
     }
   }
-  buildTypes {
-    release {
-      if (rnVersion >= versionToNumber(0, 75, 0)) {
-        proguardFiles 'proguard-rules-75.pro'
-      } else {
-        proguardFiles 'proguard-rules.pro'
-      }
-    }
-  }
   sourceSets {
     main.assets.srcDirs += files("$projectDir/src/main/certificates".toString())
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/schemas".toString())
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/certificates".toString())
 
+    def rnVersion = getRNVersion()
     if (rnVersion >= versionToNumber(0, 75, 0)) {
       main.java.srcDirs += "src/react-native-75/main"
     } else {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -41,6 +41,7 @@ def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROI
 def useDevClient = findProject(":expo-dev-client") != null
 
 android {
+  def rnVersion = getRNVersion()
   buildFeatures {
     buildConfig true
   }
@@ -77,7 +78,6 @@ android {
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/schemas".toString())
     androidTest.assets.srcDirs += files("$projectDir/src/androidTest/certificates".toString())
 
-    def rnVersion = getRNVersion()
     if (rnVersion >= versionToNumber(0, 75, 0)) {
       main.java.srcDirs += "src/react-native-75/main"
     } else {

--- a/packages/expo-updates/android/proguard-rules-75.pro
+++ b/packages/expo-updates/android/proguard-rules-75.pro
@@ -1,0 +1,7 @@
+-keepclassmembers class com.facebook.react.ReactInstanceManager {
+  private final com.facebook.react.bridge.JSBundleLoader mBundleLoader;
+}
+
+-keepclassmembers class com.facebook.react.devsupport.ReleaseDevSupportManager {
+  private final com.facebook.react.bridge.DefaultJSExceptionHandler mDefaultJSExceptionHandler;
+}


### PR DESCRIPTION
# Why
Closes #31134

# How
When using RN 0.75 on sdk 51, updates will crash in release mode when it tries to access the `mDefaultJSExceptionHandler` property because the devSupportManager was renamed in 0.75. We need to add a new set of rules to keep this property to handle both RN versions

# Test Plan
~~Unsure how to test this fully if anyone has any suggestions? @Kudo @wschurman  @douglowder~~
Tested against a user provided repro which presented the problem. 
