### PR TITLE
[core][Android] Use deduced return type to simplify conversion

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -134,7 +134,7 @@ class ExpoImageModule : Module() {
         }
         false
       }
-      Property("mediaType") { ->
+      Property<Any?>("mediaType") { ->
         null // not easily supported on Android https://github.com/bumptech/glide/issues/1378#issuecomment-236879983
       }
     }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
@@ -4,14 +4,13 @@ import com.google.common.truth.Truth
 import org.junit.Test
 
 class ExperimentalConverterTest {
-
   @Test
   fun list_should_be_convertible() = withSingleModule({
-    Function("simpleList") { listOf(1, 2, 3, 4, 5, 6) }
+    Function<_>("simpleList") { listOf(1, 2, 3, 4, 5, 6) }
       .UseExperimentalConverter()
-    Function("listWithMixedData") { listOf(1, 2, 3, "string", "expo" to "modules") }
+    Function<_>("listWithMixedData") { listOf(1, 2, 3, "string", "expo" to "modules") }
       .UseExperimentalConverter()
-    Function("complexList") { listOf(listOf(1, 2, "string"), listOf("expo", "modules"), listOf(listOf(1, 2, 3))) }
+    Function<_>("complexList") { listOf(listOf(1, 2, "string"), listOf("expo", "modules"), listOf(listOf(1, 2, 3))) }
       .UseExperimentalConverter()
   }) {
     val simpleList = call("simpleList").getArray().map { it.getInt() }
@@ -44,11 +43,11 @@ class ExperimentalConverterTest {
 
   @Test
   fun maps_should_be_convertible() = withSingleModule({
-    Function("simpleMap") { mapOf("expo" to "modules", "foo" to "bar") }
+    Function<_>("simpleMap") { mapOf("expo" to "modules", "foo" to "bar") }
       .UseExperimentalConverter()
-    Function("nestedMap") { mapOf("inner" to mapOf("foo" to "bar"), "expo" to "modules") }
+    Function<_>("nestedMap") { mapOf("inner" to mapOf("foo" to "bar"), "expo" to "modules") }
       .UseExperimentalConverter()
-    Function("mapWithList") { mapOf("list" to listOf(1, 2, 3)) }
+    Function<_>("mapWithList") { mapOf("list" to listOf(1, 2, 3)) }
       .UseExperimentalConverter()
   }) {
     val simpleMap = call("simpleMap").getObject()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/TypeConversionHelper.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/TypeConversionHelper.kt
@@ -51,13 +51,13 @@ internal class TestCase<T, R>(
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal inline fun <reified T> conversionTest(
-  vararg cases: TestCase<T, out Any?>
+internal inline fun <reified T, reified R> conversionTest(
+  vararg cases: TestCase<T, R>
 ) {
   withJSIInterop(
     inlineModule {
       Name("TestModule")
-      Function("conversionTest") { testID: Int, value: T ->
+      Function<R, Int, T>("conversionTest") { testID: Int, value: T ->
         val case = cases[testID]
         case.nativeAssertion(value)
         return@Function case.map(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.objects.PropertyComponentBuilderWithThis
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
+import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
@@ -34,7 +35,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
       throw IllegalArgumentException("constructor cannot be null")
     }
 
-    val constructor = constructor ?: SyncFunctionComponent("constructor", emptyArray()) {}
+    val constructor = constructor ?: SyncFunctionComponent("constructor", emptyArray(), toReturnType<Unit>()) {}
     constructor.canTakeOwner = true
     constructor.ownerType = ownerType
     return ClassDefinitionData(
@@ -47,7 +48,8 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun Constructor(
     crossinline body: () -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", emptyArray()) { body() }.also {
+    // TODO(@lukmccall): figure out how to pass `SharedObjectType` to the function component as a return type
+    return SyncFunctionComponent("constructor", emptyArray(), toReturnType<Any>()) { body() }.also {
       constructor = it
     }
   }
@@ -55,7 +57,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0> Constructor(
     crossinline body: (p0: P0) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0>()) { (p0) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0>(), toReturnType<Any>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {
@@ -66,7 +68,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1> Constructor(
     crossinline body: (p0: P0, p1: P1) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1>()) { (p0, p1) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1>(), toReturnType<Any>()) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -77,7 +79,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2>(), toReturnType<Any>()) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -88,7 +90,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3>(), toReturnType<Any>()) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -99,7 +101,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -110,7 +112,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -121,7 +123,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -132,7 +134,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -143,7 +145,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   /**
    * Creates the read-only property whose getter takes the caller as an argument.
    */
-  inline fun <T> Property(name: String, crossinline body: (owner: SharedObjectType) -> T): PropertyComponentBuilderWithThis<SharedObjectType> {
+  inline fun <reified T> Property(name: String, crossinline body: (owner: SharedObjectType) -> T): PropertyComponentBuilderWithThis<SharedObjectType> {
     return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType, name).also {
       it.get(body)
       properties[name] = it

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -7,15 +7,15 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.enforceType
 
-inline fun <reified T> createAsyncFunctionComponent(
+inline fun <reified ReturnType> createAsyncFunctionComponent(
   name: String,
   desiredArgsTypes: Array<AnyType>,
-  noinline body: (args: Array<out Any?>) -> T
+  noinline body: (args: Array<out Any?>) -> ReturnType
 ): AsyncFunction {
-  if (null is T) {
+  if (null is ReturnType) {
     return AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
   }
-  return when (T::class.java) {
+  return when (ReturnType::class.java) {
     Int::class.java -> {
       enforceType<(Array<out Any?>) -> Int>(body)
       IntAsyncFunctionComponent(name, desiredArgsTypes, body)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
@@ -7,6 +7,7 @@ import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
+import expo.modules.kotlin.types.toReturnType
 
 class FunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
@@ -16,7 +17,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
   inline fun Body(
     crossinline body: () -> Any?
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<Any?>()) { body() }.also {
       functionComponent = it
     }
   }
@@ -25,7 +26,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: () -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<R>()) { body() }.also {
       functionComponent = it
     }
   }
@@ -34,7 +35,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+    return SyncFunctionComponent(name, toArgsArray<P0>(), toReturnType<R>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {
@@ -46,7 +47,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>(), toReturnType<R>()) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -58,7 +59,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>(), toReturnType<R>()) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -70,7 +71,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(), toReturnType<R>()) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -82,7 +83,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(), toReturnType<R>()) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -94,7 +95,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -106,7 +107,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -118,7 +119,7 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -9,12 +9,14 @@ import expo.modules.kotlin.jni.JNIFunctionBody
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.JSTypeConverter
+import expo.modules.kotlin.types.ReturnType
 
 class SyncFunctionComponent(
   name: String,
-  desiredArgsTypes: Array<AnyType>,
+  argTypes: Array<AnyType>,
+  private val returnType: ReturnType,
   private val body: (args: Array<out Any?>) -> Any?
-) : AnyFunction(name, desiredArgsTypes) {
+) : AnyFunction(name, argTypes) {
   private var shouldUseExperimentalConverter = false
 
   @Suppress("FunctionName")
@@ -37,7 +39,11 @@ class SyncFunctionComponent(
         FunctionCallException(name, moduleName, it)
       }) {
         val result = call(args, appContext)
-        return@exceptionDecorator JSTypeConverter.convertToJSValue(result, useExperimentalConverter = shouldUseExperimentalConverter)
+        if (shouldUseExperimentalConverter) {
+          return@exceptionDecorator returnType.convertToJS(result)
+        } else {
+          return@exceptionDecorator JSTypeConverter.convertToJSValue(result)
+        }
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -21,6 +21,7 @@ import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
+import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 
@@ -98,7 +99,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: () -> Any?
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<Any?>()) { body() }.also {
       syncFunctions[name] = it
     }
   }
@@ -107,7 +108,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: () -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<R>()) { body() }.also {
       syncFunctions[name] = it
     }
   }
@@ -116,7 +117,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+    return SyncFunctionComponent(name, toArgsArray<P0>(), toReturnType<R>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {
@@ -128,7 +129,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>(), toReturnType<R>()) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -140,7 +141,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>(), toReturnType<R>()) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -152,7 +153,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(), toReturnType<R>()) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -164,7 +165,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(), toReturnType<R>()) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -176,7 +177,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -188,7 +189,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -200,7 +201,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -524,7 +525,7 @@ open class ObjectDefinitionBuilder {
   /**
    * Creates the read-only property whose getter doesn't take the caller as an argument.
    */
-  inline fun <T> Property(name: String, crossinline body: () -> T): PropertyComponentBuilder {
+  inline fun <reified T> Property(name: String, crossinline body: () -> T): PropertyComponentBuilder {
     return PropertyComponentBuilder(name).also {
       it.get(body)
       properties[name] = it

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.objects
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.KType
 
 open class PropertyComponentBuilder(
@@ -14,15 +15,15 @@ open class PropertyComponentBuilder(
   /**
    * Modifier that sets property getter that has no arguments (the caller is not used).
    */
-  inline fun <T> get(crossinline body: () -> T) = apply {
-    getter = SyncFunctionComponent("get", emptyArray()) { body() }
+  inline fun <reified R> get(crossinline body: () -> R) = apply {
+    getter = SyncFunctionComponent("get", emptyArray(), toReturnType<R>()) { body() }
   }
 
   /**
    * Modifier that sets property setter that receives only the new value as an argument.
    */
   inline fun <reified T> set(crossinline body: (newValue: T) -> Unit) = apply {
-    setter = SyncFunctionComponent("set", arrayOf(toAnyType<T>())) { body(it[0] as T) }
+    setter = SyncFunctionComponent("set", arrayOf(toAnyType<T>()), toReturnType<Unit>()) { body(it[0] as T) }
   }
 
   fun build(): PropertyComponent {
@@ -38,8 +39,8 @@ class PropertyComponentBuilderWithThis<ThisType>(
   /**
    * Modifier that sets property getter that has caller.
    */
-  inline fun <T> get(crossinline body: (ThisType) -> T) = apply {
-    getter = SyncFunctionComponent("get", arrayOf(AnyType(thisType))) {
+  inline fun <reified R> get(crossinline body: (ThisType) -> R) = apply {
+    getter = SyncFunctionComponent("get", arrayOf(AnyType(thisType)), toReturnType<R>()) {
       @Suppress("UNCHECKED_CAST")
       body(it[0] as ThisType)
     }.also {
@@ -52,7 +53,7 @@ class PropertyComponentBuilderWithThis<ThisType>(
    * Modifier that sets property setter that receives only the new value as an argument.
    */
   inline fun <reified T> set(crossinline body: (self: ThisType, newValue: T) -> Unit) = apply {
-    setter = SyncFunctionComponent("set", arrayOf(AnyType(thisType), toAnyType<T>())) {
+    setter = SyncFunctionComponent("set", arrayOf(AnyType(thisType), toAnyType<T>()), toReturnType<Unit>()) {
       @Suppress("UNCHECKED_CAST")
       body(it[0] as ThisType, it[1] as T)
     }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
@@ -1,0 +1,204 @@
+package expo.modules.kotlin.types
+
+import android.os.Bundle
+import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
+import kotlin.reflect.KClass
+
+object ReturnTypeProvider {
+  val types = mutableMapOf<KClass<*>, ReturnType>()
+
+  inline fun <reified T> get(): ReturnType {
+    return types[T::class] ?: ReturnType(T::class).also {
+      types[T::class] = it
+    }
+  }
+}
+
+inline fun <reified T> toReturnType(): ReturnType {
+  return ReturnTypeProvider.get<T>()
+}
+
+interface ExperimentalJSTypeConverter<T> {
+  fun convertToJS(value: Any?): Any?
+
+  class PassThroughConverter : ExperimentalJSTypeConverter<Any> {
+    override fun convertToJS(value: Any?): Any? {
+      return value
+    }
+  }
+
+  class BundleConverter : ExperimentalJSTypeConverter<Bundle> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Bundle?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class ArrayConverter : ExperimentalJSTypeConverter<Array<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Array<*>?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class IntArrayConverter : ExperimentalJSTypeConverter<IntArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<IntArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class FloatArrayConverter : ExperimentalJSTypeConverter<FloatArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<FloatArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class DoubleArrayConverter : ExperimentalJSTypeConverter<DoubleArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<DoubleArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class BooleanArrayConverter : ExperimentalJSTypeConverter<BooleanArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<BooleanArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class ByteArrayConverter : ExperimentalJSTypeConverter<ByteArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<ByteArray?>(value)
+      return value?.let { FollyDynamicExtensionConverter.put(it) }
+    }
+  }
+
+  class MapConverter : ExperimentalJSTypeConverter<Map<*, *>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Map<*, *>?>(value)
+      return value?.toJSValueExperimental()
+    }
+  }
+
+  class EnumConverter : ExperimentalJSTypeConverter<Enum<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Enum<*>?>(value)
+      return value?.toJSValue()
+    }
+  }
+
+  class RecordConverter : ExperimentalJSTypeConverter<expo.modules.kotlin.records.Record> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<expo.modules.kotlin.records.Record?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class URIConverter : ExperimentalJSTypeConverter<java.net.URI> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<java.net.URI?>(value)
+      return value?.toJSValue()
+    }
+  }
+
+  class URLConverter : ExperimentalJSTypeConverter<java.net.URL> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<java.net.URL?>(value)
+      return value?.toJSValue()
+    }
+  }
+
+  class UriConverter : ExperimentalJSTypeConverter<android.net.Uri> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<android.net.Uri?>(value)
+      return value?.toJSValue()
+    }
+  }
+
+  class FileConverter : ExperimentalJSTypeConverter<java.io.File> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<java.io.File?>(value)
+      return value?.toJSValue()
+    }
+  }
+
+  class PairConverter : ExperimentalJSTypeConverter<Pair<*, *>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Pair<*, *>?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+  }
+
+  class LongConverter : ExperimentalJSTypeConverter<Long> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Long?>(value)
+      return value?.toDouble()
+    }
+  }
+
+  class RawTypedArrayHolderConverter : ExperimentalJSTypeConverter<expo.modules.kotlin.typedarray.RawTypedArrayHolder> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<expo.modules.kotlin.typedarray.RawTypedArrayHolder?>(value)
+      return value?.rawArray
+    }
+  }
+
+  class CollectionConverter : ExperimentalJSTypeConverter<Collection<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Collection<*>?>(value)
+      return value?.toJSValueExperimental()
+    }
+  }
+
+  class AnyConverter : ExperimentalJSTypeConverter<Any> {
+    override fun convertToJS(value: Any?): Any? {
+      return JSTypeConverter.convertToJSValue(value, useExperimentalConverter = true)
+    }
+  }
+}
+
+class ReturnType(
+  private val klass: KClass<*>
+) {
+  private val converter: ExperimentalJSTypeConverter<*> = run {
+    val directConverter = when (klass) {
+      Unit::class -> ExperimentalJSTypeConverter.PassThroughConverter()
+      Bundle::class -> ExperimentalJSTypeConverter.BundleConverter()
+      IntArray::class -> ExperimentalJSTypeConverter.IntArrayConverter()
+      FloatArray::class -> ExperimentalJSTypeConverter.FloatArrayConverter()
+      DoubleArray::class -> ExperimentalJSTypeConverter.DoubleArrayConverter()
+      BooleanArray::class -> ExperimentalJSTypeConverter.BooleanArrayConverter()
+      ByteArray::class -> ExperimentalJSTypeConverter.ByteArrayConverter()
+      java.net.URI::class -> ExperimentalJSTypeConverter.URIConverter()
+      java.net.URL::class -> ExperimentalJSTypeConverter.URLConverter()
+      android.net.Uri::class -> ExperimentalJSTypeConverter.UriConverter()
+      java.io.File::class -> ExperimentalJSTypeConverter.FileConverter()
+      Pair::class -> ExperimentalJSTypeConverter.PairConverter()
+      Long::class -> ExperimentalJSTypeConverter.LongConverter()
+      Any::class -> ExperimentalJSTypeConverter.AnyConverter()
+      else -> null
+    }
+
+    directConverter ?: when {
+      inheritFrom<Map<*, *>>() -> ExperimentalJSTypeConverter.MapConverter()
+      inheritFrom<Enum<*>>() -> ExperimentalJSTypeConverter.EnumConverter()
+      inheritFrom<expo.modules.kotlin.records.Record>() -> ExperimentalJSTypeConverter.RecordConverter()
+      inheritFrom<expo.modules.kotlin.typedarray.RawTypedArrayHolder>() -> ExperimentalJSTypeConverter.RawTypedArrayHolderConverter()
+      inheritFrom<Array<*>>() -> ExperimentalJSTypeConverter.ArrayConverter()
+      inheritFrom<Collection<*>>() -> ExperimentalJSTypeConverter.CollectionConverter()
+      else -> ExperimentalJSTypeConverter.PassThroughConverter()
+    }
+  }
+
+  fun convertToJS(value: Any?): Any? {
+    return converter.convertToJS(value)
+  }
+
+  internal inline fun <reified T> inheritFrom(): Boolean {
+    val jClass = klass.java
+    return T::class.java.isAssignableFrom(jClass)
+  }
+}


### PR DESCRIPTION
# Why

Uses a deduced return type to simplify conversion. 

# How

In function components, we can use the return type to make our conversion more direct. This PR is only the first part of using this approche. Also, it's hidden behind the feature flag.

# Test Plan

- unit tests ✅ 