### PR TITLE
[docs] Update EAS CLI steps in Android FCM Credentials guide

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -59,6 +59,10 @@ Upload the JSON file to EAS and configure it for sending Android notifications. 
 - Run `eas credentials`
 - Select `Android` > `production` > `Google Service Account`
 - Select `Manage your Google Service Account Key for Push Notifications (FCM V1)`
+- Select `Set up a Google Service Account Key for Push Notifications (FCM V1)` > `Upload a new service account key`
+- If you've previously stored the JSON file in your project directory, the EAS CLI will automatically detect the file and prompt you to select it. Press <kbd>Y</kbd> to continue.
+
+> **Note**: Add the JSON file to your version source control's ignore file (for example, **.gitignore**) to avoid committing it to your repository since it contains sensitive data.
 
 </Tab>
 
@@ -107,7 +111,7 @@ Configure the **google-services.json** file in your project. Download it from th
   className="max-w-[800px]"
 />
 
-Then, in **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config/app/#googleservicesfile) with its value as the path of the **google-services.json**.
+In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config/app/#googleservicesfile) with its value as the path of the **google-services.json**.
 
 ```json app.json
 {
@@ -182,6 +186,10 @@ You have to specify to EAS which JSON credential file to use for sending FCM V1 
 - Run `eas credentials`
 - Select `Android` > `production` > `Google Service Account`
 - Select `Manage your Google Service Account Key for Push Notifications (FCM V1)`
+- Select `Set up a Google Service Account Key for Push Notifications (FCM V1)` > `Upload a new service account key`
+- The EAS CLI automatically detects the file on your local machine and prompts you to select it. Press <kbd>Y</kbd> to continue.
+
+> **Note**: Add the JSON file to your version source control's ignore file (for example, **.gitignore**) to avoid committing it to your repository since it contains sensitive data.
 
 </Tab>
 
@@ -230,7 +238,7 @@ Configure the **google-services.json** file in your project. Download it from th
   className="max-w-[800px]"
 />
 
-Then, in **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config/app/#googleservicesfile) with its value as the path of the **google-services.json**.
+In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config/app/#googleservicesfile) with its value as the path of the **google-services.json**.
 
 ```json app.json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR updates the EAS CLI steps to include the missing information on uploading a Google Service Account Key that is generated from the Firebase Console. Then, add a note about not committing the Account Key in their repository.

Also made a minor verbiage update.

All changes are applied to both sections.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/push-notifications/fcm-credentials/ and see step 4

## Preview

![CleanShot 2024-08-23 at 17 19 44](https://github.com/user-attachments/assets/eaa99f0e-38c5-4cfe-8b14-34a399585f67)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
