### PR TITLE
[docs] remove searchPaths configurations

### DIFF
--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -102,29 +102,6 @@ The behavior of the module resolution can be customized using some configuration
 
 <APIBox>
 
-### `searchPaths`
-
-A list of paths relative to the app's root directory where the autolinking script should search for Expo modules.
-It defaults to a list of all **node_modules** folders found when traversing up through a monorepo, starting from the app's root directory.
-Useful when your project has a custom structure or you want to link local packages from folders different than **node_modules**.
-
-```json package.json
-{
-  "expo": {
-    "autolinking": {
-      "searchPaths": ["../../packages"]
-    }
-  }
-}
-```
-
-When used with the CLI, you can pass the search paths as command arguments like this:
-
-<Terminal cmd={['$ npx expo-modules-autolinking search ../../packages']} />
-
-</APIBox>
-<APIBox>
-
 ### `exclude`
 
 A list of package names to exclude from autolinking. These packages will not be autolinked even if they are found in the search paths.


### PR DESCRIPTION
# Why

@vonovak found an issue for having `searchPaths` in package.json: https://github.com/expo/expo/blob/08cba033007a260318fc438ab1d9f872d4ebac2f/packages/expo-modules-autolinking/src/autolinking/mergeLinkingOptions.ts#L28-L41. the `searchPaths` from package.json will be overrode.

i don't think we want to support `searchPaths` customizations from package.json.

# How

remove doc for `searchPaths` configuration.

# Test Plan

doc ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
