### PR TITLE
[android] Remove redundant exceptions

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -282,7 +282,7 @@ class AudioModule : Module() {
     Class(AudioRecorder::class) {
       Constructor { options: RecordingOptions ->
         AudioRecorder(
-          appContext.activity.applicationContext,
+          appContext.throwingActivity.applicationContext,
           appContext,
           options
         )
@@ -380,7 +380,7 @@ class AudioModule : Module() {
     runBlocking(appContext.mainQueue.coroutineContext) { block() }
 
   private fun checkRecordingPermission() {
-    val permission = ContextCompat.checkSelfPermission(appContext.activity.applicationContext, Manifest.permission.RECORD_AUDIO)
+    val permission = ContextCompat.checkSelfPermission(appContext.throwingActivity.applicationContext, Manifest.permission.RECORD_AUDIO)
     if (permission != PackageManager.PERMISSION_GRANTED) {
       throw AudioPermissionsException()
     }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -41,7 +41,7 @@ import kotlin.math.min
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class AudioModule : Module() {
   private val activity: Activity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private lateinit var audioManager: AudioManager
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.audio
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioManager
@@ -40,8 +39,6 @@ import kotlin.math.min
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class AudioModule : Module() {
-  private val activity: Activity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private lateinit var audioManager: AudioManager
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
@@ -285,7 +282,7 @@ class AudioModule : Module() {
     Class(AudioRecorder::class) {
       Constructor { options: RecordingOptions ->
         AudioRecorder(
-          activity.applicationContext,
+          appContext.activity.applicationContext,
           appContext,
           options
         )
@@ -383,7 +380,7 @@ class AudioModule : Module() {
     runBlocking(appContext.mainQueue.coroutineContext) { block() }
 
   private fun checkRecordingPermission() {
-    val permission = ContextCompat.checkSelfPermission(activity.applicationContext, Manifest.permission.RECORD_AUDIO)
+    val permission = ContextCompat.checkSelfPermission(appContext.activity.applicationContext, Manifest.permission.RECORD_AUDIO)
     if (permission != PackageManager.PERMISSION_GRANTED) {
       throw AudioPermissionsException()
     }

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
@@ -23,7 +23,7 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
   private val blurView = BlurView(context).also {
     it.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
 
-    val decorView = appContext.activity.window?.decorView
+    val decorView = appContext.throwingActivity.window?.decorView
     val rootView = decorView?.findViewById<ViewGroup>(android.R.id.content) ?: throw Exceptions.MissingRootView()
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       it.setupWith(rootView, RenderEffectBlur())

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
@@ -23,7 +23,7 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
   private val blurView = BlurView(context).also {
     it.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
 
-    val decorView = (appContext.currentActivity ?: throw Exceptions.MissingActivity()).window?.decorView
+    val decorView = appContext.activity.window?.decorView
     val rootView = decorView?.findViewById<ViewGroup>(android.R.id.content) ?: throw Exceptions.MissingRootView()
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       it.setupWith(rootView, RenderEffectBlur())

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -6,7 +6,6 @@ import android.view.WindowManager
 import expo.modules.core.errors.InvalidArgumentException
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -16,7 +15,7 @@ const val brightnessChangeEvent = "Expo.brightnessDidChange"
 
 class BrightnessModule : Module() {
   private val currentActivity
-    get() = appContext.activity
+    get() = appContext.throwingActivity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoBrightness")

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -16,7 +16,7 @@ const val brightnessChangeEvent = "Expo.brightnessDidChange"
 
 class BrightnessModule : Module() {
   private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.activity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoBrightness")

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -94,11 +94,10 @@ class ExpoCameraView(
 ) : ExpoView(context, appContext),
   CameraViewInterface {
   private val currentActivity
-    get() = appContext.currentActivity as? AppCompatActivity
-      ?: throw Exceptions.MissingActivity()
+    get() = appContext.activity as AppCompatActivity
 
   val orientationEventListener by lazy {
-    object : OrientationEventListener(currentActivity) {
+    object : OrientationEventListener(appContext.activity) {
       override fun onOrientationChanged(orientation: Int) {
         if (orientation == ORIENTATION_UNKNOWN) {
           return
@@ -531,7 +530,7 @@ class ExpoCameraView(
   }
 
   private fun getDeviceOrientation() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    appContext.currentActivity?.display?.rotation ?: 0
+    appContext.activity.display?.rotation ?: 0
   } else {
     (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
   }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -94,10 +94,10 @@ class ExpoCameraView(
 ) : ExpoView(context, appContext),
   CameraViewInterface {
   private val currentActivity
-    get() = appContext.activity as AppCompatActivity
+    get() = appContext.throwingActivity as AppCompatActivity
 
   val orientationEventListener by lazy {
-    object : OrientationEventListener(appContext.activity) {
+    object : OrientationEventListener(appContext.throwingActivity) {
       override fun onOrientationChanged(orientation: Int) {
         if (orientation == ORIENTATION_UNKNOWN) {
           return
@@ -530,7 +530,7 @@ class ExpoCameraView(
   }
 
   private fun getDeviceOrientation() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    appContext.activity.display?.rotation ?: 0
+    appContext.throwingActivity.display?.rotation ?: 0
   } else {
     (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
   }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -126,7 +126,7 @@ class ContactsModule : Module() {
     get() = appContext.permissions ?: throw Exceptions.PermissionsModuleNotFound()
 
   private val currentActivity: Activity
-    get() = appContext.activity
+    get() = appContext.throwingActivity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoContacts")

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -125,8 +125,8 @@ class ContactsModule : Module() {
   private val permissionsManager: Permissions
     get() = appContext.permissions ?: throw Exceptions.PermissionsModuleNotFound()
 
-  private val activity: Activity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+  private val currentActivity: Activity
+    get() = appContext.activity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoContacts")
@@ -233,7 +233,7 @@ class ContactsModule : Module() {
         putExtra(Intent.EXTRA_STREAM, uri)
         putExtra(Intent.EXTRA_SUBJECT, subject)
       }
-      activity.startActivity(intent)
+      currentActivity.startActivity(intent)
     }
 
     AsyncFunction("writeContactToFileAsync") { contact: Map<String, Any?> ->
@@ -295,7 +295,7 @@ class ContactsModule : Module() {
       intent.setType(ContactsContract.Contacts.CONTENT_TYPE)
 
       contactPickingPromise = promise
-      activity.startActivityForResult(intent, RC_PICK_CONTACT)
+      currentActivity.startActivityForResult(intent, RC_PICK_CONTACT)
     }
   }
 
@@ -304,7 +304,7 @@ class ContactsModule : Module() {
     intent.putExtra(ContactsContract.Intents.Insert.NAME, contact.getFinalDisplayName())
     intent.putParcelableArrayListExtra(ContactsContract.Intents.Insert.DATA, contact.contentValues)
     contactManipulationPromise = promise
-    activity.startActivityForResult(intent, RC_ADD_CONTACT)
+    currentActivity.startActivityForResult(intent, RC_ADD_CONTACT)
   }
 
   private fun presentEditForm(contact: Contact, promise: Promise) {
@@ -315,7 +315,7 @@ class ContactsModule : Module() {
     val intent = Intent(Intent.ACTION_EDIT)
     intent.setDataAndType(selectedContactUri, ContactsContract.Contacts.CONTENT_ITEM_TYPE)
     contactManipulationPromise = promise
-    activity.startActivityForResult(intent, RC_EDIT_CONTACT)
+    currentActivity.startActivityForResult(intent, RC_EDIT_CONTACT)
   }
 
   private val resolver: ContentResolver

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -126,7 +126,7 @@ class ContactsModule : Module() {
     get() = appContext.permissions ?: throw Exceptions.PermissionsModuleNotFound()
 
   private val activity: Activity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoContacts")

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -43,7 +43,7 @@ class DocumentPickerModule : Module() {
           options.type[0]
         }
       }
-      appContext.activity.startActivityForResult(intent, OPEN_DOCUMENT_CODE)
+      appContext.throwingActivity.startActivityForResult(intent, OPEN_DOCUMENT_CODE)
     }
 
     OnActivityResult { _, (requestCode, resultCode, intent) ->

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -21,8 +21,6 @@ private const val OPEN_DOCUMENT_CODE = 4137
 class DocumentPickerModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private var pendingPromise: Promise? = null
   private var copyToCacheDirectory = true
 
@@ -45,7 +43,7 @@ class DocumentPickerModule : Module() {
           options.type[0]
         }
       }
-      currentActivity.startActivityForResult(intent, OPEN_DOCUMENT_CODE)
+      appContext.activity.startActivityForResult(intent, OPEN_DOCUMENT_CODE)
     }
 
     OnActivityResult { _, (requestCode, resultCode, intent) ->

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -451,8 +451,6 @@ open class FileSystemModule : Module() {
     }
 
     AsyncFunction("requestDirectoryPermissionsAsync") { initialFileUrl: String?, promise: Promise ->
-      val currentActivity = appContext.currentActivity
-        ?: throw Exceptions.MissingActivity()
       if (dirPermissionsRequest != null) {
         throw FileSystemPendingPermissionsRequestException()
       }
@@ -464,7 +462,7 @@ open class FileSystemModule : Module() {
       }
 
       dirPermissionsRequest = promise
-      currentActivity.startActivityForResult(intent, DIR_PERMISSIONS_REQUEST_CODE)
+      appContext.activity.startActivityForResult(intent, DIR_PERMISSIONS_REQUEST_CODE)
     }
 
     AsyncFunction("uploadAsync") { url: String, fileUriString: String, options: FileSystemUploadOptions, promise: Promise ->
@@ -699,8 +697,6 @@ open class FileSystemModule : Module() {
 
     OnActivityResult { _, (requestCode, resultCode, data) ->
       if (requestCode == DIR_PERMISSIONS_REQUEST_CODE && dirPermissionsRequest != null) {
-        val currentActivity =
-          appContext.currentActivity ?: throw Exceptions.MissingActivity()
         val result = Bundle()
         if (resultCode == Activity.RESULT_OK && data != null) {
           val treeUri = data.data
@@ -709,7 +705,7 @@ open class FileSystemModule : Module() {
               and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             )
           treeUri?.let {
-            currentActivity.contentResolver.takePersistableUriPermission(it, takeFlags)
+            appContext.activity.contentResolver.takePersistableUriPermission(it, takeFlags)
           }
           result.putBoolean("granted", true)
           result.putString("directoryUri", treeUri.toString())
@@ -862,12 +858,9 @@ open class FileSystemModule : Module() {
   }
 
   private fun contentUriFromFile(file: File): Uri {
-    val currentActivity = appContext.currentActivity
-      ?: throw Exceptions.MissingActivity()
-
     return FileProvider.getUriForFile(
-      currentActivity.application,
-      "${currentActivity.application.packageName}.FileSystemFileProvider",
+      appContext.activity.application,
+      "${appContext.activity.application.packageName}.FileSystemFileProvider",
       file
     )
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -462,7 +462,7 @@ open class FileSystemModule : Module() {
       }
 
       dirPermissionsRequest = promise
-      appContext.activity.startActivityForResult(intent, DIR_PERMISSIONS_REQUEST_CODE)
+      appContext.throwingActivity.startActivityForResult(intent, DIR_PERMISSIONS_REQUEST_CODE)
     }
 
     AsyncFunction("uploadAsync") { url: String, fileUriString: String, options: FileSystemUploadOptions, promise: Promise ->
@@ -705,7 +705,7 @@ open class FileSystemModule : Module() {
               and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             )
           treeUri?.let {
-            appContext.activity.contentResolver.takePersistableUriPermission(it, takeFlags)
+            appContext.throwingActivity.contentResolver.takePersistableUriPermission(it, takeFlags)
           }
           result.putBoolean("granted", true)
           result.putString("directoryUri", treeUri.toString())
@@ -859,8 +859,8 @@ open class FileSystemModule : Module() {
 
   private fun contentUriFromFile(file: File): Uri {
     return FileProvider.getUriForFile(
-      appContext.activity.application,
-      "${appContext.activity.application.packageName}.FileSystemFileProvider",
+      appContext.throwingActivity.application,
+      "${appContext.throwingActivity.application.packageName}.FileSystemFileProvider",
       file
     )
   }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerExceptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerExceptions.kt
@@ -28,9 +28,6 @@ internal class FailedToReadFileException(file: File, cause: Throwable? = null) :
 internal class MissingActivityToHandleIntent(intentType: String?) :
   CodedException("Failed to resolve activity to handle the intent of type '$intentType'")
 
-internal class MissingCurrentActivityException :
-  CodedException("Activity which was provided during module initialization is no longer available")
-
 internal class MissingModuleException(moduleName: String) :
   CodedException("Module '$moduleName' not found. Are you sure all modules are linked correctly?")
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -113,9 +113,6 @@ class ImagePickerModule : Module() {
   val context: Context
     get() = requireNotNull(appContext.reactContext) { "React Application Context is null" }
 
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
   private val mediaHandler = MediaHandler(this)
 
   private lateinit var cameraLauncher: AppContextActivityResultLauncher<CameraContractOptions, ImagePickerContractResult>
@@ -266,7 +263,7 @@ class ImagePickerModule : Module() {
 
   private fun ensureTargetActivityIsAvailable(options: ImagePickerOptions) {
     val cameraIntent = Intent(options.nativeMediaTypes.toCameraIntentAction())
-    if (cameraIntent.resolveActivity(currentActivity.application.packageManager) == null) {
+    if (cameraIntent.resolveActivity(appContext.activity.application.packageManager) == null) {
       throw MissingActivityToHandleIntent(cameraIntent.type)
     }
   }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -114,7 +114,7 @@ class ImagePickerModule : Module() {
     get() = requireNotNull(appContext.reactContext) { "React Application Context is null" }
 
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity ?: throw MissingCurrentActivityException()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   private val mediaHandler = MediaHandler(this)
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -263,7 +263,7 @@ class ImagePickerModule : Module() {
 
   private fun ensureTargetActivityIsAvailable(options: ImagePickerOptions) {
     val cameraIntent = Intent(options.nativeMediaTypes.toCameraIntentAction())
-    if (cameraIntent.resolveActivity(appContext.activity.application.packageManager) == null) {
+    if (cameraIntent.resolveActivity(appContext.throwingActivity.application.packageManager) == null) {
       throw MissingActivityToHandleIntent(cameraIntent.type)
     }
   }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/Exceptions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/Exceptions.kt
@@ -4,6 +4,3 @@ import expo.modules.kotlin.exception.CodedException
 
 class ImageLoadFailed(exception: Exception) :
   CodedException(message = "Failed to load the image: ${exception.message}")
-
-class MissingActivity :
-  CodedException(message = "The current activity is no longer available")

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -46,7 +46,7 @@ import kotlin.math.min
 @SuppressLint("ViewConstructor")
 class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
   private val activity: Activity
-    get() = appContext.activity
+    get() = appContext.throwingActivity
 
   internal val requestManager = getOrCreateRequestManager(appContext, activity)
   private val progressListener = OkHttpProgressListener(WeakReference(this))

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -34,6 +34,7 @@ import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.Source
 import expo.modules.image.svg.SVGPictureDrawable
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.tracing.beginAsyncTraceBlock
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.viewevent.EventDispatcher
@@ -46,7 +47,7 @@ import kotlin.math.min
 @SuppressLint("ViewConstructor")
 class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
   private val activity: Activity
-    get() = appContext.currentActivity ?: throw MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   internal val requestManager = getOrCreateRequestManager(appContext, activity)
   private val progressListener = OkHttpProgressListener(WeakReference(this))

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -34,7 +34,6 @@ import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.Source
 import expo.modules.image.svg.SVGPictureDrawable
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.tracing.beginAsyncTraceBlock
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.viewevent.EventDispatcher
@@ -47,7 +46,7 @@ import kotlin.math.min
 @SuppressLint("ViewConstructor")
 class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
   private val activity: Activity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.activity
 
   internal val requestManager = getOrCreateRequestManager(appContext, activity)
   private val progressListener = OkHttpProgressListener(WeakReference(this))

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -20,8 +20,6 @@ private const val ATTR_DATA = "data"
 class IntentLauncherModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private var pendingPromise: Promise? = null
 
   override fun definition() = ModuleDefinition {
@@ -65,7 +63,7 @@ class IntentLauncherModule : Module() {
       params.category?.let { intent.addCategory(it) }
 
       try {
-        currentActivity.startActivityForResult(intent, REQUEST_CODE)
+        appContext.activity.startActivityForResult(intent, REQUEST_CODE)
         pendingPromise = promise
       } catch (e: Throwable) {
         promise.reject(e.toCodedException())

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -63,7 +63,7 @@ class IntentLauncherModule : Module() {
       params.category?.let { intent.addCategory(it) }
 
       try {
-        appContext.activity.startActivityForResult(intent, REQUEST_CODE)
+        appContext.throwingActivity.startActivityForResult(intent, REQUEST_CODE)
         pendingPromise = promise
       } catch (e: Throwable) {
         promise.reject(e.toCodedException())

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -75,7 +75,7 @@ class LocalAuthenticationModule : Module() {
     }
 
     AsyncFunction("authenticateAsync") { options: AuthOptions, promise: Promise ->
-      val fragmentActivity = currentActivity as? FragmentActivity
+      val fragmentActivity = appContext.activity as? FragmentActivity
       if (fragmentActivity == null) {
         promise.reject(Exceptions.MissingActivity())
         return@AsyncFunction
@@ -137,9 +137,6 @@ class LocalAuthenticationModule : Module() {
 
   private val keyguardManager: KeyguardManager
     get() = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-
-  private val currentActivity: Activity?
-    get() = appContext.currentActivity
 
   private val biometricManager by lazy { BiometricManager.from(context) }
   private val packageManager by lazy { context.packageManager }
@@ -239,7 +236,7 @@ class LocalAuthenticationModule : Module() {
   }
 
   private fun promptDeviceCredentialsFallback(options: AuthOptions, promise: Promise) {
-    val fragmentActivity = currentActivity as FragmentActivity?
+    val fragmentActivity = appContext.activity as FragmentActivity?
     if (fragmentActivity == null) {
       promise.resolve(
         createResponse(

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -75,7 +75,7 @@ class LocalAuthenticationModule : Module() {
     }
 
     AsyncFunction("authenticateAsync") { options: AuthOptions, promise: Promise ->
-      val fragmentActivity = appContext.activity as? FragmentActivity
+      val fragmentActivity = appContext.throwingActivity as? FragmentActivity
       if (fragmentActivity == null) {
         promise.reject(Exceptions.MissingActivity())
         return@AsyncFunction
@@ -236,7 +236,7 @@ class LocalAuthenticationModule : Module() {
   }
 
   private fun promptDeviceCredentialsFallback(options: AuthOptions, promise: Promise) {
-    val fragmentActivity = appContext.activity as FragmentActivity?
+    val fragmentActivity = appContext.throwingActivity as FragmentActivity?
     if (fragmentActivity == null) {
       promise.resolve(
         createResponse(

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
@@ -47,9 +47,6 @@ internal class TaskManagerNotFoundException :
 internal class GeofencingException(message: String?, cause: Throwable? = null) :
   CodedException("A geofencing exception has occurred: ${message ?: ""} ${cause?.message ?: ""}")
 
-internal class MissingActivityManagerException :
-  CodedException("Activity manager is unavailable")
-
 internal class MissingUIManagerException :
   CodedException("UIManager is unavailable")
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -29,7 +29,6 @@ import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import expo.modules.core.interfaces.ActivityEventListener
-import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.taskManager.TaskManagerInterface

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -481,7 +481,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
         try {
           val resolvable = e as ResolvableApiException
           mUIManager.registerActivityEventListener(this@LocationModule)
-          resolvable.startResolutionForResult(appContext.activity, CHECK_SETTINGS_REQUEST_CODE)
+          resolvable.startResolutionForResult(appContext.throwingActivity, CHECK_SETTINGS_REQUEST_CODE)
         } catch (e: SendIntentException) {
           // Ignore the error.
           executePendingRequests(Activity.RESULT_CANCELED)

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -70,8 +70,6 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
   private lateinit var mSensorManager: SensorManager
   private lateinit var mUIManager: UIManager
   private lateinit var mLocationProvider: FusedLocationProviderClient
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   private var mGravity: FloatArray = FloatArray(9)
   private var mGeomagnetic: FloatArray = FloatArray(9)
@@ -483,7 +481,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
         try {
           val resolvable = e as ResolvableApiException
           mUIManager.registerActivityEventListener(this@LocationModule)
-          resolvable.startResolutionForResult(currentActivity, CHECK_SETTINGS_REQUEST_CODE)
+          resolvable.startResolutionForResult(appContext.activity, CHECK_SETTINGS_REQUEST_CODE)
         } catch (e: SendIntentException) {
           // Ignore the error.
           executePendingRequests(Activity.RESULT_CANCELED)

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
@@ -24,7 +24,7 @@ class MailComposerModule : Module() {
 
     AsyncFunction("composeAsync") { options: MailComposerOptions, promise: Promise ->
       val intent = Intent(Intent.ACTION_SENDTO).apply { data = Uri.parse("mailto:") }
-      val application = appContext.activity.application
+      val application = appContext.throwingActivity.application
       val resolveInfo = context.packageManager.queryIntentActivities(intent, 0)
 
       val mailIntents = resolveInfo.map { info ->
@@ -57,7 +57,7 @@ class MailComposerModule : Module() {
       }
 
       pendingPromise = promise
-      appContext.activity.startActivityForResult(chooser, REQUEST_CODE)
+      appContext.throwingActivity.startActivityForResult(chooser, REQUEST_CODE)
       composerOpened = true
     }
 

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
@@ -12,8 +12,6 @@ import expo.modules.kotlin.modules.ModuleDefinition
 class MailComposerModule : Module() {
   private val context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private var composerOpened = false
   private var pendingPromise: Promise? = null
 
@@ -26,7 +24,7 @@ class MailComposerModule : Module() {
 
     AsyncFunction("composeAsync") { options: MailComposerOptions, promise: Promise ->
       val intent = Intent(Intent.ACTION_SENDTO).apply { data = Uri.parse("mailto:") }
-      val application = currentActivity.application
+      val application = appContext.activity.application
       val resolveInfo = context.packageManager.queryIntentActivities(intent, 0)
 
       val mailIntents = resolveInfo.map { info ->
@@ -59,7 +57,7 @@ class MailComposerModule : Module() {
       }
 
       pendingPromise = promise
-      currentActivity.startActivityForResult(chooser, REQUEST_CODE)
+      appContext.activity.startActivityForResult(chooser, REQUEST_CODE)
       composerOpened = true
     }
 

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
@@ -16,7 +16,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("getSearchCompletions") { viewHandle: Int, searchQueryFragment: String, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.activityProvider?.currentActivity?.runOnUiThread {
+      appContext.currentActivity?.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.fetchPlacesSearchCompletions(searchQueryFragment, promise)
       }
@@ -24,7 +24,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("moveCamera") { viewHandle: Int, cameraPosition: CameraMoveRecord, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.activityProvider?.currentActivity?.runOnUiThread {
+      appContext.currentActivity?.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.moveCamera(cameraPosition, promise)
       }

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
@@ -16,7 +16,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("getSearchCompletions") { viewHandle: Int, searchQueryFragment: String, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.activity.runOnUiThread {
+      appContext.throwingActivity.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.fetchPlacesSearchCompletions(searchQueryFragment, promise)
       }
@@ -24,7 +24,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("moveCamera") { viewHandle: Int, cameraPosition: CameraMoveRecord, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.activity.runOnUiThread {
+      appContext.throwingActivity.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.moveCamera(cameraPosition, promise)
       }

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/ExpoGoogleMapsModule.kt
@@ -16,7 +16,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("getSearchCompletions") { viewHandle: Int, searchQueryFragment: String, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.currentActivity?.runOnUiThread {
+      appContext.activity.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.fetchPlacesSearchCompletions(searchQueryFragment, promise)
       }
@@ -24,7 +24,7 @@ class ExpoGoogleMapsModule : Module() {
     AsyncFunction("moveCamera") { viewHandle: Int, cameraPosition: CameraMoveRecord, promise: Promise ->
       val rnContext = appContext.reactContext as? ReactApplicationContext ?: return@AsyncFunction
       val uiManager = rnContext.getNativeModule(UIManagerModule::class.java) ?: return@AsyncFunction
-      appContext.currentActivity?.runOnUiThread {
+      appContext.activity.runOnUiThread {
         val view = uiManager.resolveView(viewHandle) as GoogleMapsView
         view.moveCamera(cameraPosition, promise)
       }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -53,9 +53,6 @@ import java.lang.ref.WeakReference
 class MediaLibraryModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
   private val moduleCoroutineScope = CoroutineScope(Dispatchers.IO)
   private var imagesObserver: MediaStoreContentObserver? = null
   private var videosObserver: MediaStoreContentObserver? = null
@@ -441,7 +438,7 @@ class MediaLibraryModule : Module() {
 
         try {
           awaitingAction = action
-          currentActivity.startIntentSenderForResult(
+          appContext.activity.startIntentSenderForResult(
             deleteRequest.intentSender,
             WRITE_REQUEST_CODE,
             null,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -438,7 +438,7 @@ class MediaLibraryModule : Module() {
 
         try {
           awaitingAction = action
-          appContext.activity.startIntentSenderForResult(
+          appContext.throwingActivity.startIntentSenderForResult(
             deleteRequest.intentSender,
             WRITE_REQUEST_CODE,
             null,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -54,7 +54,7 @@ class MediaLibraryModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   private val moduleCoroutineScope = CoroutineScope(Dispatchers.IO)
   private var imagesObserver: MediaStoreContentObserver? = null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -355,7 +355,7 @@ class AppContext(
         ?: (reactContext as? ReactApplicationContext)?.currentActivity
     }
 
-  val activity: Activity
+  val throwingActivity: Activity
     get() {
       val current = activityProvider?.currentActivity
         ?: (reactContext as? ReactApplicationContext)?.currentActivity

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -355,5 +355,12 @@ class AppContext(
         ?: (reactContext as? ReactApplicationContext)?.currentActivity
     }
 
+  val activity: Activity
+    get() {
+      val current = activityProvider?.currentActivity
+        ?: (reactContext as? ReactApplicationContext)?.currentActivity
+      return current ?: throw Exceptions.MissingActivity()
+    }
+
 // endregion
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -57,7 +57,7 @@ class CoreModule : Module() {
     }
 
     AsyncFunction("reloadAppAsync") { _: String ->
-      val reactActivity = appContext.activity as? ReactActivity ?: return@AsyncFunction
+      val reactActivity = appContext.throwingActivity as? ReactActivity ?: return@AsyncFunction
 
       // TODO(kudo): Use ReactActivity.getReactDelegate() after react-native 0.74.1
       // reactActivity.getReactDelegate()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -57,7 +57,7 @@ class CoreModule : Module() {
     }
 
     AsyncFunction("reloadAppAsync") { _: String ->
-      val reactActivity = appContext.currentActivity as? ReactActivity ?: return@AsyncFunction
+      val reactActivity = appContext.activity as? ReactActivity ?: return@AsyncFunction
 
       // TODO(kudo): Use ReactActivity.getReactDelegate() after react-native 0.74.1
       // reactActivity.getReactDelegate()

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -8,16 +8,13 @@ import android.view.WindowInsets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.navigationbar.singletons.NavigationBar
 
 class NavigationBarModule : Module() {
-  private val activity
-    get() = appContext.currentActivity
-      ?: throw Exceptions.MissingActivity()
+  private val currentActivity get() = appContext.activity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoNavigationBar")
@@ -25,7 +22,7 @@ class NavigationBarModule : Module() {
     Events(VISIBILITY_EVENT_NAME)
 
     OnStartObserving {
-      val decorView = activity.window.decorView
+      val decorView = currentActivity.window.decorView
       decorView.post {
         @Suppress("DEPRECATION")
         decorView.setOnSystemUiVisibilityChangeListener { visibility: Int ->
@@ -43,7 +40,7 @@ class NavigationBarModule : Module() {
     }
 
     OnStopObserving {
-      val decorView = activity.window.decorView
+      val decorView = currentActivity.window.decorView
       decorView.post {
         @Suppress("DEPRECATION")
         decorView.setOnSystemUiVisibilityChangeListener(null)
@@ -51,20 +48,20 @@ class NavigationBarModule : Module() {
     }
 
     AsyncFunction("setBackgroundColorAsync") { color: Int, promise: Promise ->
-      NavigationBar.setBackgroundColor(activity, color) { promise.resolve(null) }
+      NavigationBar.setBackgroundColor(currentActivity, color) { promise.resolve(null) }
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("getBackgroundColorAsync") {
-      return@AsyncFunction colorToHex(activity.window.navigationBarColor)
+      return@AsyncFunction colorToHex(currentActivity.window.navigationBarColor)
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("setBorderColorAsync") { color: Int, promise: Promise ->
-      NavigationBar.setBorderColor(activity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
+      NavigationBar.setBorderColor(currentActivity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("getBorderColorAsync") {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        return@AsyncFunction colorToHex(activity.window.navigationBarDividerColor)
+        return@AsyncFunction colorToHex(currentActivity.window.navigationBarDividerColor)
       } else {
         throw NavigationBarException("'getBorderColorAsync' is only available on Android API 28 or higher")
       }
@@ -72,7 +69,7 @@ class NavigationBarModule : Module() {
 
     AsyncFunction("setButtonStyleAsync") { buttonStyle: String, promise: Promise ->
       NavigationBar.setButtonStyle(
-        activity,
+        currentActivity,
         buttonStyle,
         {
           promise.resolve(null)
@@ -82,39 +79,39 @@ class NavigationBarModule : Module() {
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("getButtonStyleAsync") {
-      WindowInsetsControllerCompat(activity.window, activity.window.decorView).let { controller ->
+      WindowInsetsControllerCompat(currentActivity.window, currentActivity.window.decorView).let { controller ->
         return@AsyncFunction if (controller.isAppearanceLightNavigationBars) "dark" else "light"
       }
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("setVisibilityAsync") { visibility: String, promise: Promise ->
-      NavigationBar.setVisibility(activity, visibility, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
+      NavigationBar.setVisibility(currentActivity, visibility, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("getVisibilityAsync") {
       val isVisible = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        activity.window.decorView.rootWindowInsets.isVisible(WindowInsets.Type.navigationBars())
+        currentActivity.window.decorView.rootWindowInsets.isVisible(WindowInsets.Type.navigationBars())
       } else {
         @Suppress("DEPRECATION")
-        (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION and activity.window.decorView.systemUiVisibility) == 0
+        (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION and currentActivity.window.decorView.systemUiVisibility) == 0
       }
       return@AsyncFunction if (isVisible) "visible" else "hidden"
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("setPositionAsync") { position: String, promise: Promise ->
-      NavigationBar.setPosition(activity, position, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
+      NavigationBar.setPosition(currentActivity, position, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("unstable_getPositionAsync") {
-      return@AsyncFunction if (ViewCompat.getFitsSystemWindows(activity.window.decorView)) "relative" else "absolute"
+      return@AsyncFunction if (ViewCompat.getFitsSystemWindows(currentActivity.window.decorView)) "relative" else "absolute"
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("setBehaviorAsync") { behavior: String, promise: Promise ->
-      NavigationBar.setBehavior(activity, behavior, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
+      NavigationBar.setBehavior(currentActivity, behavior, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String>("getBehaviorAsync") {
-      WindowInsetsControllerCompat(activity.window, activity.window.decorView).let { controller ->
+      WindowInsetsControllerCompat(currentActivity.window, currentActivity.window.decorView).let { controller ->
         val behavior = when (controller.systemBarsBehavior) {
           // TODO: Maybe relative / absolute
           WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE -> "overlay-swipe"

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -14,7 +14,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.navigationbar.singletons.NavigationBar
 
 class NavigationBarModule : Module() {
-  private val currentActivity get() = appContext.activity
+  private val currentActivity get() = appContext.throwingActivity
 
   override fun definition() = ModuleDefinition {
     Name("ExpoNavigationBar")

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
@@ -47,9 +47,6 @@ class PrintModule : Module() {
   val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
   private suspend fun print(options: PrintOptions) {
     withContext(Dispatchers.Main) {
       suspendCancellableCoroutine { continuation ->
@@ -149,7 +146,7 @@ class PrintModule : Module() {
   }
 
   private fun printDocumentToPrinter(document: PrintDocumentAdapter, options: PrintOptions) {
-    (currentActivity.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let {
+    (appContext.activity.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let {
       val attributes = getAttributesFromOptions(options)
       it.print(jobName, document, attributes.build())
     } ?: throw PrintManagerNotAvailableException()

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
@@ -48,7 +48,7 @@ class PrintModule : Module() {
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   private suspend fun print(options: PrintOptions) {
     withContext(Dispatchers.Main) {

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.kt
@@ -146,7 +146,7 @@ class PrintModule : Module() {
   }
 
   private fun printDocumentToPrinter(document: PrintDocumentAdapter, options: PrintOptions) {
-    (appContext.activity.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let {
+    (appContext.throwingActivity.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let {
       val attributes = getAttributesFromOptions(options)
       it.print(jobName, document, attributes.build())
     } ?: throw PrintManagerNotAvailableException()

--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -17,9 +17,7 @@ import expo.modules.screenorientation.enums.OrientationAttr
 import expo.modules.screenorientation.enums.OrientationLock
 
 class ScreenOrientationModule : Module(), LifecycleEventListener {
-  private val weakCurrentActivity
-    get() = appContext.currentActivity
-
+  private val weakCurrentActivity get() = appContext.currentActivity
   private val currentActivity
     get() = weakCurrentActivity ?: throw Exceptions.MissingActivity()
 

--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -18,7 +18,7 @@ import expo.modules.screenorientation.enums.OrientationLock
 
 class ScreenOrientationModule : Module(), LifecycleEventListener {
   private val weakCurrentActivity
-    get() = appContext.activityProvider?.currentActivity
+    get() = appContext.currentActivity
 
   private val currentActivity
     get() = weakCurrentActivity ?: throw Exceptions.MissingActivity()

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -232,7 +232,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
   private fun getOrientation(): Int {
     val windowManager = appContext.reactContext?.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
     val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      appContext.activity.display?.rotation
+      appContext.throwingActivity.display?.rotation
     } else {
       @Suppress("DEPRECATION")
       windowManager?.defaultDisplay?.rotation

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -232,7 +232,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
   private fun getOrientation(): Int {
     val windowManager = appContext.reactContext?.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
     val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      appContext.currentActivity?.display?.rotation
+      appContext.activity.display?.rotation
     } else {
       @Suppress("DEPRECATION")
       windowManager?.defaultDisplay?.rotation

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingExceptions.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingExceptions.kt
@@ -2,9 +2,6 @@ package expo.modules.sharing
 
 import expo.modules.kotlin.exception.CodedException
 
-internal class MissingCurrentActivityException :
-  CodedException("Activity which was provided during module initialization is no longer available")
-
 internal class SharingInProgressException :
   CodedException("Another share request is being processed now.")
 

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
@@ -18,7 +18,7 @@ class SharingModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
   private val currentActivity
-    get() = appContext.currentActivity ?: throw MissingCurrentActivityException()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private var pendingPromise: Promise? = null
 
   override fun definition() = ModuleDefinition {

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
@@ -17,8 +17,6 @@ import java.net.URLConnection
 class SharingModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private var pendingPromise: Promise? = null
 
   override fun definition() = ModuleDefinition {
@@ -51,7 +49,7 @@ class SharingModule : Module() {
           context.grantUriPermission(packageName, contentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
         pendingPromise = promise
-        currentActivity.startActivityForResult(intent, REQUEST_CODE)
+        appContext.activity.startActivityForResult(intent, REQUEST_CODE)
       } catch (e: InvalidArgumentException) {
         throw SharingInvalidArgsException(e.message, e)
       } catch (e: Exception) {

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
@@ -49,7 +49,7 @@ class SharingModule : Module() {
           context.grantUriPermission(packageName, contentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
         pendingPromise = promise
-        appContext.activity.startActivityForResult(intent, REQUEST_CODE)
+        appContext.throwingActivity.startActivityForResult(intent, REQUEST_CODE)
       } catch (e: InvalidArgumentException) {
         throw SharingInvalidArgsException(e.message, e)
       } catch (e: Exception) {

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSExceptions.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSExceptions.kt
@@ -4,6 +4,3 @@ import expo.modules.kotlin.exception.CodedException
 
 internal class MissingSMSAppException :
   CodedException("No messaging application available")
-
-internal class MissingCurrentActivityException :
-  CodedException("Activity which was provided during module initialization is no longer available")

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
@@ -73,7 +73,7 @@ class SMSModule : Module(), LifecycleEventListener {
     }
 
     pendingPromise = promise
-    appContext.activity.startActivity(smsIntent)
+    appContext.throwingActivity.startActivity(smsIntent)
     smsComposerOpened = true
   }
 

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
@@ -19,9 +19,6 @@ class SMSModule : Module(), LifecycleEventListener {
 
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val currentActivity
-    get() = appContext.currentActivity
-      ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoSMS")
@@ -76,7 +73,7 @@ class SMSModule : Module(), LifecycleEventListener {
     }
 
     pendingPromise = promise
-    currentActivity.startActivity(smsIntent)
+    appContext.activity.startActivity(smsIntent)
     smsComposerOpened = true
   }
 

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
@@ -20,8 +20,8 @@ class SMSModule : Module(), LifecycleEventListener {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity
-      ?: throw MissingCurrentActivityException()
+    get() = appContext.currentActivity
+      ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoSMS")

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewExceptions.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewExceptions.kt
@@ -2,9 +2,6 @@ package expo.modules.storereview
 
 import expo.modules.kotlin.exception.CodedException
 
-internal class MissingCurrentActivityException :
-  CodedException("Activity which was provided during module initialization is no longer available")
-
 internal class RMTaskException :
   CodedException("Android ReviewManager task failed")
 

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -14,10 +14,6 @@ class StoreReviewModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
-  private val currentActivity
-    get() = appContext.currentActivity
-      ?: throw Exceptions.MissingActivity()
-
   override fun definition() = ModuleDefinition {
     Name("ExpoStoreReview")
 
@@ -38,7 +34,7 @@ class StoreReviewModule : Module() {
       if (task.isSuccessful) {
         val reviewInfo = task.result
         reviewInfo?.let {
-          val flow = manager.launchReviewFlow(currentActivity, it)
+          val flow = manager.launchReviewFlow(appContext.activity, it)
           flow.addOnCompleteListener { result ->
             if (result.isSuccessful) {
               promise.resolve(null)

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -34,7 +34,7 @@ class StoreReviewModule : Module() {
       if (task.isSuccessful) {
         val reviewInfo = task.result
         reviewInfo?.let {
-          val flow = manager.launchReviewFlow(appContext.activity, it)
+          val flow = manager.launchReviewFlow(appContext.throwingActivity, it)
           flow.addOnCompleteListener { result ->
             if (result.isSuccessful) {
               promise.resolve(null)

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -15,8 +15,8 @@ class StoreReviewModule : Module() {
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity
-      ?: throw MissingCurrentActivityException()
+    get() = appContext.currentActivity
+      ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoStoreReview")

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
@@ -49,7 +49,7 @@ class SystemUIModule : Module() {
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String?>("getBackgroundColorAsync") {
-      val background = appContext.activity.window.decorView.background
+      val background = appContext.throwingActivity.window.decorView.background
       return@AsyncFunction if (background is ColorDrawable) {
         colorToHex((background.mutate() as ColorDrawable).color)
       } else {
@@ -59,7 +59,7 @@ class SystemUIModule : Module() {
   }
 
   private fun setBackgroundColor(color: Int) {
-    val rootView = appContext.activity.window?.decorView
+    val rootView = appContext.throwingActivity.window?.decorView
     val colorInt = Color.parseColor(colorToHex(color))
     rootView?.setBackgroundColor(colorInt)
   }

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
@@ -14,8 +14,6 @@ import expo.modules.kotlin.modules.ModuleDefinition
 const val PREFERENCE_KEY = "expoRootBackgroundColor"
 
 class SystemUIModule : Module() {
-  private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
   private val prefs: SharedPreferences
@@ -51,7 +49,7 @@ class SystemUIModule : Module() {
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction<String?>("getBackgroundColorAsync") {
-      val background = currentActivity.window.decorView.background
+      val background = appContext.activity.window.decorView.background
       return@AsyncFunction if (background is ColorDrawable) {
         colorToHex((background.mutate() as ColorDrawable).color)
       } else {
@@ -61,7 +59,7 @@ class SystemUIModule : Module() {
   }
 
   private fun setBackgroundColor(color: Int) {
-    val rootView = currentActivity.window?.decorView
+    val rootView = appContext.activity.window?.decorView
     val colorInt = Color.parseColor(colorToHex(color))
     rootView?.setBackgroundColor(colorInt)
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -34,7 +34,7 @@ class VideoModule : Module() {
     }
 
     Function("isPictureInPictureSupported") {
-      return@Function VideoView.isPictureInPictureSupported(appContext.activity)
+      return@Function VideoView.isPictureInPictureSupported(appContext.throwingActivity)
     }
 
     View(VideoView::class) {
@@ -147,7 +147,7 @@ class VideoModule : Module() {
 
     Class(VideoPlayer::class) {
       Constructor { source: VideoSource? ->
-        val player = VideoPlayer(appContext.activity.applicationContext, appContext, source)
+        val player = VideoPlayer(appContext.throwingActivity.applicationContext, appContext, source)
         appContext.mainQueue.launch {
           player.prepare()
         }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.runBlocking
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class VideoModule : Module() {
   private val activity: Activity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoVideo")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -2,7 +2,6 @@
 
 package expo.modules.video
 
-import android.app.Activity
 import android.net.Uri
 import androidx.media3.common.C
 import androidx.media3.common.PlaybackParameters
@@ -14,7 +13,6 @@ import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.ViewProps
 import com.facebook.yoga.YogaConstants
 import expo.modules.kotlin.apifeatures.EitherType
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.types.Either
@@ -28,9 +26,6 @@ import kotlinx.coroutines.runBlocking
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class VideoModule : Module() {
-  private val activity: Activity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
   override fun definition() = ModuleDefinition {
     Name("ExpoVideo")
 
@@ -39,7 +34,7 @@ class VideoModule : Module() {
     }
 
     Function("isPictureInPictureSupported") {
-      return@Function VideoView.isPictureInPictureSupported(activity)
+      return@Function VideoView.isPictureInPictureSupported(appContext.activity)
     }
 
     View(VideoView::class) {
@@ -152,7 +147,7 @@ class VideoModule : Module() {
 
     Class(VideoPlayer::class) {
       Constructor { source: VideoSource? ->
-        val player = VideoPlayer(activity.applicationContext, appContext, source)
+        val player = VideoPlayer(appContext.activity.applicationContext, appContext, source)
         appContext.mainQueue.launch {
           player.prepare()
         }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -21,7 +21,6 @@ import com.facebook.react.uimanager.Spacing
 import com.facebook.react.views.view.ReactViewBackgroundDrawable
 import com.facebook.yoga.YogaConstants
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import expo.modules.video.drawing.OutlineProvider
@@ -43,8 +42,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   var isInFullscreen: Boolean = false
     private set
 
-  private val currentActivity = appContext.currentActivity
-    ?: throw Exceptions.MissingActivity()
+  private val currentActivity = appContext.activity
   private val decorView = currentActivity.window.decorView
   private val rootView = decorView.findViewById<ViewGroup>(android.R.id.content)
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -42,7 +42,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   var isInFullscreen: Boolean = false
     private set
 
-  private val currentActivity = appContext.activity
+  private val currentActivity = appContext.throwingActivity
   private val decorView = currentActivity.window.decorView
   private val rootView = decorView.findViewById<ViewGroup>(android.R.id.content)
 


### PR DESCRIPTION
# Why
Several packages were creating their own exceptions for handling a missing activity, all with different messages, but we provide one in core. Also, the way we access the currentActivity was not consistent

# How
Fixed the inconsistencies and removed redundant exceptions.
Add a new property on `AppContext` `throwingActivity`

# Test Plan
bare-expo. Affected packages behave as before
