### PR TITLE
fix(tools): update `peerDependencies` and `optionalDependencies` when releasing canary versions

### DIFF
--- a/tools/src/Workspace.ts
+++ b/tools/src/Workspace.ts
@@ -2,7 +2,7 @@ import JsonFile from '@expo/json-file';
 import path from 'path';
 
 import { EXPO_DIR, EXPO_GO_DIR } from './Constants';
-import { Package } from './Packages';
+import { DependencyKind, getPackageByName, Package } from './Packages';
 import { spawnAsync, spawnJSONCommandAsync } from './Utils';
 
 const NATIVE_APPS_PATHS = [EXPO_GO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
@@ -11,9 +11,16 @@ const NATIVE_APPS_PATHS = [EXPO_GO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
  * Workspace info for the single project.
  */
 export type WorkspaceProjectInfo = {
+  /** The relative location of the workspace within this monorepo */
   location: string;
-  workspaceDependencies: string[];
+  /** All `dependencies` or `devDependencies` that points to workspaces, but use a different version which is downloaded from npm */
   mismatchedWorkspaceDependencies: string[];
+  /** All `dependencies` or `devDependencies` that points to other workspaces in this monorepo */
+  workspaceDependencies: string[];
+  /** All `peerDependencies` that points to other workspaces in this monorepo */
+  workspacePeerDependencies: string[];
+  /** All `optionalDependencies` that points to other workspaces in this monorepo */
+  workspaceOptionalDependencies: string[];
 };
 
 /**
@@ -25,12 +32,39 @@ export type WorkspacesInfo = Record<string, WorkspaceProjectInfo>;
  * Returns an object containing info for all projects in the workspace.
  */
 export async function getInfoAsync(): Promise<WorkspacesInfo> {
+  // This ony lists workspace dependencies from `dependencies` and `devDependencies`.
   const info = await spawnJSONCommandAsync<{ data: string }>('yarn', [
     '--json',
     'workspaces',
     'info',
   ]);
-  return JSON.parse(info.data);
+
+  const workspaces = JSON.parse(info.data) as WorkspacesInfo;
+
+  for (const workspaceName in workspaces) {
+    const workspace = workspaces[workspaceName];
+    const workspacePackage = getPackageByName(workspaceName);
+
+    if (!workspacePackage) {
+      workspace.workspacePeerDependencies = [];
+      workspace.workspaceOptionalDependencies = [];
+      continue;
+    }
+
+    // Load all `peerDependencies` of the workspace
+    workspace.workspacePeerDependencies = workspacePackage
+      .getDependencies([DependencyKind.Peer])
+      .filter((dependency) => !!workspaces[dependency.name])
+      .map((dependency) => dependency.name);
+
+    // Load all `optionalDependencies` of the workspace
+    workspace.workspaceOptionalDependencies = workspacePackage
+      .getDependencies([DependencyKind.Optional])
+      .filter((dependency) => !!workspaces[dependency.name])
+      .map((dependency) => dependency.name);
+  }
+
+  return workspaces;
 }
 
 /**

--- a/tools/src/Workspace.ts
+++ b/tools/src/Workspace.ts
@@ -32,7 +32,7 @@ export type WorkspacesInfo = Record<string, WorkspaceProjectInfo>;
  * Returns an object containing info for all projects in the workspace.
  */
 export async function getInfoAsync(): Promise<WorkspacesInfo> {
-  // This ony lists workspace dependencies from `dependencies` and `devDependencies`.
+  // This only lists workspace dependencies from `dependencies` and `devDependencies`.
   const info = await spawnJSONCommandAsync<{ data: string }>('yarn', [
     '--json',
     'workspaces',

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -70,8 +70,13 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
             const currentVersionRange = dependenciesObject[pkg.packageName];
 
             if (
-              !currentVersionRange ||
-              !shouldUpdateDependencyVersion(projectName, currentVersionRange, state.releaseVersion)
+              !shouldUpdateDependencyVersion({
+                currentVersionRange,
+                dependencyType: dependenciesKey,
+                isCanaryRelease: options.canary,
+                packageName: projectName,
+                version: state.releaseVersion,
+              })
             ) {
               continue;
             }
@@ -108,10 +113,36 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
  * of other expo packages (e.g. expo-modules-core, expo-modules-autolinking). Any other package (or workspace project)
  * doesn't need to be updated as long as the new version still satisfies the version range.
  *
- * @param packageName Name of the package to update
- * @param currentRange Current version range of the dependency
- * @param version The new version of the dependency
+ * @param context.packageName Name of the package to update
+ * @param context.currentVersionRange Current version range of the dependency
+ * @param context.version The new version of the dependency
+ * @param context.dependencyType What type of dependency we are updating
+ * @param context.canary If this is a canary release
  */
-function shouldUpdateDependencyVersion(packageName: string, currentRange: string, version: string) {
-  return packageName === 'expo' || !semver.satisfies(version, currentRange);
+function shouldUpdateDependencyVersion(context: {
+  packageName: string;
+  currentVersionRange?: string;
+  version: string;
+  dependencyType: string;
+  isCanaryRelease: boolean;
+}) {
+  // Do not update the version if there is no current version range
+  if (!context.currentVersionRange) {
+    return false;
+  }
+
+  // Only update the peerDependencies & optionalDependencies, where the version is `*`, during canary releases
+  // Custom versioning like `x.x.x-canary-...` are NOT included when using `*` as version
+  if (
+    context.currentVersionRange === '*' &&
+    ['peerDependencies', 'optionalDependencies'].includes(context.dependencyType)
+  ) {
+    return context.isCanaryRelease;
+  }
+
+  // Otherwise, use the normal versioning logic
+  return (
+    context.packageName === 'expo' ||
+    !semver.satisfies(context.version, context.currentVersionRange)
+  );
 }

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -39,6 +39,8 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
       Object.entries(workspaceInfo).map(async ([projectName, projectInfo]) => {
         const projectDependencies = [
           ...projectInfo.workspaceDependencies,
+          ...projectInfo.workspacePeerDependencies,
+          ...projectInfo.workspaceOptionalDependencies,
           ...projectInfo.mismatchedWorkspaceDependencies,
         ]
           .map((dependencyName) => parcelsObject[dependencyName])


### PR DESCRIPTION
# Why

With the canary release for dom components, I noticed that our canary publish script does NOT update `peerDependencies` and `optionalDependencies` when it refers to a workspace package.

The best example I can give is `expo-system-ui` that refers `peerDependencies: expo: *`. Unfortunately, semver being semver, the version of `*` does NOT include custom versions (like `x.x.x-canary-20240904-69100c1` - see https://semver.npmjs.com/ with `expo@*`, no `-canary...` versions are included)

> [`expo-system-ui@4.0.0-canary-20240904-69100c1`](https://unpkg.com/expo-system-ui@4.0.0-canary-20240904-69100c1/package.json) includes `peerDependencies: expo: *`, which will auto-install `expo@latest` as dependency, not the canary.
> <img width="491" alt="image" src="https://github.com/user-attachments/assets/049f7f09-f78b-404b-a702-0df36d6f84b4">


# How

1. Updated `workspaces.getInfoAsync()` to manually add `peerDependencies` and `optionalDependencies`
    - `yarn --json workspaces info` does NOT include this information
    - This is not added to the `workspaceDependencies` or `mismatchedWorkspaceDependencies`, maintaining the default behavior for all existing scripts
    - Instead, this is stored in `workspacePeerDependencies` and `workspaceOptionalDependencies`
2. Updated publish script to also include `workspacePeerDependencies` and `workspaceOptionalDependencies`
    - ~~The `shouldUpdateDependencyVersion` should block changing `peerDependencies: expo: *` when the semver matches (e.g. for non-canary releases)~~ Edit: apparently, this didn't work properly, so I also updated the check with `canary` and `*` checks.
3. Updated the `shouldUpdateDependencyVersion` to only return `true` when updating `peer|optional` deps, is publishing a canary, and the version is `*`.

# Test Plan

Make sure create your own branch, clean from `main`, as `--dry` might commit things.

- `git reset . && git clean . -xdf && git checkout .`
- `git checkout main && git pull`
- `git checkout -b @<person>/test-canary`

To test this change:

- `et publish-packages --canary --dry`
- Check if `./packages/expo-system-ui` has `peerDependencies: expo: x.x.x-canary-...` instead of `expo: *`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
