### PR TITLE
[docs] Add tip that you should use node 18 version when using create-…

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -16,6 +16,8 @@ First, we'll create a new module. On this page we will use the name `expo-settin
 
 > **Tip**: Since you aren't going to actually ship this library, you can hit <kbd>return</kbd> for all the prompts to accept the default values.
 
+> **Tip**: Use Node.js version 18 to resolve the npm install exited with non-zero code: 1 If the at ChildProcess.completionListener error.
+
 ## 2. Set up our workspace
 
 Now let's clean up the default module a little bit so we have more of a clean slate and delete the view module that we won't use in this guide.


### PR DESCRIPTION
# Why

When using the npx create-expo-module CLI to generate an Expo module project, an error similar to the one shown in the image occurs if Node.js version 18 is not used. Therefore, I believe it would be beneficial to add a tip in the official documentation advising users to use Node.js version 18 to avoid this issue.

![image](https://github.com/user-attachments/assets/297e7ab9-497a-4be4-948c-b00ed910b4f9)


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
