### PR TITLE
[video][ios] Bump media3 version to 1.4.0

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### 💡 Others
 
+- Bump media3 version to 1.4.0. ([#31239](https://github.com/expo/expo/pull/31239) by [@behenate](https://github.com/behenate))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.75.x. ([#30034](https://github.com/expo/expo/pull/30034) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
   implementation 'com.facebook.react:react-android'
 
-  def androidxMedia3Version = "1.3.1"
+  def androidxMedia3Version = "1.4.0"
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${androidxMedia3Version}"

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -21,6 +21,7 @@ android {
 dependencies {
   implementation 'com.facebook.react:react-android'
 
+  // Remember to keep this in sync with the version in `expo-audio`
   def androidxMedia3Version = "1.4.0"
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"


### PR DESCRIPTION
# Why

We should be up to date with the newest media3 version, also when `expo-audio` is at 1.4.0 and `expo-video` at 1.3.1 the VideoViews stops working at all for some reason

# How

Bumped the version in the build.gradle

# Test Plan

Tested in Android Simulator in Bare Expo

