### PR TITLE
[cli] support prebuild to specify template npm: package

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Unify Android device prompts with iOS prompts for `npx expo run:android -d`. ([#28622](https://github.com/expo/expo/pull/28622) by [@byCedric](https://github.com/byCedric))
 - Enable `EXPO_USE_METRO_WORKSPACE_ROOT` by default and replace with `EXPO_NO_METRO_WORKSPACE_ROOT`. ([#30621](https://github.com/expo/expo/pull/30621) by [@byCedric](https://github.com/byCedric))
 - Remove `node-fetch` in favor of `undici` for improved Node 22+ support. ([#29511](https://github.com/expo/expo/pull/29511) by [@byCedric](https://github.com/byCedric))
+- Added support to download template from npm by running `npx expo prebuild --template npm:expo-template-bare-minimum@{version}`. ([#31195](https://github.com/expo/expo/pull/31195) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Unify Android device prompts with iOS prompts for `npx expo run:android -d`. ([#28622](https://github.com/expo/expo/pull/28622) by [@byCedric](https://github.com/byCedric))
 - Enable `EXPO_USE_METRO_WORKSPACE_ROOT` by default and replace with `EXPO_NO_METRO_WORKSPACE_ROOT`. ([#30621](https://github.com/expo/expo/pull/30621) by [@byCedric](https://github.com/byCedric))
 - Remove `node-fetch` in favor of `undici` for improved Node 22+ support. ([#29511](https://github.com/expo/expo/pull/29511) by [@byCedric](https://github.com/byCedric))
-- Added support to download template from npm by running `npx expo prebuild --template npm:expo-template-bare-minimum@{version}`. ([#31195](https://github.com/expo/expo/pull/31195) by [@kudo](https://github.com/kudo))
+- Added support to download template from npm when running prebuild. ([#31195](https://github.com/expo/expo/pull/31195) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -88,7 +88,7 @@ it('runs `npx expo prebuild --help`', async () => {
         --yarn                                   Use Yarn to install dependencies. Default when yarn.lock exists
         --bun                                    Use bun to install dependencies. Default when bun.lockb exists
         --pnpm                                   Use pnpm to install dependencies. Default when pnpm-lock.yaml exists
-        --template <template>                    Project template to clone from. File path pointing to a local tar file or a github repo
+        --template <template>                    Project template to clone from. File path pointing to a local tar file, npm package (\`npm:{package}\`) or a github repo
         -p, --platform <all|android|ios>         Platforms to sync: ios, android, all. Default: all
         --skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)
         -h, --help                               Usage info
@@ -186,6 +186,117 @@ it(
     await execa('node', [bin, 'prebuild', '--no-install', '--template', templateFolder], {
       cwd: projectRoot,
     });
+
+    // List output files with sizes for snapshotting.
+    // This is to make sure that any changes to the output are intentional.
+    // Posix path formatting is used to make paths the same across OSes.
+    const files = klawSync(projectRoot)
+      .map((entry) => {
+        if (entry.path.includes('node_modules') || !entry.stats.isFile()) {
+          return null;
+        }
+        return path.posix.relative(projectRoot, entry.path);
+      })
+      .filter(Boolean);
+
+    const pkg = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
+
+    await expectTemplateAppNameToHaveBeenRenamed(projectRoot);
+
+    // Added new packages
+    expect(Object.keys(pkg.dependencies ?? {}).sort()).toStrictEqual([
+      'expo',
+      'react',
+      'react-native',
+    ]);
+
+    // Updated scripts
+    expect(pkg.scripts).toStrictEqual({
+      android: 'expo run:android',
+      ios: 'expo run:ios',
+    });
+
+    // If this changes then everything else probably changed as well.
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "App.js",
+        "android/.gitignore",
+        "android/app/build.gradle",
+        "android/app/debug.keystore",
+        "android/app/proguard-rules.pro",
+        "android/app/src/debug/AndroidManifest.xml",
+        "android/app/src/main/AndroidManifest.xml",
+        "android/app/src/main/java/com/example/minimal/MainActivity.kt",
+        "android/app/src/main/java/com/example/minimal/MainApplication.kt",
+        "android/app/src/main/res/drawable/rn_edit_text_material.xml",
+        "android/app/src/main/res/drawable/splashscreen.xml",
+        "android/app/src/main/res/mipmap-hdpi/ic_launcher.png",
+        "android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png",
+        "android/app/src/main/res/mipmap-mdpi/ic_launcher.png",
+        "android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png",
+        "android/app/src/main/res/mipmap-xhdpi/ic_launcher.png",
+        "android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png",
+        "android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+        "android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png",
+        "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+        "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png",
+        "android/app/src/main/res/values/colors.xml",
+        "android/app/src/main/res/values/strings.xml",
+        "android/app/src/main/res/values/styles.xml",
+        "android/app/src/main/res/values-night/colors.xml",
+        "android/build.gradle",
+        "android/gradle/wrapper/gradle-wrapper.jar",
+        "android/gradle/wrapper/gradle-wrapper.properties",
+        "android/gradle.properties",
+        "android/gradlew",
+        "android/gradlew.bat",
+        "android/settings.gradle",
+        "app.json",
+        "bun.lockb",
+        "ios/.gitignore",
+        "ios/.xcode.env",
+        "ios/Podfile",
+        "ios/Podfile.properties.json",
+        "ios/basicprebuild/AppDelegate.h",
+        "ios/basicprebuild/AppDelegate.mm",
+        "ios/basicprebuild/Images.xcassets/AppIcon.appiconset/App-Icon-1024x1024@1x.png",
+        "ios/basicprebuild/Images.xcassets/AppIcon.appiconset/Contents.json",
+        "ios/basicprebuild/Images.xcassets/Contents.json",
+        "ios/basicprebuild/Images.xcassets/SplashScreenBackground.imageset/Contents.json",
+        "ios/basicprebuild/Images.xcassets/SplashScreenBackground.imageset/image.png",
+        "ios/basicprebuild/Info.plist",
+        "ios/basicprebuild/SplashScreen.storyboard",
+        "ios/basicprebuild/Supporting/Expo.plist",
+        "ios/basicprebuild/basicprebuild-Bridging-Header.h",
+        "ios/basicprebuild/basicprebuild.entitlements",
+        "ios/basicprebuild/main.m",
+        "ios/basicprebuild/noop-file.swift",
+        "ios/basicprebuild.xcodeproj/project.pbxproj",
+        "ios/basicprebuild.xcodeproj/project.xcworkspace/contents.xcworkspacedata",
+        "ios/basicprebuild.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist",
+        "ios/basicprebuild.xcodeproj/xcshareddata/xcschemes/basicprebuild.xcscheme",
+        "metro.config.js",
+        "package.json",
+      ]
+    `);
+  },
+  // Could take 45s depending on how fast npm installs
+  60 * 1000
+);
+
+it(
+  'runs `npx expo prebuild --template npm:expo-template-bare-minimum@50.0.43`',
+  async () => {
+    const projectRoot = await setupTestProjectWithOptionsAsync('basic-prebuild', 'with-blank');
+
+    const npmTemplatePackage = 'expo-template-bare-minimum@50.0.43';
+    await execa(
+      'node',
+      [bin, 'prebuild', '--no-install', '--template', `npm:${npmTemplatePackage}`],
+      {
+        cwd: projectRoot,
+      }
+    );
 
     // List output files with sizes for snapshotting.
     // This is to make sure that any changes to the output are intentional.

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -88,7 +88,7 @@ it('runs `npx expo prebuild --help`', async () => {
         --yarn                                   Use Yarn to install dependencies. Default when yarn.lock exists
         --bun                                    Use bun to install dependencies. Default when bun.lockb exists
         --pnpm                                   Use pnpm to install dependencies. Default when pnpm-lock.yaml exists
-        --template <template>                    Project template to clone from. File path pointing to a local tar file, npm package (\`npm:{package}\`) or a github repo
+        --template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo
         -p, --platform <all|android|ios>         Platforms to sync: ios, android, all. Default: all
         --skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)
         -h, --help                               Usage info
@@ -285,18 +285,14 @@ it(
 );
 
 it(
-  'runs `npx expo prebuild --template npm:expo-template-bare-minimum@50.0.43`',
+  'runs `npx expo prebuild --template expo-template-bare-minimum@50.0.43`',
   async () => {
     const projectRoot = await setupTestProjectWithOptionsAsync('basic-prebuild', 'with-blank');
 
     const npmTemplatePackage = 'expo-template-bare-minimum@50.0.43';
-    await execa(
-      'node',
-      [bin, 'prebuild', '--no-install', '--template', `npm:${npmTemplatePackage}`],
-      {
-        cwd: projectRoot,
-      }
-    );
+    await execa('node', [bin, 'prebuild', '--no-install', '--template', npmTemplatePackage], {
+      cwd: projectRoot,
+    });
 
     // List output files with sizes for snapshotting.
     // This is to make sure that any changes to the output are intentional.

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -38,7 +38,7 @@ export const expoPrebuild: Command = async (argv) => {
         chalk`--yarn                                   Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
         chalk`--bun                                    Use bun to install dependencies. {dim Default when bun.lockb exists}`,
         chalk`--pnpm                                   Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
-        `--template <template>                    Project template to clone from. File path pointing to a local tar file or a github repo`,
+        chalk`--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package {dim (\`npm:\{package\}\`)} or a github repo`,
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
         `-h, --help                               Usage info`,

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -38,7 +38,7 @@ export const expoPrebuild: Command = async (argv) => {
         chalk`--yarn                                   Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
         chalk`--bun                                    Use bun to install dependencies. {dim Default when bun.lockb exists}`,
         chalk`--pnpm                                   Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
-        chalk`--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package {dim (\`npm:\{package\}\`)} or a github repo`,
+        `--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo`,
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
         `-h, --help                               Usage info`,

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -128,6 +128,15 @@ export async function resolveTemplateArgAsync(
 ): Promise<string> {
   assert(template, 'template is required');
 
+  if (template.startsWith('npm:')) {
+    const templatePackageName = template.substring('npm:'.length);
+    Log.log(`Running prebuild with template from npm package: ${chalk.cyan(templatePackageName)}`);
+    return await downloadAndExtractNpmModuleAsync(templatePackageName, {
+      cwd: templateDirectory,
+      name: appName,
+    });
+  }
+
   let repoUrl: URL | undefined;
 
   try {

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -1,15 +1,13 @@
 import { ExpoConfig } from '@expo/config';
-import assert from 'assert';
 import chalk from 'chalk';
-import fs from 'fs';
 import { Ora } from 'ora';
-import path from 'path';
 import semver from 'semver';
 
+import { type ResolvedTemplateOption } from './resolveOptions';
 import { fetchAsync } from '../api/rest/client';
 import * as Log from '../log';
 import { createGlobFilter } from '../utils/createFileTransform';
-import { AbortCommandError, CommandError } from '../utils/errors';
+import { AbortCommandError } from '../utils/errors';
 import {
   ExtractProps,
   downloadAndExtractNpmModuleAsync,
@@ -34,12 +32,28 @@ export async function cloneTemplateAsync({
   ora,
 }: {
   templateDirectory: string;
-  template?: string;
+  template?: ResolvedTemplateOption;
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
   ora: Ora;
 }): Promise<string> {
   if (template) {
-    return await resolveTemplateArgAsync(templateDirectory, ora, exp.name, template);
+    const appName = exp.name;
+    const { type, uri } = template;
+    if (type === 'file') {
+      return await extractLocalNpmTarballAsync(uri, {
+        cwd: templateDirectory,
+        name: appName,
+      });
+    } else if (type === 'npm') {
+      return await downloadAndExtractNpmModuleAsync(uri, {
+        cwd: templateDirectory,
+        name: appName,
+      });
+    } else if (type === 'repository') {
+      return await resolveAndDownloadRepoTemplateAsync(templateDirectory, ora, appName, uri);
+    } else {
+      throw new Error(`Unknown template type: ${type}`);
+    }
   } else {
     const templatePackageName = await getTemplateNpmPackageName(exp.sdkVersion);
     return await downloadAndExtractNpmModuleAsync(templatePackageName, {
@@ -119,24 +133,13 @@ async function downloadAndExtractRepoAsync(
   return await extractNpmTarballFromUrlAsync(url, { ...props, strip, filter });
 }
 
-export async function resolveTemplateArgAsync(
+async function resolveAndDownloadRepoTemplateAsync(
   templateDirectory: string,
   oraInstance: Ora,
   appName: string,
   template: string,
   templatePath?: string
-): Promise<string> {
-  assert(template, 'template is required');
-
-  if (template.startsWith('npm:')) {
-    const templatePackageName = template.substring('npm:'.length);
-    Log.log(`Running prebuild with template from npm package: ${chalk.cyan(templatePackageName)}`);
-    return await downloadAndExtractNpmModuleAsync(templatePackageName, {
-      cwd: templateDirectory,
-      name: appName,
-    });
-  }
-
+) {
   let repoUrl: URL | undefined;
 
   try {
@@ -147,23 +150,11 @@ export async function resolveTemplateArgAsync(
       throw error;
     }
   }
-
-  // On Windows, we can actually create a URL from a local path
-  // Double-check if the created URL is not a path to avoid mixing up URLs and paths
-  if (process.platform === 'win32' && repoUrl && path.isAbsolute(repoUrl.toString())) {
-    repoUrl = undefined;
-  }
-
   if (!repoUrl) {
-    const templatePath = path.resolve(template);
-    if (!fs.existsSync(templatePath)) {
-      throw new CommandError(`template file does not exist: ${templatePath}`);
-    }
-
-    return await extractLocalNpmTarballAsync(templatePath, {
-      cwd: templateDirectory,
-      name: appName,
-    });
+    oraInstance.fail(
+      `Invalid URL: ${chalk.red(`"${template}"`)}. Please use a valid URL and try again.`
+    );
+    throw new AbortCommandError();
   }
 
   if (repoUrl.origin !== 'https://github.com') {

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 
 import { copyTemplateFiles, createCopyFilesSuccessMessage } from './copyTemplateFiles';
 import { getTemplateFilesToRenameAsync, renameTemplateAppNameAsync } from './renameTemplateAppName';
+import { type ResolvedTemplateOption } from './resolveOptions';
 import { cloneTemplateAsync } from './resolveTemplate';
 import { DependenciesModificationResults, updatePackageJSONAsync } from './updatePackageJson';
 import { validateTemplatePlatforms } from './validateTemplatePlatforms';
@@ -32,8 +33,8 @@ export async function updateFromTemplateAsync(
     exp: ExpoConfig;
     /** package.json as JSON */
     pkg: PackageJSONConfig;
-    /** Template reference ID. */
-    template?: string;
+    /** Template to clone from. */
+    template?: ResolvedTemplateOption;
     /** Directory to write the template to before copying into the project. */
     templateDirectory?: string;
     /** List of platforms to clone. */
@@ -92,7 +93,7 @@ export async function cloneTemplateAndCopyToProjectAsync({
 }: {
   projectRoot: string;
   templateDirectory: string;
-  template?: string;
+  template?: ResolvedTemplateOption;
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
   platforms: ModPlatform[];
 }): Promise<{ copiedPaths: string[]; templateChecksum: string }> {


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/issues/31023#issuecomment-2297880141 to add prebuild to download template from npm.

# How

add `npx expo prebuild --template expo-template-bare-minimum@{version}` support

# Test Plan

add e2e test to run `npx expo prebuild --template expo-template-bare-minimum@50.0.43`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
