### PR TITLE
[core][Android] Add `onStartListening` and `onStopListening` to the `SharedObject`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Added `onStartListening` and `onStopListening` to the `SharedObject`. ([#31385](https://github.com/expo/expo/pull/31385) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -196,11 +196,11 @@ class SharedObjectTest {
     var lastOnStartObserving = ""
     var lastOnStopObserving = ""
 
-    override fun startObserving(eventName: String) {
+    override fun onStartListening(eventName: String) {
       lastOnStartObserving = eventName
     }
 
-    override fun stopObserving(eventName: String) {
+    override fun onStopListening(eventName: String) {
       lastOnStopObserving = eventName
     }
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -196,11 +196,11 @@ class SharedObjectTest {
     var lastOnStartObserving = ""
     var lastOnStopObserving = ""
 
-    override fun onStartListening(eventName: String) {
+    override fun onStartListeningToEvent(eventName: String) {
       lastOnStartObserving = eventName
     }
 
-    override fun onStopListening(eventName: String) {
+    override fun onStopListeningToEvent(eventName: String) {
       lastOnStopObserving = eventName
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -27,7 +27,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
 
   fun buildClass(): ClassDefinitionData {
     if (eventsDefinition != null && ownerClass.isSubclassOf(SharedObject::class)) {
-      listOf("__expo_onStartListening" to SharedObject::onStartListening, "__expo_onStopListening" to SharedObject::onStopListening)
+      listOf("__expo_onStartListeningToEvent" to SharedObject::onStartListeningToEvent, "__expo_onStopListeningToEvent" to SharedObject::onStopListeningToEvent)
         .forEach { (name, function) ->
           SyncFunctionComponent(name, arrayOf(ownerType, toAnyType<String>()), toReturnType<Unit>()) { (self, eventName) ->
             enforceType<SharedObject, String>(self, eventName)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -51,7 +51,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     }
 
     val constructor = constructor
-                      ?: SyncFunctionComponent("constructor", emptyArray(), toReturnType<Unit>()) {}
+      ?: SyncFunctionComponent("constructor", emptyArray(), toReturnType<Unit>()) {}
     constructor.canTakeOwner = true
     constructor.ownerType = ownerType.kType
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -27,12 +27,13 @@ class ClassComponentBuilder<SharedObjectType : Any>(
 
   fun buildClass(): ClassDefinitionData {
     if (eventsDefinition != null && ownerClass.isSubclassOf(SharedObject::class)) {
-      listOf("__expo__startObserving" to SharedObject::startObserving, "__expo__stopObserving" to SharedObject::stopObserving)
+      listOf("__expo_onStartListening" to SharedObject::onStartListening, "__expo_onStopListening" to SharedObject::onStopListening)
         .forEach { (name, function) ->
           SyncFunctionComponent(name, arrayOf(ownerType, toAnyType<String>()), toReturnType<Unit>()) { (self, eventName) ->
             enforceType<SharedObject, String>(self, eventName)
             function.invoke(self, eventName)
           }.also { function ->
+            function.enumerable(false)
             syncFunctions[name] = function
           }
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.types.LazyKType
+import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
 import kotlin.reflect.KClass
@@ -126,7 +127,7 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   }
 
   inline fun Class(name: String, body: ClassComponentBuilder<Unit>.() -> Unit = {}) {
-    val clazzBuilder = ClassComponentBuilder(name, Unit::class, typeOf<Unit>())
+    val clazzBuilder = ClassComponentBuilder(name, Unit::class, toAnyType<Unit>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -136,7 +137,7 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(name, sharedObjectClass, typeOf<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(name, sharedObjectClass, toAnyType<SharedObjectType>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -145,7 +146,7 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(sharedObjectClass.java.simpleName, sharedObjectClass, typeOf<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(sharedObjectClass.java.simpleName, sharedObjectClass, toAnyType<SharedObjectType>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
@@ -1,9 +1,7 @@
 package expo.modules.kotlin.objects
 
-class EventObservingDefinition(
-  private val type: Type,
-  private val filer: Filter,
-  private val body: () -> Unit
+open class EventObservingDefinition(
+  private val filer: Filter
 ) {
   sealed class Filter
 
@@ -11,25 +9,45 @@ class EventObservingDefinition(
 
   class SelectedEventFiler(val event: String) : Filter()
 
-  enum class Type(val value: String) {
-    StartObserving("startObserving"),
-    StopObserving("stopObserving")
-  }
-
-  private fun shouldBeInvoked(eventType: Type, eventName: String): Boolean {
-    if (eventType != type) {
-      return false
-    }
-
+  internal fun shouldBeInvoked(eventName: String): Boolean {
     return when (filer) {
       is AllEventsFilter -> true
       is SelectedEventFiler -> filer.event == eventName
     }
   }
+}
+
+class AsyncEventObservingDefinition(
+  private val type: Type,
+  filer: Filter,
+  private val body: () -> Unit
+) : EventObservingDefinition(filer) {
+
+  enum class Type(val value: String) {
+    StartObserving("startObserving"),
+    StopObserving("stopObserving")
+  }
 
   fun invokedIfNeed(eventType: Type, eventName: String) {
-    if (shouldBeInvoked(eventType, eventName)) {
+    if (eventType == type && shouldBeInvoked(eventName)) {
       body()
+    }
+  }
+}
+
+class SyncEventObservingDefinition<SelfType>(
+  private val type: Type,
+  private val filer: Filter,
+  private val body: (self: SelfType) -> Unit
+) : EventObservingDefinition(filer) {
+  enum class Type(val value: String) {
+    StartObserving("startObservingSync"),
+    StopObserving("stopObservingSync")
+  }
+
+  fun invokedIfNeed(self: SelfType, eventType: Type, eventName: String) {
+    if (eventType == type && shouldBeInvoked(eventName)) {
+      body(self)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
@@ -1,8 +1,15 @@
 package expo.modules.kotlin.objects
 
-open class EventObservingDefinition(
-  private val filer: Filter
+class EventObservingDefinition(
+  private val type: Type,
+  private val filer: Filter,
+  private val body: () -> Unit
 ) {
+  enum class Type(val value: String) {
+    StartObserving("startObserving"),
+    StopObserving("stopObserving")
+  }
+
   sealed class Filter
 
   data object AllEventsFilter : Filter()
@@ -15,39 +22,10 @@ open class EventObservingDefinition(
       is SelectedEventFiler -> filer.event == eventName
     }
   }
-}
-
-class AsyncEventObservingDefinition(
-  private val type: Type,
-  filer: Filter,
-  private val body: () -> Unit
-) : EventObservingDefinition(filer) {
-
-  enum class Type(val value: String) {
-    StartObserving("startObserving"),
-    StopObserving("stopObserving")
-  }
 
   fun invokedIfNeed(eventType: Type, eventName: String) {
     if (eventType == type && shouldBeInvoked(eventName)) {
       body()
-    }
-  }
-}
-
-class SyncEventObservingDefinition<SelfType>(
-  private val type: Type,
-  private val filer: Filter,
-  private val body: (self: SelfType) -> Unit
-) : EventObservingDefinition(filer) {
-  enum class Type(val value: String) {
-    StartObserving("startObservingSync"),
-    StopObserving("stopObservingSync")
-  }
-
-  fun invokedIfNeed(self: SelfType, eventType: Type, eventName: String) {
-    if (eventType == type && shouldBeInvoked(eventName)) {
-      body(self)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -48,7 +48,7 @@ open class ObjectDefinitionBuilder {
   @PublishedApi
   internal var properties = mutableMapOf<String, PropertyComponentBuilder>()
 
-  private val asyncEventObservers = mutableListOf<EventObservingDefinition>()
+  private val eventObservers = mutableListOf<EventObservingDefinition>()
 
   fun buildObject(): ObjectDefinitionData {
     EventObservingDefinition.Type.entries.forEach { type ->
@@ -56,7 +56,7 @@ open class ObjectDefinitionBuilder {
       // In the long run, we probably want to add a warning here or make it impossible to export such functions.
       if (!asyncFunctions.containsKey(type.value)) {
         AsyncFunction(type.value) { eventName: String ->
-          asyncEventObservers.forEach {
+          eventObservers.forEach {
             it.invokedIfNeed(type, eventName)
           }
         }
@@ -469,7 +469,7 @@ open class ObjectDefinitionBuilder {
       EventObservingDefinition.SelectedEventFiler(eventName),
       body
     ).also {
-      asyncEventObservers.add(it)
+      eventObservers.add(it)
     }
   }
 
@@ -482,7 +482,7 @@ open class ObjectDefinitionBuilder {
       EventObservingDefinition.AllEventsFilter,
       body
     ).also {
-      asyncEventObservers.add(it)
+      eventObservers.add(it)
     }
   }
 
@@ -495,7 +495,7 @@ open class ObjectDefinitionBuilder {
       EventObservingDefinition.SelectedEventFiler(eventName),
       body
     ).also {
-      asyncEventObservers.add(it)
+      eventObservers.add(it)
     }
   }
 
@@ -508,7 +508,7 @@ open class ObjectDefinitionBuilder {
       EventObservingDefinition.AllEventsFilter,
       body
     ).also {
-      asyncEventObservers.add(it)
+      eventObservers.add(it)
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -48,10 +48,10 @@ open class ObjectDefinitionBuilder {
   @PublishedApi
   internal var properties = mutableMapOf<String, PropertyComponentBuilder>()
 
-  private val asyncEventObservers = mutableListOf<AsyncEventObservingDefinition>()
+  private val asyncEventObservers = mutableListOf<EventObservingDefinition>()
 
   fun buildObject(): ObjectDefinitionData {
-    AsyncEventObservingDefinition.Type.entries.forEach { type ->
+    EventObservingDefinition.Type.entries.forEach { type ->
       // If the user exports a function that is called `startObserving` or `stopObserving`, we don't add the observer
       // In the long run, we probably want to add a warning here or make it impossible to export such functions.
       if (!asyncFunctions.containsKey(type.value)) {
@@ -464,8 +464,8 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after the first event listener is added for given event.
    */
   fun OnStartObserving(eventName: String, body: () -> Unit) {
-    AsyncEventObservingDefinition(
-      AsyncEventObservingDefinition.Type.StartObserving,
+    EventObservingDefinition(
+      EventObservingDefinition.Type.StartObserving,
       EventObservingDefinition.SelectedEventFiler(eventName),
       body
     ).also {
@@ -477,8 +477,8 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after the first event listener is added.
    */
   fun OnStartObserving(body: () -> Unit) {
-    AsyncEventObservingDefinition(
-      AsyncEventObservingDefinition.Type.StartObserving,
+    EventObservingDefinition(
+      EventObservingDefinition.Type.StartObserving,
       EventObservingDefinition.AllEventsFilter,
       body
     ).also {
@@ -490,8 +490,8 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after all event listeners are removed for given event.
    */
   fun OnStopObserving(eventName: String, body: () -> Unit) {
-    AsyncEventObservingDefinition(
-      AsyncEventObservingDefinition.Type.StopObserving,
+    EventObservingDefinition(
+      EventObservingDefinition.Type.StopObserving,
       EventObservingDefinition.SelectedEventFiler(eventName),
       body
     ).also {
@@ -503,8 +503,8 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after all event listeners are removed.
    */
   fun OnStopObserving(body: () -> Unit) {
-    AsyncEventObservingDefinition(
-      AsyncEventObservingDefinition.Type.StopObserving,
+    EventObservingDefinition(
+      EventObservingDefinition.Type.StopObserving,
       EventObservingDefinition.AllEventsFilter,
       body
     ).also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -56,6 +56,10 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
     }
   }
 
+  open fun startObserving(eventName: String) = Unit
+
+  open fun stopObserving(eventName: String) = Unit
+
   /**
    * Called when the shared object being deallocated.
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -56,9 +56,9 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
     }
   }
 
-  open fun startObserving(eventName: String) = Unit
+  open fun onStartListening(eventName: String) = Unit
 
-  open fun stopObserving(eventName: String) = Unit
+  open fun onStopListening(eventName: String) = Unit
 
   /**
    * Called when the shared object being deallocated.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -56,9 +56,9 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
     }
   }
 
-  open fun onStartListening(eventName: String) = Unit
+  open fun onStartListeningToEvent(eventName: String) = Unit
 
-  open fun onStopListening(eventName: String) = Unit
+  open fun onStopListeningToEvent(eventName: String) = Unit
 
   /**
    * Called when the shared object being deallocated.

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -8,11 +8,11 @@ namespace expo::EventEmitter {
 
 #pragma mark - Listeners
 
-void Listeners::add(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {
+void Listeners::add(jsi::Runtime &runtime, const std::string& eventName, const jsi::Function &listener) noexcept {
   listenersMap[eventName].emplace_back(runtime, listener);
 }
 
-void Listeners::remove(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {
+void Listeners::remove(jsi::Runtime &runtime, const std::string& eventName, const jsi::Function &listener) noexcept {
   if (!listenersMap.contains(eventName)) {
     return;
   }
@@ -23,7 +23,7 @@ void Listeners::remove(jsi::Runtime &runtime, std::string eventName, const jsi::
   });
 }
 
-void Listeners::removeAll(std::string eventName) noexcept {
+void Listeners::removeAll(const std::string& eventName) noexcept {
   if (listenersMap.contains(eventName)) {
     listenersMap[eventName].clear();
   }
@@ -33,14 +33,14 @@ void Listeners::clear() noexcept {
   listenersMap.clear();
 }
 
-size_t Listeners::listenersCount(std::string eventName) noexcept {
+size_t Listeners::listenersCount(const std::string& eventName) noexcept {
   if (!listenersMap.contains(eventName)) {
     return 0;
   }
   return listenersMap[eventName].size();
 }
 
-void Listeners::call(jsi::Runtime &runtime, std::string eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept {
+void Listeners::call(jsi::Runtime &runtime, const std::string& eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept {
   if (!listenersMap.contains(eventName)) {
     return;
   }
@@ -110,7 +110,7 @@ NativeState::Shared NativeState::get(jsi::Runtime &runtime, const jsi::Object &o
 
 #pragma mark - Utils
 
-void callObservingFunction(jsi::Runtime &runtime, const jsi::Object &object, const char* functionName, std::string eventName) {
+void callObservingFunction(jsi::Runtime &runtime, const jsi::Object &object, const char* functionName, const std::string& eventName) {
   jsi::Value fnValue = object.getProperty(runtime, functionName);
 
   if (!fnValue.isObject()) {
@@ -131,6 +131,7 @@ void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::s
     state->listeners.add(runtime, eventName, listener);
 
     if (state->listeners.listenersCount(eventName) == 1) {
+      callObservingFunction(runtime, emitter, "startObservingSync", eventName);
       callObservingFunction(runtime, emitter, "startObserving", eventName);
     }
   }
@@ -143,6 +144,7 @@ void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std
     state->listeners.remove(runtime, eventName, listener);
 
     if (listenersCountBefore >= 1 && state->listeners.listenersCount(eventName) == 0) {
+      callObservingFunction(runtime, emitter, "stopObservingSync", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }
@@ -155,6 +157,7 @@ void removeAllListeners(jsi::Runtime &runtime, const jsi::Object &emitter, const
     state->listeners.removeAll(eventName);
 
     if (listenersCountBefore >= 1) {
+      callObservingFunction(runtime, emitter, "stopObservingSync", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -131,7 +131,7 @@ void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::s
     state->listeners.add(runtime, eventName, listener);
 
     if (state->listeners.listenersCount(eventName) == 1) {
-      callObservingFunction(runtime, emitter, "startObservingSync", eventName);
+      callObservingFunction(runtime, emitter, "__expo__startObserving", eventName);
       callObservingFunction(runtime, emitter, "startObserving", eventName);
     }
   }
@@ -144,7 +144,7 @@ void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std
     state->listeners.remove(runtime, eventName, listener);
 
     if (listenersCountBefore >= 1 && state->listeners.listenersCount(eventName) == 0) {
-      callObservingFunction(runtime, emitter, "stopObservingSync", eventName);
+      callObservingFunction(runtime, emitter, "__expo__stopObserving", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -131,7 +131,7 @@ void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::s
     state->listeners.add(runtime, eventName, listener);
 
     if (state->listeners.listenersCount(eventName) == 1) {
-      callObservingFunction(runtime, emitter, "__expo__startObserving", eventName);
+      callObservingFunction(runtime, emitter, "__expo_onStartListening", eventName);
       callObservingFunction(runtime, emitter, "startObserving", eventName);
     }
   }
@@ -144,7 +144,7 @@ void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std
     state->listeners.remove(runtime, eventName, listener);
 
     if (listenersCountBefore >= 1 && state->listeners.listenersCount(eventName) == 0) {
-      callObservingFunction(runtime, emitter, "__expo__stopObserving", eventName);
+      callObservingFunction(runtime, emitter, "__expo_onStopListening", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -131,7 +131,7 @@ void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::s
     state->listeners.add(runtime, eventName, listener);
 
     if (state->listeners.listenersCount(eventName) == 1) {
-      callObservingFunction(runtime, emitter, "__expo_onStartListening", eventName);
+      callObservingFunction(runtime, emitter, "__expo_onStartListeningToEvent", eventName);
       callObservingFunction(runtime, emitter, "startObserving", eventName);
     }
   }
@@ -144,7 +144,7 @@ void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std
     state->listeners.remove(runtime, eventName, listener);
 
     if (listenersCountBefore >= 1 && state->listeners.listenersCount(eventName) == 0) {
-      callObservingFunction(runtime, emitter, "__expo_onStopListening", eventName);
+      callObservingFunction(runtime, emitter, "__expo_onStopListeningToEvent", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }
@@ -157,7 +157,7 @@ void removeAllListeners(jsi::Runtime &runtime, const jsi::Object &emitter, const
     state->listeners.removeAll(eventName);
 
     if (listenersCountBefore >= 1) {
-      callObservingFunction(runtime, emitter, "stopObservingSync", eventName);
+      callObservingFunction(runtime, emitter, "__expo_onStopListeningToEvent", eventName);
       callObservingFunction(runtime, emitter, "stopObserving", eventName);
     }
   }

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -40,17 +40,17 @@ private:
   /**
    Adds a listener for the given event name.
    */
-  void add(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept;
+  void add(jsi::Runtime &runtime, const std::string& eventName, const jsi::Function &listener) noexcept;
 
   /**
    Removes the listener for the given event name.
    */
-  void remove(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept;
+  void remove(jsi::Runtime &runtime, const std::string& eventName, const jsi::Function &listener) noexcept;
 
   /**
    Removes all listeners for the given event name.
    */
-  void removeAll(std::string eventName) noexcept;
+  void removeAll(const std::string& eventName) noexcept;
 
   /**
    Clears the entire map of events and listeners.
@@ -60,12 +60,12 @@ private:
   /**
    Returns a number of listeners added for the given event name.
    */
-  size_t listenersCount(std::string eventName) noexcept;
+  size_t listenersCount(const std::string& eventName) noexcept;
 
   /**
    Calls listeners for the given event name, with the given `this` object and payload arguments.
    */
-  void call(jsi::Runtime &runtime, std::string eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept;
+  void call(jsi::Runtime &runtime, const std::string& eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept;
 };
 
 /**


### PR DESCRIPTION
# Why

Added versions of `OnStartObserving` and `OnStopObserving` that take self as a parameter.

# How

I had to introduce a new version of those observers with a `Sync` suffix. I didn't want to change the existing behavior, because the current callbacks are asynchronous. Some of our modules are taking advantage of this. 

# Test Plan

- tests ✅ 