### PR TITLE
[docs] Add documentation for .easignore file

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -323,6 +323,7 @@ const general = [
         makePage('build-reference/infrastructure.mdx'),
         makePage('build-reference/app-extensions.mdx'),
         makePage('build-reference/e2e-tests.mdx'),
+        makePage('build-reference/easignore.mdx'),
         makePage('build-reference/limitations.mdx'),
       ],
       { expanded: false }

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -37,7 +37,6 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 
 If your project does not contain **android** and **ios** directories, [EAS Build will run Prebuild](/workflow/prebuild/#usage-with-eas-build) to generate these native directories before compilation.
 
-
 </Step>
 
 <Step label="3">

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -1,43 +1,42 @@
 ---
-title: Ignoring files
+title: Ignoring files in .easignore
 description: Learn how to configure EAS to ignore unnecessary files during the build process.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-A `.easignore` file defines which files [EAS](https://expo.dev/eas) should ignore when uploading your project to the [EAS Build](/build/introduction) servers.
+A **.easignore** file defines which files [EAS](https://expo.dev/eas) should ignore when uploading your project to the [EAS Build](/build/introduction) servers.
 
 > **info** Ignoring unnecessary files can help reduce your app's archive size and upload time.
 
-By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) refers to the [`.gitignore`](https://git-scm.com/docs/gitignore) file (if it exists) to determine which files to ignore. If you create a `.easignore` file, the EAS CLI prioritizes it over the `.gitignore` file. When creating a `.easignore` file, include all files from your `.gitignore` file, and add additional files you want to ignore.
+By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) refers to the [**.gitignore**](https://git-scm.com/docs/gitignore) file (if it exists) to determine which files to ignore. If you create a **.easignore** file, the EAS CLI prioritizes it over the **.gitignore** file. When creating a **.easignore** file, include all files and directories from your **.gitignore** file and add additional files you want to ignore.
 
-## Getting started with .easignore
 
 <Step label="1">
 
-Create a `.easignore` file in the root of your project.
+Create a **.easignore** file in the root of your project.
 
 </Step>
 
 <Step label="2">
 
-Copy the content of the `.gitignore` file into the `.easignore` file. Then, add any files that are unnecessary for the build process.
+Copy the content of the **.gitignore** file into the **.easignore** file. Then, add any files that are unnecessary for the build process.
 
 ```bash .easignore
 # Copy everything from your .gitignore file here
 
 # Additional ignores specific to EAS builds
 
-# Ignore native folders (If you are using CNG)
-/ios
+# Ignore native folders (if you are using CNG)
 /android
+/ios
 
 # Ignore test coverage reports
 /coverage
 ```
 
-Learn more about [Continuous Native Generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation).
+Learn more about [Continuous Native Generation (CNG)](/workflow/continuous-native-generation).
 
 </Step>
 
@@ -49,4 +48,4 @@ Save the file and trigger a new build.
 
 </Step>
 
-Congrats! You've successfully configured your `.easignore` file.
+You've successfully configured your **.easignore** file.

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -6,11 +6,11 @@ description: Learn how to configure EAS to ignore unnecessary files during the b
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-A `.easignore` file specifies files that should be intentionally ignored by [EAS](https://expo.dev/eas) when uploading your project to the [EAS Build](/build/introduction) servers.
+A `.easignore` file defines which files [EAS](https://expo.dev/eas) should ignore when uploading your project to the [EAS Build](/build/introduction) servers.
 
-> **info** Ignoring unnecessary files can help reduce your app's archive size and the time it takes to upload.
+> **info** Ignoring unnecessary files can help reduce your app's archive size and upload time.
 
-By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) uses the [`.gitignore`](https://git-scm.com/docs/gitignore) file (if present) to determine which files to ignore. However, if you create a `.easignore` file, the EAS CLI will prioritize it over the `.gitignore` file. When using a `.easignore` file, include all files from your `.gitignore` file in your `.easignore` file; from there, you can add additional files as needed.
+By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) refers to the [`.gitignore`](https://git-scm.com/docs/gitignore) file (if it exists) to determine which files to ignore. If you create a `.easignore` file, the EAS CLI prioritizes it over the `.gitignore` file. When creating a `.easignore` file, include all files from your `.gitignore` file, and add additional files you want to ignore.
 
 ## Getting started with .easignore
 
@@ -22,20 +22,22 @@ Create a `.easignore` file in the root of your project.
 
 <Step label="2">
 
-Copy the content of the `.gitignore` file into the `.easignore` file and extend it with the files not neccessary for the build process.
+Copy the content of the `.gitignore` file into the `.easignore` file. Then, add any files that are unnecessary for the build process.
 
 ```bash .easignore
 # Copy everything from your .gitignore file here
 
 # Additional ignores specific to EAS builds
 
-# Ignore native folders (EAS handles these)
+# Ignore native folders (If you are using CNG)
 /ios
 /android
 
 # Ignore test coverage reports
 /coverage
 ```
+
+Learn more about [Continuous Native Generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation).
 
 </Step>
 
@@ -46,3 +48,5 @@ Save the file and trigger a new build.
 <Terminal cmd={['$ eas build --platform ios --profile development']} />
 
 </Step>
+
+Congrats! You've successfully configured your `.easignore` file.

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -12,7 +12,6 @@ A **.easignore** file defines which files [EAS](https://expo.dev/eas) should ign
 
 By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) refers to the [**.gitignore**](https://git-scm.com/docs/gitignore) file (if it exists) to determine which files to ignore. If you create a **.easignore** file, the EAS CLI prioritizes it over the **.gitignore** file. When creating a **.easignore** file, include all files and directories from your **.gitignore** file and add additional files you want to ignore.
 
-
 <Step label="1">
 
 Create a **.easignore** file in the root of your project.
@@ -28,7 +27,7 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 
 # Additional ignores specific to EAS builds
 
-# Ignore native folders (if you are using CNG)
+# Ignore native folders (if you are using EAS Build)
 /android
 /ios
 
@@ -36,7 +35,9 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 /coverage
 ```
 
-Learn more about [Continuous Native Generation (CNG)](/workflow/continuous-native-generation).
+If your project does not contain android and ios directories, EAS Build will run Prebuild to generate these native directories before compilation.
+
+Learn more about [EAS Build](/workflow/prebuild/#usage-with-eas-build).
 
 </Step>
 

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -1,0 +1,48 @@
+---
+title: Ignoring files
+description: Learn how to configure EAS to ignore unnecessary files during the build process.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+A `.easignore` file specifies files that should be intentionally ignored by [EAS](https://expo.dev/eas) when uploading your project to the [EAS Build](/build/introduction) servers.
+
+> **info** Ignoring unnecessary files can help reduce your app's archive size and the time it takes to upload.
+
+By default, the [EAS CLI](/build/setup/#install-the-latest-eas-cli) uses the [`.gitignore`](https://git-scm.com/docs/gitignore) file (if present) to determine which files to ignore. However, if you create a `.easignore` file, the EAS CLI will prioritize it over the `.gitignore` file. When using a `.easignore` file, include all files from your `.gitignore` file in your `.easignore` file; from there, you can add additional files as needed.
+
+## Getting started with .easignore
+
+<Step label="1">
+
+Create a `.easignore` file in the root of your project.
+
+</Step>
+
+<Step label="2">
+
+Copy the content of the `.gitignore` file into the `.easignore` file and extend it with the files not neccessary for the build process.
+
+```bash .easignore
+# Copy everything from your .gitignore file here
+
+# Additional ignores specific to EAS builds
+
+# Ignore native folders (EAS handles these)
+/ios
+/android
+
+# Ignore test coverage reports
+/coverage
+```
+
+</Step>
+
+<Step label="3">
+
+Save the file and trigger a new build.
+
+<Terminal cmd={['$ eas build --platform ios --profile development']} />
+
+</Step>

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -35,9 +35,8 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 /coverage
 ```
 
-If your project does not contain android and ios directories, EAS Build will run Prebuild to generate these native directories before compilation.
+If your project does not contain **android** and **ios** directories, [EAS Build will run Prebuild](/workflow/prebuild/#usage-with-eas-build) to generate these native directories before compilation.
 
-Learn more about [EAS Build](/workflow/prebuild/#usage-with-eas-build).
 
 </Step>
 


### PR DESCRIPTION
# Why

This solves [ENG-9211](https://linear.app/expo/issue/ENG-9211/add-documentation-for-easignore).

# How

Create a small page explaining why and how to use a `.easignore` file.

# Test Plan

Ran docs locally and validate everything looks good. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
