### PR TITLE
[expo-notifications][Android] Fix data mapping for local notifications with null trigger

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30478](https://github.com/expo/expo/pull/30478) by [@byCedric](https://github.com/byCedric))
 - [Android] Eliminate unsupported types when processing notification intents from onCreate/onNewIntent. ([#30750](https://github.com/expo/expo/pull/30750) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix content.data in scheduled notifications surfaced to JS. ([#31048](https://github.com/expo/expo/pull/31048) by [@douglowder](https://github.com/douglowder))
+- [Android] fix local notifications with null trigger. ([#31157](https://github.com/expo/expo/pull/31157) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -76,7 +76,10 @@ public class NotificationSerializer {
           // and we copy the data as is
           content.putBundle("data", toBundle(data));
         }
-      } else if(request.getTrigger() instanceof SchedulableNotificationTrigger) {
+      } else if(
+        request.getTrigger() instanceof SchedulableNotificationTrigger ||
+          request.getTrigger() == null
+      ) {
         JSONObject body = request.getContent().getBody();
         if (body != null) {
           // Expo sends notification.body as data.message, and JSON stringifies data.body


### PR DESCRIPTION
# Why

The fix in #31048 works for locally scheduled notifications, except for the case when trigger = null on Android.

# How

Modify the previous fix to include notifications with null triggers.

Completes the fix for #30868

# Test Plan

- Add a test in the test app for this case
- CI should pass

