### PR TITLE
[templates] Set userInterfaceStyle to automatic on blank and typescript templates

### DIFF
--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",


### PR DESCRIPTION
# Why

Matches the `userInterfaceStyle` property in `app.json` for the `expo-template-blank` and `expo-template-blank-typescript` templates with the `expo-template-default` and `expo-template-tabs` templates to be consistent.

# How

When trying to add dark/light mode theming to expo app, that was generated using the `expo-template-blank-typescript` template, the `useColorScheme()` method was always returning "light" and not honoring the system's theme because the `userInterfaceStyle` in the app.json file was set to "light". The default `userInterfaceStyle` value should be consistent regardless of which template is used to generate a new expo app.

To fix it, I set the `userInterfaceStyle` property to "automatic" in the following templates:
- `expo-template-blank`
- `expo-template-blank-typescript`

# Test Plan

- run `yarn create expo ./blank-template-test --template ./templates/expo-template-blank`
- The generated `app.json` file should have:
  - `"userInterfaceStyle": "automatic"`

- run `yarn create expo ./typescript-template-test --template ./templates/expo-template-blank-typescript`
- The generated `app.json` file should have:
  - `"userInterfaceStyle": "automatic"`
 
# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
