### PR TITLE
[router]: expose useScrollToTop hook

### DIFF
--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -11,6 +11,7 @@ export {
   useSegments,
   useRootNavigation,
   useRootNavigationState,
+  useScrollToTop
 } from './hooks';
 
 export { router, Router } from './imperative-api';

--- a/packages/expo-router/src/hooks.ts
+++ b/packages/expo-router/src/hooks.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import { useScrollToTop } from '@react-navigation/native';
 import { LocalRouteParamsContext } from './Route';
 import { store, useStoreRootState, useStoreRouteInfo } from './global-state/router-store';
 import { Router } from './imperative-api';
-import { RouteParams, RouteSegments, Routes, UnknownOutputParams } from './types';
+import { RouteParams, Routes, RouteSegments, UnknownOutputParams } from './types';
 
 type SearchParams = Record<string, string | string[]>;
 export function useRootNavigationState() {
@@ -185,3 +186,18 @@ class ReadOnlyURLSearchParams extends URLSearchParams {
     throw new Error('The URLSearchParams object return from useSearchParams is read-only');
   }
 }
+
+/**
+ * Returns the Navigation's function of scroll to Top where needed in scroll
+ *
+ * e.g  `const ref = useRef(null)
+ *        useScrollToTop(ref)
+ *        ....
+ *        return (
+ *          <ScrollView ref={ref}>
+ *            ...
+ *          </ScrollView>
+ *        )`
+ */
+
+export { useScrollToTop };


### PR DESCRIPTION
# Why

Needed to have a ScrollToTop functionality [builtin](https://reactnavigation.org/docs/use-scroll-to-top/) in ReactNavigation/Native , was not being exposed by expo-router api.

# How

exposed the hook from navigation package to router's hook file; then exported using exports file

# Test Plan

- Tested it via patch-package first locally with a scroll view inside a tabbed Stack

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
