### PR TITLE
[iOS][network] Fix getting IP address from USB-C ethernet interfaces

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Fix `java.lang.IllegalArgumentException: NetworkCallback was not registered`. ([#30185](https://github.com/expo/expo/pull/30185) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix wired ethernet connection being reported as unknown type. ([#30169](https://github.com/expo/expo/pull/30169) by [@Simek](https://github.com/Simek))
+- [iOS] Fix getting IP address from wired ethernet connection interfaces. ([#31223](https://github.com/expo/expo/pull/31223) by [@matt-oakes](https://github.com/matt-oakes))
 - Add missing `react` peer dependencies for isolated modules. ([#30477](https://github.com/expo/expo/pull/30477) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others

--- a/packages/expo-network/ios/NetworkModule.swift
+++ b/packages/expo-network/ios/NetworkModule.swift
@@ -68,7 +68,7 @@ public final class NetworkModule: Module {
 
       if family == UInt8(AF_INET) {
         let name = String(cString: temp.ifa_name)
-        if name == "en0" || name == "en1" {
+        if name.starts(with: "en") {
           var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
           getnameinfo(
             temp.ifa_addr,


### PR DESCRIPTION
# Why

Previously the code was checking for two specific interface names ("en0" and "en1") and only return IP addresses for these interfaces.

USB-C ethernet devices connected to an iOS device can have other valid interface names (such as "en5"). This can happen if multiple USB-C ethernet devices have been used in the past.

# How

We now just check if the interface name has the "en" prefix. This allows getting the IP address for USB-C ethernet interfaces with still ignoring the loopback interface ("lo0") and access point interfaces (prefixed with "ap").

[According to an Apple DevRel, the interface names are not actually considered an API](https://forums.developer.apple.com/forums/thread/49581?answerId=146613022#146613022). However, currently anything starting with `lo` is loopback, anything starting with `ap` is an access point, and anything starting with `en` is wifi/ethernet. I have continued the assumption the previous code was making, but made it work when there are more than 2 `en` interfaces, which seems common.

# Test Plan

I have tested with on my iPad running iPadOS 17.5.1 using an Anker USB-C adapter.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
