### PR TITLE
feat(dom): enable standard scrolling by default

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Enable normal scrolling in DOM components by default on iOS.
 - Add prototype members `set`, `delete`, `get`, `has`, `forEach`, `entries`, `keys`, `values`, `[Symbol.iterator]` to global `FormData` on native. ([#31117](https://github.com/expo/expo/pull/31117) by [@EvanBacon](https://github.com/EvanBacon))
 - Polyfill `Symbol.asyncIterator` on native. ([#31127](https://github.com/expo/expo/pull/31127) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and `expo/dom` module. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Enable normal scrolling in DOM components by default on iOS.
+- Enable normal scrolling in DOM components by default on iOS. ([#31197](https://github.com/expo/expo/pull/31197) by [@EvanBacon](https://github.com/EvanBacon))
 - Add prototype members `set`, `delete`, `get`, `has`, `forEach`, `entries`, `keys`, `values`, `[Symbol.iterator]` to global `FormData` on native. ([#31117](https://github.com/expo/expo/pull/31117) by [@EvanBacon](https://github.com/EvanBacon))
 - Polyfill `Symbol.asyncIterator` on native. ([#31127](https://github.com/expo/expo/pull/31127) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and `expo/dom` module. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/build/dom/webview-wrapper.d.ts.map
+++ b/packages/expo/build/dom/webview-wrapper.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"webview-wrapper.d.ts","sourceRoot":"","sources":["../../src/dom/webview-wrapper.tsx"],"names":[],"mappings":"AACA,OAAO,KAAK,MAAM,OAAO,CAAC;AA2B1B,QAAA,MAAM,UAAU,kFAsHd,CAAC;AAaH,eAAe,UAAU,CAAC"}
+{"version":3,"file":"webview-wrapper.d.ts","sourceRoot":"","sources":["../../src/dom/webview-wrapper.tsx"],"names":[],"mappings":"AACA,OAAO,KAAK,MAAM,OAAO,CAAC;AA2B1B,QAAA,MAAM,UAAU,kFAwHd,CAAC;AAaH,eAAe,UAAU,CAAC"}

--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -64,6 +64,8 @@ const RawWebView = React.forwardRef(({ dom, source, ...marshalProps }: any, ref)
   return (
     <WebView
       webviewDebuggingEnabled={__DEV__}
+      // Make iOS scrolling feel native.
+      decelerationRate="normal"
       originWhitelist={['*']}
       allowFileAccess
       allowFileAccessFromFileURLs


### PR DESCRIPTION
# Why

- Unclear why this isn't the default in RNWebView, scrolling feels much more native with normal deceleration.

# Test Plan

- Change default, build on to physical device, scrolling feels native again.