### PR TITLE
[core] Remove unneeded copies

### DIFF
--- a/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
@@ -7,6 +7,9 @@
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/RuntimeExecutor.h>
 
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
 namespace expo {
 
 class BridgelessJSCallInvoker : public react::CallInvoker {

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -76,7 +76,7 @@ public:
   using Shared = std::shared_ptr<NativeState>;
 
   NativeState();
-  virtual ~NativeState();
+  ~NativeState() override;
 
   /**
    A structure containing event listeners.

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -24,7 +24,7 @@ jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstruc
     nativeConstructorPropId,
     // The paramCount is not obligatory to match, it only affects the `length` property of the function.
     0,
-    [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    [constructor = std::move(constructor)](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
       if (constructor) {
         return constructor(runtime, thisValue, args, count);
       }
@@ -83,7 +83,7 @@ std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, 
   return vector;
 }
 
-void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor descriptor) {
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor& descriptor) {
   jsi::Object jsDescriptor(runtime);
 
   // These three flags are all `false` by default, so set the property only when `true`.

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -64,7 +64,7 @@ struct PropertyDescriptor {
 /**
  Defines the property on the object with the provided descriptor options.
  */
-void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor descriptor);
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor& descriptor);
 
 /**
  Calls `Object.defineProperty(object, name, descriptor)`.

--- a/packages/expo-modules-core/common/cpp/LazyObject.cpp
+++ b/packages/expo-modules-core/common/cpp/LazyObject.cpp
@@ -5,7 +5,7 @@
 
 namespace expo {
 
-LazyObject::LazyObject(const LazyObjectInitializer initializer) : initializer(initializer) {}
+LazyObject::LazyObject(LazyObjectInitializer initializer) : initializer(std::move(initializer)) {}
 
 LazyObject::~LazyObject() {
   backedObject = nullptr;

--- a/packages/expo-modules-core/common/cpp/LazyObject.h
+++ b/packages/expo-modules-core/common/cpp/LazyObject.h
@@ -22,9 +22,9 @@ class JSI_EXPORT LazyObject : public jsi::HostObject {
 public:
   using Shared = std::shared_ptr<LazyObject>;
 
-  LazyObject(const LazyObjectInitializer initializer);
+  explicit LazyObject(LazyObjectInitializer initializer);
 
-  virtual ~LazyObject();
+  ~LazyObject() override;
 
   jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
 

--- a/packages/expo-modules-core/common/cpp/ObjectDeallocator.cpp
+++ b/packages/expo-modules-core/common/cpp/ObjectDeallocator.cpp
@@ -11,7 +11,7 @@ void setDeallocator(
   ObjectDeallocator::Block deallocatorBlock
 ) {
   std::shared_ptr<ObjectDeallocator> objectDeallocator = std::make_shared<ObjectDeallocator>(
-    deallocatorBlock
+    std::move(deallocatorBlock)
   );
   jsThis->setNativeState(runtime, objectDeallocator);
 }

--- a/packages/expo-modules-core/common/cpp/ObjectDeallocator.h
+++ b/packages/expo-modules-core/common/cpp/ObjectDeallocator.h
@@ -14,9 +14,9 @@ class JSI_EXPORT ObjectDeallocator : public jsi::NativeState {
 public:
   typedef std::function<void()> Block;
 
-  ObjectDeallocator(const Block deallocator) : deallocator(deallocator) {};
+  ObjectDeallocator(Block deallocator) : deallocator(std::move(deallocator)) {};
 
-  virtual ~ObjectDeallocator() {
+  ~ObjectDeallocator() override {
     deallocator();
   }
 

--- a/packages/expo-modules-core/common/cpp/SharedObject.cpp
+++ b/packages/expo-modules-core/common/cpp/SharedObject.cpp
@@ -7,8 +7,8 @@ namespace expo::SharedObject {
 
 #pragma mark - NativeState
 
-NativeState::NativeState(const ObjectId objectId, const ObjectReleaser releaser)
-: EventEmitter::NativeState(), objectId(objectId), releaser(releaser) {}
+NativeState::NativeState(ObjectId objectId, ObjectReleaser releaser)
+: EventEmitter::NativeState(), objectId(objectId), releaser(std::move(releaser)) {}
 
 NativeState::~NativeState() {
   releaser(objectId);
@@ -16,7 +16,7 @@ NativeState::~NativeState() {
 
 #pragma mark - Utils
 
-void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser) {
+void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser& releaser) {
   jsi::Function baseClass = EventEmitter::getClass(runtime);
   jsi::Function klass = expo::common::createInheritingClass(runtime, "SharedObject", baseClass);
   jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
@@ -86,7 +86,7 @@ jsi::Function getBaseClass(jsi::Runtime &runtime) {
 
 jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::ClassConstructor constructor) {
   jsi::Function baseSharedObjectClass = getBaseClass(runtime);
-  return common::createInheritingClass(runtime, className, baseSharedObjectClass, constructor);
+  return common::createInheritingClass(runtime, className, baseSharedObjectClass, std::move(constructor));
 }
 
 } // namespace expo::SharedObject

--- a/packages/expo-modules-core/common/cpp/SharedObject.h
+++ b/packages/expo-modules-core/common/cpp/SharedObject.h
@@ -26,7 +26,7 @@ typedef std::function<void(const ObjectId)> ObjectReleaser;
 /**
  Installs a base JavaScript class for all shared object with a shared release block.
  */
-void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser);
+void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser& releaser);
 
 /**
  Returns the base JavaScript class for all shared objects, i.e. `global.expo.SharedObject`.
@@ -49,9 +49,9 @@ public:
   /**
    The default constructor that initializes a native state for the shared object with given ID.
    */
-  NativeState(const ObjectId objectId, const ObjectReleaser releaser);
+  NativeState(ObjectId objectId, ObjectReleaser releaser);
 
-  virtual ~NativeState();
+  ~NativeState() override;
 }; // class NativeState
 
 } // namespace expo::SharedObject

--- a/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
@@ -9,6 +9,7 @@
 #include <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
 
@@ -16,9 +17,9 @@ namespace expo {
  * Dummy CallInvoker that invokes everything immediately.
  * Used in the test environment to check the async flow.
  */
-class TestingSyncJSCallInvoker : public facebook::react::CallInvoker {
+class TestingSyncJSCallInvoker : public react::CallInvoker {
 public:
-  TestingSyncJSCallInvoker(std::shared_ptr<jsi::Runtime> runtime) : runtime(runtime) {}
+  explicit TestingSyncJSCallInvoker(const std::shared_ptr<jsi::Runtime>& runtime) : runtime(runtime) {}
 
 #if REACT_NATIVE_TARGET_VERSION >= 75
   void invokeAsync(react::CallFunc &&func) noexcept override {

--- a/packages/expo-modules-core/common/cpp/TypedArray.cpp
+++ b/packages/expo-modules-core/common/cpp/TypedArray.cpp
@@ -35,11 +35,11 @@ TypedArrayKind TypedArray::getKind(jsi::Runtime &runtime) const {
 };
 
 size_t TypedArray::byteOffset(jsi::Runtime &runtime) const {
-  return getProperty(runtime, "byteOffset").asNumber();
+  return static_cast<size_t>(getProperty(runtime, "byteOffset").asNumber());
 }
 
 size_t TypedArray::byteLength(jsi::Runtime &runtime) const {
-  return getProperty(runtime, "byteLength").asNumber();
+  return static_cast<size_t>(getProperty(runtime, "byteLength").asNumber());
 }
 
 jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
@@ -51,7 +51,7 @@ jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
   }
 }
 
-void* TypedArray::getRawPointer(jsi::Runtime &runtime) {
+void* TypedArray::getRawPointer(jsi::Runtime &runtime) const {
   return reinterpret_cast<void *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
 }
 

--- a/packages/expo-modules-core/common/cpp/TypedArray.h
+++ b/packages/expo-modules-core/common/cpp/TypedArray.h
@@ -29,8 +29,8 @@ enum class TypedArrayKind {
 class TypedArray : public jsi::Object {
  public:
   TypedArray(jsi::Runtime &, const jsi::Object &);
-  TypedArray(TypedArray &&) = default;
-  TypedArray &operator=(TypedArray &&) = default;
+  TypedArray(TypedArray &&) noexcept = default;
+  TypedArray &operator=(TypedArray &&) noexcept = default;
 
   TypedArrayKind getKind(jsi::Runtime &runtime) const;
 
@@ -40,7 +40,7 @@ class TypedArray : public jsi::Object {
 
   jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
 
-  void* getRawPointer(jsi::Runtime &runtime);
+  void* getRawPointer(jsi::Runtime &runtime) const;
 };
 
 bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);


### PR DESCRIPTION
# Why

Removes unneeded copies.
Adds missing attributes.

# How

Moves objects more aggressively. 
Starts using `override` over `virtual` when overriding virtual destructor. 
Marks some functions as a const.

# Test Plan

- tests ✅ 