### PR TITLE
[docs] Remove unused React import statements and other clean up

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -98,7 +98,6 @@ If you'd like to see more, you can [open a PR](https://github.com/expo/expo/edit
 
 {/* prettier-ignore */}
 ```tsx IdentityServer 4 Example
-import * as React from 'react';
 import { Button, Text, View } from 'react-native';
 import * as AuthSession from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
@@ -268,7 +267,7 @@ const styles = StyleSheet.create({
 
 {/* prettier-ignore */}
 ```tsx Azure Example
-import * as React from 'react';
+import { useState } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import {
   exchangeCodeAsync,
@@ -298,7 +297,7 @@ export default function App() {
   const clientId = '<CLIENT_ID>';
 
   // We store the JWT in here
-  const [token, setToken] = React.useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
 
   // Request
   const [request, , promptAsync] = useAuthRequest(
@@ -442,7 +441,6 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```jsx Auth Code
-import React from 'react';
 import { Button } from 'react-native';
 /* @info Import the Beyond Identity Embedded SDK.*/
 import { Embedded } from '@beyondidentity/bi-sdk-react-native';
@@ -510,7 +508,7 @@ import {
   useAuthRequest,
   exchangeCodeAsync,
 } from "expo-auth-session";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native, this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
@@ -619,7 +617,7 @@ extraParams: {
 
 {/* prettier-ignore */}
 ```tsx Cognito Auth Example
-import * as React from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { useAuthRequest, exchangeCodeAsync, revokeAsync, ResponseType } from 'expo-auth-session';
 import { Button, Alert } from 'react-native';
@@ -632,8 +630,8 @@ const userPoolUrl =
 const redirectUri = 'your-redirect-uri';
 
 export default function App() {
-  const [authTokens, setAuthTokens] = React.useState(null);
-  const discoveryDocument = React.useMemo(() => ({
+  const [authTokens, setAuthTokens] = useState(null);
+  const discoveryDocument = useMemo(() => ({
     authorizationEndpoint: userPoolUrl + '/oauth2/authorize',
     tokenEndpoint: userPoolUrl + '/oauth2/token',
     revocationEndpoint: userPoolUrl + '/oauth2/revoke',
@@ -649,7 +647,7 @@ export default function App() {
     discoveryDocument
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const exchangeFn = async (exchangeTokenReq) => {
       try {
         const exchangeTokenResponse = await exchangeCodeAsync(
@@ -745,7 +743,7 @@ import {
   useAuthRequest,
 } from "expo-auth-session";
 import * as WebBrowser from "expo-web-browser";
-import * as React from "react";
+import { useEffect, useMemo, useReducer, useRef } from "react";
 import { Button } from "react-native";
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
@@ -783,7 +781,7 @@ export default function App() {
     /* @end */
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (token) {
       /* @info The access token is now ready to be used to make authenticated requests. */
       console.log("My Token:", token.accessToken);
@@ -815,13 +813,13 @@ type State = {
 // this should be performed in a server and not here in the application.
 // For educational purposes only:
 function useAutoExchange(code?: string): State {
-  const [state, setState] = React.useReducer(
+  const [state, setState] = useReducer(
     (state: State, action: Partial<State>) => ({ ...state, ...action }),
     { token: null, exchangeError: null }
   );
   const isMounted = useMounted();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!code) {
       setState({ token: null, exchangeError: null });
       return;
@@ -856,8 +854,8 @@ function useAutoExchange(code?: string): State {
 }
 
 function useMounted() {
-  const isMounted = React.useRef(true);
-  React.useEffect(() => {
+  const isMounted = useRef(true);
+  useEffect(() => {
     return () => {
       isMounted.current = false;
     };
@@ -886,7 +884,7 @@ function useMounted() {
 
 {/* prettier-ignore */}
 ```tsx Descope Auth Example
-import * as React from 'react';
+import { useState, useEffect } React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import * as AuthSession from 'expo-auth-session';
 import { Button, View } from 'react-native';
@@ -898,7 +896,7 @@ const descopeUrl = `https://api.descope.com/${descopeProjectId}`;
 const redirectUri = AuthSession.makeRedirectUri();
 
 export default function App() {
-  const [authTokens, setAuthTokens] = React.useState(null);
+  const [authTokens, setAuthTokens] = useState(null);
   const discovery = AuthSession.useAutoDiscovery(descopeUrl);
 
   const [request, response, promptAsync] = AuthSession.useAuthRequest(
@@ -912,7 +910,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response) {
       if (response.error) {
         console.error(
@@ -1001,7 +999,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Dropbox Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -1031,7 +1029,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1077,7 +1075,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Fitbit Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -1107,7 +1105,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1154,7 +1152,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx GitHub Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1184,7 +1182,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1226,7 +1224,7 @@ export default function App() {
 - Learn more here: [imgur.com/oauth2](https://api.imgur.com/oauth2)
 
 ```tsx Imgur Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -1257,7 +1255,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1295,7 +1293,6 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Keycloak Auth Example
-import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
 import { Button, Text, View } from 'react-native';
@@ -1398,7 +1395,7 @@ const App = () => {
 
 {/* prettier-ignore */}
 ```tsx Okta Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -1422,7 +1419,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1468,7 +1465,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Reddit Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1495,7 +1492,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1543,7 +1540,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Slack Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1572,7 +1569,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1630,7 +1627,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Spotify Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1662,7 +1659,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1707,7 +1704,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Strava Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1736,7 +1733,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1795,7 +1792,7 @@ const { accessToken } = await AuthSession.exchangeCodeAsync(
 
 {/* prettier-ignore */}
 ```tsx Strivacity Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1821,7 +1818,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1865,7 +1862,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Twitch Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -1895,7 +1892,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -1944,7 +1941,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Twitter Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -1977,7 +1974,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -2021,7 +2018,7 @@ export default function App() {
 
 {/* prettier-ignore */}
 ```tsx Uber Auth Example
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -2051,7 +2048,7 @@ export default function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. */
       const { code } = response.params;
@@ -2120,11 +2117,11 @@ On Android you can optionally warm up the web browser before it's used. This all
 
 {/* prettier-ignore */}
 ```tsx
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 
 function App() {
-  React.useEffect(() => {
+  useEffect(() => {
     /* @info <strong>Android only:</strong> Start loading the default browser app in the background to improve transition time. */
     WebBrowser.warmUpAsync();
     /* @end */
@@ -2148,7 +2145,7 @@ Because there was no secure way to do this to store client secrets in your app b
 
 {/* prettier-ignore */}
 ```tsx
-import * as React from 'react';
+import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, ResponseType } from 'expo-auth-session';
 
@@ -2178,7 +2175,7 @@ function App() {
     discovery
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response && response.type === 'success') {
       /* @info You can use this access token to make calls into the Spotify API. */
       const token = response.params.access_token;
@@ -2205,7 +2202,7 @@ const MY_SECURE_AUTH_STATE_KEY = 'MySecureAuthStateKey';
 function App() {
   const [, response] = useAuthRequest({});
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (response && response.type === 'success') {
       const auth = response.params;
       const storageValue = JSON.stringify(auth);

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -17,7 +17,6 @@ The component loads the `Ionicons` font and renders a checkmark icon in the foll
 <SnackInline label='Vector icons' dependencies={['@expo/vector-icons']}>
 
 ```jsx collapseHeight=350
-import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
@@ -57,7 +56,6 @@ The `createIconSet` method returns a custom font based on the `glyphMap` where t
 In the example below, the `glyphMap` object is defined and then passed as the first argument to the `createIconSet` method. The second argument `fontFamily` is the name of the font (not the filename). Optionally, you can pass the third argument for Android support, which is the custom font file name.
 
 ```jsx createIconSet example
-import * as React from 'react';
 import createIconSet from '@expo/vector-icons/createIconSet';
 
 const glyphMap = { 'icon-name': 1234, test: '∆' };

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -171,7 +171,7 @@ If your app uses [Expo Router](/router/introduction), then you can configure Sen
 
 ```tsx app/_layout.tsx
 import { Slot, useNavigationContainerRef } from 'expo-router';
-import React from 'react';
+import { useEffect } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { isRunningInExpoGo } from 'expo';
 
@@ -195,7 +195,7 @@ function RootLayout() {
   // Capture the NavigationContainer ref and register it with the instrumentation.
   const ref = useNavigationContainerRef();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref) {
       routingInstrumentation.registerNavigationContainer(ref);
     }

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -308,7 +308,7 @@ export function setTheme(theme: string): void {
 
 ```tsx example/App.tsx
 import * as Settings from 'expo-settings';
-import {useEffect, useState } React from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -308,13 +308,13 @@ export function setTheme(theme: string): void {
 
 ```tsx example/App.tsx
 import * as Settings from 'expo-settings';
-import * as React from 'react';
+import {useEffect, useState } React from 'react';
 import { Button, Text, View } from 'react-native';
 
 export default function App() {
-  const [theme, setTheme] = React.useState<string>(Settings.getTheme());
+  const [theme, setTheme] = useState<string>(Settings.getTheme());
 
-  React.useEffect(() => {
+  useEffect(() => {
     const subscription = Settings.addThemeListener(({ theme: newTheme }) => {
       setTheme(newTheme);
     });

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -98,9 +98,8 @@ The following code snippet is a basic hook that persists tokens securely on nati
 
 {/* prettier-ignore */}
 ```tsx useStorageState.ts
-import  { useEffect, useCallback } from 'react';
+import  { useEffect, useCallback, useReducer } from 'react';
 import * as SecureStore from 'expo-secure-store';
-import * as React from 'react';
 import { Platform } from 'react-native';
 
 type UseStateHook<T> = [[boolean, T | null], (value: T | null) => void];
@@ -108,7 +107,7 @@ type UseStateHook<T> = [[boolean, T | null], (value: T | null) => void];
 function useAsyncState<T>(
   initialValue: [boolean, T | null] = [true, null],
 ): UseStateHook<T> {
-  return React.useReducer(
+  return useReducer(
     (state: [boolean, T | null], action: T | null = null): [boolean, T | null] => [false, action],
     initialValue
   ) as UseStateHook<T>;

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -98,6 +98,7 @@ The following code snippet is a basic hook that persists tokens securely on nati
 
 {/* prettier-ignore */}
 ```tsx useStorageState.ts
+import  { useEffect, useCallback } from 'react';
 import * as SecureStore from 'expo-secure-store';
 import * as React from 'react';
 import { Platform } from 'react-native';
@@ -138,7 +139,7 @@ export function useStorageState(key: string): UseStateHook<string> {
   const [state, setState] = useAsyncState<string>();
 
   // Get
-  React.useEffect(() => {
+  useEffect(() => {
     if (Platform.OS === 'web') {
       try {
         if (typeof localStorage !== 'undefined') {
@@ -155,7 +156,7 @@ export function useStorageState(key: string): UseStateHook<string> {
   }, [key]);
 
   // Set
-  const setValue = React.useCallback(
+  const setValue = useCallback(
     (value: string | null) => {
       setState(value);
       setStorageItemAsync(key, value);

--- a/docs/pages/versions/unversioned/sdk/accelerometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -40,7 +40,7 @@ Below is an example that demonstrates how to use `expo-background-fetch`.
 <SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
@@ -77,10 +77,10 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState(false);
-  const [status, setStatus] = React.useState(null);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [status, setStatus] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     checkStatusAsync();
   }, []);
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -121,7 +121,7 @@ You must request permission to access the user's camera before attempting to get
 <SnackInline label="Basic BarCodeScanner usage" dependencies={['expo-barcode-scanner']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
 import { BarCodeScanner } from 'expo-barcode-scanner';
 

--- a/docs/pages/versions/unversioned/sdk/barometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/barometer.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Barometer usage' dependencies={['expo-sensors']} platforms={['android', 'ios']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import { Barometer } from 'expo-sensors';
 

--- a/docs/pages/versions/unversioned/sdk/brightness.mdx
+++ b/docs/pages/versions/unversioned/sdk/brightness.mdx
@@ -34,7 +34,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Brightness Usage' dependencies={['expo-brightness']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Brightness from 'expo-brightness';
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -75,7 +75,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Calendar usage' dependencies={['expo-calendar']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text, Button, Platform } from 'react-native';
 import * as Calendar from 'expo-calendar';
 

--- a/docs/pages/versions/unversioned/sdk/clipboard.mdx
+++ b/docs/pages/versions/unversioned/sdk/clipboard.mdx
@@ -22,12 +22,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android', 'web']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
 export default function App() {
-  const [copiedText, setCopiedText] = React.useState('');
+  const [copiedText, setCopiedText] = useState('');
 
   const copyToClipboard = async () => {
     /* @info Copy the text to the clipboard */

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -70,7 +70,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Contacts Usage' dependencies={['expo-contacts']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Contacts from 'expo-contacts';
 

--- a/docs/pages/versions/unversioned/sdk/crypto.mdx
+++ b/docs/pages/versions/unversioned/sdk/crypto.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Crypto from 'expo-crypto';
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -40,7 +40,6 @@ You can use the following snippet to detect faces in a fast mode without detecti
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 
 ```jsx
-import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';
 

--- a/docs/pages/versions/unversioned/sdk/gyroscope.mdx
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
 

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -35,7 +35,6 @@ On Android, this library requires permission to control vibration on the device.
 <SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
 
 ```jsx
-import * as React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
 import * as Haptics from 'expo-haptics';
 

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
@@ -22,7 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
 ```tsx
-import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 

--- a/docs/pages/versions/unversioned/sdk/magnetometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.mdx
@@ -24,7 +24,7 @@ You can access the calibrated values with `Magnetometer` and uncalibrated raw va
 <SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Magnetometer } from 'expo-sensors';
 

--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, StyleSheet, Button, Platform, Text } from 'react-native';
 import * as Print from 'expo-print';
 import { shareAsync } from 'expo-sharing';
@@ -44,7 +44,7 @@ const html = `
 `;
 
 export default function App() {
-  const [selectedPrinter, setSelectedPrinter] = React.useState();
+  const [selectedPrinter, setSelectedPrinter] = useState();
 
   const print = async () => {
     // On iOS/android prints the given html. On web prints the HTML from the current page.

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -152,7 +152,7 @@ If you are using your own Auto Backup configuration, you should exclude the `Sec
 <SnackInline label='SecureStore' dependencies={['expo-secure-store']} platforms={['ios', 'android']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { Text, View, StyleSheet, TextInput, Button } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
@@ -170,8 +170,8 @@ async function getValueFor(key) {
 }
 
 export default function App() {
-  const [key, onChangeKey] = React.useState('Your key here');
-  const [value, onChangeValue] = React.useState('Your value here');
+  const [key, onChangeKey] = useState('Your key here');
+  const [value, onChangeValue] = useState('Your value here');
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -22,7 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Speech' dependencies={['expo-speech']}>
 
 ```jsx
-import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import * as Speech from 'expo-speech';
 

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -32,7 +32,6 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
 export default function SvgComponent(props) {

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -71,7 +71,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 

--- a/docs/pages/versions/unversioned/sdk/video-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-av.mdx
@@ -28,13 +28,13 @@ Here's a simple example of a video with a play/pause button.
 <SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
+import { useState, useRef } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
-  const video = React.useRef(null);
-  const [status, setStatus] = React.useState({});
+  const video = useRef(null);
+  const [status, setStatus] = useState({});
   return (
     <View style={styles.container}>
       <Video

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -21,7 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Video Thumbnails' dependencies={['expo-video-thumbnails']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Button, View, Image, Text } from 'react-native';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.mdx
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic WebBrowser usage" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Text, View, StyleSheet } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 /* @hide */

--- a/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
@@ -42,7 +42,7 @@ Below is an example that demonstrates how to use `expo-background-fetch`.
 <SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
@@ -79,10 +79,10 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState(false);
-  const [status, setStatus] = React.useState(null);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [status, setStatus] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     checkStatusAsync();
   }, []);
 

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -121,7 +121,7 @@ You must request permission to access the user's camera before attempting to get
 <SnackInline label="Basic BarCodeScanner usage" dependencies={['expo-barcode-scanner']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
 import { BarCodeScanner } from 'expo-barcode-scanner';
 

--- a/docs/pages/versions/v49.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/barometer.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Barometer usage' dependencies={['expo-sensors']} platforms={['android', 'ios']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import { Barometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v49.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/brightness.mdx
@@ -36,7 +36,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Brightness Usage' dependencies={['expo-brightness']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Brightness from 'expo-brightness';
 

--- a/docs/pages/versions/v49.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/calendar.mdx
@@ -75,7 +75,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Calendar usage' dependencies={['expo-calendar']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text, Button, Platform } from 'react-native';
 import * as Calendar from 'expo-calendar';
 

--- a/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
@@ -24,12 +24,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android', 'web']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
 export default function App() {
-  const [copiedText, setCopiedText] = React.useState('');
+  const [copiedText, setCopiedText] = useState('');
 
   const copyToClipboard = async () => {
     /* @info Copy the text to the clipboard */

--- a/docs/pages/versions/v49.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/contacts.mdx
@@ -72,7 +72,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Contacts Usage' dependencies={['expo-contacts']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Contacts from 'expo-contacts';
 

--- a/docs/pages/versions/v49.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/crypto.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Crypto from 'expo-crypto';
 

--- a/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
@@ -40,7 +40,6 @@ You can use the following snippet to detect faces in a fast mode without detecti
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 
 ```jsx
-import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';
 

--- a/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
 

--- a/docs/pages/versions/v49.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/haptics.mdx
@@ -37,7 +37,6 @@ On Android, this library requires permission to control vibration on the device.
 <SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
 
 ```jsx
-import * as React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
 import * as Haptics from 'expo-haptics';
 

--- a/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
@@ -31,7 +31,7 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';

--- a/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
@@ -93,7 +93,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
 ```tsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Image, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 

--- a/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
@@ -24,7 +24,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
 ```tsx
-import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -120,7 +120,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 <SnackInline label='Location' dependencies={['expo-location', 'expo-constants']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
 import * as Device from 'expo-device';

--- a/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
@@ -26,7 +26,7 @@ You can access the calibrated values with `Magnetometer` and uncalibrated raw va
 <SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Magnetometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -204,7 +204,7 @@ import * as Notifications from 'expo-notifications';
 import { router } from 'expo-router';
 
 function useNotificationObserver() {
-  React.useEffect(() => {
+  useEffect(() => {
     let isMounted = true;
 
     function redirect(notification: Notifications.Notification) {

--- a/docs/pages/versions/v49.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/print.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, StyleSheet, Button, Platform, Text } from 'react-native';
 import * as Print from 'expo-print';
 import { shareAsync } from 'expo-sharing';
@@ -46,7 +46,7 @@ const html = `
 `;
 
 export default function App() {
-  const [selectedPrinter, setSelectedPrinter] = React.useState();
+  const [selectedPrinter, setSelectedPrinter] = useState();
 
   const print = async () => {
     // On iOS/android prints the given html. On web prints the HTML from the current page.

--- a/docs/pages/versions/v49.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/securestore.mdx
@@ -62,7 +62,7 @@ Setting this property automatically handles the compliance information prompt.
 <SnackInline label='SecureStore' dependencies={['expo-secure-store']} platforms={['ios', 'android']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { Text, View, StyleSheet, TextInput, Button } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
@@ -80,8 +80,8 @@ async function getValueFor(key) {
 }
 
 export default function App() {
-  const [key, onChangeKey] = React.useState('Your key here');
-  const [value, onChangeValue] = React.useState('Your value here');
+  const [key, onChangeKey] = useState('Your key here');
+  const [value, onChangeValue] = useState('Your value here');
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v49.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/speech.mdx
@@ -24,7 +24,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Speech' dependencies={['expo-speech']}>
 
 ```jsx
-import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import * as Speech from 'expo-speech';
 

--- a/docs/pages/versions/v49.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/svg.mdx
@@ -34,7 +34,6 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
 export default function SvgComponent(props) {

--- a/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
@@ -73,7 +73,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 

--- a/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Video Thumbnails' dependencies={['expo-video-thumbnails']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Button, View, Image, Text } from 'react-native';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 

--- a/docs/pages/versions/v49.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video.mdx
@@ -28,13 +28,13 @@ Here's a simple example of a video with a play/pause button.
 <SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
+import { useState, useRef } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
-  const video = React.useRef(null);
-  const [status, setStatus] = React.useState({});
+  const video = useRef(null);
+  const [status, setStatus] = useState({});
   return (
     <View style={styles.container}>
       <Video

--- a/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic WebBrowser usage" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Text, View, StyleSheet } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 /* @hide */

--- a/docs/pages/versions/v49.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webview.mdx
@@ -25,7 +25,6 @@ You should refer to the [`react-native-webview` documentation](https://github.co
 
 {/* prettier-ignore */}
 ```jsx
-import * as React from 'react';
 import { WebView } from 'react-native-webview';
 /* @hide */
 import { StyleSheet } from 'react-native';
@@ -58,7 +57,6 @@ Minimal example with inline HTML:
 <SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
 
 ```jsx
-import * as React from 'react';
 import { WebView } from 'react-native-webview';
 /* @hide */
 import { StyleSheet } from 'react-native';

--- a/docs/pages/versions/v50.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/accelerometer.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v50.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/background-fetch.mdx
@@ -42,7 +42,7 @@ Below is an example that demonstrates how to use `expo-background-fetch`.
 <SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
@@ -79,10 +79,10 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState(false);
-  const [status, setStatus] = React.useState(null);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [status, setStatus] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     checkStatusAsync();
   }, []);
 

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -123,7 +123,7 @@ You must request permission to access the user's camera before attempting to get
 <SnackInline label="Basic BarCodeScanner usage" dependencies={['expo-barcode-scanner']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
 import { BarCodeScanner } from 'expo-barcode-scanner';
 

--- a/docs/pages/versions/v50.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/barometer.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Barometer usage' dependencies={['expo-sensors']} platforms={['android', 'ios']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import { Barometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v50.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/brightness.mdx
@@ -36,7 +36,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Brightness Usage' dependencies={['expo-brightness']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Brightness from 'expo-brightness';
 

--- a/docs/pages/versions/v50.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/calendar.mdx
@@ -75,7 +75,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Calendar usage' dependencies={['expo-calendar']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text, Button, Platform } from 'react-native';
 import * as Calendar from 'expo-calendar';
 

--- a/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
@@ -24,12 +24,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android', 'web']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
 export default function App() {
-  const [copiedText, setCopiedText] = React.useState('');
+  const [copiedText, setCopiedText] = useState('');
 
   const copyToClipboard = async () => {
     /* @info Copy the text to the clipboard */

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -72,7 +72,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Contacts Usage' dependencies={['expo-contacts']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Contacts from 'expo-contacts';
 

--- a/docs/pages/versions/v50.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/crypto.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Crypto from 'expo-crypto';
 

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -42,7 +42,6 @@ You can use the following snippet to detect faces in a fast mode without detecti
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 
 ```jsx
-import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';
 

--- a/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
 

--- a/docs/pages/versions/v50.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/haptics.mdx
@@ -37,7 +37,6 @@ On Android, this library requires permission to control vibration on the device.
 <SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
 
 ```jsx
-import * as React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
 import * as Haptics from 'expo-haptics';
 

--- a/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
@@ -31,7 +31,7 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';

--- a/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
@@ -24,7 +24,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
 ```tsx
-import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -128,7 +128,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 <SnackInline label='Location' dependencies={['expo-location', 'expo-constants']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
 import * as Device from 'expo-device';

--- a/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
@@ -26,7 +26,7 @@ You can access the calibrated values with `Magnetometer` and uncalibrated raw va
 <SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Magnetometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v50.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/print.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, StyleSheet, Button, Platform, Text } from 'react-native';
 import * as Print from 'expo-print';
 import { shareAsync } from 'expo-sharing';
@@ -46,7 +46,7 @@ const html = `
 `;
 
 export default function App() {
-  const [selectedPrinter, setSelectedPrinter] = React.useState();
+  const [selectedPrinter, setSelectedPrinter] = useState();
 
   const print = async () => {
     // On iOS/android prints the given html. On web prints the HTML from the current page.

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -114,7 +114,7 @@ Setting this property automatically handles the compliance information prompt.
 <SnackInline label='SecureStore' dependencies={['expo-secure-store']} platforms={['ios', 'android']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { Text, View, StyleSheet, TextInput, Button } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
@@ -132,8 +132,8 @@ async function getValueFor(key) {
 }
 
 export default function App() {
-  const [key, onChangeKey] = React.useState('Your key here');
-  const [value, onChangeValue] = React.useState('Your value here');
+  const [key, onChangeKey] = useState('Your key here');
+  const [value, onChangeValue] = useState('Your value here');
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v50.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/speech.mdx
@@ -24,7 +24,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Speech' dependencies={['expo-speech']}>
 
 ```jsx
-import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import * as Speech from 'expo-speech';
 

--- a/docs/pages/versions/v50.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/svg.mdx
@@ -34,7 +34,6 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
 export default function SvgComponent(props) {

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -73,7 +73,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 

--- a/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Video Thumbnails' dependencies={['expo-video-thumbnails']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Button, View, Image, Text } from 'react-native';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 

--- a/docs/pages/versions/v50.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video.mdx
@@ -28,13 +28,13 @@ Here's a simple example of a video with a play/pause button.
 <SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
+import { useState, useRef } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
-  const video = React.useRef(null);
-  const [status, setStatus] = React.useState({});
+  const video = useRef(null);
+  const [status, setStatus] = useState({});
   return (
     <View style={styles.container}>
       <Video

--- a/docs/pages/versions/v50.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webbrowser.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic WebBrowser usage" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Text, View, StyleSheet } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 /* @hide */

--- a/docs/pages/versions/v51.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/accelerometer.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v51.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/background-fetch.mdx
@@ -40,7 +40,7 @@ Below is an example that demonstrates how to use `expo-background-fetch`.
 <SnackInline label="Background Fetch Usage" dependencies={['expo-background-fetch', 'expo-task-manager']}>
 
 ```tsx
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
@@ -77,10 +77,10 @@ async function unregisterBackgroundFetchAsync() {
 }
 
 export default function BackgroundFetchScreen() {
-  const [isRegistered, setIsRegistered] = React.useState(false);
-  const [status, setStatus] = React.useState(null);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [status, setStatus] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     checkStatusAsync();
   }, []);
 

--- a/docs/pages/versions/v51.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/bar-code-scanner.mdx
@@ -121,7 +121,7 @@ You must request permission to access the user's camera before attempting to get
 <SnackInline label="Basic BarCodeScanner usage" dependencies={['expo-barcode-scanner']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
 import { BarCodeScanner } from 'expo-barcode-scanner';
 

--- a/docs/pages/versions/v51.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/barometer.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Barometer usage' dependencies={['expo-sensors']} platforms={['android', 'ios']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import { Barometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v51.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/brightness.mdx
@@ -34,7 +34,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Brightness Usage' dependencies={['expo-brightness']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Brightness from 'expo-brightness';
 

--- a/docs/pages/versions/v51.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/calendar.mdx
@@ -73,7 +73,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Calendar usage' dependencies={['expo-calendar']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text, Button, Platform } from 'react-native';
 import * as Calendar from 'expo-calendar';
 

--- a/docs/pages/versions/v51.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/clipboard.mdx
@@ -22,12 +22,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Clipboard' dependencies={['expo-clipboard']} platforms={['ios', 'android', 'web']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 
 export default function App() {
-  const [copiedText, setCopiedText] = React.useState('');
+  const [copiedText, setCopiedText] = useState('');
 
   const copyToClipboard = async () => {
     /* @info Copy the text to the clipboard */

--- a/docs/pages/versions/v51.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/contacts.mdx
@@ -70,7 +70,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic Contacts Usage' dependencies={['expo-contacts']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Contacts from 'expo-contacts';
 

--- a/docs/pages/versions/v51.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/crypto.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import * as Crypto from 'expo-crypto';
 

--- a/docs/pages/versions/v51.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/facedetector.mdx
@@ -40,7 +40,6 @@ You can use the following snippet to detect faces in a fast mode without detecti
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 
 ```jsx
-import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';
 

--- a/docs/pages/versions/v51.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gyroscope.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
 

--- a/docs/pages/versions/v51.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/haptics.mdx
@@ -35,7 +35,6 @@ On Android, this library requires permission to control vibration on the device.
 <SnackInline label='Haptics usage' dependencies={['expo-haptics']}>
 
 ```jsx
-import * as React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
 import * as Haptics from 'expo-haptics';
 

--- a/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
@@ -29,7 +29,7 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';

--- a/docs/pages/versions/v51.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/linear-gradient.mdx
@@ -22,7 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
 ```tsx
-import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -126,7 +126,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 <SnackInline label='Location' dependencies={['expo-location', 'expo-constants']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
 import * as Device from 'expo-device';

--- a/docs/pages/versions/v51.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/magnetometer.mdx
@@ -24,7 +24,7 @@ You can access the calibrated values with `Magnetometer` and uncalibrated raw va
 <SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Magnetometer } from 'expo-sensors';
 

--- a/docs/pages/versions/v51.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/print.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Print usage' dependencies={['expo-print', 'expo-sharing']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { View, StyleSheet, Button, Platform, Text } from 'react-native';
 import * as Print from 'expo-print';
 import { shareAsync } from 'expo-sharing';
@@ -44,7 +44,7 @@ const html = `
 `;
 
 export default function App() {
-  const [selectedPrinter, setSelectedPrinter] = React.useState();
+  const [selectedPrinter, setSelectedPrinter] = useState();
 
   const print = async () => {
     // On iOS/android prints the given html. On web prints the HTML from the current page.

--- a/docs/pages/versions/v51.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/securestore.mdx
@@ -112,7 +112,7 @@ Setting this property automatically handles the compliance information prompt.
 <SnackInline label='SecureStore' dependencies={['expo-secure-store']} platforms={['ios', 'android']}>
 
 ```jsx
-import * as React from 'react';
+import { useState } from 'react';
 import { Text, View, StyleSheet, TextInput, Button } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
@@ -130,8 +130,8 @@ async function getValueFor(key) {
 }
 
 export default function App() {
-  const [key, onChangeKey] = React.useState('Your key here');
-  const [value, onChangeValue] = React.useState('Your value here');
+  const [key, onChangeKey] = useState('Your key here');
+  const [value, onChangeValue] = useState('Your value here');
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v51.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/speech.mdx
@@ -22,7 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Speech' dependencies={['expo-speech']}>
 
 ```jsx
-import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import * as Speech from 'expo-speech';
 

--- a/docs/pages/versions/v51.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/svg.mdx
@@ -32,7 +32,6 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
 export default function SvgComponent(props) {

--- a/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
@@ -71,7 +71,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <SnackInline label='Basic tracking transparency usage' dependencies={['expo-tracking-transparency']}>
 
 ```jsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { requestTrackingPermissionsAsync } from 'expo-tracking-transparency';
 

--- a/docs/pages/versions/v51.0.0/sdk/video-av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/video-av.mdx
@@ -28,13 +28,13 @@ Here's a simple example of a video with a play/pause button.
 <SnackInline label='Video' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
+import { useState, useRef } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
-  const video = React.useRef(null);
-  const [status, setStatus] = React.useState({});
+  const video = useRef(null);
+  const [status, setStatus] = useState({});
   return (
     <View style={styles.container}>
       <Video

--- a/docs/pages/versions/v51.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/video-thumbnails.mdx
@@ -21,7 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Video Thumbnails' dependencies={['expo-video-thumbnails']}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Button, View, Image, Text } from 'react-native';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 

--- a/docs/pages/versions/v51.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/webbrowser.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic WebBrowser usage" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button, Text, View, StyleSheet } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 /* @hide */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Different examples use different patterns when importing a hook from React. We need to establish a pattern so that it is easier to write these code snippets in our docs and also follow a singular pattern.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Removes all instances of unused React import statements from code examples (I've also found we're using two different patterns for this which is a bit confusing)
- Update import statements to import hooks (such as `useState`, `useEffect`, and so on) in code examples where they are used

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check the modified files manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
