### PR TITLE
[dev-client] Option to disable dev-client app scheme

### DIFF
--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -92,7 +92,7 @@ You can customize other aspects of your app on a per-variant basis. You can swap
 **Examples:**
 
 - If you are using a library that requires you to register your application identifier with an external service to use its SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
-- If you are using [development builds](/develop/development-builds/introduction/) you can set the `expo-dev-client` config plugin to disable the app scheme used by Expo CLI and EAS Update QR codes on your non-development build, so those URL's will always launch the development build regardless of your device defaults:
+- - If you're using [development builds](/develop/development-builds/introduction/), you can configure the `expo-dev-client` plugin to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
 
 ```js app.config.js
 plugins: [

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -79,13 +79,31 @@ export default {
   },
   android: {
     package: IS_DEV ? 'com.myapp.dev' : 'com.myapp',
-  },
+  }
 };
 ```
 
 In the above example, the environment variable `IS_DEV` is used to differentiate between the development and production environment. Based on its value, the different Application IDs or Bundle Identifiers are set for each variant.
 
-> **Note**: If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`. You can also swap this configuration using the same approach as above.
+#### Additional app variant customizations
+
+You may wish to customize other aspects of your app on a per-variant basis. You can swap any configuration that you used previously in **app.json** using the same approach as above.
+
+Some examples:
+
+- If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
+- If you are using [development builds](/develop/development-builds/introduction/) you can set the `expo-dev-client` config plugin to disable the app scheme used by Expo CLI and EAS Update QR codes on your non-development build, so those URL's will always launch the development build regardless of your device defaults:
+
+```js app.config.js
+plugins: [
+  [
+    'expo-dev-client',
+    {
+      disableDevClientScheme: !IS_DEV,
+    },
+  ],
+],
+```
 
 ### Configuration for EAS Build
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -87,7 +87,7 @@ In the above example, the environment variable `IS_DEV` is used to differentiate
 
 #### Additional app variant customizations
 
-You may wish to customize other aspects of your app on a per-variant basis. You can swap any configuration that you used previously in **app.json** using the same approach as above.
+You can customize other aspects of your app on a per-variant basis. You can swap any configuration that you used previously in **app.json** using the same approach as above.
 
 **Examples:**
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -4,6 +4,7 @@ maxHeadingDepth: 4
 description: Learn how to install multiple variants of an app on the same device.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 When creating [development, preview, and production builds](/build/eas-json/#common-use-cases), installing these build variants simultaneously on the same device is common. This allows working in development, previewing the next version of the app, and running the production version on a device without needing to uninstall and reinstall the app.
@@ -85,25 +86,27 @@ export default {
 
 In the above example, the environment variable `IS_DEV` is used to differentiate between the development and production environment. Based on its value, the different Application IDs or Bundle Identifiers are set for each variant.
 
-#### Additional app variant customizations
+<Collapsible summary="Additional app variant customizations">
 
 You can customize other aspects of your app on a per-variant basis. You can swap any configuration that you used previously in **app.json** using the same approach as above.
 
 **Examples:**
 
 - If you are using a library that requires you to register your application identifier with an external service to use its SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
-- - If you're using [development builds](/develop/development-builds/introduction/), you can configure the `expo-dev-client` plugin to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
+- If you're using [development builds](/develop/development-builds/introduction/), you can configure the `expo-dev-client` plugin to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
 
 ```js app.config.js
 plugins: [
   [
     'expo-dev-client',
     {
-      addGeneratedScheme: IS_DEV,
+      addGeneratedScheme: !IS_DEV,
     },
   ],
 ],
 ```
+
+</Collapsible>
 
 ### Configuration for EAS Build
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -99,7 +99,7 @@ plugins: [
   [
     'expo-dev-client',
     {
-      disableDevClientScheme: !IS_DEV,
+      addGeneratedScheme: IS_DEV,
     },
   ],
 ],

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -91,7 +91,7 @@ You can customize other aspects of your app on a per-variant basis. You can swap
 
 **Examples:**
 
-- If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
+- If you are using a library that requires you to register your application identifier with an external service to use its SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
 - If you are using [development builds](/develop/development-builds/introduction/) you can set the `expo-dev-client` config plugin to disable the app scheme used by Expo CLI and EAS Update QR codes on your non-development build, so those URL's will always launch the development build regardless of your device defaults:
 
 ```js app.config.js

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -89,7 +89,7 @@ In the above example, the environment variable `IS_DEV` is used to differentiate
 
 You may wish to customize other aspects of your app on a per-variant basis. You can swap any configuration that you used previously in **app.json** using the same approach as above.
 
-Some examples:
+**Examples:**
 
 - If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
 - If you are using [development builds](/develop/development-builds/introduction/) you can set the `expo-dev-client` config plugin to disable the app scheme used by Expo CLI and EAS Update QR codes on your non-development build, so those URL's will always launch the development build regardless of your device defaults:

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -57,6 +57,13 @@ You can configure development client launcher using its built-in [config plugin]
       ].join('\n'),
       default: '"most-recent"',
     },
+    {
+      name: 'disableDevClientScheme',
+      description: [
+        'By default, `expo-dev-client` will register a custom URL scheme to open a project. Set this property to `true` to disable this scheme.',
+      ].join('\n'),
+      default: 'false',
+    },
   ]}
 />
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -58,11 +58,11 @@ You can configure development client launcher using its built-in [config plugin]
       default: '"most-recent"',
     },
     {
-      name: 'disableDevClientScheme',
+      name: 'addGeneratedScheme',
       description: [
-        'By default, `expo-dev-client` will register a custom URL scheme to open a project. Set this property to `true` to disable this scheme.',
+        'By default, `expo-dev-client` will register a custom URL scheme to open a project. Set this property to `false` to disable this scheme.',
       ].join('\n'),
-      default: 'false',
+      default: 'true',
     },
   ]}
 />

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -57,6 +57,13 @@ You can configure development client launcher using its built-in [config plugin]
       ].join('\n'),
       default: '"most-recent"',
     },
+    {
+      name: 'addGeneratedScheme',
+      description: [
+        'By default, `expo-dev-client` will register a custom URL scheme to open a project. Set this property to `false` to disable this scheme.',
+      ].join('\n'),
+      default: 'true',
+    },
   ]}
 />
 

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Add `addGeneratedScheme` config plugin option to disable automatic adding of dev client app scheme. ([#31147](https://github.com/expo/expo/pull/31147) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🛠 Breaking changes
 
 - Bumped iOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,3 +1,6 @@
 import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
-declare const _default: import("expo/config-plugins").ConfigPlugin<PluginConfigType>;
+type DevClientPluginConfigType = PluginConfigType & {
+    disableDevClientScheme?: boolean;
+};
+declare const _default: import("expo/config-plugins").ConfigPlugin<DevClientPluginConfigType>;
 export default _default;

--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,6 +1,6 @@
 import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
 type DevClientPluginConfigType = PluginConfigType & {
-    disableDevClientScheme?: boolean;
+    addGeneratedScheme?: boolean;
 };
 declare const _default: import("expo/config-plugins").ConfigPlugin<DevClientPluginConfigType>;
 export default _default;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -14,8 +14,10 @@ const pkg = require('expo-dev-client/package.json');
 function withDevClient(config, props) {
     config = (0, app_plugin_2.default)(config);
     config = (0, app_plugin_1.default)(config, props);
-    config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
-    config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
+    if (!props.disableDevClientScheme) {
+        config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
+        config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
+    }
     return config;
 }
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withDevClient, pkg.name, pkg.version);

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -14,7 +14,8 @@ const pkg = require('expo-dev-client/package.json');
 function withDevClient(config, props) {
     config = (0, app_plugin_2.default)(config);
     config = (0, app_plugin_1.default)(config, props);
-    if (!props.disableDevClientScheme) {
+    const mySchemeProps = { addGeneratedScheme: true, ...props };
+    if (mySchemeProps.addGeneratedScheme) {
         config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
         config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
     }

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -12,14 +12,16 @@ import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 const pkg = require('expo-dev-client/package.json');
 
 type DevClientPluginConfigType = PluginConfigType & {
-  disableDevClientScheme?: boolean;
+  addGeneratedScheme?: boolean;
 };
 
 function withDevClient(config: ExpoConfig, props: DevClientPluginConfigType) {
   config = withDevMenu(config);
   config = withDevLauncher(config, props);
 
-  if (!props.disableDevClientScheme) {
+  const mySchemeProps = { addGeneratedScheme: true, ...props };
+
+  if (mySchemeProps.addGeneratedScheme) {
     config = withGeneratedAndroidScheme(config);
     config = withGeneratedIosScheme(config);
   }

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -11,12 +11,19 @@ import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 
-function withDevClient(config: ExpoConfig, props: PluginConfigType) {
+type DevClientPluginConfigType = PluginConfigType & {
+  disableDevClientScheme?: boolean;
+};
+
+function withDevClient(config: ExpoConfig, props: DevClientPluginConfigType) {
   config = withDevMenu(config);
   config = withDevLauncher(config, props);
-  config = withGeneratedAndroidScheme(config);
-  config = withGeneratedIosScheme(config);
+
+  if (!props.disableDevClientScheme) {
+    config = withGeneratedAndroidScheme(config);
+    config = withGeneratedIosScheme(config);
+  }
   return config;
 }
 
-export default createRunOncePlugin<PluginConfigType>(withDevClient, pkg.name, pkg.version);
+export default createRunOncePlugin<DevClientPluginConfigType>(withDevClient, pkg.name, pkg.version);


### PR DESCRIPTION
# Why
You can make multiple app variants by changing your app config based on an environment variable, and install all of those app variants on a single device. However, practically-speaking, it doesn't work for development builds. Development builds register their own `exp+slug` app scheme, which is used by QR codes from the Expo CLI and EAS Update, and that scheme gets registered on every build, even if it can't launch such a bundle URL. On iOS, it's quite likely that a non-development build app variant will intercept the bundle URL. Thus, you have to constantly install/ uninstall builds anyway if you want to use some of our most-value-added test workflows on your daily driver.

Ideally, we would strip this scheme (see [ENG-12281](https://linear.app/expo/issue/ENG-12281/explore-how-to-strip-dev-client-scheme-from-release-builds)) from non-debug builds. But that's more complicated, and there might be reasons why developers just don't want these dev client schemes around where they're not needed (maybe not even on dev builds themselves- you can customize the scheme on the QR codes coming from the PR preview publish Github action, for instance). Or maybe you have another config plugin that further customizes build schemes / app flavors and conflicts with some future automatic handling.

Thus, I wanted to propose such a flag and experiment with how we would document it as we describe app variants.

# How
- added a config plugin variable to `expo-dev-client`
- made that variable skip registering the app schemes
- documented the API
- documented usage in the course of the app variants guide

# Discussion
- The naming of the flag is probably wrong. Enabling-by-disabling feels a little off to me. But wanted to not get hung up on that for the moment and solicit better naming if the idea was otherwise acceptable.

# Test Plan
- [x] Flag`false`: run prebuild, build dev client -> can't use app-specific scheme
- [x] Flag `true`: run prebuild, build dev client -> can use app-specific scheme
- [x] No flag: run prebuild, build dev client -> can use app-specific scheme

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
