### PR TITLE
[dom-webview] fix buildBrowserScript type errors

### DIFF
--- a/packages/@expo/dom-webview/scripts/bun.d.ts
+++ b/packages/@expo/dom-webview/scripts/bun.d.ts
@@ -1,0 +1,28 @@
+// Separated partial Bun types, eliminating the need to install @types/bun in the project.
+
+declare const Bun: {
+  build: (config: BuildConfig) => Promise<BuildOutput>;
+  argv: string[];
+};
+
+interface BuildConfig {
+  entrypoints: string[];
+  target?: string;
+}
+
+interface BuildArtifact extends Blob {
+  path: string;
+  hash: string | null;
+  kind: 'entry-point' | 'chunk' | 'asset' | 'sourcemap';
+  sourcemap: BuildArtifact | null;
+}
+
+interface BuildOutput {
+  outputs: BuildArtifact[];
+  success: boolean;
+  logs: BuildMessage[];
+}
+
+interface BuildMessage {
+  message: string;
+}


### PR DESCRIPTION
# Why

fix the `yarn prepare` error in `@expo/dom-webview`
```
Error: npm error scripts/buildBrowserScripts.ts(11,49): error TS2304: Cannot find name 'Bun'.
Error: npm error scripts/buildBrowserScripts.ts(14,9): error TS2304: Cannot find name 'Bun'.
Error: npm error scripts/buildBrowserScripts.ts(32,29): error TS2304: Cannot find name 'Bun'.
Error: npm error scripts/buildBrowserScripts.ts(37,43): error TS7006: Parameter 'log' implicitly has an 'any' type.
Error: npm error scripts/buildBrowserScripts.ts(56,55): error TS7006: Parameter 'output' implicitly has an 'any' type.
```

# How

installing `@types/bun` will pull to much in repo/repo monorepo. let's add `bun.d.ts` for what we need

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
