### PR TITLE
chore: bot's suggestion to only remove first square-bracket

### DIFF
--- a/tools/src/code-review/reviewers/checkMissingChangelogs.ts
+++ b/tools/src/code-review/reviewers/checkMissingChangelogs.ts
@@ -92,7 +92,7 @@ function generateChangelogStub(pullRequest: PullRequest) {
 
 function filterBracketContent(input: string): string {
   // many PR titles start with package name (e.g. [video]). We don't want that in a package-specific changelog.
-  return input.replace(/\[.*?\]/g, '').trim();
+  return input.replace(/\[.*?\]/, '').trim();
 }
 
 function globalChangelogEntriesOutput(changelogLinks: string): ReviewOutput {


### PR DESCRIPTION
# Why

another small follow up on the bot's message. The suggestion should only remove first square-bracket form PR title.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
