### PR TITLE
[notifications] run android unit tests in ci

### DIFF
--- a/apps/bare-expo/scripts/setup-android-project.sh
+++ b/apps/bare-expo/scripts/setup-android-project.sh
@@ -13,10 +13,10 @@ else
 fi
 
 "${CURR_DIR}/../../../bin/expotools" android-generate-dynamic-macros --configuration $1 --bare
-echo " ✅ Generete dynamic macros"
+echo " ✅ Generate dynamic macros"
 
 if [ ! -d "android/app/src/androidTest/assets" ]; then
   mkdir -p android/app/src/androidTest/assets
 fi
 yarn --silent ts-node --print --transpile-only -e 'JSON.stringify(require("./e2e/TestSuite-test.native.js").TESTS, null, 2)' > android/app/src/androidTest/assets/TestSuite.json
-echo " ✅ Generete e2e test cases"
+echo " ✅ Generate e2e test cases"

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -20,6 +20,17 @@ android {
   buildFeatures {
     buildConfig true
   }
+  testOptions {
+    unitTests.all { test ->
+      testLogging {
+        outputs.upToDateWhen { false }
+        events "passed", "failed", "skipped", "standardError"
+        showCauses true
+        showExceptions true
+        showStandardStreams true
+      }
+    }
+  }
 }
 
 dependencies {

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -11,7 +11,6 @@ const BARE_EXPO_DIR = path.join(Directories.getAppsDir(), 'bare-expo', 'android'
 const excludedInTests = [
   'expo-module-template',
   'expo-module-template-local',
-  'expo-notifications',
   'expo-splash-screen',
   'expo-modules-test-core',
   'expo-dev-client',


### PR DESCRIPTION
# Why

planning to add some tests to the package and I want to run them in CI 😄 

# How

do not exclude notification tests, plus print their results

# Test Plan

should see the tests in logs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
