### PR TITLE
[docs][notifications] Add Android and iOS notification object examples

### DIFF
--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -4,6 +4,7 @@ description: Learn how to respond to a notification received by your app and tak
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { CODE } from '~/ui/components/Text';
 
 The [`expo-notifications`](/versions/latest/sdk/notifications) library contains event listeners that handle how your app responds when receiving a notification.
 
@@ -36,12 +37,12 @@ useEffect(() => {
 }, []);
 ```
 
-<Collapsible summary="Android Notification Object Example from addNotificationReceivedListener">
+<Collapsible summary={<>Android notification object example from <CODE>addNotificationReceivedListener</CODE></>}>
 
-Here's a sample of the notification object received by the callback function when using `Notifications.addNotificationReceivedListener`:
+Sample of the `notification` object received by the callback function when using `Notifications.addNotificationReceivedListener`:
 
-```jsx
-console.log(notification);
+```json
+// console.log(notification);
 {
   "request": {
     "trigger": {
@@ -116,9 +117,12 @@ console.log(notification);
   },
   "date": 1724782348210
 }
+```
 
-// You can access the notification custom data as follows:
-console.log(notification.request.content.data);
+You can directly access the notification custom data by logging the `notification.request.content.data` object:
+
+```json
+// console.log(notification.request.content.data);
 {
   "senderId": "user123",
   "senderName": "John Doe",
@@ -131,12 +135,12 @@ console.log(notification.request.content.data);
 
 </Collapsible>
 
-<Collapsible summary="iOS Notification Object Example from addNotificationReceivedListener">
+<Collapsible summary={<>iOS notification object example from <CODE>addNotificationReceivedListener</CODE></>}>
 
-Here's a sample of the notification object received by the callback function when using `Notifications.addNotificationReceivedListener`:
+Sample of the `notification` object received by the callback function when using `Notifications.addNotificationReceivedListener`:
 
-```jsx
-console.log(notification);
+```json
+// console.log(notification);
 {
   "request": {
     "trigger": {
@@ -195,9 +199,12 @@ console.log(notification);
   },
   "date": 1724798493.0589335
 }
+```
 
-// You can access the notification custom data as follows:
-console.log(notification.request.content.data);
+You can directly access the notification custom data by logging the `notification.request.content.data` object:
+
+```json
+// console.log(notification.request.content.data);
 {
   "senderId": "user123",
   "senderName": "John Doe",

--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -3,6 +3,8 @@ title: Receive notifications
 description: Learn how to respond to a notification received by your app and take action based on the event.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
+
 The [`expo-notifications`](/versions/latest/sdk/notifications) library contains event listeners that handle how your app responds when receiving a notification.
 
 ## Notification event listeners
@@ -33,6 +35,180 @@ useEffect(() => {
   };
 }, []);
 ```
+
+<Collapsible summary="Android Notification Object Example from addNotificationReceivedListener">
+
+Here's a sample of the notification object received by the callback function when using `Notifications.addNotificationReceivedListener`:
+
+```jsx
+console.log(notification);
+{
+  "request": {
+    "trigger": {
+      "remoteMessage": {
+        "originalPriority": 2,
+        "sentTime": 1724782348210,
+        "notification": {
+          "usesDefaultVibrateSettings": false,
+          "color": null,
+          "channelId": null,
+          "visibility": null,
+          "sound": null,
+          "tag": null,
+          "bodyLocalizationArgs": null,
+          "imageUrl": null,
+          "title": "Chat App",
+          "ticker": null,
+          "eventTime": null,
+          "body": "New message from John Doe",
+          "titleLocalizationKey": null,
+          "notificationPriority": null,
+          "icon": null,
+          "usesDefaultLightSettings": false,
+          "sticky": false,
+          "link": null,
+          "titleLocalizationArgs": null,
+          "bodyLocalizationKey": null,
+          "usesDefaultSound": false,
+          "clickAction": null,
+          "localOnly": false,
+          "lightSettings": null,
+          "notificationCount": null
+        },
+        "data": {
+          "channelId": "default",
+          "message": "New message from John Doe",
+          "title": "Chat App",
+          "body": "{\"senderId\":\"user123\",\"senderName\":\"John Doe\",\"messageId\":\"msg789\",\"conversationId\":\"conversation-456\",\"messageType\":\"text\",\"timestamp\":1724766427}",
+          "scopeKey": "@betoatexpo/expo-notifications-app",
+          "experienceId": "@betoatexpo/expo-notifications-app",
+          "projectId": "51092087-87a4-4b12-8008-145625477434"
+        },
+        "to": null,
+        "ttl": 0,
+        "collapseKey": "dev.expo.notificationsapp",
+        "messageType": null,
+        "priority": 2,
+        "from": "115310547649",
+        "messageId": "0:1724782348220771%0f02879c0f02879c"
+      },
+      "channelId": "default",
+      "type": "push"
+    },
+    "content": {
+      "autoDismiss": true,
+      "title": "Chat App",
+      "badge": null,
+      "sticky": false,
+      "sound": "default",
+      "body": "New message from John Doe",
+      "subtitle": null,
+      "data": {
+        "senderId": "user123",
+        "senderName": "John Doe",
+        "messageId": "msg789",
+        "conversationId": "conversation-456",
+        "messageType": "text",
+        "timestamp": 1724766427
+      }
+    },
+    "identifier": "0:1724782348220771%0f02879c0f02879c"
+  },
+  "date": 1724782348210
+}
+
+// You can access the notification custom data as follows:
+console.log(notification.request.content.data);
+{
+  "senderId": "user123",
+  "senderName": "John Doe",
+  "messageId": "msg789",
+  "conversationId": "conversation-456",
+  "messageType": "text",
+  "timestamp": 1724766427
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="iOS Notification Object Example from addNotificationReceivedListener">
+
+Here's a sample of the notification object received by the callback function when using `Notifications.addNotificationReceivedListener`:
+
+```jsx
+console.log(notification);
+{
+  "request": {
+    "trigger": {
+      "class": "UNPushNotificationTrigger",
+      "type": "push",
+      "payload": {
+        "experienceId": "@betoatexpo/expo-notifications-app",
+        "projectId": "51092087-87a4-4b12-8008-145625477434",
+        "scopeKey": "@betoatexpo/expo-notifications-app",
+        "aps": {
+          "thread-id": "",
+          "category": "",
+          "badge": 1,
+          "alert": {
+            "subtitle": "Hey there! How's your day going?",
+            "title": "Chat App",
+            "launch-image": "",
+            "body": "New message from John Doe"
+          },
+          "sound": "default"
+        },
+        "body": {
+          "messageId": "msg789",
+          "timestamp": 1724766427,
+          "messageType": "text",
+          "senderId": "user123",
+          "senderName": "John Doe",
+          "conversationId": "conversation-456"
+        }
+      }
+    },
+    "identifier": "3AEB849E-9059-4D09-BC3B-9A0B104CF062",
+    "content": {
+      "body": "New message from John Doe",
+      "sound": "default",
+      "launchImageName": "",
+      "badge": 1,
+      "subtitle": "Hey there! How's your day going?",
+      "title": "Chat App",
+      "data": {
+        "conversationId": "conversation-456",
+        "senderName": "John Doe",
+        "senderId": "user123",
+        "messageType": "text",
+        "timestamp": 1724766427,
+        "messageId": "msg789"
+      },
+      "summaryArgument": null,
+      "categoryIdentifier": "",
+      "attachments": [],
+      "interruptionLevel": "active",
+      "threadIdentifier": "",
+      "targetContentIdentifier": null,
+      "summaryArgumentCount": 0
+    }
+  },
+  "date": 1724798493.0589335
+}
+
+// You can access the notification custom data as follows:
+console.log(notification.request.content.data);
+{
+  "senderId": "user123",
+  "senderName": "John Doe",
+  "messageId": "msg789",
+  "conversationId": "conversation-456",
+  "messageType": "text",
+  "timestamp": 1724766427
+}
+```
+
+</Collapsible>
 
 For more information on these objects, see [`Notification`](/versions/latest/sdk/notifications/#notification) documentation.
 


### PR DESCRIPTION
# Why

The PR adds examples of notification objects for both Android and iOS platforms when using addNotificationReceivedListener. These examples highlight key structural differences: Android uses a nested structure with FCM-specific fields, while iOS has a flatter structure with APN-specific elements. 

# How

Create a [minimal expo notifications app](https://github.com/betomoedano/expo-notifications-app.git) integrating FCM v1, create development builds for Android and iOS using EAS

# Test Plan

Register both devices to receive push notifications, get the tokens, and trigger notifications using [Push Notification Tool](https://expo.dev/notifications)

Paste notification object examples and run docs locally.

<img width="1487" alt="image" src="https://github.com/user-attachments/assets/02dfce45-2b7d-4baa-9bbc-5348c45f1f83">

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/054d1e33-d083-4807-ba9d-6f420311d444">

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/7b52e7da-6ec6-4883-ae8f-34606c6f0cd2">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
