### PR TITLE
[docs] Fix custom `collapseHeight` not applied on a code block

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -108,6 +108,13 @@ export function Code({ className, children }: CodeProps) {
     !isExpanded && !collapseHeight && EXPAND_SNIPPET_BOUND_CLASSNAME,
   ];
 
+  const customCollapseStyle =
+    !isExpanded && collapseHeight
+      ? {
+          maxHeight: collapseHeight,
+        }
+      : undefined;
+
   return codeBlockData?.title ? (
     <Snippet>
       <SnippetHeader title={codeBlockData.title} Icon={getIconForFile(codeBlockData.title)}>
@@ -118,6 +125,7 @@ export function Code({ className, children }: CodeProps) {
         <pre
           ref={contentRef}
           css={STYLES_CODE_CONTAINER}
+          style={customCollapseStyle}
           className={mergeClasses('relative', ...commonClasses)}
           {...attributes}>
           <code
@@ -132,6 +140,7 @@ export function Code({ className, children }: CodeProps) {
     <pre
       ref={contentRef}
       css={[STYLES_CODE_CONTAINER, STYLES_CODE_CONTAINER_BLOCK]}
+      style={customCollapseStyle}
       className={mergeClasses(
         'relative',
         preferredTheme === Themes.DARK && 'dark-theme',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, when applying `collapseHeight` as a custom value on a code block (using a value less than the default 408px), the functionality stops working.


https://github.com/user-attachments/assets/54407ac9-1120-4926-b8ae-4b5743441376



# How

<!--
How did you build this feature or fix this bug and why?
-->

In #30961, I noticed the `customCollapseStyle` was removed. Adding this class back and passing it as a `style` to the `pre` component, makes the `collapseHeight` custom value work.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## After applying changes from this PR


https://github.com/user-attachments/assets/4903c248-50c9-45f8-b91a-642044b79067





# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
