### PR TITLE
[bare-expo][core] enable r8

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -57,3 +57,5 @@ EX_DEV_CLIENT_NETWORK_INSPECTOR=true
 expo.useLegacyPackaging=false
 
 EXPO_ALLOW_GLIDE_LOGS=true
+
+android.enableProguardInReleaseBuilds=true

--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -80,6 +80,14 @@
           "userTrackingPermission": "Allow Expo projects to use data for tracking the user or the device"
         }
       ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "enableProguardInReleaseBuilds": true
+          }
+        }
+      ],
       "./plugins/withAndroidNetworkSecurityConfig"
     ]
   }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -48,6 +48,7 @@
     "@react-native-segmented-control/segmented-control": "2.5.2",
     "@shopify/flash-list": "1.6.4",
     "expo": "~51.0.0",
+    "expo-build-properties": "~0.12.0",
     "expo-camera": "~15.0.0",
     "expo-dev-client": "~4.0.0",
     "expo-face-detector": "~12.7.0",

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [Android] Fixed `Class declares 0 type parameters, but X were provided` on Android when R8 is enabled. ([#30659](https://github.com/expo/expo/pull/30659) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed SharedObject class names are obfuscated when R8 is enabled. ([#30948](https://github.com/expo/expo/pull/30948) by [@lukmccall](https://github.com/lukmccall))
 - Fix support for macOS. ([#31307](https://github.com/expo/expo/pull/31307) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fixed `CodedException.getCode()` crash when R8 is enabled. ([#31392](https://github.com/expo/expo/pull/31392) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -27,6 +27,7 @@ open class CodedException(
   // the javaClass property in the constructor.
   private var providedCode: String? = null
 
+  @get:DoNotStrip
   val code
     get() = providedCode ?: inferCode(javaClass)
 


### PR DESCRIPTION
# Why

according to previous sdk sync, let's enable r8 for bare-expo

# How

- enable r8 for bare-expo
- [core] fix a crash when testing expo-file-system/next because `CodedException.getCode()` method is mangled. 

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
