### PR TITLE
[expo-image] Web: Factor in screen density when choosing image size

### DIFF
--- a/packages/expo-image/src/web/useSourceSelection.ts
+++ b/packages/expo-image/src/web/useSourceSelection.ts
@@ -11,11 +11,19 @@ function findBestSourceForSize(
   if (sources?.length === 1) {
     return sources[0];
   }
+
+  const pixelRatio = window?.devicePixelRatio ?? 1;
+
+  const scaledSize = size ?  {
+    width:  size.width * pixelRatio,
+    height: size.height * pixelRatio
+  } : null
+
   return (
     [...(sources || [])]
       // look for the smallest image that's still larger then a container
       ?.map((source) => {
-        if (!size) {
+        if (!scaledSize) {
           return { source, penalty: 0, covers: false };
         }
         const { width, height } =
@@ -23,10 +31,10 @@ function findBestSourceForSize(
         if (width == null || height == null) {
           return { source, penalty: 0, covers: false };
         }
-        if (width < size.width || height < size.height) {
+        if (width < scaledSize.width || height < scaledSize.height) {
           return {
             source,
-            penalty: Math.max(size.width - width, size.height - height),
+            penalty: Math.max(scaledSize.width - width, scaledSize.height - height),
             covers: false,
           };
         }


### PR DESCRIPTION
# Why

Currently images with to low resolution is selected when using screens that has pixel density > 1.
This PR aims to select an image which looks sharps on higher density screens.

# How
We scale the DomRect size that we get from `getBoundingClientRect` by multiplying it with `window.devicePixelRatio` to get the correct physical pixels we need to select the best image size. 


# Test Plan
Run expo web and check so that the correct image size is selected.

# Checklist
- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
