### PR TITLE
[docs] Add notes about old Android Build Infra required for Maestro tests

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -51,6 +51,16 @@ The following command creates a new project on Expo servers for your app and cre
 </Step>
 
 <Step label="3">
+
+## Ensure new Android Build Infrastructure is disabled
+
+Go to [**Project Settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.
+
+Unfortunately, the new build infrastructure is not compatible with E2E tests, it lacks support for virtualization which is required to start an Android emulator. We are working on better solutions for running various tests on EAS.
+
+</Step>
+
+<Step label="4">
 ## Add example Maestro test cases
 
 This is what the UI of the app created from the default Expo template looks like:
@@ -86,7 +96,7 @@ If you want to run these flows locally to verify that they work as expected, you
 
 </Step>
 
-<Step label="4">
+<Step label="5">
 ## Create a custom build workflow for running Maestro E2E tests
 
 The easiest way to run Maestro E2E tests on EAS Build is to create a [custom build workflow](/custom-builds/get-started/). This workflow will build your app and run the Maestro tests on it.
@@ -134,7 +144,7 @@ Now modify the **eas.json** by adding a new [build profile](/build/eas-json/#bui
 
 </Step>
 
-<Step label="5">
+<Step label="6">
 ## Build your app and run E2E tests on EAS Build
 
 To execute a custom build using the `build-and-maestro-test` profile that will build your app and run the Maestro E2E tests afterward, run the following command:
@@ -161,3 +171,13 @@ When the flow fails, any Maestro artifacts are automatically uploaded as build a
 If you want to build more advanced custom builds workflows, see the [custom build schema reference](/custom-builds/schema/) for more information.
 
 To learn more about Maestro flows and how to write them, see the [Maestro documentation](https://maestro.mobile.dev).
+
+## Troubleshooting
+
+If you encounter the following error message when trying to start an Android emulator for E2E tests on EAS Build:
+
+```
+Failed to configure emulator: emulator with required ID not found.
+```
+
+This is likely because the New Build Infrastructure is enabled for your project. Go to [**Project Settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -52,11 +52,11 @@ The following command creates a new project on Expo servers for your app and cre
 
 <Step label="3">
 
-## Ensure new Android Build Infrastructure is disabled
+## Disable Android Build Infrastructure
 
-Go to [**Project Settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.
+Go to [**Project settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.
 
-Unfortunately, the new build infrastructure is not compatible with E2E tests, it lacks support for virtualization which is required to start an Android emulator. We are working on better solutions for running various tests on EAS.
+Unfortunately, the new build infrastructure is incompatible with E2E tests due to the lack of virtualization support required to start Android Emulator. We are working on better solutions for running various tests on EAS.
 
 </Step>
 
@@ -174,7 +174,7 @@ To learn more about Maestro flows and how to write them, see the [Maestro docume
 
 ## Troubleshooting
 
-If you encounter the following error message when trying to start an Android emulator for E2E tests on EAS Build:
+If you encounter the following error message when starting an Android Emulator for E2E tests on EAS Build:
 
 ```
 Failed to configure emulator: emulator with required ID not found.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -739,7 +739,7 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 All-in-one function that installs Maestro, prepares a testing environment (Android Emulator or iOS Simulator), and tests the app.
 
-> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
+> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [Project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
 
 | Input       | Type     | Description                                                                                                                                                                                                                        |
 | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1692,7 +1692,7 @@ build:
 
 Starts an Android Emulator you can use to test your apps on. Only available when running a build for Android.
 
-> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
+> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [Project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
 
 ```yaml build-and-test.yml
 build:

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -739,6 +739,8 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 All-in-one function that installs Maestro, prepares a testing environment (Android Emulator or iOS Simulator), and tests the app.
 
+> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
+
 | Input       | Type     | Description                                                                                                                                                                                                                        |
 | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                   |
@@ -1689,6 +1691,8 @@ build:
 #### `eas/start_android_emulator`
 
 Starts an Android Emulator you can use to test your apps on. Only available when running a build for Android.
+
+> **warning** Your project must be configured to use the old Build Infrastructure to start Android Emulator. Go to [project settings](https://expo.dev/accounts/[account]/projects/[project]/settings) to configure. See [this changelog post](https://expo.dev/changelog/2024/08-29-c3d-default) for more information.
 
 ```yaml build-and-test.yml
 build:


### PR DESCRIPTION
# Why

Our new defaults prevent people from running E2E tests.

# How

Added notes about toggling "New Android Build Infrastructure" setting wherever we advertize E2E tests with Maestro in the docs.

# Test Plan

<img width="976" alt="Zrzut ekranu 2024-09-3 o 16 59 29" src="https://github.com/user-attachments/assets/d0e49624-b3c4-4b6f-b9e1-e12aebae0c69">
<img width="832" alt="Zrzut ekranu 2024-09-3 o 17 05 25" src="https://github.com/user-attachments/assets/dd7513f7-4596-47ca-8dbf-483a94356142">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
