### PR TITLE
[docs][Notifications] Fix Typescript error in notification with sound example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -501,6 +501,7 @@ You only need to provide the base filename. Here's an example using the config a
 ```js
 await Notifications.setNotificationChannelAsync('new-emails', {
   name: 'E-mail notifications',
+  importance: Notifications.AndroidImportance.HIGH,
   sound: 'mySoundFile.wav', // Provide ONLY the base filename
 });
 


### PR DESCRIPTION
Fix Typescript error when copy and paste the docs example code.

# Why

When copy and paste the example we see an typescript error:

![image](https://github.com/user-attachments/assets/a5af500c-03fa-4fd8-bf10-fe623ab5d7bb)

![image](https://github.com/user-attachments/assets/b531a6da-96d9-438f-9e69-28a07ee3c74f)

# How

`importance` is marked as required for `setNotificationChannelAsync` method. I just insert the missing property following the other examples in the same docs page.

# Test Plan

Copy and paste the docs example

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


<!-- disable:changelog-checks -->
