### PR TITLE
[core][Android] Add function that can cast between shared refs

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -15,3 +15,12 @@ open class SharedRef<RefType>(
 ) : SharedObject(runtimeContext) {
   constructor(ref: RefType, appContext: AppContext) : this(ref, appContext.hostingRuntimeContext)
 }
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified RefType> SharedRef<*>.cast(): SharedRef<RefType>? {
+  if (ref is RefType) {
+    return this as SharedRef<RefType>
+  }
+
+  return null
+}


### PR DESCRIPTION
# Why

Adds function that can cast between shared refs.

# How

Added a small utility function which can be used when users want to receives multiple different shared refs as a parameter. 

For instance:

```
Function("t") { ref: Either<SharedRef<X>, SharedRef<Y>, ...> -> }
```
can be coded like this:
```
Function("t") { ref: SharedRef<*> -> }
```
and later users can use `ref.cast<type>` to convert between types.
