### PR TITLE
Update apple-authentication.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -30,8 +30,10 @@ To enable the **Sign In with Apple** capability in your app, set the [`ios.usesA
 
 ```json app.json
 {
-  "ios": {
-    "usesAppleSignIn": true
+  "expo": {
+    "ios": {
+      "usesAppleSignIn": true
+    }
   }
 }
 ```

--- a/docs/pages/versions/v51.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/apple-authentication.mdx
@@ -30,8 +30,10 @@ To enable the **Sign In with Apple** capability in your app, set the [`ios.usesA
 
 ```json app.json
 {
-  "ios": {
-    "usesAppleSignIn": true
+  "expo": {
+    "ios": {
+      "usesAppleSignIn": true
+    }
   }
 }
 ```


### PR DESCRIPTION
Fix `usesAppleSignIn` example code snippet to use the top level `expo` JSON key.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The code snippet was wrong and confused me

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
