### PR TITLE
[expo] fix fast refresh broken in dom components

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add support for server root in `expo/scripts/resolveAppEntry.js`. ([#30652](https://github.com/expo/expo/pull/30652) by [@byCedric](https://github.com/byCedric))
 - Fixed expo-updates crash when R8 is enabled on Android. ([#30765](https://github.com/expo/expo/pull/30765) by [@kudo](https://github.com/kudo))
 - Fixed `devtools` module not found. ([#30933](https://github.com/expo/expo/pull/30933) by [@kudo](https://github.com/kudo))
+- Fixed fast refresh error in DOM components. ([#31254](https://github.com/expo/expo/pull/31254) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/build/dom/dom-entry.d.ts.map
+++ b/packages/expo/build/dom/dom-entry.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"dom-entry.d.ts","sourceRoot":"","sources":["../../src/dom/dom-entry.tsx"],"names":[],"mappings":"AACA,OAAO,qBAAqB,CAAC;AAsD7B,wBAAgB,oBAAoB,CAAC,SAAS,EAAE,GAAG,QA4DlD"}
+{"version":3,"file":"dom-entry.d.ts","sourceRoot":"","sources":["../../src/dom/dom-entry.tsx"],"names":[],"mappings":"AACA,OAAO,qBAAqB,CAAC;AAsD7B,wBAAgB,oBAAoB,CAAC,SAAS,EAAE,GAAG,QAmElD"}

--- a/packages/expo/src/dom/dom-entry.tsx
+++ b/packages/expo/src/dom/dom-entry.tsx
@@ -54,6 +54,13 @@ function convertError(error: any) {
 }
 
 export function registerDOMComponent(AppModule: any) {
+  // Prevent double registration from fast refresh
+  if (window.$$EXPO_DOM_COMPONENT_REGISTERED == null) {
+    window.$$EXPO_DOM_COMPONENT_REGISTERED = true;
+  } else {
+    return;
+  }
+
   function DOMComponentRoot(props) {
     // Props listeners
     const [marshalledProps, setProps] = React.useState(() => {


### PR DESCRIPTION
# Why

fix a fast refresh regression in #31182. when a fast refresh happened inside a dom components, it will call `registerRootComponent` twice, which is not allowed for react and cause the error.

```
 ERROR  Warning: You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render() on the existing root instead if you want to update it.
```

# How

ensure the `registerDOMComponent` to be executed only once.

# Test Plan

use bare-expo to load router-e2e with `yarn start:dom`, change something in **04-tailwind.tsx** will trigger the error

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
