### PR TITLE
[docs] Update Expo Router introduction to add info about using other navigation libraries

### DIFF
--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -26,7 +26,7 @@ It brings the best file-system routing concepts from the web to a universal appl
 - **Universal**: Android, iOS, and web share a unified navigation structure, with the ability to drop-down to platform-specific APIs at the route level.
 - **Discoverable**: Expo Router enables build-time static rendering on web, and universal linking to native. Meaning your app content can be indexed by search engines.
 
-<Collapsible summary="Can I use any other navigation library?">
+<Collapsible summary="Can I use a different navigation library?">
 
 You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, we recommend using Expo Router for all the features described above. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -28,7 +28,7 @@ It brings the best file-system routing concepts from the web to a universal appl
 
 <Collapsible summary="Can I use any other navigation library?">
 
-Yes! You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, we recommend using Expo Router for all the features described above. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
+You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, we recommend using Expo Router for all the features described above. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
 
 </Collapsible>
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -10,6 +10,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
 
 Expo Router is a file-based router for React Native and web applications. It allows you to manage navigation between screens in your app, allowing users to move seamlessly between different parts of your app's UI, using the same components on multiple platforms (Android, iOS, and web).
 
@@ -24,6 +25,12 @@ It brings the best file-system routing concepts from the web to a universal appl
 - **Iteration**: Universal Fast Refresh across Android, iOS, and web, along with artifact memoization in the bundler to keep you moving fast at scale.
 - **Universal**: Android, iOS, and web share a unified navigation structure, with the ability to drop-down to platform-specific APIs at the route level.
 - **Discoverable**: Expo Router enables build-time static rendering on web, and universal linking to native. Meaning your app content can be indexed by search engines.
+
+<Collapsible summary="Can I use any other navigation library?">
+
+Yes! You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, we recommend using Expo Router for all the features described above. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
+
+</Collapsible>
 
 ## Next steps
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1725421147082709)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Use a collapsible to add an FAQ item for using other navigation libraries in Expo project
- Briefly explain that using any other navigation library, developer might have to handle some of the features that Expo Router provides automatically.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/introduction/#can-i-use-any-other-navigation-library

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
