### PR TITLE
[docs][components] Improve video style using aspect-video

### DIFF
--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -8,7 +8,7 @@ import { LightboxImage } from './LightboxImage';
 const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
 
 const PLAYER_WIDTH = '100%' as const;
-const PLAYER_HEIGHT = 400 as const;
+const PLAYER_HEIGHT = '100%' as const;
 const YOUTUBE_DOMAINS = ['youtube.com', 'youtu.be'] as const;
 
 type ContentSpotlightProps = {
@@ -64,7 +64,7 @@ export function ContentSpotlight({
       ) : isVideo ? (
         <VisibilitySensor partialVisibility>
           {({ isVisible }: { isVisible: boolean }) => (
-            <div className="relative w-full h-[400px] bg-palette-black rounded-lg overflow-hidden">
+            <div className="relative aspect-video bg-palette-black rounded-lg overflow-hidden">
               <ReactPlayer
                 url={isVisible ? url || `/static/videos/${file}` : undefined}
                 className="react-player"


### PR DESCRIPTION
# Why

The embedded videos have a fixed height, which breaks embedded video thumbnails on large and small screens (see screenshots)

<img width="1784" alt="Screenshot 2024-08-23 at 8 51 42 AM" src="https://github.com/user-attachments/assets/ff6d9d1b-044f-4576-b4e8-6da4c85d7c7d">

<img width="549" alt="Screenshot 2024-08-23 at 8 51 56 AM" src="https://github.com/user-attachments/assets/a8947f30-7c57-467d-934f-b291d02e77e7">

# How

Using the `aspect-video` class from Tailwind, the video will resize according to the available space, always retaining the nice aspect radio and showing the entire thumbnail. 

# Test Plan

Run docs locally and validate new look on embedded videos. 

<img width="470" alt="Screenshot 2024-08-23 at 8 53 32 AM" src="https://github.com/user-attachments/assets/ad77d446-16c9-49ed-b261-70ebb4cadd53">

<img width="1849" alt="Screenshot 2024-08-23 at 8 53 45 AM" src="https://github.com/user-attachments/assets/0a188812-b310-4bf5-bfc8-d493dab13796">

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
