### PR TITLE
chore: have bot suggest a changelog entry

### DIFF
--- a/tools/src/code-review/reports.ts
+++ b/tools/src/code-review/reports.ts
@@ -60,3 +60,10 @@ function prefixForStatus(status: ReviewStatus): string {
   }
   return '';
 }
+
+/**
+ * Returns a link in markdown format.
+ */
+export function markdownLink(name: string, url: string): string {
+  return `[${name}](${url})`;
+}

--- a/tools/src/code-review/reviewers/checkMissingChangelogs.ts
+++ b/tools/src/code-review/reviewers/checkMissingChangelogs.ts
@@ -4,9 +4,11 @@ import path from 'path';
 
 import { ANDROID_VENDORED_DIR, EXPO_DIR, IOS_VENDORED_DIR } from '../../Constants';
 import { GitFileDiff } from '../../Git';
+import { PullRequest } from '../../GitHub';
 import logger from '../../Logger';
 import { getListOfPackagesAsync, Package } from '../../Packages';
 import { filterAsync } from '../../Utils';
+import { markdownLink } from '../reports';
 import { ReviewInput, ReviewOutput, ReviewStatus } from '../types';
 
 // glob patterns for paths where changes are negligible
@@ -44,7 +46,7 @@ export default async function ({ pullRequest, diff }: ReviewInput): Promise<Revi
   if (globalChangelogHasChanges && !isModifyingVendoredModules(diff)) {
     return globalChangelogEntriesOutput(changelogLinks);
   } else if (pkgsWithoutChangelogChanges.length > 0) {
-    return missingChangelogOutput(changelogLinks);
+    return missingChangelogOutput(changelogLinks, pullRequest);
   }
 
   return null;
@@ -67,15 +69,30 @@ function relativeChangelogPath(head: ReviewInput['pullRequest']['head'], pkg: Pa
   return `[\`${relativePath}\`](${head.repo?.html_url}/blob/${head.ref}/${relativePath})`;
 }
 
-function missingChangelogOutput(changelogLinks: string): ReviewOutput {
+function missingChangelogOutput(changelogLinks: string, pullRequest: PullRequest): ReviewOutput {
   return {
     status: ReviewStatus.WARN,
     title: 'Missing changelog entries',
     body:
-      'Your changes should be noted in the changelog. ' +
+      'Your changes should be noted in the changelog, e.g.: \n' +
+      generateChangelogStub(pullRequest) +
+      '\n' +
       'Read [Updating Changelogs](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md) ' +
       `guide and consider adding an appropriate entry to the following changelogs: \n${changelogLinks}`,
   };
+}
+
+function generateChangelogStub(pullRequest: PullRequest) {
+  const prLink = markdownLink('#' + pullRequest.number, pullRequest.html_url);
+  const userLink = markdownLink('@' + pullRequest.user!.login, pullRequest.user!.html_url);
+  const suggestedTitle = filterBracketContent(pullRequest.title);
+
+  return `- ${suggestedTitle} (${prLink} by ${userLink})`;
+}
+
+function filterBracketContent(input: string): string {
+  // many PR titles start with package name (e.g. [video]). We don't want that in a package-specific changelog.
+  return input.replace(/\[.*?\]/g, '').trim();
 }
 
 function globalChangelogEntriesOutput(changelogLinks: string): ReviewOutput {

--- a/tools/src/code-review/reviewers/reviewChangelogEntries.ts
+++ b/tools/src/code-review/reviewers/reviewChangelogEntries.ts
@@ -5,6 +5,7 @@ import { Changelog } from '../../Changelogs';
 import { EXPO_DIR } from '../../Constants';
 import { PullRequest } from '../../GitHub';
 import * as Markdown from '../../Markdown';
+import { markdownLink } from '../reports';
 import { ReviewComment, ReviewInput, ReviewOutput, ReviewStatus } from '../types';
 
 export default async function ({ pullRequest, diff }: ReviewInput): Promise<ReviewOutput> {
@@ -71,13 +72,6 @@ export default async function ({ pullRequest, diff }: ReviewInput): Promise<Revi
       status: ReviewStatus.PASSIVE,
     };
   }
-}
-
-/**
- * Returns a link in markdown format.
- */
-function markdownLink(name: string, url: string): string {
-  return `[${name}](${url})`;
 }
 
 /**


### PR DESCRIPTION
# Why

The bot already warns about missing changelog entries, and if I add an entry title, it will enhance it for me (by adding the author and PR link part) with a suggestion which I can commit. However, I have found that I sometimes commit the suggestion and then go make changes locally, and forget to pull the changelog entry in.
The bot already has the information that it needs to suggest a changelog entry which I could add locally and not worry about the above.

# How

took some code from `reviewChangelogEntries.ts` and refitted it for `checkMissingChangelogs.ts`

# Test Plan

merge and see 😅 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
