### PR TITLE
[iOS][core] Improve arguments conversion (part 1)

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -87,6 +87,8 @@ public final class AppContext: NSObject {
    */
   internal private(set) lazy var coreModuleHolder = ModuleHolder(appContext: self, module: coreModule)
 
+  internal private(set) lazy var converter = MainValueConverter(appContext: self)
+
   /**
    Designated initializer without modules provider.
    */

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
@@ -27,15 +27,23 @@ public protocol AnyDynamicType: CustomStringConvertible {
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `Convertible`).
    */
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue
 }
 
 extension AnyDynamicType {
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    return jsValue.getRaw()
+    return jsValue.getRaw() as Any
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     return value
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    // This conversion isn't the most efficient way to convert Objective-C value to JS value.
+    // Better performance should be provided in dynamic type specializations.
+    return try JavaScriptValue.from(value, runtime: appContext.runtime)
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
@@ -22,10 +22,12 @@ internal struct DynamicDictionaryType: AnyDynamicType {
   }
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    let converter = appContext.converter
+
     if let jsObject = try? jsValue.asObject() {
       var result: [AnyHashable: Any] = [:]
       for key in jsObject.getPropertyNames() {
-        result[key] = try valueType.cast(jsValue: jsObject.getProperty(key), appContext: appContext)
+        result[key] = try converter.toNative(jsObject.getProperty(key), valueType)
       }
       return result
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
@@ -25,7 +25,7 @@ internal struct DynamicOptionalType: AnyDynamicType {
     if jsValue.isUndefined() || jsValue.isNull() {
       return Optional<Any>.none as Any
     }
-    return try wrappedType.cast(jsValue: jsValue, appContext: appContext)
+    return try appContext.converter.toNative(jsValue, wrappedType)
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -14,6 +14,13 @@ internal protocol AnySyncFunctionDefinition: AnyFunctionDefinition {
    - Returns: A value returned by the called function when succeeded or an error when it failed.
    */
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any
+
+  /**
+   Calls the function synchronously with given `this` and arguments as JavaScript values.
+   It **must** be run on the thread used by the JavaScript runtime.
+   */
+  @discardableResult
+  func call(_ appContext: AppContext, withThis this: JavaScriptValue?, arguments: [JavaScriptValue]) throws -> JavaScriptValue
 }
 
 /**
@@ -53,7 +60,7 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
     do {
       let result = try call(by: owner, withArguments: args, appContext: appContext)
-      callback(.success(Conversions.convertFunctionResult(result)))
+      callback(.success(Conversions.convertFunctionResult(result, appContext: appContext, dynamicType: ~ReturnType.self)))
     } catch let error as Exception {
       callback(.failure(error))
     } catch {
@@ -93,6 +100,42 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
     }
   }
 
+  func call(_ appContext: AppContext, withThis this: JavaScriptValue?, arguments: [JavaScriptValue]) throws -> JavaScriptValue {
+    do {
+      try validateArgumentsNumber(function: self, received: arguments.count)
+
+      // This array will include the owner (if needed) and function arguments.
+      var allNativeArguments: [Any] = []
+
+      // If the function takes the owner, convert it and add to the final arguments.
+      if takesOwner, let this, let ownerType = dynamicArgumentTypes.first {
+        let nativeOwner = try appContext.converter.toNative(this, ownerType)
+        allNativeArguments.append(nativeOwner)
+      }
+
+      // Convert JS values to non-JS native types desired by the function.
+      let nativeArguments = try appContext.converter.toNative(arguments, Array(dynamicArgumentTypes.dropFirst(allNativeArguments.count)))
+
+      allNativeArguments.append(contentsOf: nativeArguments)
+
+      // Fill in with nils in place of missing optional arguments.
+      if arguments.count < argumentsCount {
+        allNativeArguments.append(contentsOf: Array(repeating: Any?.none as Any, count: argumentsCount - arguments.count))
+      }
+
+      guard let argumentsTuple = try Conversions.toTuple(allNativeArguments) as? Args else {
+        throw ArgumentConversionException()
+      }
+      let result = try body(argumentsTuple)
+
+      return try appContext.converter.toJS(result, ~ReturnType.self)
+    } catch let error as Exception {
+      throw FunctionCallException(name).causedBy(error)
+    } catch {
+      throw UnexpectedException(error)
+    }
+  }
+
   // MARK: - JavaScriptObjectBuilder
 
   func build(appContext: AppContext) throws -> JavaScriptObject {
@@ -100,12 +143,11 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
     // immediately lose the reference to the definition and thus the underlying native function.
     // It may potentially cause memory leaks, but at the time of writing this comment,
     // the native definition instance deallocates correctly when the JS VM triggers the garbage collector.
-    return try appContext.runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak appContext, self] this, args in
+    return try appContext.runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak appContext, self] this, arguments in
       guard let appContext else {
         throw Exceptions.AppContextLost()
       }
-      let result = try self.call(by: this, withArguments: args, appContext: appContext)
-      return Conversions.convertFunctionResult(result, appContext: appContext, dynamicType: ~ReturnType.self)
+      return try self.call(appContext, withThis: this, arguments: arguments)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
@@ -45,7 +45,7 @@ public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptVal
     let value = rawFunction.call(withArguments: arguments, thisObject: this, asConstructor: false)
     let dynamicType = ~ReturnType.self
 
-    guard let result = try dynamicType.cast(jsValue: value, appContext: appContext) as? ReturnType else {
+    guard let result = try appContext.converter.toNative(value, dynamicType) as? ReturnType else {
       throw UnexpectedReturnType(dynamicType.description)
     }
     return result

--- a/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
@@ -95,7 +95,7 @@ internal func concat(
   var result = arguments
 
   if function.takesOwner {
-    result = [owner] + arguments
+    result = [owner as Any] + arguments
   }
   if arguments.count < function.argumentsCount {
     result += Array(repeating: Any?.none as Any, count: function.argumentsCount - arguments.count)

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -1,0 +1,47 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+/**
+ A converter associated with the specific app context that delegates value conversions to the dynamic type converters.
+ */
+public struct MainValueConverter {
+  /**
+   It holds a strong reference as the AppContext is the only owner of the converter.
+   */
+  internal let appContext: AppContext
+
+  /**
+   Casts the given JavaScriptValue to a non-JS value.
+   It **must** be run on the thread used by the JavaScript runtime.
+   */
+  public func toNative(_ value: JavaScriptValue, _ type: AnyDynamicType) throws -> Any {
+    // Preliminary cast from JS value to a common native type.
+    let rawValue = try type.cast(jsValue: value, appContext: appContext)
+
+    // Cast common native type to more complex types (e.g. records, convertibles, enumerables, shared objects).
+    return try type.cast(rawValue, appContext: appContext)
+  }
+
+  /**
+   Casts the given JS values to non-JS values.
+   It **must** be run on the thread used by the JavaScript runtime.
+   */
+  public func toNative(_ values: [JavaScriptValue], _ types: [AnyDynamicType]) throws -> [Any] {
+    return try values.enumerated().map { index, value in
+      let type = types[index]
+
+      do {
+        return try toNative(value, types[index])
+      } catch {
+        throw ArgumentCastException((index: index, type: type)).causedBy(error)
+      }
+    }
+  }
+
+  /**
+   Converts the given value to the type compatible with JavaScript.
+   */
+  public func toJS<ValueType>(_ value: ValueType, _ type: AnyDynamicType) throws -> JavaScriptValue {
+    let result = Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: type)
+    return try type.castToJS(result, appContext: appContext)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
@@ -134,7 +134,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
    Creates the JavaScript function that will be used as a getter of the property.
    */
   internal func buildGetter(appContext: AppContext) throws -> JavaScriptObject {
-    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] this, args in
+    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] this, arguments in
       guard let appContext else {
         throw Exceptions.AppContextLost()
       }
@@ -142,9 +142,9 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
         throw NativePropertyUnavailableException(name)
       }
       guard let getter = self.getter else {
-        return
+        return .undefined
       }
-      return try getter.call(by: this, withArguments: args, appContext: appContext)
+      return try getter.call(appContext, withThis: this, arguments: arguments)
     }
   }
 
@@ -152,7 +152,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
    Creates the JavaScript function that will be used as a setter of the property.
    */
   internal func buildSetter(appContext: AppContext) throws -> JavaScriptObject {
-    return try appContext.runtime.createSyncFunction(name, argsCount: 1) { [weak appContext, weak self, name] this, args in
+    return try appContext.runtime.createSyncFunction(name, argsCount: 1) { [weak appContext, weak self, name] this, arguments in
       guard let appContext else {
         throw Exceptions.AppContextLost()
       }
@@ -160,9 +160,9 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
         throw NativePropertyUnavailableException(name)
       }
       guard let setter = self.setter else {
-        return
+        return .undefined
       }
-      return try setter.call(by: this, withArguments: args, appContext: appContext)
+      return try setter.call(appContext, withThis: this, arguments: arguments)
     }
   }
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -23,9 +23,9 @@ typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
                                      RCTPromiseResolveBlock _Nonnull resolve,
                                      RCTPromiseRejectBlock _Nonnull reject);
 
-typedef id _Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
-                                            NSArray<EXJavaScriptValue *> * _Nonnull arguments,
-                                            NSError * _Nullable __autoreleasing * _Nullable error);
+typedef EXJavaScriptValue * _Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
+                                                             NSArray<EXJavaScriptValue *> * _Nonnull arguments,
+                                                             NSError * _Nullable __autoreleasing * _Nullable error);
 
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime,

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -107,10 +107,10 @@
     EXJavaScriptValue * _Nonnull thisValue,
     NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
       NSError *error;
-      id result = block(thisValue, arguments, &error);
+      EXJavaScriptValue *result = block(thisValue, arguments, &error);
 
       if (error == nil) {
-        return expo::convertObjCObjectToJSIValue(runtime, result);
+        return jsi::Value(runtime, *[result get]);
       } else {
         // `expo::makeCodedError` doesn't work during unit tests, so we construct Error and add a code,
         // instead of using the CodedError subclass.

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -19,7 +19,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 @interface EXJavaScriptValue : NSObject
 
 #ifdef __cplusplus
-- (nonnull instancetype)initWithRuntime:(nonnull EXJavaScriptRuntime *)runtime
+- (nonnull instancetype)initWithRuntime:(nullable EXJavaScriptRuntime *)runtime
                                   value:(std::shared_ptr<jsi::Value>)value;
 
 /**
@@ -56,5 +56,11 @@ NS_SWIFT_NAME(JavaScriptValue)
 #pragma mark - Helpers
 
 - (nonnull NSString *)toString;
+
+#pragma mark - Statics
+
+@property (class, nonatomic, assign, readonly, nonnull) EXJavaScriptValue *undefined;
+
++ (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -12,7 +12,7 @@
   std::shared_ptr<jsi::Value> _value;
 }
 
-- (nonnull instancetype)initWithRuntime:(nonnull EXJavaScriptRuntime *)runtime
+- (nonnull instancetype)initWithRuntime:(nullable EXJavaScriptRuntime *)runtime
                                   value:(std::shared_ptr<jsi::Value>)value
 {
   if (self = [super init]) {
@@ -166,6 +166,21 @@
 {
   jsi::Runtime *runtime = [_runtime get];
   return expo::convertJSIStringToNSString(*runtime, _value->toString(*runtime));
+}
+
+#pragma mark - Static properties
+
++ (nonnull EXJavaScriptValue *)undefined
+{
+  auto undefined = std::make_shared<jsi::Value>();
+  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:undefined];
+}
+
++ (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  jsi::Runtime *jsiRuntime = [runtime get];
+  auto jsiValue = std::make_shared<jsi::Value>(*jsiRuntime, expo::convertObjCObjectToJSIValue(*jsiRuntime, value));
+  return [[EXJavaScriptValue alloc] initWithRuntime:runtime value:jsiValue];
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -4,7 +4,7 @@ public extension JavaScriptRuntime {
   /**
    A type of the closure that you pass to the `createSyncFunction` function.
    */
-  typealias SyncFunctionClosure = (_ this: JavaScriptValue, _ arguments: [JavaScriptValue]) throws -> Any
+  typealias SyncFunctionClosure = (_ this: JavaScriptValue, _ arguments: [JavaScriptValue]) throws -> JavaScriptValue
 
   /**
    Evaluates JavaScript code represented as a string.

--- a/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
@@ -122,8 +122,8 @@ final class EventEmitterSpec: ExpoSpec {
       it("calls startObserving on addListener") {
         var calls: Int = 0
         let eventName = "testEvent"
-        let listenerA = runtime.createSyncFunction("listenerA") { _, _ in }
-        let listenerB = runtime.createSyncFunction("listenerB") { _, _ in }
+        let listenerA = runtime.createSyncFunction("listenerA") { _, _ in .undefined }
+        let listenerB = runtime.createSyncFunction("listenerB") { _, _ in .undefined }
         let observer = try setupEventObserver(runtime: runtime, functionName: "startObserving") { arguments in
           expect(try arguments.first?.asString()) == eventName
           calls = calls + 1
@@ -138,7 +138,7 @@ final class EventEmitterSpec: ExpoSpec {
       it("calls stopObserving on removeListener") {
         var calls: Int = 0
         let eventName = "testEvent"
-        let listener = runtime.createSyncFunction("listener") { _, _ in }
+        let listener = runtime.createSyncFunction("listener") { _, _ in .undefined }
         let observer = try setupEventObserver(runtime: runtime, functionName: "stopObserving") { arguments in
           expect(try arguments.first?.asString()) == eventName
           calls = calls + 1
@@ -154,7 +154,7 @@ final class EventEmitterSpec: ExpoSpec {
       it("calls stopObserving on removeAllListeners") {
         var calls: Int = 0
         let eventName = "testEvent"
-        let listener = runtime.createSyncFunction("listener") { _, _ in }
+        let listener = runtime.createSyncFunction("listener") { _, _ in .undefined }
         let observer = try setupEventObserver(runtime: runtime, functionName: "stopObserving") { arguments in
           expect(try arguments.first?.asString()) == eventName
           calls = calls + 1
@@ -260,7 +260,7 @@ private func setupEventObserver(
   let emitter = try! runtime.eval("new expo.EventEmitter()").asObject()
   let observingFunction = runtime.createSyncFunction(functionName) { [callback] this, arguments in
     try callback(arguments)
-    return Optional<Any>.none as Any
+    return .undefined
   }
 
   emitter.setProperty(functionName, value: observingFunction)

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -251,6 +251,10 @@ class FunctionSpec: ExpoSpec {
             return nil
           }
 
+          Function("returnUndefined") { () -> JavaScriptValue in
+            return .undefined
+          }
+
           Function("isArgNull") { (arg: Double?) -> Bool in
             return arg == nil
           }
@@ -279,6 +283,7 @@ class FunctionSpec: ExpoSpec {
       it("returns values") {
         expect(try runtime.eval("expo.modules.TestModule.returnPi()").asDouble()) == Double.pi
         expect(try runtime.eval("expo.modules.TestModule.returnNull()").isNull()) == true
+        expect(try runtime.eval("expo.modules.TestModule.returnUndefined()").isUndefined()) == true
       }
 
       it("accepts optional arguments") {


### PR DESCRIPTION
# Why

Argument and function results conversions are quite messy right now. Cleaning this up may improve the performance as well. It may look a bit incomplete, but it's just the first PR that I plan to submit.

# How

- Introduced the main converter that holds the app context and will be the entry point for all conversions
- Sync functions and properties are now returning `JavaScriptValue` instead of `Any` (one conversion less)
- Added another type of `call` function to sync functions – they will always receive and return `JavaScriptValue`s. Previously they were always casted to `Any` to support handling both JS and native values (we pass native values in our native tests).
- Added `JavaScriptValue.undefined` property as a convenience way to return `undefined`

These changes in theory shouldn't change the performance of synchronous function calls, but they do. Benchmarks that add strings and doubles 100k times are now about 12% faster. They will be improved even more in the upcoming PRs.

# Test Plan

- All native unit tests are passing
- I went through some test-suite tests and examples (SQLite, ImageManipulator, Crypto)
