### PR TITLE
[android][image] Fix NoSuchMethodException on 0.75 and proguard

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed `resolvedLayoutDirection` building issues when using react-native 0.75.X. ([#31062](https://github.com/expo/expo/pull/31062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fix `NoSuchMethodException` when running react-native 0.75.X in release mode with Proguard enabled.
 
 ## 1.12.13 — 2024-07-16
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed `resolvedLayoutDirection` building issues when using react-native 0.75.X. ([#31062](https://github.com/expo/expo/pull/31062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [Android] Fix `NoSuchMethodException` when running react-native 0.75.X in release mode with Proguard enabled.
+- [Android] Fix `NoSuchMethodException` when running react-native 0.75.X in release mode with Proguard enabled. ([#31153](https://github.com/expo/expo/pull/31153) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 1.12.13 — 2024-07-16
 

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -15,11 +15,16 @@ buildscript {
 }
 
 android {
+  def rnVersion = getRNVersion()
   namespace "expo.modules.image"
   defaultConfig {
     versionCode 1
     versionName "1.12.14"
-    consumerProguardFiles("proguard-rules.pro")
+    if (rnVersion >= versionToNumber(0, 75, 0)) {
+      consumerProguardFiles('proguard-rules.pro', 'proguard-rules-75.pro')
+    } else {
+      consumerProguardFiles('proguard-rules.pro')
+    }
 
     buildConfigField("boolean", "ALLOW_GLIDE_LOGS", project.properties.get("EXPO_ALLOW_GLIDE_LOGS", "false"))
   }
@@ -53,3 +58,29 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
   implementation "jp.wasabeef:glide-transformations:4.3.0"
 }
+
+def versionToNumber(major, minor, patch) {
+  return patch * 100 + minor * 10000 + major * 1000000
+}
+
+def getNodeModulesPackageVersion(packageName, overridePropName) {
+  def nodeModulesVersion = providers.exec {
+    workingDir(projectDir)
+    commandLine("node", "-e", "console.log(require('$packageName/package.json').version);")
+  }.standardOutput.asText.get().trim()
+  def version = safeExtGet(overridePropName, nodeModulesVersion)
+
+  def coreVersion = version.split("-")[0]
+  def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
+
+  return versionToNumber(
+      major,
+      minor,
+      patch
+  )
+}
+
+def getRNVersion() {
+  return getNodeModulesPackageVersion("react-native", "reactNativeVersion")
+}
+

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -83,4 +83,3 @@ def getNodeModulesPackageVersion(packageName, overridePropName) {
 def getRNVersion() {
   return getNodeModulesPackageVersion("react-native", "reactNativeVersion")
 }
-

--- a/packages/expo-image/android/proguard-rules-75.pro
+++ b/packages/expo-image/android/proguard-rules-75.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class com.facebook.react.uimanager.drawable.CSSBackgroundDrawable {
+   public void setLayoutDirectionOverride(int);
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -219,9 +219,12 @@ class ExpoImageView(
 
       borderDrawable.apply {
         val setLayoutDirectionMethod = try {
+          // 0.74
           ReactViewBackgroundDrawable::class.java.getDeclaredMethod("setResolvedLayoutDirection", Int::class.java)
         } catch (e: NoSuchMethodException) {
-          ReactViewBackgroundDrawable::class.java.getMethod("setLayoutDirectionOverride", Int::class.java)
+          // 0.75
+          val clazz = Class.forName("com.facebook.react.uimanager.drawable.CSSBackgroundDrawable")
+          clazz.getDeclaredMethod("setLayoutDirectionOverride", Int::class.java)
         }
         setLayoutDirectionMethod.invoke(this, newLayoutDirection)
         setBounds(0, 0, width, height)


### PR DESCRIPTION
# Why
Closes #31118

# How
 On 0.75 `ReactViewBackgroundDrawable` has been deprecated and now extends `CSSBackgroundDrawable`. When proguard is enabled this class is obfuscated so reflection fails to find the method. Instead of adding rules for both of these classes, we can just add one for `CSSBackgroundDrawable` and use that instead on 0.75. This class is found through reflection because it does not exist in 0.74

# Test Plan
Tested in a new project in release mode using 0.74 and 0.75 with proguard enabled.

