### PR TITLE
[eslint-config-expo] update deprecated rules ban-types to no-restricted-types

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Update deprecated `@typescript-eslint/ban-types` rule to `@typescript-eslint/no-restricted-types` rule. ([#31328](https://github.com/expo/expo/pull/31328) by [@kimGnab](https://github.com/kimGnab))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eslint-config-expo/utils/typescript.js
+++ b/packages/eslint-config-expo/utils/typescript.js
@@ -24,7 +24,7 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       rules: {
         '@typescript-eslint/array-type': ['warn', { default: 'array' }],
-        '@typescript-eslint/ban-types': [
+        '@typescript-eslint/no-restricted-types': [
           'error',
           {
             types: {
@@ -49,7 +49,6 @@ module.exports = {
                 fixWith: 'string',
               },
             },
-            extendDefaults: false,
           },
         ],
         '@typescript-eslint/consistent-type-assertions': [


### PR DESCRIPTION
# Why
I encountered the same issue as #31205 and discovered that the `@typescript-eslint/ban-types` rule has been deprecated by the typescript-eslint team. To maintain our ESLint configuration's compatibility with the latest TypeScript ESLint recommendations, we need to replace this rule with the newer `@typescript-eslint/no-restricted-types` rule.

Reference: https://typescript-eslint.io/rules/ban-types/

# How
I updated the `/packages/eslint-config-expo/utils/typescript.js` file by:
1. Removing the `@typescript-eslint/ban-types` rule configuration.
2. Adding the `@typescript-eslint/no-restricted-types` rule with equivalent functionality.


# Test Plan
[Please describe how you tested this change and how a reviewer could reproduce your test.]

# Checklist
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).