### PR TITLE
[core] fix r8 error

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fix support for macOS. ([#31307](https://github.com/expo/expo/pull/31307) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed `CodedException.getCode()` crash when R8 is enabled. ([#31392](https://github.com/expo/expo/pull/31392) by [@kudo](https://github.com/kudo))
 - [Android] Fixed getter for the third parameter of `Either`. ([#31443](https://github.com/expo/expo/pull/31443) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
@@ -111,7 +111,7 @@ interface ExperimentalJSTypeConverter<T> {
     }
   }
 
-  class UriConverter : ExperimentalJSTypeConverter<android.net.Uri> {
+  class AndroidUriConverter : ExperimentalJSTypeConverter<android.net.Uri> {
     override fun convertToJS(value: Any?): Any? {
       enforceType<android.net.Uri?>(value)
       return value?.toJSValue()
@@ -174,7 +174,7 @@ class ReturnType(
       ByteArray::class -> ExperimentalJSTypeConverter.ByteArrayConverter()
       java.net.URI::class -> ExperimentalJSTypeConverter.URIConverter()
       java.net.URL::class -> ExperimentalJSTypeConverter.URLConverter()
-      android.net.Uri::class -> ExperimentalJSTypeConverter.UriConverter()
+      android.net.Uri::class -> ExperimentalJSTypeConverter.AndroidUriConverter()
       java.io.File::class -> ExperimentalJSTypeConverter.FileConverter()
       Pair::class -> ExperimentalJSTypeConverter.PairConverter()
       Long::class -> ExperimentalJSTypeConverter.LongConverter()


### PR DESCRIPTION
# Why

having a R8 error from bare-expo only on **macos**:
```
> Task :app:minifyReleaseWithR8 FAILED
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/kudo/expo/expo/apps/bare-expo/android/app/build/outputs/mapping/release/missing_rules.txt.
ERROR: R8: Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter (referenced from: void expo.modules.kotlin.types.ReturnType.<init>(kotlin.reflect.KClass))
```


# How

i guess it's because case-insensitive file system on macos and we have both `URIConverter` and `UriConverter`. and maybe R8 accesses to some file system stuff. this pr tries to rename the class name from ambiguous

# Test Plan

`./gradlew :app:assembleRelease` on bare-expo and macos host

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
