### PR TITLE
[template][Android] Define packages as a val

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -21,9 +21,10 @@ class MainApplication : Application(), ReactApplication {
         this,
         object : DefaultReactNativeHost(this) {
           override fun getPackages(): List<ReactPackage> {
+            val packages = PackageList(this).packages
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // packages.add(new MyReactNativePackage());
-            return PackageList(this).packages
+            return packages
           }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"


### PR DESCRIPTION
# Why

Defines `packages` as a val to help in adding more packages that aren't linked by the auto-linking - less modification is require to an add additional package. 

# How

Modified the template to introduce a temporary variable that can be used for packages that aren't supported by auto-linking. 

It might be controversial, as it could break some config plugins, but it seems like a good direction.

I've decided to open a pull request to initiate the discussion about whether you like that change or not.