### PR TITLE
[iOS][core] Improve arguments conversion (part 2)

### DIFF
--- a/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
@@ -16,23 +16,80 @@ extension AnyArgument {
 // Extend the primitive types — these may come from React Native bridge.
 extension Bool: AnyArgument {}
 
-extension Int: AnyArgument {}
-extension Int8: AnyArgument {}
-extension Int16: AnyArgument {}
-extension Int32: AnyArgument {}
-extension Int64: AnyArgument {}
+extension Int: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Int.self)
+  }
+}
+extension Int8: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Int8.self)
+  }
+}
+extension Int16: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Int16.self)
+  }
+}
+extension Int32: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Int32.self)
+  }
+}
+extension Int64: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Int64.self)
+  }
+}
 
-extension UInt: AnyArgument {}
-extension UInt8: AnyArgument {}
-extension UInt16: AnyArgument {}
-extension UInt32: AnyArgument {}
-extension UInt64: AnyArgument {}
+extension UInt: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: UInt.self)
+  }
+}
+extension UInt8: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: UInt8.self)
+  }
+}
+extension UInt16: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: UInt16.self)
+  }
+}
+extension UInt32: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: UInt32.self)
+  }
+}
+extension UInt64: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: UInt64.self)
+  }
+}
 
-extension Float32: AnyArgument {}
-extension Double: AnyArgument {}
-extension CGFloat: AnyArgument {}
+extension Float32: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Float32.self)
+  }
+}
+extension Double: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: Double.self)
+  }
+}
 
-extension String: AnyArgument {}
+extension CGFloat: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicNumberType(numberType: CGFloat.self)
+  }
+}
+
+extension String: AnyArgument {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicStringType()
+  }
+}
 
 extension Optional: AnyArgument where Wrapped: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -201,6 +201,30 @@ public struct Conversions {
   }
 
   /**
+   An exception thrown when the native value cannot be converted to JavaScript value.
+   */
+  internal final class ConversionToJSFailedException: GenericException<(kind: JavaScriptValueKind, nativeType: Any.Type)> {
+    override var code: String {
+      "ERR_CONVERTING_TO_JS_FAILED"
+    }
+    override var reason: String {
+      "Conversion from native '\(param.nativeType)' to JavaScript value of type '\(param.kind.rawValue)' failed"
+    }
+  }
+
+  /**
+   An exception thrown when the JavaScript value cannot be converted to native value.
+   */
+  internal final class ConversionToNativeFailedException: GenericException<(kind: JavaScriptValueKind, nativeType: Any.Type)> {
+    override var code: String {
+      "ERR_CONVERTING_TO_NATIVE_FAILED"
+    }
+    override var reason: String {
+      "Conversion from JavaScript value of type '\(param.kind.rawValue)' to native '\(param.nativeType)' failed"
+    }
+  }
+
+  /**
    An exception that can be thrown by convertible types, when given value cannot be converted.
    */
   public class ConvertingException<TargetType>: GenericException<Any?> {

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
@@ -1,0 +1,68 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+internal struct DynamicNumberType<NumberType>: AnyDynamicType {
+  let numberType: NumberType.Type
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type == numberType
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    return type is Self
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    if jsValue.kind == .number {
+      if let FloatingPointType = NumberType.self as? any BinaryFloatingPoint.Type {
+        return FloatingPointType.init(jsValue.getDouble())
+      }
+      if let IntegerType = NumberType.self as? any BinaryInteger.Type {
+        // JS stores all numbers as doubles, so using `getDouble` makes more sense
+        // than `getInt` and lets us do schoolbook rounding instead of floor.
+        return IntegerType.init(jsValue.getDouble().rounded())
+      }
+    }
+    throw Conversions.ConversionToNativeFailedException((kind: jsValue.kind, nativeType: numberType))
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if let number = value as? NumberType {
+      return number
+    }
+    if let number = value as? any BinaryInteger {
+      if let IntegerType = NumberType.self as? any BinaryInteger.Type {
+        // integer -> another integer
+        return IntegerType.init(number)
+      }
+      if let FloatingPointType = NumberType.self as? any BinaryFloatingPoint.Type {
+        // integer -> float
+        return FloatingPointType.init(number)
+      }
+    }
+    if let number = value as? any BinaryFloatingPoint {
+      if let FloatingPointType = NumberType.self as? any BinaryFloatingPoint.Type {
+        // float -> another float
+        return FloatingPointType.init(number)
+      }
+      if let IntegerType = NumberType.self as? any BinaryInteger.Type {
+        // float -> integer (schoolbook rounding)
+        return IntegerType.init(number.rounded())
+      }
+    }
+    throw Conversions.CastingException<NumberType>(value)
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? any BinaryFloatingPoint {
+      return .number(Double(value))
+    }
+    if let value = value as? any BinaryInteger {
+      return .number(Double(value))
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .number, nativeType: ValueType.self))
+  }
+
+  var description: String {
+    "\(numberType)"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicStringType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicStringType.swift
@@ -1,0 +1,36 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+internal struct DynamicStringType: AnyDynamicType {
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type == String.self
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    return type is Self
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if let string = value as? String {
+      return string
+    }
+    throw Conversions.CastingException<String>(value)
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    if jsValue.kind == .string {
+      return jsValue.getString()
+    }
+    throw Conversions.ConversionToNativeFailedException((kind: jsValue.kind, nativeType: String.self))
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let string = value as? String {
+      return .string(string, runtime: try appContext.runtime)
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .string, nativeType: ValueType.self))
+  }
+
+  var description: String {
+    "String"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -11,6 +11,12 @@
  see the `~` prefix operator below that handles types conforming to `AnyArgument` in a faster way.
  */
 private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
+  if type is any Numeric.Type {
+    return DynamicNumberType(numberType: T.self)
+  }
+  if type is String.Type {
+    return DynamicStringType()
+  }
   if let ArrayType = T.self as? AnyArray.Type {
     return DynamicArrayType(elementType: ArrayType.getElementDynamicType())
   }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -61,6 +61,10 @@ NS_SWIFT_NAME(JavaScriptValue)
 
 @property (class, nonatomic, assign, readonly, nonnull) EXJavaScriptValue *undefined;
 
++ (nonnull EXJavaScriptValue *)number:(double)value;
+
++ (nonnull EXJavaScriptValue *)string:(nonnull NSString *)value runtime:(nonnull EXJavaScriptRuntime *)runtime;
+
 + (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -176,6 +176,19 @@
   return [[EXJavaScriptValue alloc] initWithRuntime:nil value:undefined];
 }
 
++ (nonnull EXJavaScriptValue *)number:(double)value
+{
+  auto number = std::make_shared<jsi::Value>(value);
+  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:number];
+}
+
++ (nonnull EXJavaScriptValue *)string:(nonnull NSString *)value runtime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  jsi::Runtime *jsiRuntime = [runtime get];
+  auto string = std::make_shared<jsi::Value>(jsi::String::createFromUtf8(*jsiRuntime, [value UTF8String]));
+  return [[EXJavaScriptValue alloc] initWithRuntime:runtime value:string];
+}
+
 + (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime
 {
   jsi::Runtime *jsiRuntime = [runtime get];

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -8,12 +8,13 @@ import ExpoModulesTestCore
 final class DynamicTypeSpec: ExpoSpec {
   override class func spec() {
     let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
 
     // MARK: - DynamicRawType
 
     describe("DynamicRawType") {
       it("is created") {
-        expect(~String.self).to(beAKindOf(DynamicRawType<String>.self))
+        expect(~Any.self).to(beAKindOf(DynamicRawType<Any>.self))
         expect(~Bool.self).to(beAKindOf(DynamicRawType<Bool>.self))
         expect(~ExpoSpec.self).to(beAKindOf(DynamicRawType<ExpoSpec>.self))
       }
@@ -24,11 +25,10 @@ final class DynamicTypeSpec: ExpoSpec {
           expect(try (~Bool.self).cast(false, appContext: appContext) as? Bool) == false
         }
         it("throws NullCastException") {
-          let value: Double? = nil
-          let anyValue = value as Any
+          let value: Bool? = nil
 
-          expect { try (~Double.self).cast(anyValue, appContext: appContext) }.to(
-            throwError(errorType: Conversions.NullCastException<Double>.self)
+          expect { try (~Bool.self).cast(value as Any, appContext: appContext) }.to(
+            throwError(errorType: Conversions.NullCastException<Bool>.self)
           )
         }
         it("throws CastingException") {
@@ -61,6 +61,54 @@ final class DynamicTypeSpec: ExpoSpec {
           expect(~String.self != ~CGSize.self) == true
           expect(~Bool.self != ~Promise.self) == true
         }
+      }
+    }
+
+    // MARK: - DynamicNumberType
+
+    describe("DynamicNumberType") {
+      it("is created") {
+        expect(~Double.self).to(beAKindOf(DynamicNumberType<Double>.self))
+        expect(~Int32.self).to(beAKindOf(DynamicNumberType<Int32>.self))
+        expect(~CGFloat.self).to(beAKindOf(DynamicNumberType<CGFloat>.self))
+      }
+      it("casts from the same numeric type") {
+        // integer literal (Int) -> Int
+        expect(try (~Int.self).cast(7, appContext: appContext) as? Int) == 7
+        // Int16 -> Int16
+        expect(try (~Int16.self).cast(Int16(5), appContext: appContext) as? Int16) == Int16(5)
+        // float literal (Double) -> Double
+        expect(try (~Double.self).cast(3.14, appContext: appContext) as? Double) == 3.14
+        // Float64 -> Float64
+        expect(try (~Float64.self).cast(Float64(1.61), appContext: appContext) as? Float64) == Float64(1.61)
+      }
+      it("casts from different numeric type") {
+        // integer literal (Int) -> Int64
+        expect(try (~Int64.self).cast(11, appContext: appContext) as? Int64) == Int64(11)
+        // integer literal (Int) -> Double
+        expect(try (~Double.self).cast(37, appContext: appContext) as? Double) == 37.0
+        // float literal (Double) -> Int (schoolbook rounding)
+        expect(try (~Int.self).cast(21.8, appContext: appContext) as? Int) == 22
+        // float literal (Double) -> Float64
+        expect(try (~Float64.self).cast(6.6, appContext: appContext) as? Float64) == Float64(6.6)
+      }
+      it("casts from JS value") {
+        expect(try (~Double.self).cast(jsValue: .number(12.34), appContext: appContext) as? Double) == 12.34
+        expect(try (~Int.self).cast(jsValue: .number(0.8), appContext: appContext) as? Int) == 1
+      }
+    }
+
+    // MARK: - DynamicStringType
+
+    describe("DynamicStringType") {
+      it("is created") {
+        expect(~String.self).to(beAKindOf(DynamicStringType.self))
+      }
+      it("casts") {
+        expect(try (~String.self).cast("foo", appContext: appContext) as? String) == "foo"
+      }
+      it("casts from JS value") {
+        expect(try (~String.self).cast(jsValue: .string("bar", runtime: runtime), appContext: appContext) as? String) == "bar"
       }
     }
 


### PR DESCRIPTION
# Why

Follow up on #31141 

# How

This PR adds `DynamicStringType` and `DynamicNumberType` in place of `DynamicRawType` for string and numeric types.
Benefits:
- Resolving dynamic types here https://github.com/expo/expo/blob/08cba033007a260318fc438ab1d9f872d4ebac2f/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift#L13 is *turbo* slow as it goes through many checks against other, more complex types (this resolution is used mostly only for return types, for arguments we use the more efficient generic `getDynamicType`). `DynamicRawType` is returned as the last.
- It no longer needs to go through this: https://github.com/expo/expo/blob/08cba033007a260318fc438ab1d9f872d4ebac2f/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm#L145 to convert JS value to Objective-C. The dynamic type can be associated with the specific kind of JS value instead of resolving it in runtime.
- It was not possible to convert between different types (like `Int` to `Double`). This might be useful only in native tests, but it's still nice to have.
- Benchmarks that add strings and doubles 100k times are now about 10% faster. They will be improved even more in the upcoming PRs.

# Test Plan

I went through some sync functions examples in NCL and ran native unit tests.

<!-- disable:changelog-checks -->
