### PR TITLE
[media-library][android] Fix exceptions when moving or deleting video assets

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On `Android`, throw an error when deleting an asset was unsuccessful. ([#29777](https://github.com/expo/expo/pull/29777) by [@mathieupost](https://github.com/mathieupost))
 - Add missing `react-native` peer dependencies for isolated modules. ([#30476](https://github.com/expo/expo/pull/30476) by [@byCedric](https://github.com/byCedric))
 - On `Android`, adding an asset to an album containing another album would throw an exception. ([#29777](https://github.com/expo/expo/pull/31027) by [@nafeij](https://github.com/Nafeij))
+- [Android] Fix exceptions when moving or deleting video assets. ([#31424](https://github.com/expo/expo/pull/31424) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AssetFileStrategy.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AssetFileStrategy.kt
@@ -18,7 +18,11 @@ internal fun interface AssetFileStrategy {
     val moveStrategy = AssetFileStrategy strategy@{ src, dir, context ->
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && src is MediaLibraryUtils.AssetFile) {
         val assetId = src.assetId
-        val assetUri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId.toLong())
+        val assetUri = if (src.mimeType.startsWith("video")) {
+          ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, assetId.toLong())
+        } else {
+          ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId.toLong())
+        }
         val newFile = MediaLibraryUtils.safeCopyFile(src, dir)
         context.contentResolver.delete(assetUri, null)
         return@strategy newFile


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/31358

# How

In the move strategy and delete we need to handle video types separately as images and videos are stored in different tables in the MediaStore database

# Test Plan

Tested in BareExpo on Android SDK 34
