### PR TITLE
[dom-webview] fix canary publish issue

### DIFF
--- a/packages/@expo/dom-webview/package.json
+++ b/packages/@expo/dom-webview/package.json
@@ -10,9 +10,10 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare && ./scripts/buildBrowserScripts.ts",
+    "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
-    "expo-module": "expo-module"
+    "expo-module": "expo-module",
+    "syncBrowserScripts": "./scripts/buildBrowserScripts.ts"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
# Why

`buildBrowserScripts.ts` requires bun which is not available for all workflows like canary publish.

# How

moving `buildBrowserScripts.ts` to a separated `syncBrowserScripts` action and run it manually

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
