### PR TITLE
[docs] fix typo.

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -119,7 +119,7 @@ Supported by default if the project directory contains **yarn.lock**.
 
 See [Yarn documentation](https://yarnpkg.com/getting-started/install) for installation instructions.
 
-Yarn 2+ handles package management differently than Yarn 1. One of the core changes in Yarn 2+ is the [Pug'n'Play (PnP)](https://yarnpkg.com/features/pnp) node linking model that does not work with React Native.
+Yarn 2+ handles package management differently than Yarn 1. One of the core changes in Yarn 2+ is the [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) node linking model that does not work with React Native.
 
 By default, a project created with `create-expo-app` and Yarn 2+ uses [`nodeLinker`](https://yarnpkg.com/features/linkers#nodelinker-node-modules) with its value set to `node-modules` to install dependencies.
 


### PR DESCRIPTION
Fix typo (from "Pug" to "Plug").

# Why

The feature in question is called [Plug'n'Play](https://yarnpkg.com/features/pnp). There are no pugs involved.

# How

The spelling error in question caught my eye.

# Test Plan

Manually verified [the proper name](https://yarnpkg.com/features/pnp) and the typo fix itself.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
