### PR TITLE
[expo-secure-store] Add Apple TV support

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - [Android] Add a config plugin for configuring the Android backup system. ([#29944](https://github.com/expo/expo/pull/29944) by [@behenate](https://github.com/behenate))
+- Add Apple TV support. ([#31374](https://github.com/expo/expo/pull/31374) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-secure-store/expo-module.config.json
+++ b/packages/expo-secure-store/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["SecureStoreModule"]
   },
   "android": {

--- a/packages/expo-secure-store/ios/ExpoSecureStore.podspec
+++ b/packages/expo-secure-store/ios/ExpoSecureStore.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1',
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -1,5 +1,7 @@
 import ExpoModulesCore
+#if !os(tvOS)
 import LocalAuthentication
+#endif
 import Security
 
 public final class SecureStoreModule: Module {
@@ -51,6 +53,9 @@ public final class SecureStoreModule: Module {
     }
 
     Function("canUseBiometricAuthentication") {() -> Bool in
+      #if os(tvOS)
+      return false
+      #else
       let context = LAContext()
       var error: NSError?
       let isBiometricsSupported: Bool = context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: &error)
@@ -59,6 +64,7 @@ public final class SecureStoreModule: Module {
         return false
       }
       return isBiometricsSupported
+      #endif
     }
   }
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -51,6 +51,7 @@ function getExpoDependencyChunks({
             'expo-localization',
             'expo-crypto',
             'expo-network',
+            'expo-secure-store',
             'expo-video',
           ],
         ]
@@ -355,7 +356,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.74.3-0',
+        'react-native': 'npm:react-native-tvos@~0.75.2-0',
         '@react-native-tvos/config-tv': '^0.0.10',
       },
       expo: {


### PR DESCRIPTION
# Why

Allow TV applications to use expo-secure-store.

# How

Modify podspec and config to include the Apple TV platform.

Make code changes to remove LocalAuthentication (face/touch ID support) dependency for tvOS only.

# Test Plan

- Test that values can be stored and retrieved on a real Apple TV
- TV compilation CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
