### PR TITLE
[docs] Fix Rotation Behavior of Inner Accordion on Expand/Collapse

### DIFF
--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -40,7 +40,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
     open = false,
   }: CollapsibleProps & HeadingManagerProps) => {
     // track open state so we can collapse header if it is set to open by the URL hash
-    const [isOpen, setOpen] = useState<boolean>(open);
+    const [isOpen, setIsOpen] = useState<boolean>(open);
     const router = useRouter();
 
     // HeadingManager is used to generate a slug that corresponds to the collapsible summary.
@@ -54,7 +54,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
         const splitUrl = router.asPath.split('#');
         const hash = splitUrl.length ? splitUrl[1] : undefined;
         if (hash && hash === heading.current.slug) {
-          setOpen(true);
+          setIsOpen(true);
         }
       }
     }, []);
@@ -63,10 +63,10 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
       // Detect if we are clicking the PermalinkIcon. Probably a better way to do this?
       if (event.target instanceof SVGElement) {
         if (!isOpen) {
-          setOpen(true);
+          setIsOpen(true);
         }
       } else {
-        setOpen(!isOpen);
+        setIsOpen(!isOpen);
         // Ensure that the collapsible opens nicely on the first click
         event.preventDefault();
       }
@@ -158,6 +158,7 @@ const markerStyle = css({
   // Only rotate the icon when its direct parent 'details' is open
   'details[open] > summary &': {
     transform: 'rotate(0)',
+  },
 });
 
 const contentStyle = css({

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -155,7 +155,9 @@ const markerStyle = css({
   transform: 'rotate(-90deg)',
   transition: `transform 200ms`,
 
-  'details[open] &': { transform: 'rotate(0)' },
+  // Only rotate the icon when its direct parent 'details' is open
+  'details[open] > summary &': {
+    transform: 'rotate(0)',
 });
 
 const contentStyle = css({


### PR DESCRIPTION
This PR addresses an issue with the inner accordion where the rotation indicator (Triangle Icon) fails to update its state when the accordion is expanded or collapsed. The fix ensures that the rotation correctly reflects the open or closed state of the accordion, improving the overall user experience and visual consistency.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I observed the issue on https://docs.expo.dev/workflow/overview/ which doesn't look good and gives the inner intuition to the user that accordion is already expanded.
Relevant issue link: [issue-31218](https://github.com/expo/expo/issues/31218)

# How

<!--
How did you build this feature or fix this bug and why?
-->
Running the project locally first and following the steps whatever was mentioned in the contributing guideline.I fixed this by adding the css for rotation to happen based upon closest details element. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Before: Even if inner accordion is not open its triangular icon seems representing its open which is bit confusing.
---
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/b035f32c-f22e-481a-a145-6a57e49135b3">

After: Triangular icon in correct state and representing its not open & opened respectively.
---
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/dde0f6e2-262f-44c7-ab9c-d11fb01d37e1">
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/c3365e22-f97c-48a3-9e49-4057794b4031">

## Miscellaneous

- Also improves the setter function name used in the component

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
