### PR TITLE
[iOS][core] Fix a bottleneck in enumerated() function

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Cleaned up the podspec and replaced `RN_FABRIC_ENABLED` flag with `RCT_NEW_ARCH_ENABLED`. ([#31044](https://github.com/expo/expo/pull/31044) by [@tsapeta](https://github.com/tsapeta))
 - JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use singletons for string and data dynamic types. ([#31220](https://github.com/expo/expo/pull/31220) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -71,7 +71,7 @@
 - Cleaned up the podspec and replaced `RN_FABRIC_ENABLED` flag with `RCT_NEW_ARCH_ENABLED`. ([#31044](https://github.com/expo/expo/pull/31044) by [@tsapeta](https://github.com/tsapeta))
 - JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use singletons for string and data dynamic types. ([#31220](https://github.com/expo/expo/pull/31220) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function.
+- [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function. ([#31226](https://github.com/expo/expo/pull/31226) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -26,13 +26,18 @@ public struct MainValueConverter {
    It **must** be run on the thread used by the JavaScript runtime.
    */
   public func toNative(_ values: [JavaScriptValue], _ types: [AnyDynamicType]) throws -> [Any] {
-    return try values.enumerated().map { index, value in
+    // While using `values.enumerated().map` sounds like a more straightforward approach,
+    // this code seems quite critical for performance and using a standard `map` performs much better.
+    var index = 0
+
+    return try values.map { value in
       let type = types[index]
+      index += 1
 
       do {
-        return try toNative(value, types[index])
+        return try toNative(value, type)
       } catch {
-        throw ArgumentCastException((index: index, type: type)).causedBy(error)
+        throw ArgumentCastException((index: index - 1, type: type)).causedBy(error)
       }
     }
   }


### PR DESCRIPTION
# Why

I identified that using the `enumerated()` function on the Swift array is quite slow and is a bottleneck in the performance-critical code that converts function arguments.

# How

Instead of using `enumerated()`, I used only a `map` and manually increment the index. Looks like it made function calls about 9% faster.

# Test Plan

Native tests and test-suite are passing