### PR TITLE
[docs] Update some vale rules to error level

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -1,7 +1,7 @@
 extends: substitution
 message: "Consider using '%s' instead of '%s'"
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#follow-external-product-casing'
-level: warning
+level: error
 ignorecase: true
 swap:
   '\b & \b': and

--- a/docs/.vale/writing-styles/expo-docs/Lists.yml
+++ b/docs/.vale/writing-styles/expo-docs/Lists.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: "Use '1.' instead of '0.' for numbered lists."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#numbered-lists'
-level: warning
+level: error
 scope: raw
 nonword: true
 tokens:

--- a/docs/.vale/writing-styles/expo-docs/SmartQuotes.yml
+++ b/docs/.vale/writing-styles/expo-docs/SmartQuotes.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: Use straight quotes instead of smart quotes.
-level: warning
+level: error
 nonword: true
 tokens:
   - “


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #31361

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the `Consistency`, `SmartQuotes`, and `Lists` Vale rules to throw an error instead of a warning when the condition is not matched.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
