### PR TITLE
[babel-preset] inline process.env.EXPO_DOM_BASE_URL on web

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix JSC builds. ([#30763](https://github.com/expo/expo/pull/30763) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
+- Fixed `process.env.EXPO_DOM_BASE_URL` is undefined on web for DOM components. ([#31299](https://github.com/expo/expo/pull/31299) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -124,6 +124,9 @@ function babelPresetExpo(api, options = {}) {
     if (process.env.NODE_ENV !== 'test') {
         inlines['process.env.EXPO_BASE_URL'] = baseUrl;
     }
+    if (platform === 'web') {
+        inlines['process.env.EXPO_DOM_BASE_URL'] = baseUrl;
+    }
     extraPlugins.push([require('./define-plugin'), inlines]);
     if (isProduction) {
         // Metro applies a version of this plugin too but it does it after the Platform modules have been transformed to CJS, this breaks the transform.

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -248,6 +248,10 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     inlines['process.env.EXPO_BASE_URL'] = baseUrl;
   }
 
+  if (platform === 'web') {
+    inlines['process.env.EXPO_DOM_BASE_URL'] = baseUrl;
+  }
+
   extraPlugins.push([require('./define-plugin'), inlines]);
 
   if (isProduction) {


### PR DESCRIPTION
# Why

fixed `process.env.EXPO_DOM_BASE_URL` is undefined on web for dom components

# How

on native, the `process.env.EXPO_DOM_BASE_URL` is injected from webview. we didn't go through the same process on web. instead, we could follow `process.env.EXPO_BASE_URL` inline on web.

# Test Plan

test router-e2e/dom-component 05-public-asset on web

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
