### PR TITLE
[core][Android] `SharedRef` converter now checks the inner ref type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] `EitherTypeConverter` now can work with the `Dynamic` class. ([#31074](https://github.com/expo/expo/pull/31074) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
+- [Android] `SharedRef` converter now checks the inner ref type.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Android] `EitherTypeConverter` now can work with the `Dynamic` class. ([#31074](https://github.com/expo/expo/pull/31074) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
-- [Android] `SharedRef` converter now checks the inner ref type.
+- [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -188,6 +188,13 @@ internal class InvalidSharedObjectException(
   message = "Cannot convert provided JavaScriptObject to the '$sharedType', because it doesn't contain valid id"
 )
 
+internal class IncorrectRefTypeException(
+  desiredType: KType,
+  receivedClass: Class<*>
+) : CodedException(
+  message = "Cannot convert received '$receivedClass' to the '$desiredType', because of the inner ref type mismatch"
+)
+
 internal class FieldCastException(
   fieldName: String,
   fieldType: KType,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -2,12 +2,15 @@ package expo.modules.kotlin.sharedobjects
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.IncorrectRefTypeException
 import expo.modules.kotlin.exception.InvalidSharedObjectException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.toStrongReference
 import expo.modules.kotlin.types.NullAwareTypeConverter
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
 
 class SharedObjectTypeConverter<T : SharedObject>(
   val type: KType
@@ -32,4 +35,58 @@ class SharedObjectTypeConverter<T : SharedObject>(
   override fun getCppRequiredTypes() = ExpectedType(CppType.SHARED_OBJECT_ID, CppType.INT)
 
   override fun isTrivial(): Boolean = false
+}
+
+class SharedRefTypeConverter<T : SharedRef<*>>(
+  val type: KType
+) : NullAwareTypeConverter<T>(type.isMarkedNullable) {
+  private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(type)
+
+  val sharedRefType: KType? by lazy {
+    var currentClass: KClass<*>? = type.classifier as? KClass<*>
+    var currentType: KType? = type
+    while (currentClass != null) {
+      if (currentClass == SharedRef::class) {
+        val firstArgument = currentType?.arguments?.first()
+        // If someone uses `SharedRef<*>` we can't determine the type.
+        // In that case, the API will allow to pass any shared ref.
+        if (firstArgument == KTypeProjection.STAR) {
+          return@lazy null
+        }
+
+        return@lazy requireNotNull(firstArgument?.type) {
+          "The $sharedRefType type should contain the type of the inner ref"
+        }
+      }
+      currentType = currentClass.supertypes.firstOrNull()
+      currentClass = currentType?.classifier as? KClass<*>
+    }
+
+    return@lazy null
+  }
+
+  override fun convertNonOptional(value: Any, context: AppContext?): T {
+    val sharedObject = sharedObjectTypeConverter.convert(value, context)
+    if (sharedObject !is SharedRef<*>) {
+      throw InvalidSharedObjectException(type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return checkInnerRef(sharedObject) as T
+  }
+
+  private fun checkInnerRef(sharedRef: SharedRef<*>): SharedRef<*> {
+    val ref = sharedRef.ref ?: return sharedRef
+    val sharedRefClass = sharedRefType?.classifier as? KClass<*>
+      ?: return sharedRef
+    if (sharedRefClass.java.isAssignableFrom(ref.javaClass)) {
+      return sharedRef
+    }
+
+    throw IncorrectRefTypeException(type, sharedRef.javaClass)
+  }
+
+  override fun getCppRequiredTypes() = sharedObjectTypeConverter.getCppRequiredTypes()
+
+  override fun isTrivial() = sharedObjectTypeConverter.isTrivial()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -18,6 +18,8 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.sharedobjects.SharedObjectTypeConverter
+import expo.modules.kotlin.sharedobjects.SharedRef
+import expo.modules.kotlin.sharedobjects.SharedRefTypeConverter
 import expo.modules.kotlin.typedarray.BigInt64Array
 import expo.modules.kotlin.typedarray.BigUint64Array
 import expo.modules.kotlin.typedarray.Float32Array
@@ -129,6 +131,10 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     if (View::class.java.isAssignableFrom(jClass)) {
       return ViewTypeConverter<View>(type)
+    }
+
+    if (SharedRef::class.java.isAssignableFrom(jClass)) {
+      return SharedRefTypeConverter<SharedRef<*>>(type)
     }
 
     if (SharedObject::class.java.isAssignableFrom(jClass)) {


### PR DESCRIPTION
# Why

Adds check to SharedRef's converter, ensuring the ref type is correct. 

# How

Before, we didn't care about internal refs, so users could pass any ShareRef as an argument. This PR aims to check ref types during conversion.

# Test Plan

- new screen - https://github.com/expo/expo/pull/31439