### PR TITLE
[image][Android] Refactor glide model providers

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -518,8 +518,8 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
       val bestSource = bestSource
       val bestPlaceholder = bestPlaceholder
 
-      val sourceToLoad = bestSource?.createGlideModel(context)
-      val placeholder = bestPlaceholder?.createGlideModel(context)
+      val sourceToLoad = bestSource?.createGlideModelProvider(context)
+      val placeholder = bestPlaceholder?.createGlideModelProvider(context)
 
       if (cleanIfNeeded(bestSource, sourceToLoad, placeholder)) {
         // the view was cleaned
@@ -550,7 +550,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
       val options = bestSource?.createGlideOptions(context)
       val propOptions = createPropOptions()
 
-      val model = sourceToLoad?.glideModel
+      val model = sourceToLoad?.getGlideModel()
       if (model is GlideUrlWrapper) {
         model.progressListener = progressListener
       }
@@ -576,7 +576,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
           }
           newTarget.placeholderContentFit = newPlaceholderContentFit
 
-          thumbnail(requestManager.load(placeholderModel.glideModel))
+          thumbnail(requestManager.load(placeholderModel.getGlideModel()))
             .apply(placeholderSource.createGlideOptions(context))
         }
         .downsample(downsampleStrategy)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/GlideModelProvider.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/GlideModelProvider.kt
@@ -3,70 +3,49 @@ package expo.modules.image
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import com.bumptech.glide.load.model.GlideUrl
+import expo.modules.image.blurhash.BlurhashModel
 import expo.modules.image.decodedsource.DecodedModel
 import expo.modules.image.okhttp.GlideUrlWrapper
+import expo.modules.image.thumbhash.ThumbhashModel
 
-sealed class GlideModelProvider {
-  abstract val glideModel: Any
-
-  override fun equals(other: Any?): Boolean {
-    return this === other || (other is GlideModelProvider && glideModel == other.glideModel)
-  }
-
-  override fun hashCode(): Int = glideModel.hashCode()
+fun interface GlideModelProvider {
+  fun getGlideModel(): Any
 }
 
-class DecodedModelProvider(drawable: Drawable) : GlideModelProvider() {
-  override val glideModel = DecodedModel(drawable)
+data class DecodedModelProvider(
+  private val drawable: Drawable
+) : GlideModelProvider {
+  override fun getGlideModel() = DecodedModel(drawable)
 }
 
-class UrlModelProvider(
-  glideUrl: GlideUrl
-) : GlideModelProvider() {
-  override val glideModel: GlideUrlWrapper = GlideUrlWrapper(glideUrl)
+data class UrlModelProvider(
+  private val glideUrl: GlideUrl
+) : GlideModelProvider {
+  override fun getGlideModel() = GlideUrlWrapper(glideUrl)
 }
 
-class RawModelProvider(
-  data: String
-) : GlideModelProvider() {
-  override val glideModel: String = data
+data class RawModelProvider(
+  private val data: String
+) : GlideModelProvider {
+  override fun getGlideModel() = data
 }
 
-class UriModelProvider(
-  uri: Uri
-) : GlideModelProvider() {
-  override val glideModel: Uri = uri
+data class UriModelProvider(
+  private val uri: Uri
+) : GlideModelProvider {
+  override fun getGlideModel() = uri
 }
 
-class BlurhashModelProvider(
-  val uri: Uri,
-  val width: Int,
-  val height: Int
-) : GlideModelProvider() {
-  override val glideModel: BlurhashModelProvider = this
-
-  override fun equals(other: Any?): Boolean {
-    return this === other || (other is BlurhashModelProvider && uri == other.uri && width == other.width && height == other.height)
-  }
-
-  override fun hashCode(): Int {
-    var result = uri.hashCode()
-    result = 31 * result + width
-    result = 31 * result + height
-    return result
-  }
+data class BlurhashModelProvider(
+  private val uri: Uri,
+  private val width: Int,
+  private val height: Int
+) : GlideModelProvider {
+  override fun getGlideModel() = BlurhashModel(uri, width, height)
 }
 
-class ThumbhashModelProvider(
-  var uri: Uri
-) : GlideModelProvider() {
-  override val glideModel: ThumbhashModelProvider = this
-
-  override fun equals(other: Any?): Boolean {
-    return this === other || (other is ThumbhashModelProvider && uri == other.uri)
-  }
-
-  override fun hashCode(): Int {
-    return uri.hashCode()
-  }
+data class ThumbhashModelProvider(
+  private val uri: Uri
+) : GlideModelProvider {
+  override fun getGlideModel() = ThumbhashModel(uri)
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModel.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModel.kt
@@ -1,0 +1,9 @@
+package expo.modules.image.blurhash
+
+import android.net.Uri
+
+data class BlurhashModel(
+  val uri: Uri,
+  val width: Int,
+  val height: Int
+)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModelLoader.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModelLoader.kt
@@ -5,13 +5,12 @@ import android.net.Uri
 import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.model.ModelLoader
 import com.bumptech.glide.signature.ObjectKey
-import expo.modules.image.BlurhashModelProvider
 
-class BlurhashModelLoader : ModelLoader<BlurhashModelProvider, Bitmap> {
-  override fun handles(model: BlurhashModelProvider): Boolean = true
+class BlurhashModelLoader : ModelLoader<BlurhashModel, Bitmap> {
+  override fun handles(model: BlurhashModel): Boolean = true
 
   override fun buildLoadData(
-    model: BlurhashModelProvider,
+    model: BlurhashModel,
     width: Int,
     height: Int,
     options: Options

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModelLoaderFactory.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModelLoaderFactory.kt
@@ -4,10 +4,9 @@ import android.graphics.Bitmap
 import com.bumptech.glide.load.model.ModelLoader
 import com.bumptech.glide.load.model.ModelLoaderFactory
 import com.bumptech.glide.load.model.MultiModelLoaderFactory
-import expo.modules.image.BlurhashModelProvider
 
-class BlurhashModelLoaderFactory : ModelLoaderFactory<BlurhashModelProvider, Bitmap> {
-  override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<BlurhashModelProvider, Bitmap> =
+class BlurhashModelLoaderFactory : ModelLoaderFactory<BlurhashModel, Bitmap> {
+  override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<BlurhashModel, Bitmap> =
     BlurhashModelLoader()
 
   override fun teardown() = Unit

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashModule.kt
@@ -6,12 +6,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.LibraryGlideModule
-import expo.modules.image.BlurhashModelProvider
 
 @GlideModule
 class BlurhashModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
     super.registerComponents(context, glide, registry)
-    registry.prepend(BlurhashModelProvider::class.java, Bitmap::class.java, BlurhashModelLoaderFactory())
+    registry.prepend(BlurhashModel::class.java, Bitmap::class.java, BlurhashModelLoaderFactory())
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -30,7 +30,7 @@ sealed interface Source {
   val pixelCount: Double
     get() = width * height * scale * scale
 
-  fun createGlideModel(context: Context): GlideModelProvider?
+  fun createGlideModelProvider(context: Context): GlideModelProvider?
   fun createGlideOptions(context: Context): RequestOptions
 
   /**
@@ -42,7 +42,7 @@ sealed interface Source {
 class DecodedSource(
   val drawable: Drawable
 ) : Source {
-  override fun createGlideModel(context: Context): GlideModelProvider {
+  override fun createGlideModelProvider(context: Context): GlideModelProvider {
     return DecodedModelProvider(drawable)
   }
 
@@ -92,7 +92,7 @@ data class SourceMap(
     }
   }
 
-  override fun createGlideModel(context: Context): GlideModelProvider? {
+  override fun createGlideModelProvider(context: Context): GlideModelProvider? {
     if (uri.isNullOrBlank()) {
       return null
     }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModel.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModel.kt
@@ -1,0 +1,7 @@
+package expo.modules.image.thumbhash
+
+import android.net.Uri
+
+data class ThumbhashModel(
+  val uri: Uri
+)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModelLoader.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModelLoader.kt
@@ -6,13 +6,11 @@ import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.model.ModelLoader
 import com.bumptech.glide.signature.ObjectKey
 
-import expo.modules.image.ThumbhashModelProvider
+class ThumbhashModelLoader : ModelLoader<ThumbhashModel, Bitmap> {
 
-class ThumbhashModelLoader : ModelLoader<ThumbhashModelProvider, Bitmap> {
+  override fun handles(model: ThumbhashModel): Boolean = true
 
-  override fun handles(model: ThumbhashModelProvider): Boolean = true
-
-  override fun buildLoadData(model: ThumbhashModelProvider, width: Int, height: Int, options: Options): ModelLoader.LoadData<Bitmap> {
+  override fun buildLoadData(model: ThumbhashModel, width: Int, height: Int, options: Options): ModelLoader.LoadData<Bitmap> {
     // The URI looks like this: thumbhash:/3OcRJYB4d3h\iIeHeEh3eIhw+j2w
     // ThumbHash may include slashes which could break the structure of the URL, so we replace them
     // with backslashes on the JS side and revert them back to slashes here, before generating the image.

--- a/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModelLoaderFactory.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModelLoaderFactory.kt
@@ -4,10 +4,9 @@ import android.graphics.Bitmap
 import com.bumptech.glide.load.model.ModelLoader
 import com.bumptech.glide.load.model.ModelLoaderFactory
 import com.bumptech.glide.load.model.MultiModelLoaderFactory
-import expo.modules.image.ThumbhashModelProvider
 
-class ThumbhashModelLoaderFactory : ModelLoaderFactory<ThumbhashModelProvider, Bitmap> {
-  override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<ThumbhashModelProvider, Bitmap> =
+class ThumbhashModelLoaderFactory : ModelLoaderFactory<ThumbhashModel, Bitmap> {
+  override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<ThumbhashModel, Bitmap> =
     ThumbhashModelLoader()
 
   override fun teardown() = Unit

--- a/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/thumbhash/ThumbhashModule.kt
@@ -6,12 +6,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.LibraryGlideModule
-import expo.modules.image.ThumbhashModelProvider
 
 @GlideModule
 class ThumbhashModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
     super.registerComponents(context, glide, registry)
-    registry.prepend(ThumbhashModelProvider::class.java, Bitmap::class.java, ThumbhashModelLoaderFactory())
+    registry.prepend(ThumbhashModel::class.java, Bitmap::class.java, ThumbhashModelLoaderFactory())
   }
 }


### PR DESCRIPTION
# Why

A follow-up to the suggestion under different PR - https://github.com/expo/expo/pull/31098#discussion_r1751774242.

# How

Made a clear distinguish between model providers and glide models. 
Removed unneeded `hashCode` and `equals` functions.

# Test Plan

- bare-expo with NCL ✅ 