### PR TITLE
[docs] fix command syntax in TV guide

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -135,7 +135,7 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 ### Add the TV config plugin
 
-<Terminal cmd={['$ npx expo install --dev @react-native-tvos/config-tv']} />
+<Terminal cmd={['$ npx expo install @react-native-tvos/config-tv -- --dev']} />
 
 When installed, the plugin will modify the project for TV when either:
 


### PR DESCRIPTION
![2024-09-02 09-39-32](https://github.com/user-attachments/assets/54695da9-90ac-4e61-bfdb-78293d759b34)

Fix:
```
npx expo install @react-native-tvos/config-tv -- --dev
```