### PR TITLE
[docs] Update step 2 to add instructions on enabling developer mode for local iOS physical builds

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -30,11 +30,23 @@ Run the following command in your project's root directory:
 
 Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
-Make sure you have enabled Developer Mode on your device. See [Enable iOS developer mode with a Mac](https://docs.expo.dev/guides/ios-developer-mode/#connect-an-ios-device-with-a-mac) for instructions.
-
 </Step>
 
 <Step label="3">
+
+### Enable developer mode
+
+1. Open Xcode. From the menu bar, select **Window** > **Devices and Simulators**. You will see a warning in Xcode to enable developer mode.
+
+2. On your iOS device, open **Settings** > **Privacy & Security**, scroll down to the **Developer Mode** list item and navigate into it.
+
+3. Tap the switch to enable **Developer Mode**. After you do so, Settings presents an alert to warn you that Developer Mode reduces your device's security. To continue enabling **Developer Mode**, tap the alert's **Restart** button.
+
+4. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap **Turn On**, and enter your device passcode when prompted.
+
+</Step>
+
+<Step label="4">
 
 ### Run the project on your device
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -26,23 +26,17 @@ Run the following command in your project's root directory:
 
 <Step label="2">
 
-### Plug in your device via USB
+### Plug in your device via USB and enable developer mode
 
-Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
+1. Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
-</Step>
+2. Open Xcode. From the menu bar, select **Window** > **Devices and Simulators**. You will see a warning in Xcode to enable developer mode.
 
-<Step label="3">
+3. On your iOS device, open **Settings** > **Privacy & Security**, scroll down to the **Developer Mode** list item and navigate into it.
 
-### Enable developer mode
+4. Tap the switch to enable **Developer Mode**. After you do so, Settings presents an alert to warn you that Developer Mode reduces your device's security. To continue enabling **Developer Mode**, tap the alert's **Restart** button.
 
-1. Open Xcode. From the menu bar, select **Window** > **Devices and Simulators**. You will see a warning in Xcode to enable developer mode.
-
-2. On your iOS device, open **Settings** > **Privacy & Security**, scroll down to the **Developer Mode** list item and navigate into it.
-
-3. Tap the switch to enable **Developer Mode**. After you do so, Settings presents an alert to warn you that Developer Mode reduces your device's security. To continue enabling **Developer Mode**, tap the alert's **Restart** button.
-
-4. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap **Turn On**, and enter your device passcode when prompted.
+5. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap **Turn On**, and enter your device passcode when prompted.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #30890

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update step 2 for Local builds on iOS physical devices to provide instructions on enabling developer mode instructions by connecting the physical device with a Mac.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#plug-in-your-device-via-usb-and-enable-developer-mode

## Preview

![CleanShot 2024-08-26 at 16 21 19](https://github.com/user-attachments/assets/b9f9bb84-0900-4087-81fb-5a56e1cb216f)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
