### PR TITLE
chore: align spotless between expo-go and bare-expo

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -61,9 +61,9 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🚨 Run Spotless lint check
+      - name: 💅 Run Spotless lint check
         working-directory: apps/expo-go/android
-        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
+        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` from `apps/expo-go/android` to automatically fix formatting.' && exit 1; }
       - name: 🎸 Run native Android unit tests
         timeout-minutes: 30
         run: expotools native-unit-tests --platform android

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -73,12 +73,6 @@ subprojects {
   plugins.apply("com.diffplug.spotless")
   spotless {
     // note that spotless config is currently duplicated in expo-go too
-    format 'gradle', {
-      target '*.gradle'
-      trimTrailingWhitespace()
-      indentWithSpaces()
-      endWithNewline()
-    }
     kotlin {
       target '**/*.kt'
       ktlint("1.0.1")

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -72,6 +72,13 @@ allprojects {
 subprojects {
   plugins.apply("com.diffplug.spotless")
   spotless {
+    // note that spotless config is currently duplicated in expo-go too
+    format 'gradle', {
+      target '*.gradle'
+      trimTrailingWhitespace()
+      indentWithSpaces()
+      endWithNewline()
+    }
     kotlin {
       target '**/*.kt'
       ktlint("1.0.1")

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -102,6 +102,7 @@ subprojects { project ->
 
   plugins.apply("com.diffplug.spotless")
   spotless {
+    // note that spotless config is currently duplicated in bare-expo too
     format 'gradle', {
       target '*.gradle'
       trimTrailingWhitespace()

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -103,12 +103,6 @@ subprojects { project ->
   plugins.apply("com.diffplug.spotless")
   spotless {
     // note that spotless config is currently duplicated in bare-expo too
-    format 'gradle', {
-      target '*.gradle'
-      trimTrailingWhitespace()
-      indentWithSpaces()
-      endWithNewline()
-    }
     kotlin {
       target(ktlintTarget)
       // TODO: (barthap) Replace this with raw string when dropped shell app macros


### PR DESCRIPTION
# Why

This drove me almost crazy today because I assumed that spotless checks in CI are run from bare-expo, but they are run from expo-go, and the configs were different, resulting in failures.

Did this quick remedy, but ideally the spotless config should be in 1 place only and shared, or should be only in 1 place.

Additionally, I'd really love to not have to use spotless much if at all to format my code (it takes ~24 seconds to format a single SDK package) - I'd like to format from my IDE with a shortcut. If I do that now, the result usually doesn't align with spotless's expectations, unfortunately. That's another topic though.

# How

use the same (except `targetExclude`) spotless config in bare expo and expo go.

# Test Plan

running spotless locally from expo go and bare expo behaves the same

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
