### PR TITLE
[doctor] fix bad check for build properties targetSdkVersion

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix error when `expo-build-properties` is present but `android` key is not. ([#31228](https://github.com/expo/expo/pull/31228) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.10.0 — 2024-08-27

--- a/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
+++ b/packages/expo-doctor/src/checks/StoreCompatibilityCheck.ts
@@ -46,7 +46,7 @@ export class StoreCompatibilityCheck implements DoctorCheck {
       if (
         buildPropertiesConfig &&
         buildPropertiesConfig.length > 1 &&
-        buildPropertiesConfig[1].android.targetSdkVersion <
+        buildPropertiesConfig[1].android?.targetSdkVersion <
           PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion
       ) {
         issue = `This project is using expo-build-properties to target Android API level ${PLAY_STORE_MINIMUM_REQS.AndroidSdkVersion - 1} or lower. `;

--- a/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/StoreCompatibilityCheck.test.ts
@@ -117,6 +117,36 @@ describe('runAsync', () => {
     expect(result.isSuccessful).toBeTruthy();
   });
 
+  it('returns result with isSuccessful = true if expo-build-properties plugin added but does not include android prop', async () => {
+    jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: {
+        ...expProjectProps,
+        sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0`,
+        plugins: [['expo-build-properties', { blah: 'blah' }]],
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = true if expo-build-properties plugin added, includes android prop, but not targetSdkVersion prop', async () => {
+    jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
+    const check = new StoreCompatibilityCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      exp: {
+        ...expProjectProps,
+        sdkVersion: `${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}.0.0`,
+        plugins: [['expo-build-properties', { android: { compileSdkVersion: 15 } }]],
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
   it(`returns result with isSuccessful = false if SDK <${PLAY_STORE_MINIMUM_REQS.ExpoSdkVersion}`, async () => {
     jest.mocked(existsAndIsNotIgnoredAsync).mockResolvedValue(false);
     const check = new StoreCompatibilityCheck();


### PR DESCRIPTION
# Why

Fixes: https://github.com/expo/expo/issues/31224

# How

- Use optional unwrapping of `android` key
- Add unit tests for this scenario

# Test Plan

- [x] Doctor check passes with `expo-build-properties` props that do not include `android` key
- [x] Doctor check passes with `expo-build-properties` props that include `android` key but not `targetSdkVersion`.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
