### PR TITLE
fix(cli): Force DOM components to be minified in production exports.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### 🐛 Bug fixes
 
-- Force DOM components to be minified in production exports.
+- Force DOM components to be minified in production exports. ([#31271](https://github.com/expo/expo/pull/31271) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component re-renders in dev. ([#31259](https://github.com/expo/expo/pull/31259) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component exports in CI. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))
 - prevent RSC errors from crashing server. ([#31019](https://github.com/expo/expo/pull/31019) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### 🐛 Bug fixes
 
+- Force DOM components to be minified in production exports.
 - Fix DOM component re-renders in dev. ([#31259](https://github.com/expo/expo/pull/31259) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component exports in CI. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))
 - prevent RSC errors from crashing server. ([#31019](https://github.com/expo/expo/pull/31019) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -228,6 +228,7 @@ async function exportDomComponentsAsync(
 ) {
   const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
   await Promise.all(
+    // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.
     expoDomComponentReferences.map(async (filePath) => {
       debug('Bundle DOM Component:', filePath);
       // MUST MATCH THE BABEL PLUGIN!

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -248,6 +248,8 @@ async function exportDomComponentsAsync(
         bytecode: false,
         reactCompiler: !!exp.experiments?.reactCompiler,
         baseUrl: './',
+        // Minify may be false because it's skipped on native when Hermes is enabled, default to true.
+        minify: true,
       });
 
       const html = await serializeHtmlWithAssets({


### PR DESCRIPTION
# Why

- The react native build script forces `--minify` to false to skip minify in favor of HBC, but this doesn't apply to DOM components. Forcing minify on for now.
