### PR TITLE
[docs] Update verbiage in Analyzing bundles for SDK 50 and below

### DIFF
--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -105,7 +105,7 @@ Web bundles are output to the **dist/client** subdirectory to prevent exposing s
 
 <Step label="3">
 
-Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps. For native apps using hermes, you can use `--no bytecode` option to disable bytecode generation.
+Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps. For native apps using Hermes, you can use the `--no-bytecode` option to disable bytecode generation.
 
 <Terminal
   cmd={[

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -67,7 +67,7 @@ Inside Atlas, you can hold <kbd>⌘ Cmd</kbd> and click on a graph node to see t
 
 > Alternative method for **SDK 50 and below**.
 
-If you are using SDK 50 or below, you can use the [source-map-explorer](https://www.npmjs.com/package/source-map-explorer) package to visualize and analyze the production JavaScript bundle.
+If you are using SDK 50 or below, you can use the [`source-map-explorer`](https://www.npmjs.com/package/source-map-explorer) library to visualize and analyze the production JavaScript bundle.
 
 <Step label="1">
 
@@ -105,11 +105,12 @@ Web bundles are output to the **dist/client** subdirectory to prevent exposing s
 
 <Step label="3">
 
-Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps:
+Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps. For native apps using hermes, you can use `--no bytecode` option to disable bytecode generation.
 
 <Terminal
   cmd={[
     '$ npx expo export --source-maps --platform web',
+    '',
     '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
     '$ npx expo export --source-maps --platform ios --no-bytecode',
   ]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #27022

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update verbiage in Step 3 under "Analyzing bundle size with source-map-explorer" to include the context about using `--no-bytecode` option.

Add missing code syntax highlight when referencing source map explorer library in the introduction of the section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit http://localhost:3002/guides/analyzing-bundles/#analyzing-bundle-size-with-source-map-explorer, and see the changes under Step 3.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
