### PR TITLE
[expo-go] Fix compiler error from notifications

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
@@ -58,7 +58,7 @@ class ExpoFirebaseMessagingDelegate(context: Context) : FirebaseMessagingDelegat
     content: NotificationContent,
     notificationTrigger: FirebaseNotificationTrigger
   ): NotificationRequest {
-    val data = notificationTrigger.remoteMessage.data
+    val data = notificationTrigger.getRemoteMessage().data
     return ScopedNotificationRequest(
       identifier,
       content,

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
@@ -54,7 +54,7 @@ class ScopedExpoPresentationDelegate(context: Context) : ExpoPresentationDelegat
       return super.getNotifyId(request)
     }
     val experienceId = if (request.trigger is FirebaseNotificationTrigger) {
-      (request.trigger as FirebaseNotificationTrigger).remoteMessage.data["scopeKey"]
+      (request.trigger as FirebaseNotificationTrigger).getRemoteMessage().data["scopeKey"]
     } else if (request is ScopedNotificationRequest) {
       request.experienceScopeKeyString
     } else {

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
@@ -53,8 +53,8 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     Activity activity = getCurrentActivity();
     if (activity != null && mInitialOrientation != null) {

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ShakeModule.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ShakeModule.java
@@ -45,8 +45,8 @@ public class ShakeModule extends ReactContextBaseJavaModule {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
     mShakeDetector.stop();
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
@@ -56,8 +56,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
     }
 
     @Override
-    public void onCatalystInstanceDestroy() {
-        super.onCatalystInstanceDestroy();
+    public void invalidate() {
+        super.invalidate();
         new CleanTask(getReactApplicationContext()).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -67,7 +67,6 @@ const screens = [
   'Notification',
   'Pedometer',
   'Print',
-  'Random',
   'SMS',
   'NavigationBar',
   'SafeAreaContext',


### PR DESCRIPTION
# Why
`remoteMessage` is now a private property that needs to be accessed with `getRemoteMessage` instead. 

# How
Use the getter instead of the property. Also replaced the deprecated functions in some of the modules and removed `Random` from the apis list. 

# Test Plan
expo-go runs without error