### PR TITLE
[modules-core][font] Fix support for macos

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On iOS `loadAsync()` will reject if font loading fails. ([#31053](https://github.com/expo/expo/pull/31053) by [@vonovak](https://github.com/vonovak))
 - Add missing `react` peer dependencies for isolated modules. ([#30467](https://github.com/expo/expo/pull/30467) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config` to follow proper dependency chains. ([#30501](https://github.com/expo/expo/pull/30501) by [@byCedric](https://github.com/byCedric))
+- Fix support for macOS. ([#31307](https://github.com/expo/expo/pull/31307) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -47,6 +47,7 @@ private func maybeSwizzleUIFont() {
   if hasSwizzled {
     return
   }
+#if !os(macOS)
   let originalFontNamesMethod = class_getClassMethod(UIFont.self, #selector(UIFont.fontNames(forFamilyName:)))
   let newFontNamesMethod = class_getClassMethod(UIFont.self, #selector(UIFont._expo_fontNames(forFamilyName:)))
 
@@ -55,5 +56,6 @@ private func maybeSwizzleUIFont() {
   } else {
     log.error("expo-font is unable to swizzle `UIFont.fontNames(forFamilyName:)`")
   }
+#endif
   hasSwizzled = true
 }

--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -25,7 +25,11 @@ internal func queryCustomNativeFonts() -> [String] {
   // [2] Retrieve font names by family names
   return fontFamilies.flatMap { fontFamilyNames in
     return fontFamilyNames.flatMap { fontFamilyName in
+    #if os(iOS) || os(tvOS)
       return UIFont.fontNames(forFamilyName: fontFamilyName)
+    #elseif os(macOS)
+      return NSFontManager.shared.availableMembers(ofFontFamily: fontFamilyName)?.compactMap { $0[0] as? String } ?? []
+    #endif
     }
   }
 }

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -1,3 +1,4 @@
+#if !os(macOS)
 /**
  An extension to ``UIFont`` that adds a custom implementation of `fontNames(forFamilyName:)` that supports aliasing font families.
  */
@@ -25,3 +26,4 @@ public extension UIFont {
     return fontNames
   }
 }
+#endif

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [Android] Fixed `expo.modules.kotlin.jni.tests.RuntimeHolder` class not found crash when R8 is enabled. ([#30572](https://github.com/expo/expo/pull/30572) by [@kudo](https://github.com/kudo))
 - [Android] Fixed `Class declares 0 type parameters, but X were provided` on Android when R8 is enabled. ([#30659](https://github.com/expo/expo/pull/30659) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed SharedObject class names are obfuscated when R8 is enabled. ([#30948](https://github.com/expo/expo/pull/30948) by [@lukmccall](https://github.com/lukmccall))
+- Fix support for macOS. ([#31307](https://github.com/expo/expo/pull/31307) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -111,8 +111,10 @@
   return [[EXReactRootViewFactory alloc] initWithReactDelegate:self.reactDelegate configuration:configuration turboModuleManagerDelegate:self];
 }
 
+#if !TARGET_OS_OSX
 - (void)customizeRootView:(UIView *)rootView {
   [_expoAppDelegate customizeRootView:rootView];
 }
+#endif // !TARGET_OS_OSX
 
 @end

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -34,7 +34,8 @@ extension UIColor: Convertible {
         let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0, appContext: appContext) }) {
         let highContrastLightColor = try appearances["highContrastLight"].map({ try UIColor.convert(from: $0, appContext: appContext) })
         let highContrastDarkColor = try appearances["highContrastDark"].map({ try UIColor.convert(from: $0, appContext: appContext) })
-
+ 
+        #if os(iOS) || os(tvOS)
         let color = UIColor { (traitCollection: UITraitCollection) -> UIColor in
           if traitCollection.userInterfaceStyle == .dark {
             if traitCollection.accessibilityContrast == .high, let highContrastDarkColor {
@@ -48,6 +49,24 @@ extension UIColor: Convertible {
           }
           return lightColor
         }
+        #elseif os(macOS)
+        let color = NSColor(name: nil) { (appearance: NSAppearance) -> NSColor in
+          let isDarkMode = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+          let isHighContrast = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+
+          if isDarkMode {
+            if isHighContrast, let highContrastDarkColor = highContrastDarkColor {
+              return highContrastDarkColor
+            }
+            return darkColor
+          }
+
+          if isHighContrast, let highContrastLightColor = highContrastLightColor {
+            return highContrastLightColor
+          }
+          return lightColor
+        }
+        #endif
         return color as! Self
       }
     }

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -34,7 +34,7 @@ extension UIColor: Convertible {
         let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0, appContext: appContext) }) {
         let highContrastLightColor = try appearances["highContrastLight"].map({ try UIColor.convert(from: $0, appContext: appContext) })
         let highContrastDarkColor = try appearances["highContrastDark"].map({ try UIColor.convert(from: $0, appContext: appContext) })
- 
+
         #if os(iOS) || os(tvOS)
         let color = UIColor { (traitCollection: UITraitCollection) -> UIColor in
           if traitCollection.userInterfaceStyle == .dark {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -38,9 +38,11 @@ extension ExpoSwiftUI {
 
       super.init(frame: .zero)
 
+      #if os(iOS) || os(tvOS)
       // Hosting controller has white background by default,
       // but we always want it to be transparent.
       hostingController.view.backgroundColor = .clear
+      #endif
     }
 
     @available(*, unavailable)
@@ -55,6 +57,7 @@ extension ExpoSwiftUI {
       try? props.updateRawProps(rawProps, appContext: appContext)
     }
 
+#if os(iOS) || os(tvOS)
     /**
      Setups layout constraints of the hosting controller view to match the layout set by React.
      */
@@ -87,5 +90,6 @@ extension ExpoSwiftUI {
         hostingController.removeFromParent()
       }
     }
+#endif
   }
 }

--- a/packages/expo-modules-core/ios/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 
 import AppKit
+import SwiftUI
 
 public typealias UIApplication = NSApplication
 public typealias UIView = NSView
@@ -8,5 +9,6 @@ public typealias UIViewController = NSViewController
 public typealias UIResponder = NSResponder
 public typealias UIApplicationDelegate = NSApplicationDelegate
 public typealias UIWindow = NSWindow
+public typealias UIHostingController = NSHostingController
 
 #endif // os(macOS)

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -11,6 +11,7 @@ public class ExpoReactDelegate: NSObject {
     self.handlers = handlers
   }
 
+  #if os(iOS) || os(tvOS)
   @objc
   public func createReactRootView(
     moduleName: String,
@@ -32,6 +33,16 @@ public class ExpoReactDelegate: NSObject {
         )
       }()
   }
+  #elseif os(macOS)
+  @objc
+  public func createReactRootView(
+    moduleName: String,
+    initialProperties: [AnyHashable: Any]?,
+    launchOptions: [AnyHashable: Any]?
+  ) -> UIView {
+    return UIView()
+  }
+  #endif
 
   @objc
   public func bundleURL() -> URL? {

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
@@ -11,6 +11,7 @@ open class ExpoReactDelegateHandler: NSObject {
    If this module wants to handle React instance and the root view creation, it can return the instance.
    Otherwise return nil.
    */
+  #if os(iOS) || os(tvOS)
   @objc
   open func createReactRootView(
     reactDelegate: ExpoReactDelegate,
@@ -20,6 +21,7 @@ open class ExpoReactDelegateHandler: NSObject {
   ) -> UIView? {
     return nil
   }
+  #endif
 
   /**
    Clients could override this getter to serve the latest bundleURL for React instance.

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTAppDelegate (Recreate)
 
+#if !TARGET_OS_OSX
 /**
  Recreates a root view bound with customized bundleURL, moduleName, initialProps, and launchOptions.
  If any of these parameters is null, the method will use the original one from `RCTAppDelegate` or `RCTRootViewFactory`.
@@ -22,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
                                moduleName:(nullable NSString *)moduleName
                              initialProps:(nullable NSDictionary *)initialProps
                             launchOptions:(nullable NSDictionary *)launchOptions;
-
+#endif
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

When trying to upgrade Orbit to use SDK51 I notice that macos support is broken 

# How

Update modules-core and font to build on macos again

# Test Plan

Run BareExpo on macos

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
