### PR TITLE
[notifications] remove toLegacyPromise

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Exceptions.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/Exceptions.kt
@@ -7,16 +7,3 @@ class ModuleNotFoundException(moduleClass: KClass<*>) :
   CodedException(message = "$moduleClass module not found")
 
 class NotificationWasAlreadyHandledException(val id: String) : CodedException("Failed to handle notification $id, it has already been handled.")
-
-fun expo.modules.kotlin.Promise.toLegacyPromise(): expo.modules.core.Promise {
-  val newPromise = this
-  return object : expo.modules.core.Promise {
-    override fun resolve(value: Any?) {
-      newPromise.resolve(value)
-    }
-
-    override fun reject(c: String?, m: String?, e: Throwable?) {
-      newPromise.reject(c ?: "unknown", m, e)
-    }
-  }
-}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
@@ -13,7 +13,6 @@ import expo.modules.notifications.notifications.interfaces.NotificationListener
 import expo.modules.notifications.notifications.interfaces.NotificationManager
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationBehavior
-import expo.modules.notifications.toLegacyPromise
 
 class NotificationBehaviourRecord : Record {
   @Field
@@ -102,7 +101,7 @@ open class NotificationsHandler : Module(), NotificationListener {
     with(behavior) {
       task.handleResponse(
         NotificationBehavior(shouldShowAlert, shouldPlaySound, shouldSetBadge, priority),
-        promise.toLegacyPromise()
+        promise
       )
     }
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
@@ -5,7 +5,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.ResultReceiver;
 
-import expo.modules.core.Promise;
+import expo.modules.kotlin.Promise;
 import expo.modules.core.interfaces.services.EventEmitter;
 import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.model.Notification;
@@ -98,7 +98,7 @@ public class SingleNotificationHandlerTask {
           protected void onReceiveResult(int resultCode, Bundle resultData) {
             super.onReceiveResult(resultCode, resultData);
             if (resultCode == NotificationsService.SUCCESS_CODE) {
-              promise.resolve(null);
+              promise.resolve();
             } else {
               Exception e = (Exception) resultData.getSerializable(NotificationsService.EXCEPTION_KEY);
               promise.reject("ERR_NOTIFICATION_PRESENTATION_FAILED", "Notification presentation failed.", e);


### PR DESCRIPTION
# Why

to remove the legacy promise

# How

removed the `toLegacyPromise` bcs it wasn't needed

# Test Plan

given:

```
    expo-notifications.setNotificationHandler({
      handleNotification: async (notification) => {
        console.log({
          handleNotification: JSON.stringify(notification),
        });
        return {
          shouldShowAlert: true,
          shouldPlaySound: true,
          shouldSetBadge: false,
        };
      },
      handleSuccess: (id) => {
        console.log(`Notification handled successfully: ${id}`);
      },
    })
```

`handleSuccess` is still called from [here](https://github.com/expo/expo/blob/a519ed742bad04f8ca3b6347b41800f05100dfb2/packages/expo-notifications/src/NotificationsHandler.ts#L112). It wouldn't be the case if the change didn't work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
