### PR TITLE
[ios][expo-store-review] Add migration for SkStoreReviewController (iOS 16+)

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Added availability-check and migration for SkStoreReviewController on iOS. (by [@chrfalch](https://github.com/chrfalch))
+
 ## 7.0.2 — 2024-05-02
 
 ### 🐛 Bug fixes

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- Added availability-check and migration for SkStoreReviewController on iOS. (by [@chrfalch](https://github.com/chrfalch))
+- Added availability-check and migration for SkStoreReviewController on iOS. (by [@chrfalch](https://github.com/chrfalch)) ([#31341](https://github.com/expo/expo/pull/31341) by [@chrfalch](https://github.com/chrfalch))
 
 ## 7.0.2 — 2024-05-02
 

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -15,13 +15,13 @@ public class StoreReviewModule: Module {
           guard let currentScene = getForegroundActiveScene() else {
             throw MissingCurrentWindowSceneException()
           }
-          
+
           AppStore.requestReview(in: currentScene)
         } else if #available(iOS 14.0, *) {
           guard let currentScene = getForegroundActiveScene() else {
             throw MissingCurrentWindowSceneException()
           }
-          
+
           SKStoreReviewController.requestReview(in: currentScene)
         } else {
           SKStoreReviewController.requestReview()
@@ -29,7 +29,7 @@ public class StoreReviewModule: Module {
       }
     }
   }
-  
+
   private func getForegroundActiveScene() -> UIWindowScene? {
     return UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
   }

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -10,16 +10,28 @@ public class StoreReviewModule: Module {
     }
 
     AsyncFunction("requestReview") {
-      if #available(iOS 14, *) {
-        guard let currentScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
-          throw MissingCurrentWindowSceneException()
+      Task { @MainActor in
+        if #available(iOS 16.0, *) {
+          guard let currentScene = getForegroundActiveScene() else {
+            throw MissingCurrentWindowSceneException()
+          }
+          
+          AppStore.requestReview(in: currentScene)
+        } else if #available(iOS 14.0, *) {
+          guard let currentScene = getForegroundActiveScene() else {
+            throw MissingCurrentWindowSceneException()
+          }
+          
+          SKStoreReviewController.requestReview(in: currentScene)
+        } else {
+          SKStoreReviewController.requestReview()
         }
-
-        SKStoreReviewController.requestReview(in: currentScene)
-      } else {
-        SKStoreReviewController.requestReview()
       }
-    }.runOnQueue(DispatchQueue.main)
+    }
+  }
+  
+  private func getForegroundActiveScene() -> UIWindowScene? {
+    return UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
   }
 
   private func isRunningFromTestFlight() -> Bool {

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -10,21 +10,14 @@ public class StoreReviewModule: Module {
     }
 
     AsyncFunction("requestReview") {
+      guard let currentScene = getForegroundActiveScene() else {
+        throw MissingCurrentWindowSceneException()
+      }
       Task { @MainActor in
         if #available(iOS 16.0, *) {
-          guard let currentScene = getForegroundActiveScene() else {
-            throw MissingCurrentWindowSceneException()
-          }
-
           AppStore.requestReview(in: currentScene)
-        } else if #available(iOS 14.0, *) {
-          guard let currentScene = getForegroundActiveScene() else {
-            throw MissingCurrentWindowSceneException()
-          }
-
-          SKStoreReviewController.requestReview(in: currentScene)
         } else {
-          SKStoreReviewController.requestReview()
+          SKStoreReviewController.requestReview(in: currentScene)
         }
       }
     }


### PR DESCRIPTION
# Why
SkStoreReviewController is marked as deprecated in the docs and will be removed after iOS 18: (https://developer.apple.com/documentation/storekit/skstorereviewcontroller).

closes #ENG-123

# How
This commit fixes this by adding a new availability check that uses `Appstore.requestReview(in:)` method instead on iOS 16 and up. (https://developer.apple.com/documentation/storekit/appstore/3954432-requestreview)

In addition we're now using the new Swift 5.5 @MainActor notation to ensure that our methods run on the main thread. This is required for the `Appstore.requestReview(in:)` method to compile successfully.

Task/@MainActor is available from iOS 13.
https://developer.apple.com/documentation/swift/mainactor/ https://developer.apple.com/documentation/swift/task

Also added a new private function to get the active foreground scene in the module to avoid code duplication.

# Test Plan
expo-go runs without error on iOS.
Should be tested on multiple platforms like 13, 14 and 16 and above.

