### PR TITLE
[dev-menu][iOS] Fix loading local bundle for development

### DIFF
--- a/packages/expo-dev-menu/index.js
+++ b/packages/expo-dev-menu/index.js
@@ -1,0 +1,1 @@
+import './app/index';

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -55,7 +55,7 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
     #if DEBUG
     if let packagerHost = jsPackagerHost(),
       let url = RCTBundleURLProvider.jsBundleURL(
-        forBundleRoot: "index",
+        forBundleRoot: "packages/expo-dev-menu/index",
         packagerHost: packagerHost,
         enableDev: true,
         enableMinification: false,
@@ -76,9 +76,9 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
     }
     // Return `nil` if the content is not a valid URL.
     guard let content = try? String(contentsOfFile: packagerHostPath, encoding: String.Encoding.utf8).trimmingCharacters(in: CharacterSet.newlines),
-      let url = URL(string: content) else {
+      let url = URL(string: "http://\(content)") else {
       return nil
     }
-    return url.absoluteString
+    return "\(url.host ?? ""):\(url.port ?? 8081)"
   }
 }


### PR DESCRIPTION
# Why

Running `yarn start` inside `dev-menu` does not cause the app to load the menu bundle from the local bundler

# How

Fix loading local bundle for development by adding back the `index.js` that was removed in https://github.com/expo/expo/pull/30743 and update bundleRoot to `packages/expo-dev-menu/index` due to the metro workspace root changes of https://github.com/expo/expo/pull/30621 


# Test Plan

BareExpo iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
