### PR TITLE
[docs] Clarify the purpose of running a build interactively prior to implementing CI

### DIFF
--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -15,7 +15,7 @@ This document outlines how to trigger builds on EAS for your app from a CI envir
 To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. To do this, go through the EAS Build initialization steps and run a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
 
 Running a build locally will accomplish the following critical configuration steps:
-- Initialize the project on EAS, generating a `projectId`.
+- Initialize the project on EAS by generating a `projectId`.
 - Add an **eas.json** file defining your build profiles.
 - Ensure app config fields critical for native builds are populated, such as Android `packageName` and iOS `bundleIdentifier`.
 - Ensure build credentials are created, including Android keystores and iOS distribution certs and provisioning profiles.

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -8,17 +8,21 @@ import { Terminal } from '~/ui/components/Snippet';
 
 This document outlines how to trigger builds on EAS for your app from a CI environment such as GitHub Actions, Travis CI, and more.
 
-Before building with EAS on CI, we need to install and configure `eas-cli`. Then, we can trigger new builds with the `eas build` command.
-
 ## Prerequisites
 
 ### Run a successful build from your local machine
 
-To trigger EAS builds from a CI environment, we first need to configure our app for EAS Build and successfully run a build from our local machine for each platform that we'd like to support on CI.
+To trigger EAS builds from a CI environment, your app needs to be setup to use EAS Build in non-interactive mode. The  way to do this is by taking care of the EAS Build initialization steps and running a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt interactively for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
 
-If you have run `eas build -p [all|android|ios]` successfully before, then you can continue.
+Running a build locally will accomplish the following critical configuration steps:
+- Initialize the project on EAS, generating a `projectId`.
+- Add an **eas.json** file defining your build profiles.
+- Ensure app config fields critical for native builds are populated, such as Android `packageName` and iOS `bundleIdentifier`.
+- Ensure build credentials are created, including Android keystores and iOS distribution certs and provisioning profiles.
 
-If you haven't done this yet, see [Create your first build](/build/setup/) guide and return here when you're ready.
+Run `eas build -p [all|android|ios]` and verify that your builds for each platform complete successfully. Then, continue with the below steps for implementing EAS Build on CI.
+
+If you haven't done this yet, see the [Create your first build](/build/setup/) guide and return here when you're ready.
 
 ## Configure your app for CI
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -15,6 +15,7 @@ This document outlines how to trigger builds on EAS for your app from a CI envir
 To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. To do this, go through the EAS Build initialization steps and run a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
 
 Running a build locally will accomplish the following critical configuration steps:
+
 - Initialize the project on EAS by generating a `projectId`.
 - Add an **eas.json** file defining your build profiles.
 - Populates critical app config properties for native builds, such as `android.packageName` and `ios.bundleIdentifier`.

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -12,7 +12,7 @@ This document outlines how to trigger builds on EAS for your app from a CI envir
 
 ### Run a successful build from your local machine
 
-To trigger EAS builds from a CI environment, your app needs to be setup to use EAS Build in non-interactive mode. The  way to do this is by taking care of the EAS Build initialization steps and running a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt interactively for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
+To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. To do this, go through the EAS Build initialization steps and run a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
 
 Running a build locally will accomplish the following critical configuration steps:
 - Initialize the project on EAS, generating a `projectId`.

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -17,7 +17,7 @@ To trigger EAS builds from a CI environment, your app needs to be set up to use 
 Running a build locally will accomplish the following critical configuration steps:
 - Initialize the project on EAS by generating a `projectId`.
 - Add an **eas.json** file defining your build profiles.
-- Ensure app config fields critical for native builds are populated, such as Android `packageName` and iOS `bundleIdentifier`.
+- Populates critical app config properties for native builds, such as `android.packageName` and `ios.bundleIdentifier`.
 - Ensure build credentials are created, including Android keystores and iOS distribution certs and provisioning profiles.
 
 Run `eas build -p [all|android|ios]` and verify that your builds for each platform complete successfully. Then, continue with the below steps for implementing EAS Build on CI.


### PR DESCRIPTION
# Why
Got  a question to the effect of "what's going on here that I need to do this manually? There's no way to automate this?" There's nothing magical about running a build from the local terminal prompt first, but it sounds a little magical here, and this can throw off those who want to automate _all the things_. It's still a really good idea for the vast majority of projects. So, let's clarify exactly what we're accomplishing here, why it's so important to run things manually before automating them.

# How
Clarified what building manually first accomplishes.

I noticed that this doc uses "we" a lot, vs. "you", which I think is more common in our docs, though I'm not sure if it's an implicit standard. I can update the perspective of the entire doc if that's desired.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
