### PR TITLE
[expo-modules-core][Android] Backport modules backward compatbility for sdk-50 created with 51 template

### DIFF
--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -54,6 +54,13 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
 }
 
 ext.applyKotlinExpoModulesCorePlugin = {
+  try {
+    // Tries to apply the kotlin-android plugin if the client project does not apply yet.
+    // On previous `applyKotlinExpoModulesCorePlugin`, it is inside the `project.buildscript` block.
+    // We cannot use `project.plugins.hasPlugin()` yet but only to try-catch instead.
+    apply plugin: 'kotlin-android'
+  } catch (e) {}
+  
   apply plugin: KotlinExpoModulesCorePlugin
 }
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -58,6 +58,10 @@ ext.applyKotlinExpoModulesCorePlugin = {
 }
 
 ext.useExpoPublishing = {
+  if (!project.plugins.hasPlugin('maven-publish')) {
+    apply plugin: 'maven-publish'
+  }
+  
   afterEvaluate {
     publishing {
       publications {


### PR DESCRIPTION
# Why

It seems like [these changes](https://github.com/expo/expo/blame/951da0601f5b9ba1ca3819520d94e83a53bd3c8b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle#L70-L72) on sdk-51 introduced in [this pull request](https://github.com/expo/expo/pull/28083) was not backported to the previous sdk versions and expo modules created with 51 template is not compatible with expo-50 anymore causing this issue:

https://github.com/matinzd/react-native-health-connect/issues/150

I am not sure if you have plans to still support sdk-50 backward compatibility but this can really help fixing that edge case. If this fix should go on the library level let me know.

# How
Added a check to apply `maven-publish` plugin if it's not available inside `useExpoPublishing` closure.

# Test Plan

Try changes in this repository:

https://github.com/PercipioDrew/expo-health-connect-example

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
