### PR TITLE
fix(expo): ignore built in types

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- Add ts-ignore statements to make ts-jest work with polyfill.
 - Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 🐛 Bug fixes
 
-- Add ts-ignore statements to make ts-jest work with polyfill.
+- Add ts-ignore statements to make ts-jest work with polyfill. ([#31244](https://github.com/expo/expo/pull/31244) by [@EvanBacon](https://github.com/EvanBacon))
 - Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))

--- a/packages/expo/build/winter/FormData.d.ts.map
+++ b/packages/expo/build/winter/FormData.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"FormData.d.ts","sourceRoot":"","sources":["../../src/winter/FormData.ts"],"names":[],"mappings":"AA6BA,wBAAgB,oBAAoB,CAAC,QAAQ,EAAE,OAAO,QAAQ;;;EAoH7D"}
+{"version":3,"file":"FormData.d.ts","sourceRoot":"","sources":["../../src/winter/FormData.ts"],"names":[],"mappings":"AA6BA,wBAAgB,oBAAoB,CAAC,QAAQ,EAAE,OAAO,QAAQ;;;EAyH7D"}

--- a/packages/expo/src/winter/FormData.ts
+++ b/packages/expo/src/winter/FormData.ts
@@ -34,6 +34,7 @@ export function installFormDataPatch(formData: typeof FormData) {
     this._parts.push(normalizeArgs(name, value));
   };
 
+  // @ts-ignore: DOM.iterable is disabled for jest compat
   formData.prototype.set ??= function set(this: ReactNativeFormDataInternal, ...props) {
     ensureMinArgCount('set', props, 2);
     const [name, value] = props;
@@ -57,6 +58,7 @@ export function installFormDataPatch(formData: typeof FormData) {
     }
   };
 
+  // @ts-ignore: DOM.iterable is disabled for jest compat
   formData.prototype.delete ??= function (this: ReactNativeFormDataInternal, ...props) {
     ensureMinArgCount('delete', props, 1);
     let [name] = props;
@@ -69,6 +71,7 @@ export function installFormDataPatch(formData: typeof FormData) {
     }
   };
 
+  // @ts-ignore: DOM.iterable is disabled for jest compat
   formData.prototype.get ??= function (
     this: ReactNativeFormDataInternal,
     ...props
@@ -86,6 +89,7 @@ export function installFormDataPatch(formData: typeof FormData) {
     return null;
   };
 
+  // @ts-ignore: DOM.iterable is disabled for jest compat
   formData.prototype.has ??= function (this: ReactNativeFormDataInternal, ...props) {
     ensureMinArgCount('has', props, 1);
     let [name] = props;
@@ -99,6 +103,7 @@ export function installFormDataPatch(formData: typeof FormData) {
   };
 
   // Required for RSC: https://github.com/facebook/react/blob/985747f81033833dca22f30b0c04704dd4bd3714/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js#L1056
+  // @ts-ignore: DOM.iterable is disabled for jest compat
   formData.prototype.forEach ??= function forEach(this: ReactNativeFormDataInternal, ...props) {
     ensureMinArgCount('forEach', props, 1);
 


### PR DESCRIPTION
# Why

Our ts-jest is mixing types and can't resolve all of the FormData functions. This hack fixes CI.
