### PR TITLE
[core] expose RuntimeContext.eval on Android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -80,6 +80,7 @@
 - [iOS] Fixed a bottleneck in the performance-critical code by getting away from `enumerated` function. ([#31226](https://github.com/expo/expo/pull/31226) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Cached argument's type information to improve memory and startup time. ([#31297](https://github.com/expo/expo/pull/31297) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Make `func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?)` `open`. ([#31398](https://github.com/expo/expo/pull/31398) by [@abulenok](https://github.com/abulenok))
+- [Android] Expose `RuntimeContext.eval()` as `JavaScriptRuntime.eval()` on iOS. ([#31445](https://github.com/expo/expo/pull/31445) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
@@ -7,6 +7,7 @@ import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.defaultmodules.CoreModule
 import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
+import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.sharedobjects.ClassRegistry
 import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import expo.modules.kotlin.tracing.trace
@@ -33,6 +34,13 @@ class RuntimeContext(
 
   private fun isJSIContextInitialized(): Boolean {
     return this::jsiContext.isInitialized
+  }
+
+  /**
+   * Evaluates JavaScript code represented as a string.
+   */
+  fun eval(source: String): JavaScriptValue {
+    return jsiContext.evaluateScript(source)
   }
 
   /**


### PR DESCRIPTION
# Why

to support `@expo/dom-webview`, we need a way to evaluate javascript from native side on android.

# How

like the `JavaScriptRuntime.eval()` on ios, this pr tries to expose `RuntimeContext.eval()` on android.

# Test Plan

ci passed and also test it on the upstack pr

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
