### PR TITLE
[expo-modules-core] Add failing testcase

### DIFF
--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -241,6 +241,10 @@ class FunctionSpec: ExpoSpec {
     context("JavaScript") {
       let runtime = try! appContext.runtime
 
+      struct TestRecord: Record {
+        @Field var property: String = "expo"
+      }
+
       beforeSuite {
         appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
           Name("TestModule")
@@ -276,6 +280,14 @@ class FunctionSpec: ExpoSpec {
 
           Function("withCGFloat") { (f: CGFloat) in
             return "\(f)"
+          }
+
+          Function("withRecord") { (f: TestRecord) in
+            return "\(f.property)"
+          }
+
+          Function("withOptionalRecord") { (f: TestRecord?) in
+            return "\(f?.property ?? "no value")"
           }
         })
       }
@@ -313,6 +325,18 @@ class FunctionSpec: ExpoSpec {
 
       it("accepts CGFloat argument") {
         expect(try runtime.eval("expo.modules.TestModule.withCGFloat(20.23)").asString()) == "20.23"
+      }
+
+      it("accepts record") {
+        expect(try runtime.eval("expo.modules.TestModule.withRecord({property: \"123\"})").asString()) == "123"
+      }
+
+      it("accepts no optional record") {
+        expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord()").asString()) == "no value"
+      }
+
+      it("accepts optional record") {
+        expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
       }
     }
   }


### PR DESCRIPTION
# Why

Adding a test to ensure that it's possible to create optional record arguments in module core.
This was a behavior that was broken for a while and got probably fixed in https://github.com/expo/expo/pull/31827.

# Old behavior

```
      it("accepts optional record") {
        expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
      }
```

used to result in

```
JavaScript, accepts optional record(): unexpected error thrown: <FunctionCallException: Calling the 'withOptionalRecord' function has failed (at ExpoModulesCore/SyncFunctionDefinition.swift:137)
→ Caused by: ArgumentCastException: The 1st argument cannot be cast to type TestRecord? (at ExpoModulesCore/MainValueConverter.swift:40)
→ Caused by: ConvertingException<TestRecord>: Cannot convert 'Optional(ExpoModulesCore_Unit_Tests.FunctionSpec.(unknown context at $148d4e5a4).(unknown context at $148d4e5f0).(unknown context at $148d4e5fc).TestRecord(_property: ExpoModulesCore.Field<Swift.String>))' to TestRecord (at ExpoModulesCore/Record.swift:34)>

```

now it correctly passes an optional record.

# Test Plan

Tests pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
