### PR TITLE
[docs] [next-js] add react-native-web to transpilePackages

### DIFF
--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -97,6 +97,7 @@ module.exports = withExpo({
   // older versions can use next-transpile-modules
   transpilePackages: [
     'react-native',
+    'react-native-web',
     'expo',
     // Add more React Native/Expo packages here...
   ],
@@ -114,6 +115,7 @@ const nextConfig = withExpo({
   swcMinify: true,
   transpilePackages: [
     'react-native',
+    'react-native-web',
     'expo',
     // Add more React Native/Expo packages here...
   ],
@@ -216,8 +218,9 @@ module.exports = withExpo({
     transpilePackages: [
       // NOTE: Even though `react-native` is never used in Next.js,
       // you need to list `react-native` because `react-native-web`
-      // is aliased to `react-native`. Adding `react-native-web` will not work.
+      // is aliased to `react-native`.
       'react-native',
+      'react-native-web',
       'expo',
       // Add more React Native/Expo packages here...
     ],
@@ -285,6 +288,7 @@ module.exports = withExpo({
   experimental: {
     transpilePackages: [
       'react-native',
+      'react-native-web',
       'expo',
       // Add the failing package here, and restart the server...
     ],


### PR DESCRIPTION
# Why

Fixes the docs issue reported in https://github.com/expo/expo/issues/31272

# How

Adds `react-native-web` to the `transpiledPackages` in the next.js docs page (https://docs.expo.dev/guides/using-nextjs)

# Test Plan

- Review this PR on the examples repo first: https://github.com/expo/examples/pull/502
- If it gets merged it makes sense to also update the docs with this PR

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
