### PR TITLE
[image][Android] Added support for rendering shared refs of `Bitmap's`

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [iOS] Added `Image.loadAsync` API. ([#25079](https://github.com/expo/expo/pull/25079) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added support for rendering shared image refs. ([#30661](https://github.com/expo/expo/pull/30661) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Added support for rendering shared image refs. ([#31098](https://github.com/expo/expo/pull/31098) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Added support for rendering shared refs of `Bitmap's`.
+- [Android] Added support for rendering shared refs of `Bitmap's`. ([#31440](https://github.com/expo/expo/pull/31440) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [iOS] Added `Image.loadAsync` API. ([#25079](https://github.com/expo/expo/pull/25079) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added support for rendering shared image refs. ([#30661](https://github.com/expo/expo/pull/30661) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Added support for rendering shared image refs. ([#31098](https://github.com/expo/expo/pull/31098) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added support for rendering shared refs of `Bitmap's`.
 
 ### 🐛 Bug fixes
 
@@ -20,7 +21,6 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30469](https://github.com/expo/expo/pull/30469) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
 - [Web] Fix type incompatibility between style prop and `@types/react-native-web` ([#31150](https://github.com/expo/expo/pull/31150) by [@adamhari](https://github.com/adamhari))
-
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -2,6 +2,8 @@
 
 package expo.modules.image
 
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import androidx.core.graphics.drawable.toBitmapOrNull
 import androidx.core.view.doOnDetach
@@ -31,11 +33,12 @@ import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.apifeatures.EitherType
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.sharedobjects.SharedRef
-import expo.modules.kotlin.types.Either
+import expo.modules.kotlin.types.EitherOfThree
 import expo.modules.kotlin.types.toKClass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -183,7 +186,7 @@ class ExpoImageModule : Module() {
         "onLoad"
       )
 
-      Prop("source") { view: ExpoImageViewWrapper, sources: Either<List<SourceMap>, SharedRef<Drawable>>? ->
+      Prop("source") { view: ExpoImageViewWrapper, sources: EitherOfThree<List<SourceMap>, SharedRef<Drawable>, SharedRef<Bitmap>>? ->
         if (sources == null) {
           view.sources = emptyList()
           return@Prop
@@ -194,7 +197,14 @@ class ExpoImageModule : Module() {
           return@Prop
         }
 
-        val drawable = sources.get(toKClass<SharedRef<Drawable>>()).ref
+        if (sources.`is`(toKClass<SharedRef<Drawable>>())) {
+          val drawable = sources.get(toKClass<SharedRef<Drawable>>()).ref
+          view.sources = listOf(DecodedSource(drawable))
+        }
+
+        val bitmap = sources.get(toKClass<SharedRef<Bitmap>>()).ref
+        val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+        val drawable = BitmapDrawable(context.resources, bitmap)
         view.sources = listOf(DecodedSource(drawable))
       }
 


### PR DESCRIPTION
# Why

Adds the ability to display shared references for Bitmaps.

# How

Handle `SharedRef<Bitmap>` and `SharedRef<Drawable>` as an image source.

# Test Plan

- new screen - https://github.com/expo/expo/pull/31439