### PR TITLE
[router] Change appendBaseUrl to not modify urls begining with a scheme

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix hoisted index routes being incorrectly sorted. ([#31212](https://github.com/expo/expo/pull/31212) by [@marklawlor](https://github.com/marklawlor))
 - Fix Typed Routes crashing on folder rename. ([#31221](https://github.com/expo/expo/pull/31221) by [@marklawlor](https://github.com/marklawlor))
 - Fix incorrect initialRouteName for nested groups. ([#31025](https://github.com/expo/expo/pull/31025) by [@marklawlor](https://github.com/marklawlor))
+- Prevent `basePath` from being added to external URLs. ([#31402](https://github.com/expo/expo/pull/31402) by [@6TELOIV](https://github.com/6teloiv))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/fork/__tests__/getPathFromState.test.web.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState.test.web.ts
@@ -1,4 +1,4 @@
-import getPathFromState from '../getPathFromState';
+import getPathFromState, { appendBaseUrl } from '../getPathFromState';
 
 describe('hash support', () => {
   it('appends hash to the path', () => {
@@ -90,4 +90,24 @@ it(`handles url search params params`, () => {
   };
 
   expect(getPathFromState(state, config)).toBe('/?test=true&hello=world&array=1&array=2');
+});
+
+describe('basePath support', () => {
+  const oldBaseUrl = process.env.EXPO_BASE_URL;
+
+  beforeAll(() => {
+    process.env.EXPO_BASE_URL = '/test';
+  });
+
+  afterAll(() => {
+    process.env.EXPO_BASE_URL = oldBaseUrl;
+  });
+
+  it('appends baseUrl to the paths without schemes', () => {
+    expect(appendBaseUrl('/home')).toBe('/test/home');
+  });
+
+  it('does not appends baseUrl to the paths without schemes', () => {
+    expect(appendBaseUrl('http://www.example.com/home')).toBe('/test/home');
+  });
 });

--- a/packages/expo-router/src/fork/__tests__/getPathFromState.test.web.ts
+++ b/packages/expo-router/src/fork/__tests__/getPathFromState.test.web.ts
@@ -108,6 +108,6 @@ describe('basePath support', () => {
   });
 
   it('does not appends baseUrl to the paths without schemes', () => {
-    expect(appendBaseUrl('http://www.example.com/home')).toBe('/test/home');
+    expect(appendBaseUrl('http://www.example.com/home')).toBe('http://www.example.com/home');
   });
 });

--- a/packages/expo-router/src/fork/getPathFromState.ts
+++ b/packages/expo-router/src/fork/getPathFromState.ts
@@ -694,11 +694,13 @@ const createNormalizedConfigs = (
     Object.entries(options).map(([name, c]) => [name, createConfigItem(c, pattern)])
   );
 
+const schemeCheck = /^[a-zA-Z\d+.-]+:/;
+
 export function appendBaseUrl(
   path: string,
   baseUrl: string | undefined = process.env.EXPO_BASE_URL
 ) {
-  if (process.env.NODE_ENV !== 'development') {
+  if (process.env.NODE_ENV !== 'development' && !schemeCheck.test(path)) {
     if (baseUrl) {
       return `/${baseUrl.replace(/^\/+/, '').replace(/\/$/, '')}${path}`;
     }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/26566 by preventing `basePath` from being appended to external URLs

# How

The `Link` component, in the `useLinkToPathProps` hook, calls `appendBaseUrl` on the passed `href`. In production builds, this causes issues. The `basePath` will be appended to external URLs. Example: `http://example.com/` becomes `/base-pathhttp://example.com/`.

On web, clicking the link will work OK, but middle clicking or r-click > copy URL will get the erroneous one. This is because the event handler blocks the default navigation event on the regular click, but not other cases.

To fix this, the regex `/^[a-zA-Z\d+.-]+:/` checks if the "path" param begins with a valid scheme (one or more of: alpha-numeric character, `+`, `-`, or `.`; followed by a colon). See appendix A of [rfc2396](https://www.ietf.org/rfc/rfc2396.txt). If it does, we should not append the `basePath` (as it is not a path the router should handle).

# Test Plan

Added 2 tests in `getPathFromState.test.web.ts`, as that is the file where the function is declared and the bug is really only relevant on web (on native, the event handle will always handle the link click). The tests include one where a path where `basePath` should be appended and one where it should not be appended.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
