### PR TITLE
[iOS][core] Use JS values directly instead of shared pointers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -69,6 +69,7 @@
 - [Android] Supports passing `Accept: text/event-stream` header to bypass streaming requests from `ExpoNetworkInspectOkHttpInterceptors`. ([#30219](https://github.com/expo/expo/pull/30219) by [@kudo](https://github.com/kudo))
 - Replaced `@testing-library/react-hooks` with `@testing-library/react-native`. ([#30742](https://github.com/expo/expo/pull/30742) by [@byCedric](https://github.com/byCedric))
 - Cleaned up the podspec and replaced `RN_FABRIC_ENABLED` flag with `RCT_NEW_ARCH_ENABLED`. ([#31044](https://github.com/expo/expo/pull/31044) by [@tsapeta](https://github.com/tsapeta))
+- JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -70,7 +70,7 @@ jsi::Value createUint8Array(jsi::Runtime &runtime, NSData *data) {
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
 {
   if ([value isKindOfClass:[EXJavaScriptValue class]]) {
-    return jsi::Value(runtime, *[(EXJavaScriptValue *)value get]);
+    return [(EXJavaScriptValue *)value get];
   }
   if ([value isKindOfClass:[EXJavaScriptObject class]]) {
     return jsi::Value(runtime, *[(EXJavaScriptObject *)value get]);
@@ -120,8 +120,8 @@ NSArray<EXJavaScriptValue *> *convertJSIValuesToNSArray(EXJavaScriptRuntime *run
   jsi::Runtime *jsiRuntime = [runtime get];
 
   for (int i = 0; i < count; i++) {
-    std::shared_ptr<jsi::Value> value = std::make_shared<jsi::Value>(*jsiRuntime, values[i]);
-    array[i] = [[EXJavaScriptValue alloc] initWithRuntime:runtime value:value];
+    array[i] = [[EXJavaScriptValue alloc] initWithRuntime:runtime
+                                                    value:jsi::Value(*jsiRuntime, values[i])];
   }
   return array;
 }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -52,8 +52,8 @@
 
 - (nonnull EXJavaScriptValue *)getProperty:(nonnull NSString *)name
 {
-  std::shared_ptr<jsi::Value> value = std::make_shared<jsi::Value>(_jsObjectPtr->getProperty(*[_runtime get], [name UTF8String]));
-  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime value:value];
+  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime
+                                              value:_jsObjectPtr->getProperty(*[_runtime get], [name UTF8String])];
 }
 
 - (nonnull NSArray<NSString *> *)getPropertyNames
@@ -111,7 +111,7 @@
   if ([object isKindOfClass:EXJavaScriptObject.class]) {
     jsi::Runtime *runtime = [_runtime get];
     jsi::Object *a = _jsObjectPtr.get();
-    jsi::Object *b = [object get];
+    jsi::Object *b = [(EXJavaScriptObject *)object get];
     return jsi::Object::strictEquals(*runtime, *a, *b);
   }
   return false;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -110,7 +110,7 @@
       EXJavaScriptValue *result = block(thisValue, arguments, &error);
 
       if (error == nil) {
-        return jsi::Value(runtime, *[result get]);
+        return [result get];
       } else {
         // `expo::makeCodedError` doesn't work during unit tests, so we construct Error and add a code,
         // instead of using the CodedError subclass.
@@ -203,10 +203,10 @@
 - (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource
 {
   std::shared_ptr<jsi::StringBuffer> scriptBuffer = std::make_shared<jsi::StringBuffer>([scriptSource UTF8String]);
-  std::shared_ptr<jsi::Value> result;
+  jsi::Value result;
 
   try {
-    result = std::make_shared<jsi::Value>(_runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"));
+    result = _runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>");
   } catch (jsi::JSError &error) {
     NSString *reason = [NSString stringWithUTF8String:error.getMessage().c_str()];
     NSString *stack = [NSString stringWithUTF8String:error.getStack().c_str()];
@@ -222,7 +222,7 @@
       @"message": reason
     }];
   }
-  return [[EXJavaScriptValue alloc] initWithRuntime:self value:result];
+  return [[EXJavaScriptValue alloc] initWithRuntime:self value:std::move(result)];
 }
 
 #pragma mark - Runtime execution
@@ -251,8 +251,7 @@
     // there is no need to care about that for synchronous calls, so it's ensured in `createAsyncFunction` instead.
     auto callInvoker = weakCallInvoker.lock();
     NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
-    std::shared_ptr<jsi::Value> thisValPtr = std::make_shared<jsi::Value>(runtime, std::move(thisVal));
-    EXJavaScriptValue *thisValue = [[EXJavaScriptValue alloc] initWithRuntime:self value:thisValPtr];
+    EXJavaScriptValue *thisValue = [[EXJavaScriptValue alloc] initWithRuntime:self value:jsi::Value(runtime, thisVal)];
 
     return block(runtime, callInvoker, thisValue, arguments);
   };

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -20,12 +20,12 @@ NS_SWIFT_NAME(JavaScriptValue)
 
 #ifdef __cplusplus
 - (nonnull instancetype)initWithRuntime:(nullable EXJavaScriptRuntime *)runtime
-                                  value:(std::shared_ptr<jsi::Value>)value;
+                                  value:(jsi::Value)value;
 
 /**
- \return the underlying `jsi::Value`.
+ Returns a copy of the underlying `jsi::Value`.
  */
-- (nonnull jsi::Value *)get;
+- (jsi::Value)get;
 #endif // __cplusplus
 
 #pragma mark - Type checking

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -9,75 +9,79 @@
 
 @implementation EXJavaScriptValue {
   __weak EXJavaScriptRuntime *_runtime;
-  std::shared_ptr<jsi::Value> _value;
+
+  /**
+   The underlying JS value of which the `JavaScriptValue` is the only owner.
+   */
+  jsi::Value _value;
 }
 
 - (nonnull instancetype)initWithRuntime:(nullable EXJavaScriptRuntime *)runtime
-                                  value:(std::shared_ptr<jsi::Value>)value
+                                  value:(jsi::Value)value
 {
   if (self = [super init]) {
     _runtime = runtime;
-    _value = value;
+    _value = std::move(value);
   }
   return self;
 }
 
-- (nonnull jsi::Value *)get
+- (jsi::Value)get
 {
-  return _value.get();
+  return jsi::Value(*[_runtime get], _value);
 }
 
 #pragma mark - Type checking
 
 - (BOOL)isUndefined
 {
-  return _value->isUndefined();
+  return _value.isUndefined();
 }
 
 - (BOOL)isNull
 {
-  return _value->isNull();
+  return _value.isNull();
 }
 
 - (BOOL)isBool
 {
-  return _value->isBool();
+  return _value.isBool();
 }
 
 - (BOOL)isNumber
 {
-  return _value->isNumber();
+  return _value.isNumber();
 }
 
 - (BOOL)isString
 {
-  return _value->isString();
+  return _value.isString();
 }
 
 - (BOOL)isSymbol
 {
-  return _value->isSymbol();
+  return _value.isSymbol();
 }
 
 - (BOOL)isObject
 {
-  return _value->isObject();
+  return _value.isObject();
 }
 
 - (BOOL)isFunction
 {
-  if (_value->isObject()) {
+  if (_value.isObject()) {
     jsi::Runtime *runtime = [_runtime get];
-    return _value->getObject(*runtime).isFunction(*runtime);
+    return _value.getObject(*runtime).isFunction(*runtime);
   }
   return false;
 }
 
 - (BOOL)isTypedArray
 {
-  if (_value->isObject()) {
+  if (_value.isObject()) {
     jsi::Runtime *runtime = [_runtime get];
-    return expo::isTypedArray(*runtime, _value->getObject(*runtime));
+    return expo::isTypedArray(*runtime, _value.getObject(*runtime));
   }
   return false;
 }
@@ -86,34 +90,34 @@
 
 - (nullable id)getRaw
 {
-  return expo::convertJSIValueToObjCObject(*[_runtime get], *_value, [_runtime callInvoker]);
+  return expo::convertJSIValueToObjCObject(*[_runtime get], _value, [_runtime callInvoker]);
 }
 
 - (BOOL)getBool
 {
-  return _value->getBool();
+  return _value.getBool();
 }
 
 - (NSInteger)getInt
 {
-  return _value->getNumber();
+  return _value.getNumber();
 }
 
 - (double)getDouble
 {
-  return _value->getNumber();
+  return _value.getNumber();
 }
 
 - (nonnull NSString *)getString
 {
   jsi::Runtime *runtime = [_runtime get];
-  return expo::convertJSIStringToNSString(*runtime, _value->getString(*runtime));
+  return expo::convertJSIStringToNSString(*runtime, _value.getString(*runtime));
 }
 
 - (nonnull NSArray<EXJavaScriptValue *> *)getArray
 {
   jsi::Runtime *runtime = [_runtime get];
-  jsi::Array jsiArray = _value->getObject(*runtime).getArray(*runtime);
+  jsi::Array jsiArray = _value.getObject(*runtime).getArray(*runtime);
   size_t arraySize = jsiArray.size(*runtime);
   NSMutableArray *result = [NSMutableArray arrayWithCapacity:arraySize];
 
@@ -123,8 +127,7 @@
     if (item.isUndefined() || item.isNull()) {
       [result addObject:(id)kCFNull];
     } else {
-      std::shared_ptr<jsi::Value> valuePtr = std::make_shared<jsi::Value>(*runtime, item);
-      [result addObject:[[EXJavaScriptValue alloc] initWithRuntime:_runtime value:valuePtr]];
+      [result addObject:[[EXJavaScriptValue alloc] initWithRuntime:_runtime value:std::move(item)]];
     }
   }
   return result;
@@ -133,20 +136,20 @@
 - (nonnull NSDictionary<NSString *, id> *)getDictionary
 {
   jsi::Runtime *runtime = [_runtime get];
-  return expo::convertJSIObjectToNSDictionary(*runtime, _value->getObject(*runtime), [_runtime callInvoker]);
+  return expo::convertJSIObjectToNSDictionary(*runtime, _value.getObject(*runtime), [_runtime callInvoker]);
 }
 
 - (nonnull EXJavaScriptObject *)getObject
 {
   jsi::Runtime *runtime = [_runtime get];
-  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
+  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value.asObject(*runtime));
   return [[EXJavaScriptObject alloc] initWith:objectPtr runtime:_runtime];
 }
 
 - (nonnull EXRawJavaScriptFunction *)getFunction
 {
   jsi::Runtime *runtime = [_runtime get];
-  std::shared_ptr<jsi::Function> functionPtr = std::make_shared<jsi::Function>(_value->asObject(*runtime).asFunction(*runtime));
+  std::shared_ptr<jsi::Function> functionPtr = std::make_shared<jsi::Function>(_value.asObject(*runtime).asFunction(*runtime));
   return [[EXRawJavaScriptFunction alloc] initWith:functionPtr runtime:_runtime];
 }
 
@@ -156,7 +159,7 @@
     return nil;
   }
   jsi::Runtime *runtime = [_runtime get];
-  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
+  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value.asObject(*runtime));
   return [[EXJavaScriptTypedArray alloc] initWith:objectPtr runtime:_runtime];
 }
 
@@ -165,7 +168,7 @@
 - (nonnull NSString *)toString
 {
   jsi::Runtime *runtime = [_runtime get];
-  return expo::convertJSIStringToNSString(*runtime, _value->toString(*runtime));
+  return expo::convertJSIStringToNSString(*runtime, _value.toString(*runtime));
 }
 
 #pragma mark - Static properties
@@ -173,27 +176,26 @@
 + (nonnull EXJavaScriptValue *)undefined
 {
   auto undefined = std::make_shared<jsi::Value>();
-  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:undefined];
+  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:jsi::Value::undefined()];
 }
 
 + (nonnull EXJavaScriptValue *)number:(double)value
 {
-  auto number = std::make_shared<jsi::Value>(value);
-  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:number];
+  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:jsi::Value(value)];
 }
 
 + (nonnull EXJavaScriptValue *)string:(nonnull NSString *)value runtime:(nonnull EXJavaScriptRuntime *)runtime
 {
   jsi::Runtime *jsiRuntime = [runtime get];
-  auto string = std::make_shared<jsi::Value>(jsi::String::createFromUtf8(*jsiRuntime, [value UTF8String]));
-  return [[EXJavaScriptValue alloc] initWithRuntime:runtime value:string];
+  return [[EXJavaScriptValue alloc] initWithRuntime:runtime
+                                              value:jsi::String::createFromUtf8(*jsiRuntime, [value UTF8String])];
 }
 
 + (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime
 {
   jsi::Runtime *jsiRuntime = [runtime get];
-  auto jsiValue = std::make_shared<jsi::Value>(*jsiRuntime, expo::convertObjCObjectToJSIValue(*jsiRuntime, value));
-  return [[EXJavaScriptValue alloc] initWithRuntime:runtime value:jsiValue];
+  return [[EXJavaScriptValue alloc] initWithRuntime:runtime
+                                              value:expo::convertObjCObjectToJSIValue(*jsiRuntime, value)];
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.mm
+++ b/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.mm
@@ -45,8 +45,7 @@
     result = _function->call(*runtime, data, arguments.count);
   }
 
-  std::shared_ptr<jsi::Value> resultPtr = std::make_shared<jsi::Value>(*runtime, result);
-  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime value:resultPtr];
+  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime value:std::move(result)];
 }
 
 @end


### PR DESCRIPTION
# Why

We don't really need to use shared pointers for `jsi::Value` in `EXJavaScriptValue` class. Shared pointers have some additional impact that we can get rid of.

# How

In the `EXJavaScriptValue` class, used `jsi::Value` directly instead of `std::shared_ptr<jsi::Value>` to avoid some overhead brought by shared pointers. Now it's also clear that instances of this class are the only owners of the underlying value. Thus, `get` function no longer returns the stored pointer, but does an explicit copy of the value.

# Test Plan

Native unit tests passed. I went through some examples in NCL and ran some test-suite tests, it all looks good.