### PR TITLE
[core][Android] Cache `AnyType`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -74,6 +74,7 @@
 - JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use singletons for string and data dynamic types. ([#31220](https://github.com/expo/expo/pull/31220) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function. ([#31226](https://github.com/expo/expo/pull/31226) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Cached argument's type information to improve memory and startup time.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -74,7 +74,7 @@
 - JS values are now used directly instead of using shared pointers to improve the overall performance. ([#31219](https://github.com/expo/expo/pull/31219) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use singletons for string and data dynamic types. ([#31220](https://github.com/expo/expo/pull/31220) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function. ([#31226](https://github.com/expo/expo/pull/31226) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Cached argument's type information to improve memory and startup time.
+- [Android] Cached argument's type information to improve memory and startup time. ([#31297](https://github.com/expo/expo/pull/31297) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -129,15 +129,6 @@ class KotlinInteropModuleRegistryTest {
       Triple(
         "test-2",
         "f2",
-        JavaOnlyArray().apply { pushString("string") }
-      ) to """
-        Call to function 'test-2.f2' has been rejected.
-        → Caused by: The 1st argument cannot be cast to type kotlin.Int (received String)
-        → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
-      """.trimIndent(),
-      Triple(
-        "test-2",
-        "f2",
         JavaOnlyArray()
       ) to """
         Call to function 'test-2.f2' has been rejected.


### PR DESCRIPTION
# Why

Caches `AnyType` to improve startup time and memory.

# How

We don't need to recreate `LazyType` for all parameters. When dealing with simple types, we can cache some information, improving memory consumption and startup time.

# Test Plan

- unit test ✅ 
- benchmark ✅