### PR TITLE
docs: Updates new-architecture.mdx flashlist issue

### DIFF
--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -198,7 +198,6 @@ Refer to [React Native Directory](https://reactnative.directory/) a more complet
 - **react-native-fs**: use `expo-file-system` or [a fork of react-native-fs](https://github.com/birdofpreyru/react-native-fs) instead.
 - **react-native-geolocation-service**: use `expo-location` instead.
 - **react-native-datepicker**: use `react-native-date-picker` or `@react-native-community/datetimepicker` instead.
-- **@shopify/flash-list**: may have not correctly in some cases. Be sure to test it thoroughly when migrating your app, and consider temporarily moving back to `FlatList` if you encounter issues.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why
The current docs has a grammar issue on the Flashlist section. When fixing the issue, I found out that Flashlist now does support the new architecture  (see https://github.com/Shopify/flash-list/pull/550 released in [v1.7.0](https://github.com/Shopify/flash-list/releases/tag/v1.7.0) on July 4th) and propose this line item be removed from the docs.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
I removed the note about FlashList.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
N/A
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
