### PR TITLE
fix(template): add `f12` to open devtools in template

### DIFF
--- a/templates/expo-template-default/app/(tabs)/index.tsx
+++ b/templates/expo-template-default/app/(tabs)/index.tsx
@@ -25,7 +25,11 @@ export default function HomeScreen() {
           Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
           Press{' '}
           <ThemedText type="defaultSemiBold">
-            {Platform.select({ ios: 'cmd + d', android: 'cmd + m' })}
+            {Platform.select({
+              ios: 'cmd + d',
+              android: 'cmd + m',
+              web: 'F12'
+            })}
           </ThemedText>{' '}
           to open developer tools.
         </ThemedText>


### PR DESCRIPTION
# Why

On web, we show the image below, which isn't great.

![image](https://github.com/user-attachments/assets/8b5c82da-2076-4311-9c8f-756059326e58)

Either we hide that full sentence on Web, or we add the shortcut to open the browser devtools.

# How

F12 is the default chrome/edge devtools shortcut.

# Test Plan

Template content change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
