### PR TITLE
refactor(cli): clean up the old `UserSettings` file

### DIFF
--- a/packages/@expo/cli/e2e/setup.ts
+++ b/packages/@expo/cli/e2e/setup.ts
@@ -5,11 +5,11 @@ jest.mock('@expo/rudder-sdk-node');
 jest.mock('@expo/spawn-async');
 jest.mock('@expo/webpack-config');
 jest.mock('@expo/package-manager');
-jest.mock('fs/promises');
 jest.mock('child_process');
+jest.mock('fs');
+jest.mock('fs/promises');
 jest.mock('better-opn');
 jest.mock('env-editor');
-jest.mock('fs');
 jest.mock('internal-ip');
 jest.mock('ora');
 jest.mock('os');
@@ -20,3 +20,7 @@ jest.mock('webpack-dev-server');
 jest.mock('webpack');
 
 jest.mock('../src/utils/createTempPath');
+
+// Work-around to mock node built-in modules
+jest.mock('node:fs', () => require('fs'));
+jest.mock('node:fs/promises', () => require('fs/promises'));

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -18,7 +18,7 @@ import { fetch } from '../../utils/fetch';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { wrapFetchWithOffline } from '../rest/wrapFetchWithOffline';
 import { wrapFetchWithProxy } from '../rest/wrapFetchWithProxy';
-import UserSettings from '../user/UserSettings';
+import { getAccessToken, getSession } from '../user/UserSettings';
 
 type AccessTokenHeaders = {
   authorization: string;
@@ -43,7 +43,7 @@ export const graphqlClient = createUrqlClient({
   // @ts-ignore Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.
   fetch: wrapFetchWithOffline(wrapFetchWithProxy(fetch)),
   fetchOptions: (): { headers?: AccessTokenHeaders | SessionHeaders } => {
-    const token = UserSettings.getAccessToken();
+    const token = getAccessToken();
     if (token) {
       return {
         headers: {
@@ -51,7 +51,7 @@ export const graphqlClient = createUrqlClient({
         },
       };
     }
-    const sessionSecret = UserSettings.getSession()?.sessionSecret;
+    const sessionSecret = getSession()?.sessionSecret;
     if (sessionSecret) {
       return {
         headers: {

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -5,11 +5,14 @@ import { CommandError } from '../../../utils/errors';
 import { fetch } from '../../../utils/fetch';
 import { getExpoApiBaseUrl } from '../../endpoint';
 import { disableNetwork } from '../../settings';
-import UserSettings from '../../user/UserSettings';
+import { getAccessToken, getSession } from '../../user/UserSettings';
 import { ApiV2Error, fetchAsync } from '../client';
 
 jest.mock('../../settings');
-jest.mock('../../user/UserSettings');
+jest.mock('../../user/UserSettings', () => ({
+  getAccessToken: jest.fn(),
+  getSession: jest.fn(),
+}));
 jest.mock('../../../utils/fetch', () => ({
   fetch: jest.fn(jest.requireActual('../../../utils/fetch').fetch),
 }));
@@ -128,7 +131,7 @@ it('makes a request using an absolute URL', async () => {
 });
 
 it('makes an authenticated request with access token', async () => {
-  jest.mocked(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
+  jest.mocked(getAccessToken).mockClear().mockReturnValue('my-access-token');
 
   nock(getExpoApiBaseUrl())
     .matchHeader('authorization', 'Bearer my-access-token')
@@ -139,13 +142,13 @@ it('makes an authenticated request with access token', async () => {
 });
 
 it('makes an authenticated request with session secret', async () => {
-  jest.mocked(UserSettings.getSession).mockClear().mockReturnValue({
+  jest.mocked(getSession).mockClear().mockReturnValue({
     sessionSecret: 'my-secret-token',
     userId: '',
     username: '',
     currentConnection: 'Username-Password-Authentication',
   });
-  jest.mocked(UserSettings.getAccessToken).mockReturnValue(null);
+  jest.mocked(getAccessToken).mockReturnValue(null);
 
   nock(getExpoApiBaseUrl())
     .matchHeader('expo-session', 'my-secret-token')
@@ -156,8 +159,8 @@ it('makes an authenticated request with session secret', async () => {
 });
 
 it('only uses access token when both authentication methods are available', async () => {
-  jest.mocked(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
-  jest.mocked(UserSettings.getSession).mockClear().mockReturnValue({
+  jest.mocked(getAccessToken).mockClear().mockReturnValue('my-access-token');
+  jest.mocked(getSession).mockClear().mockReturnValue({
     sessionSecret: 'my-secret-token',
     userId: '',
     username: '',

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -13,7 +13,7 @@ import { CommandError } from '../../utils/errors';
 import { fetch } from '../../utils/fetch';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { disableNetwork } from '../settings';
-import UserSettings from '../user/UserSettings';
+import { getAccessToken, getSession } from '../user/UserSettings';
 
 export class ApiV2Error extends Error {
   readonly name = 'ApiV2Error';
@@ -77,11 +77,11 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
 
     const resolvedHeaders = options.headers ?? ({} as any);
 
-    const token = UserSettings.getAccessToken();
+    const token = getAccessToken();
     if (token) {
       resolvedHeaders.authorization = `Bearer ${token}`;
     } else {
-      const sessionSecret = UserSettings.getSession()?.sessionSecret;
+      const sessionSecret = getSession()?.sessionSecret;
       if (sessionSecret) {
         resolvedHeaders['expo-session'] = sessionSecret;
       }

--- a/packages/@expo/cli/src/api/user/UserSettings.ts
+++ b/packages/@expo/cli/src/api/user/UserSettings.ts
@@ -21,32 +21,31 @@ export type UserSettingsData = {
 };
 
 /** Return the user cache directory. */
-function getDirectory() {
+export function getSettingsDirectory() {
   return getExpoHomeDirectory();
 }
 
-function getFilePath(): string {
+/** Return the file path of the settings file */
+export function getSettingsFilePath(): string {
   return getUserStatePath();
 }
 
-function userSettingsJsonFile(): JsonFile<UserSettingsData> {
-  return new JsonFile<UserSettingsData>(getFilePath(), {
+/** Get a new JsonFile instance pointed towards the settings file */
+export function getSettings(): JsonFile<UserSettingsData> {
+  return new JsonFile<UserSettingsData>(getSettingsFilePath(), {
     ensureDir: true,
     jsonParseErrorDefault: {},
     cantReadFileDefault: {},
   });
 }
 
-async function setSessionAsync(sessionData?: SessionData): Promise<void> {
-  await UserSettings.setAsync('auth', sessionData, {
-    default: {},
-    ensureDir: true,
-  });
+export function getAccessToken(): string | null {
+  return process.env.EXPO_TOKEN ?? null;
 }
 
-function getSession(): SessionData | null {
+export function getSession() {
   try {
-    return JsonFile.read<UserSettingsData>(getUserStatePath())?.auth ?? null;
+    return getSettings().get('auth', null);
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       return null;
@@ -55,13 +54,20 @@ function getSession(): SessionData | null {
   }
 }
 
-function getAccessToken(): string | null {
-  return process.env.EXPO_TOKEN ?? null;
+export async function setSessionAsync(sessionData?: SessionData) {
+  await getSettings().setAsync('auth', sessionData, {
+    default: {},
+    ensureDir: true,
+  });
 }
 
-// returns an anonymous, unique identifier for a user on the current computer
-async function getAnonymousIdentifierAsync(): Promise<string> {
-  const settings = await userSettingsJsonFile();
+/**
+ * Get an anonymous and randomly generated identifier.
+ * This is used to group telemetry event by unknown actor,
+ * and cannot be used to identify a single user.
+ */
+export async function getAnonymousIdAsync(): Promise<string> {
+  const settings = getSettings();
   let id = await settings.getAsync('uuid', null);
 
   if (!id) {
@@ -71,15 +77,3 @@ async function getAnonymousIdentifierAsync(): Promise<string> {
 
   return id;
 }
-
-const UserSettings = Object.assign(userSettingsJsonFile(), {
-  getSession,
-  setSessionAsync,
-  getAccessToken,
-  getDirectory,
-  getFilePath,
-  userSettingsJsonFile,
-  getAnonymousIdentifierAsync,
-});
-
-export default UserSettings;

--- a/packages/@expo/cli/src/api/user/UserSettings.ts
+++ b/packages/@expo/cli/src/api/user/UserSettings.ts
@@ -44,14 +44,7 @@ export function getAccessToken(): string | null {
 }
 
 export function getSession() {
-  try {
-    return getSettings().get('auth', null);
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
-      return null;
-    }
-    throw error;
-  }
+  return getSettings().get('auth', null);
 }
 
 export async function setSessionAsync(sessionData?: SessionData) {

--- a/packages/@expo/cli/src/api/user/__tests__/UserSettings-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/UserSettings-test.ts
@@ -2,9 +2,15 @@ import fs from 'fs-extra';
 import { vol } from 'memfs';
 import path from 'path';
 
-import UserSettings from '../UserSettings';
+import {
+  getAccessToken,
+  getSession,
+  getSettingsDirectory,
+  getSettingsFilePath,
+  setSessionAsync,
+} from '../UserSettings';
 
-describe(UserSettings.getDirectory, () => {
+describe(getSettingsDirectory, () => {
   beforeEach(() => {
     delete process.env.__UNSAFE_EXPO_HOME_DIRECTORY;
     delete process.env.EXPO_STAGING;
@@ -17,19 +23,19 @@ describe(UserSettings.getDirectory, () => {
   });
 
   it(`gets the default state directory`, () => {
-    expect(UserSettings.getDirectory()).toBe('/home/.expo');
+    expect(getSettingsDirectory()).toBe('/home/.expo');
   });
   it(`gets the staging state directory`, () => {
     process.env.EXPO_STAGING = 'true';
-    expect(UserSettings.getDirectory()).toBe('/home/.expo-staging');
+    expect(getSettingsDirectory()).toBe('/home/.expo-staging');
   });
   it(`gets the local state directory`, () => {
     process.env.EXPO_LOCAL = 'true';
-    expect(UserSettings.getDirectory()).toBe('/home/.expo-local');
+    expect(getSettingsDirectory()).toBe('/home/.expo-local');
   });
   it(`gets the custom state directory`, () => {
     process.env.__UNSAFE_EXPO_HOME_DIRECTORY = '/foobar/yolo';
-    expect(UserSettings.getDirectory()).toBe('/foobar/yolo');
+    expect(getSettingsDirectory()).toBe('/foobar/yolo');
   });
 });
 
@@ -44,38 +50,38 @@ beforeEach(() => {
   vol.reset();
 });
 
-describe(UserSettings.getSession, () => {
+describe(getSession, () => {
   it('returns null when session is not stored', () => {
-    expect(UserSettings.getSession()).toBeNull();
+    expect(getSession()).toBeNull();
   });
 
   it('returns stored session data', async () => {
-    await fs.mkdirp(path.dirname(UserSettings.getFilePath()));
-    await fs.writeJSON(UserSettings.getFilePath(), { auth: authStub });
-    expect(UserSettings.getSession()).toMatchObject(authStub);
+    await fs.mkdirp(path.dirname(getSettingsFilePath()));
+    await fs.writeJSON(getSettingsFilePath(), { auth: authStub });
+    expect(getSession()).toMatchObject(authStub);
   });
 });
 
-describe(UserSettings.setSessionAsync, () => {
+describe(setSessionAsync, () => {
   it('stores empty session data', async () => {
-    await UserSettings.setSessionAsync();
-    expect(await fs.pathExists(UserSettings.getFilePath())).toBeTruthy();
+    await setSessionAsync();
+    expect(await fs.pathExists(getSettingsFilePath())).toBeTruthy();
   });
 
   it('stores actual session data', async () => {
-    await UserSettings.setSessionAsync(authStub);
-    expect(await fs.readJSON(UserSettings.getFilePath())).toMatchObject({ auth: authStub });
+    await setSessionAsync(authStub);
+    expect(await fs.readJSON(getSettingsFilePath())).toMatchObject({ auth: authStub });
   });
 });
 
-describe(UserSettings.getAccessToken, () => {
+describe(getAccessToken, () => {
   it('returns null when envvar is undefined', () => {
-    expect(UserSettings.getAccessToken()).toBeNull();
+    expect(getAccessToken()).toBeNull();
   });
 
   it('returns token when envar is defined', () => {
     process.env.EXPO_TOKEN = 'mytesttoken';
-    expect(UserSettings.getAccessToken()).toBe('mytesttoken');
+    expect(getAccessToken()).toBe('mytesttoken');
     process.env.EXPO_TOKEN = undefined;
   });
 });

--- a/packages/@expo/cli/src/api/user/__tests__/user-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/user-test.ts
@@ -7,7 +7,7 @@ import {
   getDevelopmentCodeSigningDirectory,
 } from '../../../utils/codesigning';
 import { getExpoApiBaseUrl } from '../../endpoint';
-import UserSettings from '../UserSettings';
+import { getSession } from '../UserSettings';
 import { getSessionUsingBrowserAuthFlowAsync } from '../expoSsoLauncher';
 import {
   Actor,
@@ -161,10 +161,10 @@ describe(logoutAsync, () => {
   it('removes the session secret', async () => {
     mockLoginRequest();
     await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
-    expect(UserSettings.getSession()?.sessionSecret).toBe('SESSION_SECRET');
+    expect(getSession()?.sessionSecret).toBe('SESSION_SECRET');
 
     await logoutAsync();
-    expect(UserSettings.getSession()?.sessionSecret).toBeUndefined();
+    expect(getSession()?.sessionSecret).toBeUndefined();
   });
 
   it('removes code signing data', async () => {

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import gql from 'graphql-tag';
 
-import UserSettings from './UserSettings';
+import { getAccessToken, getSession, setSessionAsync } from './UserSettings';
 import { getSessionUsingBrowserAuthFlowAsync } from './expoSsoLauncher';
 import { CurrentUserQuery } from '../../graphql/generated';
 import * as Log from '../../log';
@@ -38,7 +38,7 @@ export function getActorDisplayName(user?: Actor): string {
 }
 
 export async function getUserAsync(): Promise<Actor | undefined> {
-  const hasCredentials = UserSettings.getAccessToken() || UserSettings.getSession()?.sessionSecret;
+  const hasCredentials = getAccessToken() || getSession()?.sessionSecret;
   if (!env.EXPO_OFFLINE && !currentUser && hasCredentials) {
     const user = await UserQuery.currentUserAsync();
     currentUser = user ?? undefined;
@@ -61,7 +61,7 @@ export async function loginAsync(credentials: {
 
   const userData = await fetchUserAsync({ sessionSecret });
 
-  await UserSettings.setSessionAsync({
+  await setSessionAsync({
     sessionSecret,
     userId: userData.id,
     username: userData.username,
@@ -75,7 +75,7 @@ export async function ssoLoginAsync(): Promise<void> {
   });
   const userData = await fetchUserAsync({ sessionSecret });
 
-  await UserSettings.setSessionAsync({
+  await setSessionAsync({
     sessionSecret,
     userId: userData.id,
     username: userData.username,
@@ -87,7 +87,7 @@ export async function logoutAsync(): Promise<void> {
   currentUser = undefined;
   await Promise.all([
     fs.rm(getDevelopmentCodeSigningDirectory(), { recursive: true, force: true }),
-    UserSettings.setSessionAsync(undefined),
+    setSessionAsync(undefined),
   ]);
   Log.log('Logged out');
 }

--- a/packages/@expo/cli/src/run/ios/codeSigning/settings.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/settings.ts
@@ -1,12 +1,13 @@
-import UserSettings from '../../../api/user/UserSettings';
+import { getSettings } from '../../../api/user/UserSettings';
 
 /** Get the cached code signing ID from the last time a user configured code signing via the CLI. */
 export async function getLastDeveloperCodeSigningIdAsync(): Promise<string | null> {
-  const { developmentCodeSigningId } = await UserSettings.readAsync();
-  return developmentCodeSigningId ?? null;
+  return await getSettings().getAsync('developmentCodeSigningId', null);
 }
 
 /** Cache the code signing ID that the user chose for their project, we'll recommend this value for the next project they code sign. */
 export async function setLastDeveloperCodeSigningIdAsync(id: string): Promise<void> {
-  await UserSettings.setAsync('developmentCodeSigningId', id).catch(() => {});
+  await getSettings()
+    .setAsync('developmentCodeSigningId', id)
+    .catch(() => {});
 }

--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import * as path from 'path';
 import slugify from 'slugify';
 
-import UserSettings from '../../api/user/UserSettings';
+import { getSettingsDirectory } from '../../api/user/UserSettings';
 import { getActorDisplayName, getUserAsync } from '../../api/user/user';
 import * as Log from '../../log';
 import { delayAsync, resolveWithTimeout } from '../../utils/delay';
@@ -158,7 +158,7 @@ export class AsyncNgrok {
   ): Promise<string | false> {
     try {
       // Global config path.
-      const configPath = path.join(UserSettings.getDirectory(), 'ngrok.yml');
+      const configPath = path.join(getSettingsDirectory(), 'ngrok.yml');
       debug('Global config path:', configPath);
       const urlProps = await this._getConnectionPropsAsync();
 

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -8,7 +8,7 @@ import { serializeDictionary, Dictionary } from 'structured-headers';
 import { ManifestMiddleware, ManifestRequestInfo } from './ManifestMiddleware';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { ServerHeaders, ServerRequest } from './server.types';
-import UserSettings from '../../../api/user/UserSettings';
+import { getAnonymousIdAsync } from '../../../api/user/UserSettings';
 import { ANONYMOUS_USERNAME } from '../../../api/user/user';
 import {
   CodeSigningInfo,
@@ -276,7 +276,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
 }
 
 async function getAnonymousScopeKeyAsync(slug: string): Promise<string> {
-  const userAnonymousIdentifier = await UserSettings.getAnonymousIdentifierAsync();
+  const userAnonymousIdentifier = await getAnonymousIdAsync();
   return `@${ANONYMOUS_USERNAME}/${slug}-${userAnonymousIdentifier}`;
 }
 

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
@@ -88,7 +88,7 @@ describe('startAsync', () => {
     });
 
     // Cache is cleared...
-    expect(vol.toJSON()['/.expo/web/cache']).toBe(undefined);
+    expect(vol.toJSON()['/.expo/web/cache']).toBe(null);
   });
 });
 

--- a/packages/@expo/cli/src/utils/__tests__/glob-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/glob-test.ts
@@ -2,9 +2,6 @@ import { vol } from 'memfs';
 
 import { anyMatchAsync, everyMatchAsync } from '../glob';
 
-// See: https://github.com/isaacs/node-glob/issues/515#issuecomment-1478780708
-jest.mock('node:fs/promises');
-
 describe(everyMatchAsync, () => {
   beforeEach(() => {
     vol.reset();

--- a/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
@@ -2,7 +2,7 @@ import RudderAnalytics from '@expo/rudder-sdk-node';
 
 import { getContext } from './getContext';
 import type { TelemetryClient, TelemetryRecord, TelemetryRecordWithDate } from './types';
-import UserSettings from '../../api/user/UserSettings';
+import { getAnonymousIdAsync } from '../../api/user/UserSettings';
 import { type Actor, getActorDisplayName, getUserAsync } from '../../api/user/user';
 import { env } from '../env';
 
@@ -61,7 +61,7 @@ export class RudderClient implements TelemetryClient {
     debug('Actor received');
 
     const userId = actor.id;
-    const anonymousId = await UserSettings.getAnonymousIdentifierAsync();
+    const anonymousId = await getAnonymousIdAsync();
 
     if (this.identity?.userId === userId && this.identity?.anonymousId === anonymousId) {
       return;

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
@@ -6,7 +6,7 @@ import { getContext } from '../getContext';
 
 jest.mock('@expo/rudder-sdk-node');
 jest.mock('../../../api/user/UserSettings', () => ({
-  getAnonymousIdentifierAsync: jest.fn().mockResolvedValue('anonymous-id'),
+  getAnonymousIdAsync: jest.fn().mockResolvedValue('anonymous-id'),
 }));
 jest.mock('../../../api/user/user', () => ({
   getActorDisplayName: jest.fn(),


### PR DESCRIPTION
# Why

This cleans up the `UserSettings` file, which was copied over from the legacy `expo-cli`. It exports individual methods and does not mutate the `getSettings` function to add all methods.

I did this in advance of the telemetry refactor, which will be the next stacked PR.

# How

- Refactored `UserSettings` without `Object.assign` and `export {}`

# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
