### PR TITLE
chore(cli): remove unused export helper

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -11,7 +11,6 @@ import MetroHmrServer from 'metro/src/HmrServer';
 import { loadConfig, resolveConfig, ConfigT } from 'metro-config';
 import { Terminal } from 'metro-core';
 import util from 'node:util';
-import semver from 'semver';
 import { URL } from 'url';
 
 import { createDevToolsPluginWebsocketEndpoint } from './DevToolsPluginWebsocketEndpoint';

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -39,22 +39,6 @@ type MessageSocket = {
   broadcast: (method: string, params?: Record<string, any> | undefined) => void;
 };
 
-function gteSdkVersion(exp: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion: string): boolean {
-  if (!exp.sdkVersion) {
-    return false;
-  }
-
-  if (exp.sdkVersion === 'UNVERSIONED') {
-    return true;
-  }
-
-  try {
-    return semver.gte(exp.sdkVersion, sdkVersion);
-  } catch {
-    throw new Error(`${exp.sdkVersion} is not a valid version. Must be in the form of x.y.z`);
-  }
-}
-
 // Wrap terminal and polyfill console.log so we can log during bundling without breaking the indicator.
 class LogRespectingTerminal extends Terminal {
   constructor(stream: import('node:net').Socket | import('node:stream').Writable) {
@@ -118,27 +102,15 @@ export async function loadMetroConfigAsync(
     },
   };
 
-  if (
-    // Requires SDK 50 for expo-assets hashAssetPlugin change.
-    !exp.sdkVersion ||
-    gteSdkVersion(exp, '50.0.0')
-  ) {
-    if (isExporting) {
-      // This token will be used in the asset plugin to ensure the path is correct for writing locally.
-      // @ts-expect-error: typed as readonly.
-      config.transformer.publicPath = `/assets?export_path=${
-        (exp.experiments?.baseUrl ?? '') + '/assets'
-      }`;
-    } else {
-      // @ts-expect-error: typed as readonly
-      config.transformer.publicPath = '/assets/?unstable_path=.';
-    }
+  if (isExporting) {
+    // This token will be used in the asset plugin to ensure the path is correct for writing locally.
+    // @ts-expect-error: typed as readonly.
+    config.transformer.publicPath = `/assets?export_path=${
+      (exp.experiments?.baseUrl ?? '') + '/assets'
+    }`;
   } else {
-    if (isExporting && exp.experiments?.baseUrl) {
-      // This token will be used in the asset plugin to ensure the path is correct for writing locally.
-      // @ts-expect-error: typed as readonly.
-      config.transformer.publicPath = exp.experiments?.baseUrl;
-    }
+    // @ts-expect-error: typed as readonly
+    config.transformer.publicPath = '/assets/?unstable_path=.';
   }
 
   const platformBundlers = getPlatformBundlers(projectRoot, exp);

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### 💡 Others
 
+- Remove back-compat asset helper from SDK 50.
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove nested loading for DOM components. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))
 - Redesign Fast Refresh overlay for web. ([#30507](https://github.com/expo/expo/pull/30507) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### 💡 Others
 
-- Remove back-compat asset helper from SDK 50.
+- Remove back-compat asset helper from SDK 50. ([#31296](https://github.com/expo/expo/pull/31296) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove nested loading for DOM components. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))
 - Redesign Fast Refresh overlay for web. ([#30507](https://github.com/expo/expo/pull/30507) by [@EvanBacon](https://github.com/EvanBacon))


### PR DESCRIPTION
# Why

This helper was added to test a new feature during the SDK 49/50 release cycle, but that's no longer needed and can lead to unexpected issues when the SDK version is set incorrectly.
