### PR TITLE
[iOS] Add local module to bare-expo for benchmarking

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1,4 +1,26 @@
 PODS:
+  - BenchmarkingModule (0.0.1):
+    - DoubleConversion
+    - ExpoModulesCore
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - EASClient (0.12.0):
@@ -2580,6 +2602,7 @@ PODS:
     - ZXingObjC/Core
 
 DEPENDENCIES:
+  - BenchmarkingModule (from `../modules/benchmarking/ios`)
   - boost (from `../../../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EASClient (from `../../../packages/expo-eas-client/ios`)
@@ -2764,6 +2787,9 @@ SPEC REPOS:
     - ZXingObjC
 
 EXTERNAL SOURCES:
+  BenchmarkingModule:
+    inhibit_warnings: false
+    :path: "../modules/benchmarking/ios"
   boost:
     :podspec: "../../../node_modules/react-native/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -3134,6 +3160,7 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  BenchmarkingModule: 0be4117c4bf255d2e21df9e4a4a486ec89c8640f
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   EASClient: 00a5bbc03a76fbcca972e7a4465f0e939d567e0d
@@ -3279,7 +3306,7 @@ SPEC CHECKSUMS:
   React-RuntimeHermes: 860cf64708a12a2fa62366fe51fe000121fa031b
   React-runtimescheduler: fff88d51ad2c8815fc75930dbac224d680593e6b
   React-utils: 81a715d9c0a2a49047e77a86f3a2247408540deb
-  ReactCodegen: 4c29be59257644159393c3996669167e0d3f19a5
+  ReactCodegen: 506d0e24c7fefd38e1559ab6fa52064dbbd21a2b
   ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
   RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906

--- a/apps/bare-expo/modules/benchmarking/expo-module.config.json
+++ b/apps/bare-expo/modules/benchmarking/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": [
+    "apple"
+  ],
+  "apple": {
+    "modules": [
+      "BenchmarkingExpoModule"
+    ]
+  }
+}

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.h
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.h
@@ -1,0 +1,5 @@
+#import <React/RCTBridgeModule.h>
+
+@interface BenchmarkingBridgeModule : NSObject <RCTBridgeModule>
+
+@end

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
@@ -1,0 +1,22 @@
+#import <BenchmarkingModule/BenchmarkingBridgeModule.h>
+
+@implementation BenchmarkingBridgeModule
+
+RCT_EXPORT_MODULE(BenchmarkingBridgeModule);
+
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(void, nothing) {}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(addNumbers:(double)a b:(double)b)
+{
+  NSNumber* number = [[NSNumber alloc] initWithDouble:a + b];
+  return number;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(addStrings:(NSString *)a b:(NSString *)b)
+{
+  NSMutableString* result = [[NSMutableString alloc] initWithString:a];
+  [result appendString:b];
+  return result;
+}
+
+@end

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -1,0 +1,17 @@
+import ExpoModulesCore
+
+public final class BenchmarkingExpoModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("BenchmarkingExpoModule")
+
+    Function("nothing") {}
+
+    Function("addNumbers") { (a: Double, b: Double) in
+      return a + b
+    }
+
+    Function("addStrings") { (a: String, b: String) in
+      return a + b
+    }
+  }
+}

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingModule.podspec
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingModule.podspec
@@ -1,0 +1,25 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'BenchmarkingModule'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.platforms      = {
+    :ios => '15.1',
+  }
+  s.swift_version  = '5.4'
+  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.static_framework = true
+
+  s.source_files = '**/*.{h,cpp,m,mm,swift}'
+  
+  s.dependency 'ExpoModulesCore'
+
+  install_modules_dependencies(s)
+end

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.h
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+
+#import <ReactCodegen/LocalModules/LocalModules.h>
+
+@interface BenchmarkingTurboModule : NSObject <NativeBenchmarkingTurboModuleSpec>
+
+@end
+
+#endif // __cplusplus

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
@@ -1,0 +1,27 @@
+#import <BenchmarkingModule/BenchmarkingTurboModule.h>
+
+@implementation BenchmarkingTurboModule
+
+RCT_EXPORT_MODULE()
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeBenchmarkingTurboModuleSpecJSI>(params);
+}
+
+- (void)nothing {}
+
+- (NSNumber *)addNumbers:(double)a b:(double)b
+{
+  NSNumber* number = [[NSNumber alloc] initWithDouble:a + b];
+  return number;
+}
+
+- (NSString *)addStrings:(NSString *)a b:(NSString *)b
+{
+  NSMutableString* result = [[NSMutableString alloc] initWithString:a];
+  [result appendString:b];
+  return result;
+}
+
+@end

--- a/apps/bare-expo/modules/benchmarking/package.json
+++ b/apps/bare-expo/modules/benchmarking/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "benchmarking-module",
+  "version": "0.0.1",
+  "private": true,
+  "description": "A local module for benchmarking Expo, Turbo and Bridge modules",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "homepage": "https://expo.dev",
+  "author": "650 Industries, Inc.",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingBridgeModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingBridgeModule.ts
@@ -1,0 +1,3 @@
+import { NativeModules } from 'react-native';
+
+export default NativeModules.BenchmarkingBridgeModule;

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -1,0 +1,9 @@
+import { requireNativeModule, NativeModule } from 'expo';
+
+declare class BenchmarkingExpoModule extends NativeModule {
+  nothing(): void;
+  addNumbers(a: number, b: number): number;
+  addStrings(a: string, b: string): string;
+}
+
+export default requireNativeModule<BenchmarkingExpoModule>('BenchmarkingExpoModule');

--- a/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
@@ -1,0 +1,9 @@
+import { TurboModule, TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  nothing(): void;
+  addNumbers(a: number, b: number): number;
+  addStrings(a: string, b: string): string;
+}
+
+export default TurboModuleRegistry.get<Spec>('BenchmarkingTurboModule') as Spec | null;

--- a/apps/bare-expo/modules/benchmarking/src/index.ts
+++ b/apps/bare-expo/modules/benchmarking/src/index.ts
@@ -1,0 +1,5 @@
+import BridgeModule from './BenchmarkingBridgeModule';
+import ExpoModule from './BenchmarkingExpoModule';
+import TurboModule from './NativeBenchmarkingTurboModule';
+
+export { TurboModule, ExpoModule, BridgeModule };

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -78,5 +78,10 @@
     "getenv": "^1.0.0",
     "jest": "^29.3.1",
     "serve": "^11.3.0"
+  },
+  "codegenConfig": {
+    "name": "LocalModules",
+    "type": "all",
+    "jsSrcsDir": "./modules"
   }
 }

--- a/apps/bare-expo/tsconfig.json
+++ b/apps/bare-expo/tsconfig.json
@@ -8,6 +8,7 @@
     ],
     "paths": {
       "ThemeProvider": ["../common/ThemeProvider"],
+      "benchmarking": ["./modules/benchmarking"]
     }
   }
 }

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesBenchmarksScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesBenchmarksScreen.tsx
@@ -1,0 +1,216 @@
+import { useTheme } from 'ThemeProvider';
+import { TurboModule, ExpoModule, BridgeModule } from 'benchmarking';
+import { useCallback, useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+type BenchmarkResult = {
+  expoTime: number;
+  turboTime: number;
+  bridgeTime: number;
+};
+
+const runs = 100_000;
+
+function runVoidBenchmark(): BenchmarkResult {
+  let expoTime = 0;
+  {
+    ExpoModule.nothing();
+
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      ExpoModule.nothing();
+    }
+    const end = performance.now();
+    expoTime = end - start;
+    console.log(`ExpoModule took ${expoTime.toFixed(2)}ms to run nothing() ${runs}x!`);
+  }
+
+  let turboTime = 0;
+  if (TurboModule) {
+    TurboModule.nothing();
+
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      TurboModule.nothing();
+    }
+    const end = performance.now();
+    turboTime = end - start;
+    console.log(`TurboModule took ${turboTime.toFixed(2)}ms to run nothing() ${runs}x!`);
+  }
+
+  let bridgeTime = 0;
+  {
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      BridgeModule.nothing();
+    }
+    const end = performance.now();
+    bridgeTime = end - start;
+    console.log(`BridgeModule took ${expoTime.toFixed(2)}ms to run nothing() ${runs}x!`);
+  }
+
+  return { expoTime, turboTime, bridgeTime };
+}
+
+function runNumberBenchmark(): BenchmarkResult {
+  let expoTime = 0;
+  {
+    ExpoModule.addNumbers(0, 1);
+
+    const start = performance.now();
+    let num = 0;
+    for (let i = 0; i < runs; i++) {
+      num = ExpoModule.addNumbers(num, 5);
+    }
+    const end = performance.now();
+    expoTime = end - start;
+    console.log(`ExpoModule took ${expoTime.toFixed(2)}ms to run addNumbers(...) ${runs}x!`);
+  }
+
+  let turboTime = 0;
+  if (TurboModule) {
+    TurboModule.addNumbers(0, 1);
+
+    const start = performance.now();
+    let num = 0;
+    for (let i = 0; i < runs; i++) {
+      num = TurboModule.addNumbers(num, 5);
+    }
+    const end = performance.now();
+    turboTime = end - start;
+    console.log(`TurboModule took ${turboTime.toFixed(2)}ms to run addNumbers(...) ${runs}x!`);
+  }
+
+  let bridgeTime = 0;
+  {
+    const start = performance.now();
+    let num = 0;
+    for (let i = 0; i < runs; i++) {
+      num = BridgeModule.addNumbers(num, 5);
+    }
+    const end = performance.now();
+    bridgeTime = end - start;
+    console.log(`BridgeModule took ${bridgeTime.toFixed(2)}ms to run nothing() ${runs}x!`);
+  }
+
+  return { expoTime, turboTime, bridgeTime };
+}
+
+function runStringsBenchmark(): BenchmarkResult {
+  let expoTime = 0;
+  {
+    ExpoModule.addStrings('hello', 'world');
+
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      ExpoModule.addStrings('hello ', 'world');
+    }
+    const end = performance.now();
+    expoTime = end - start;
+    console.log(`ExpoModule took ${expoTime.toFixed(2)}ms to run addNumbers(...) ${runs}x!`);
+  }
+
+  let turboTime = 0;
+  if (TurboModule) {
+    TurboModule.addStrings('hello', 'world');
+
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      TurboModule.addStrings('hello ', 'world');
+    }
+    const end = performance.now();
+    turboTime = end - start;
+    console.log(`TurboModule took ${turboTime.toFixed(2)}ms to run addStrings(...) ${runs}x!`);
+  }
+
+  let bridgeTime = 0;
+  {
+    const start = performance.now();
+    for (let i = 0; i < runs; i++) {
+      BridgeModule.addStrings('hello', 'world');
+    }
+    const end = performance.now();
+    bridgeTime = end - start;
+    console.log(`BridgeModule took ${bridgeTime.toFixed(2)}ms to run nothing() ${runs}x!`);
+  }
+
+  return { expoTime, turboTime, bridgeTime };
+}
+
+function BenchmarkResultContainer(props: { functionName: string; result: BenchmarkResult | null }) {
+  const { theme } = useTheme();
+  const { functionName, result } = props;
+
+  const expoTime = result?.expoTime ? result.expoTime.toFixed(2) + 'ms' : 'null';
+  const turboTime = result?.turboTime ? result.turboTime.toFixed(2) + 'ms' : 'null';
+  const bridgeTime = result?.bridgeTime ? result.bridgeTime.toFixed(2) + 'ms' : 'null';
+
+  return (
+    <View style={styles.benchmarkContainer}>
+      <Text style={[styles.testHeader, { color: theme.text.default }]}>
+        Calling `{functionName}` 100.000 times
+      </Text>
+      <View style={styles.testResult}>
+        <Text style={[styles.testResultText, { color: theme.text.default }]}>
+          ExpoModule took: <Text style={styles.testResultTime}>{expoTime}</Text>
+        </Text>
+        <Text style={[styles.testResultText, { color: theme.text.default }]}>
+          TurboModule took: <Text style={styles.testResultTime}>{turboTime}</Text>
+        </Text>
+        <Text style={[styles.testResultText, { color: theme.text.default }]}>
+          BridgeModule took: <Text style={styles.testResultTime}>{bridgeTime}</Text>
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export default function ModulesBenchmarksScreen() {
+  const { theme } = useTheme();
+
+  const [voidTimes, setVoidTimes] = useState<BenchmarkResult | null>(null);
+  const [numberTimes, setNumberTimes] = useState<BenchmarkResult | null>(null);
+  const [stringTimes, setStringTimes] = useState<BenchmarkResult | null>(null);
+
+  const startBenchmarks = useCallback(() => {
+    setVoidTimes(runVoidBenchmark());
+    setNumberTimes(runNumberBenchmark());
+    setStringTimes(runStringsBenchmark());
+  }, []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background.screen }]}>
+      <BenchmarkResultContainer functionName="nothing" result={voidTimes} />
+      <BenchmarkResultContainer functionName="addNumbers" result={numberTimes} />
+      <BenchmarkResultContainer functionName="addStrings" result={stringTimes} />
+
+      <Button title="Start" color={theme.text.link} onPress={startBenchmarks} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 30,
+    alignItems: 'center',
+  },
+  benchmarkContainer: {
+    margin: 10,
+    alignItems: 'center',
+  },
+  testHeader: {
+    fontWeight: 'bold',
+    fontSize: 17,
+  },
+  testResult: {
+    margin: 10,
+  },
+  testResultText: {
+    fontSize: 16,
+  },
+  testResultTime: {
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+  },
+});

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
@@ -1,3 +1,6 @@
+import { isRunningInExpoGo } from 'expo';
+import { Platform } from 'expo-modules-core';
+
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { ListElement } from '../ComponentListScreen';
 
@@ -17,6 +20,16 @@ export const ModulesCoreScreens = [
     },
   },
 ];
+
+if (Platform.OS === 'ios' && !isRunningInExpoGo()) {
+  ModulesCoreScreens.push({
+    name: 'Benchmarks',
+    route: 'modulescore/benchmarks',
+    getComponent() {
+      return optionalRequire(() => require('./ModulesBenchmarksScreen'));
+    },
+  });
+}
 
 export default function ModulesCoreScreen() {
   const apis: ListElement[] = ModulesCoreScreens.map((screen) => {

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": ".",
     "paths": {
       "@expo/vector-icons": ["react-native-vector-icons"],
-      "ThemeProvider": ["../common/ThemeProvider"]
+      "ThemeProvider": ["../common/ThemeProvider"],
+      "benchmarking": ["../bare-expo/modules/benchmarking"]
     },
     "types": ["jest"],
     "typeRoots": ["./ts-declarations", "./node_modules/@types", "../../node_modules/@types"],


### PR DESCRIPTION
# Why

bare-expo needs to have some local modules in order to do proper benchmarks and to test some functionalities in Expo Modules.

# How

I created one for benchmarking that contains Expo, Turbo and Bridge modules with the same set of functions.
Added a new screen to NCL with the benchmarks for these three types of native modules.

# Test Plan

![Simulator Screenshot - iPhone 15 Pro Max - 2024-09-02 at 16 52 26](https://github.com/user-attachments/assets/a1d46de4-cf5e-4f17-8248-ace2809bba3d)
