### PR TITLE
[dev-launcher][iOS] Fix loading local bundle for development

### DIFF
--- a/packages/expo-dev-launcher/index.js
+++ b/packages/expo-dev-launcher/index.js
@@ -1,0 +1,1 @@
+import './bundle/index';

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -41,7 +41,7 @@
 #define VERSION @ STRINGIZE2(EX_DEV_LAUNCHER_VERSION)
 #endif
 
-#define EX_DEV_LAUNCHER_PACKAGER_PATH @"index.bundle?platform=ios&dev=true&minify=false"
+#define EX_DEV_LAUNCHER_PACKAGER_PATH @"packages/expo-dev-launcher/index.bundle?platform=ios&dev=true&minify=false"
 
 
 @interface EXDevLauncherController ()


### PR DESCRIPTION
# Why

Running `yarn start` inside `dev-launcher` does not cause the app to load the launcher bundle from the local bundler

# How

Fix loading local bundle for development by adding back the `index.js` that was removed in https://github.com/expo/expo/pull/30743 and update `EX_DEV_LAUNCHER_PACKAGER_PATH` to `packages/expo-dev-launcher/index` due to the metro workspace root changes of https://github.com/expo/expo/pull/30621 


# Test Plan

BareExpo iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
