### PR TITLE
[docs] Fix broken annotation inside code block in Fonts guide

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -283,8 +283,12 @@ After installing the font package, map the font using the `useFonts` hook in a t
 
 ```tsx app/_layout.tsx
 // Rest of the import statements
-/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/ import { Inter_900Black, useFonts } from '@expo-google-fonts/inter';
-/* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/
+import { Inter_900Black, useFonts } from '@expo-google-fonts/inter';
+/* @end */
+/* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */
+import * as SplashScreen from 'expo-splash-screen';
+/* @end */
 import {useEffect} from 'react';
 
 /* @info This prevents <CODE>SplashScreen</CODE> from auto hiding while the fonts are in loading state. */
@@ -300,7 +304,9 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (loaded || error) {
+      /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
       SplashScreen.hideAsync();
+      /* @end */
     }
   }, [loaded, error]);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Going through Fonts guide, found an issue where closing annotation was missing inside a code block under Google Fonts section.

![CleanShot 2024-09-03 at 16 27 32](https://github.com/user-attachments/assets/0b090ec3-69f7-48a6-9e2e-796a3d6afbc1)


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add missing `/* @end */` in the Google Fonts section's code block to fix the issue
- Add the missing annotation for hiding SplashScreen inside `useEffect` in the same code block.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

### After applying changes

![CleanShot 2024-09-03 at 16 27 41](https://github.com/user-attachments/assets/903b9dd3-a5ae-49c4-b3ef-4aa57948e27a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
