### PR TITLE
[iOS][core] Optimize calling void functions

### DIFF
--- a/packages/expo-modules-core/ios/Api/Factories/SyncFunctionFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/SyncFunctionFactories.swift
@@ -9,6 +9,7 @@ public func Function<R>(
     name,
     firstArgType: Void.self,
     dynamicArgumentTypes: [],
+    returnType: ~R.self,
     closure
   )
 }
@@ -24,6 +25,7 @@ public func Function<R, A0: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self],
+    returnType: ~R.self,
     closure
   )
 }
@@ -39,6 +41,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self, ~A1.self],
+    returnType: ~R.self,
     closure
   )
 }
@@ -58,6 +61,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
       ~A1.self,
       ~A2.self
     ],
+    returnType: ~R.self,
     closure
   )
 }
@@ -78,6 +82,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A2.self,
       ~A3.self
     ],
+    returnType: ~R.self,
     closure
   )
 }
@@ -99,6 +104,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A3.self,
       ~A4.self
     ],
+    returnType: ~R.self,
     closure
   )
 }
@@ -121,6 +127,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A4.self,
       ~A5.self
     ],
+    returnType: ~R.self,
     closure
   )
 }
@@ -144,6 +151,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A5.self,
       ~A6.self
     ],
+    returnType: ~R.self,
     closure
   )
 }
@@ -168,6 +176,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A6.self,
       ~A7.self
     ],
+    returnType: ~R.self,
     closure
   )
 }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -47,6 +47,9 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
     return DynamicJavaScriptType(innerType: JavaScriptValueType)
   }
+  if T.self == Void.self {
+    return DynamicVoidType.shared
+  }
   return DynamicRawType(innerType: T.self)
 }
 
@@ -60,4 +63,8 @@ internal prefix func ~ <T>(type: T.Type) -> AnyDynamicType {
 
 internal prefix func ~ <T>(type: T.Type) -> AnyDynamicType where T: AnyArgument {
   return T.getDynamicType()
+}
+
+internal prefix func ~ (type: Void.Type) -> AnyDynamicType {
+  return DynamicVoidType.shared
 }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicVoidType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicVoidType.swift
@@ -1,0 +1,29 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+internal struct DynamicVoidType: AnyDynamicType {
+  static let shared = DynamicVoidType()
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type == Void.self
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    return type is Self
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    return Optional<Any>.none as Any
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    return value
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    return .undefined
+  }
+
+  var description: String {
+    "Void"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -38,10 +38,12 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
     _ name: String,
     firstArgType: FirstArgType.Type,
     dynamicArgumentTypes: [AnyDynamicType],
+    returnType: AnyDynamicType = ~ReturnType.self,
     _ body: @escaping ClosureType
   ) {
     self.name = name
     self.dynamicArgumentTypes = dynamicArgumentTypes
+    self.returnType = returnType
     self.body = body
   }
 
@@ -50,6 +52,8 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
   let name: String
 
   let dynamicArgumentTypes: [AnyDynamicType]
+
+  let returnType: AnyDynamicType
 
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
@@ -128,7 +132,7 @@ public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySy
       }
       let result = try body(argumentsTuple)
 
-      return try appContext.converter.toJS(result, ~ReturnType.self)
+      return try appContext.converter.toJS(result, returnType)
     } catch let error as Exception {
       throw FunctionCallException(name).causedBy(error)
     } catch {

--- a/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
@@ -66,6 +66,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
       "get",
       firstArgType: Void.self,
       dynamicArgumentTypes: [],
+      returnType: ~ReturnType.self,
       getter
     )
     return self
@@ -81,6 +82,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
       "get",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self],
+      returnType: ~ReturnType.self,
       getter
     )
     self.getter?.takesOwner = true
@@ -96,6 +98,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
       "set",
       firstArgType: ValueType.self,
       dynamicArgumentTypes: [~ValueType.self],
+      returnType: ~Void.self,
       setter
     )
     return self
@@ -111,6 +114,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
       "set",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self, ~ValueType.self],
+      returnType: ~Void.self,
       setter
     )
     self.setter?.takesOwner = true


### PR DESCRIPTION
# Why

Invoking void functions on iOS can be a bit faster by introducing a separate dynamic type for `Void`. This also ensures that void functions return `undefined` instead of `null`.

Sadly, `Void` cannot be extended and cannot conform to anything (ideally if it conforms to `AnyArgument`) so in most cases it still goes through many `if` checks. We would probably have quite significant gains if we make more factories for sync functions – dedicated for void functions.

# How

Added `DynamicVoidType`

# Test Plan

Native unit tests are passing