### PR TITLE
[docs][modules] Add native module video guide

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -4,9 +4,14 @@ sidebar_title: Create a native module
 description: A tutorial on creating a native module with Expo modules API.
 ---
 
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
+
+## How to create a native module video tutorial
+
+<ContentSpotlight url="https://www.youtube.com/embed/CdaQSlyGik8" />
 
 ## 1. Initialize a new module
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 
-All the steps for creating a native module are listed below. And here is a video version of the tutorial if that is your preference:
+All the steps for creating a native module are listed below. If you're a visual learner, check out the video tutorial:
 
 <ContentSpotlight url="https://www.youtube.com/embed/CdaQSlyGik8" />
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 
-## How to create a native module video tutorial
+All the steps for creating a native module are listed below. And here is a video version of the tutorial if that is your preference:
 
 <ContentSpotlight url="https://www.youtube.com/embed/CdaQSlyGik8" />
 


### PR DESCRIPTION
# Why

This solves [ENG-13165](https://linear.app/expo/issue/ENG-13165/expo-modules-videos)

# How

Add video to guide using `ContentSpotlight`

# Test Plan

Ran locally and validate video shows correctly

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/73a902f4-491f-422a-8212-b7393c3a28a4">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
