### PR TITLE
feat(cli): Add log formatting for DOM components.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add log formatting for DOM components.
 - Add support for CSS in server components. ([#31073](https://github.com/expo/expo/pull/31073) by [@EvanBacon](https://github.com/EvanBacon))
 - Added production exports for experimental server renderer. ([#30850](https://github.com/expo/expo/pull/30850) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and support for iOS production exports. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add log formatting for DOM components.
+- Add log formatting for DOM components. ([#31265](https://github.com/expo/expo/pull/31265) by [@EvanBacon](https://github.com/EvanBacon))
 - Add support for CSS in server components. ([#31073](https://github.com/expo/expo/pull/31073) by [@EvanBacon](https://github.com/EvanBacon))
 - Added production exports for experimental server renderer. ([#30850](https://github.com/expo/expo/pull/30850) by [@EvanBacon](https://github.com/EvanBacon))
 - Add initial version of DOM Components and support for iOS production exports. ([#30938](https://github.com/expo/expo/pull/30938) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -42,9 +42,22 @@ export class MetroTerminalReporter extends TerminalReporter {
     const platform = env || getPlatformTagForBuildDetails(progress.bundleDetails);
     const inProgress = phase === 'in_progress';
 
-    const localPath = progress.bundleDetails.entryFile.startsWith(path.sep)
-      ? path.relative(this.projectRoot, progress.bundleDetails.entryFile)
-      : progress.bundleDetails.entryFile;
+    let localPath: string;
+
+    if (
+      typeof progress.bundleDetails?.customTransformOptions?.dom === 'string' &&
+      progress.bundleDetails.customTransformOptions.dom.includes('/')
+    ) {
+      // Because we use a generated entry file for DOM components, we need to adjust the logging path so it
+      // shows a unique path for each component.
+      // Here, we take the relative import path and remove all the starting slashes.
+      localPath = progress.bundleDetails.customTransformOptions.dom.replace(/^(\.?\.\/)+/, '');
+    } else {
+      const inputFile = progress.bundleDetails.entryFile;
+      localPath = inputFile.startsWith(path.sep)
+        ? path.relative(this.projectRoot, inputFile)
+        : inputFile;
+    }
 
     if (!inProgress) {
       const status = phase === 'done' ? `Bundled ` : `Bundling failed `;
@@ -262,6 +275,13 @@ function getEnvironmentForBuildDetails(bundleDetails?: BundleDetails | null): st
     return chalk.bold('λ') + ' ';
   } else if (env === 'react-server') {
     return chalk.bold(`RSC(${getPlatformTagForBuildDetails(bundleDetails).trim()})`) + ' ';
+  }
+
+  if (
+    bundleDetails?.customTransformOptions?.dom &&
+    typeof bundleDetails?.customTransformOptions?.dom === 'string'
+  ) {
+    return chalk.bold(`DOM`) + ' ';
   }
 
   return '';

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
@@ -14,7 +14,7 @@ export type BundleDetails = {
   entryFile: string;
   minify: boolean;
   platform: string | null | undefined;
-  customTransformOptions?: { environment?: MetroEnvironment };
+  customTransformOptions?: { environment?: MetroEnvironment; dom?: string };
   runtimeBytecodeVersion: number | null | undefined;
 };
 


### PR DESCRIPTION
# Why

- Add better bundling format for DOM components.
<img width="830" alt="Screenshot 2024-08-30 at 8 39 09 PM" src="https://github.com/user-attachments/assets/df3bcbf6-bc9f-404b-870c-709a7f074157">


