### PR TITLE
[docs] Fix typo in installing-expo-modules.mdx

### DIFF
--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -222,11 +222,11 @@ index ff83531..bd8651d 100644
 
 - func application(\_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-* override func application(\_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
++ override func application(\_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
 - return true
 
-* super.application(application, didFinishLaunchingWithOptions: launchOptions)
++ super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
   `}
   />


### PR DESCRIPTION
# Why

There seems to be a typo in `installing-expo-modules.mdx`. Lines starting with `*` [are not displayed in docs](https://docs.expo.dev/brownfield/installing-expo-modules/#:~:text=(Optional)%20Complete%20the%20following%20if,ios/%3CMyAppProject%3E/AppDelegate.swift).  
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
