### PR TITLE
[iOS][core] Use singletons for string and data dynamic types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Replaced `@testing-library/react-hooks` with `@testing-library/react-native`. ([#30742](https://github.com/expo/expo/pull/30742) by [@byCedric](https://github.com/byCedric))
 - Cleaned up the podspec and replaced `RN_FABRIC_ENABLED` flag with `RCT_NEW_ARCH_ENABLED`. ([#31044](https://github.com/expo/expo/pull/31044) by [@tsapeta](https://github.com/tsapeta))
 - JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Use singletons for string and data dynamic types. ([#31220](https://github.com/expo/expo/pull/31220) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
@@ -87,7 +87,7 @@ extension CGFloat: AnyArgument {
 
 extension String: AnyArgument {
   public static func getDynamicType() -> any AnyDynamicType {
-    return DynamicStringType()
+    return DynamicStringType.shared
   }
 }
 
@@ -111,6 +111,6 @@ extension Array: AnyArgument {
 
 extension Data: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {
-    return DynamicDataType()
+    return DynamicDataType.shared
   }
 }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDataType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDataType.swift
@@ -4,6 +4,8 @@
  A dynamic type representing Swift `Data` or Objective-C `NSData` type and backing by JavaScript `Uint8Array`.
  */
 internal struct DynamicDataType: AnyDynamicType {
+  static let shared = DynamicDataType()
+
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return InnerType.self == Data.self
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicStringType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicStringType.swift
@@ -1,6 +1,8 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
 internal struct DynamicStringType: AnyDynamicType {
+  static let shared = DynamicStringType()
+
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return type == String.self
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -15,7 +15,7 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
     return DynamicNumberType(numberType: T.self)
   }
   if type is String.Type {
-    return DynamicStringType()
+    return DynamicStringType.shared
   }
   if let ArrayType = T.self as? AnyArray.Type {
     return DynamicArrayType(elementType: ArrayType.getElementDynamicType())
@@ -41,8 +41,8 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let TypedArrayType = T.self as? AnyTypedArray.Type {
     return DynamicTypedArrayType(innerType: TypedArrayType)
   }
-  if let DataType = T.self as? Data.Type {
-    return DynamicDataType()
+  if T.self is Data.Type {
+    return DynamicDataType.shared
   }
   if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
     return DynamicJavaScriptType(innerType: JavaScriptValueType)


### PR DESCRIPTION
# Why

We can use shared instance for `DynamicStringType` and `DynamicDataType` as they are not generic. It reduces a number of dynamic types we need to create for arguments on startup and for the returned values during a function call.
Swift doesn't support static stored properties in generic types, so doing this in other dynamic types requires more work.

# How

Added `shared` static property to `DynamicStringType` and `DynamicDataType` and confirmed that only one object is created for the type (instead of more than 30 for strings).

# Test Plan

Ensured it works fine in my benchmarks and also tested it against some test-suite tests