### PR TITLE
Fix type error in ImagePicker docs 

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -90,13 +90,13 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```jsx
+```tsx
 import { useState } from 'react';
 import { Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library

--- a/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
@@ -92,13 +92,13 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```js
+```tsx
 import React, { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library

--- a/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
@@ -92,13 +92,13 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```jsx
+```tsx
 import { useState } from 'react';
 import { Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library

--- a/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
@@ -90,13 +90,13 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```jsx
+```tsx
 import { useState } from 'react';
 import { Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library


### PR DESCRIPTION
# Why

When we want to use the example given in the usage of the ImagePicker library in a project that supports TypeScript, we get a type error: `Argument of type 'string' is not assignable to parameter of type 'SetStateAction<null>'.ts(2345)`

# How

I added union type as type to the useState hook.

# Test Plan

It is related to MDX files, no test required.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
