### PR TITLE
[dev-client][expo-updates] Use expo-updates as source of truth for runtime version

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Fix `"launchMode": "launcher"` support. ([#30004](https://github.com/expo/expo/pull/30004) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Prevent React Native Dev Menu from showing up on launcher screen. ([#28936](https://github.com/expo/expo/pull/28936) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Skip dev server websocket connection for expo updates. ([#30535](https://github.com/expo/expo/pull/30535) by [@joeporpeglia](https://github.com/joeporpeglia))
+- Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -56,8 +56,8 @@ import org.koin.dsl.module
 private val DEV_LAUNCHER_HOST: String? = null
 
 private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
-  Intent.FLAG_ACTIVITY_CLEAR_TASK or
-  Intent.FLAG_ACTIVITY_NO_ANIMATION
+    Intent.FLAG_ACTIVITY_CLEAR_TASK or
+    Intent.FLAG_ACTIVITY_NO_ANIMATION
 
 class DevLauncherController private constructor() :
   DevLauncherKoinComponent, DevLauncherControllerInterface {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.interfaces.devmenu.ReactHostWrapper
 import expo.modules.devlauncher.helpers.createUpdatesConfigurationWithUrl
-import expo.modules.devlauncher.helpers.getRuntimeVersion
 import expo.modules.devlauncher.helpers.loadUpdate
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.koin.optInject
@@ -34,31 +33,43 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
 
   override suspend fun createAppLoader(url: Uri, projectUrl: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader {
     instanceWasCreated = true
-    return if (!manifestParser.isManifestUrl()) {
-      // It's (maybe) a raw React Native bundle
-      DevLauncherReactNativeAppLoader(url, appHost, context, controller)
-    } else {
-      val runtimeVersion = getRuntimeVersion(context)
-      val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
 
-      if (updatesInterface?.isValidUpdatesConfiguration(configuration, context) != true) {
-        manifest = manifestParser.parseManifest()
-        if (!manifest!!.isUsingDeveloperTool()) {
-          throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
+    if (!manifestParser.isManifestUrl()) {
+      // It's (maybe) a raw React Native bundle
+      return DevLauncherReactNativeAppLoader(url, appHost, context, controller)
+    }
+
+    val validConfiguration = updatesInterface?.let {
+      val runtimeVersion = it.getRuntimeVersion(context)
+      if (runtimeVersion == null) {
+        null
+      } else {
+        val configurationCandidate = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
+        if (it.isValidUpdatesConfiguration(configurationCandidate, context)) {
+          configurationCandidate
+        } else {
+          null
         }
+      }
+    }
+
+    return if (validConfiguration == null) {
+      manifest = manifestParser.parseManifest()
+      if (!manifest!!.isUsingDeveloperTool()) {
+        throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
+      }
+      DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
+    } else {
+      val update = updatesInterface!!.loadUpdate(validConfiguration, context) {
+        manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
+        return@loadUpdate !manifest!!.isUsingDeveloperTool()
+      }
+      if (manifest!!.isUsingDeveloperTool()) {
         DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
       } else {
-        val update = updatesInterface!!.loadUpdate(configuration, context) {
-          manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
-          return@loadUpdate !manifest!!.isUsingDeveloperTool()
-        }
-        if (manifest!!.isUsingDeveloperTool()) {
-          DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
-        } else {
-          useDeveloperSupport = false
-          val localBundlePath = update.launchAssetPath
-          DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context, controller)
-        }
+        useDeveloperSupport = false
+        val localBundlePath = update.launchAssetPath
+        DevLauncherPublishedAppLoader(manifest!!, localBundlePath, appHost, context, controller)
       }
     }
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -60,25 +60,18 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   private fun getUpdatesConfig(): WritableMap {
     val map = Arguments.createMap()
 
-    val runtimeVersion = DevLauncherController.getMetadataValue(reactApplicationContext, "expo.modules.updates.EXPO_RUNTIME_VERSION")
-    var projectUrl = DevLauncherController.getMetadataValue(reactApplicationContext, "expo.modules.updates.EXPO_UPDATE_URL")
+    val runtimeVersion = controller.updatesInterface?.getRuntimeVersion(reactApplicationContext)
+    val projectUri = controller.updatesInterface?.getUpdateUrl(reactApplicationContext)
+    val appId = projectUri?.lastPathSegment ?: ""
 
-    val appId = if (projectUrl.isNotEmpty()) {
-      Uri.parse(projectUrl).lastPathSegment ?: ""
-    } else {
-      ""
-    }
-
-    val projectUri = Uri.parse(projectUrl)
-
-    val isModernManifestProtocol = projectUri.host.equals("u.expo.dev") || projectUri.host.equals("staging-u.expo.dev")
+    val isModernManifestProtocol = projectUri?.host.equals("u.expo.dev") || projectUri?.host.equals("staging-u.expo.dev")
     val usesEASUpdates = isModernManifestProtocol && appId.isNotEmpty()
 
     return map.apply {
       putString("appId", appId)
       putString("runtimeVersion", runtimeVersion)
       putBoolean("usesEASUpdates", usesEASUpdates)
-      putString("projectUrl", projectUrl)
+      putString("projectUrl", projectUri.toString())
     }
   }
 
@@ -231,15 +224,14 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
     val packageInfo = packageManager.getPackageInfo(packageName, 0)
     val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
     val appName = packageManager.getApplicationLabel(applicationInfo).toString()
-    val runtimeVersion = DevLauncherController.getMetadataValue(reactApplicationContext, "expo.modules.updates.EXPO_RUNTIME_VERSION")
-    var appIcon = getApplicationIconUri()
+    val runtimeVersion = controller.updatesInterface?.getRuntimeVersion(reactApplicationContext)
+    val appIcon = getApplicationIconUri()
 
-    var updatesUrl = DevLauncherController.getMetadataValue(reactApplicationContext, "expo.modules.updates.EXPO_UPDATE_URL")
-    var appId = ""
-
-    if (updatesUrl.isNotEmpty()) {
-      var uri = Uri.parse(updatesUrl)
-      appId = uri.lastPathSegment ?: ""
+    val updatesUrl = controller.updatesInterface?.getUpdateUrl(reactApplicationContext)
+    val appId = if (updatesUrl !== null) {
+      updatesUrl.lastPathSegment ?: ""
+    } else {
+      ""
     }
 
     map.apply {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -63,7 +63,3 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, runtimeVersion:
     "runtimeVersion" to runtimeVersion
   )
 }
-
-fun getRuntimeVersion(context: Context): String {
-  return DevLauncherMetadataHelper.getMetadataValue(context, "expo.modules.updates.EXPO_RUNTIME_VERSION")
-}

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) EXAppContext * _Nullable appContext;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;
-@property (nonatomic, strong) id updatesInterface;
+@property (nonatomic, strong) id<EXUpdatesExternalInterface> updatesInterface;
 @property (nonatomic, readonly, assign) BOOL isStarted;
 
 + (instancetype)sharedInstance;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -443,8 +443,8 @@
 
   // an update url requires a matching projectUrl
   // if one isn't provided, default to the configured project url in Expo.plist
-  if (isEASUpdate && projectUrl == nil) {
-    NSString *projectUrlString = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesURL"];
+  if (isEASUpdate && projectUrl == nil && _updatesInterface) {
+    NSString *projectUrlString = [_updatesInterface.updateURL absoluteString] ?: @"";
     projectUrl = [NSURL URLWithString:projectUrlString];
   }
 
@@ -456,7 +456,10 @@
   // Disable onboarding popup if "&disableOnboarding=1" is a param
   [EXDevLauncherURLHelper disableOnboardingPopupIfNeeded:expoUrl];
 
-  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = @"";
+  if (_updatesInterface) {
+    runtimeVersion = _updatesInterface.runtimeVersion ?: @"";
+  }
   NSString *installationID = [_installationIDHelper getOrCreateInstallationID];
 
   NSDictionary *updatesConfiguration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:expoUrl
@@ -676,7 +679,11 @@
   NSMutableDictionary *buildInfo = [NSMutableDictionary new];
 
   NSString *appIcon = [self getAppIcon];
-  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = @"";
+  if (_updatesInterface) {
+    runtimeVersion = _updatesInterface.runtimeVersion ?: @"";
+  }
+
   NSString *appVersion = [self getFormattedAppVersion];
   NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleDisplayName"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleExecutable"];
 
@@ -738,12 +745,19 @@
 {
   NSMutableDictionary *updatesConfig = [NSMutableDictionary new];
 
-  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = @"";
+  if (_updatesInterface) {
+    runtimeVersion = _updatesInterface.runtimeVersion ?: @"";
+  }
 
   // url structure for EASUpdates: `http://u.expo.dev/{appId}`
   // this url field is added to app.json.updates when running `eas update:configure`
   // the `u.expo.dev` determines that it is the modern manifest protocol
-  NSString *projectUrl = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesURL"];
+  NSString *projectUrl = @"";
+  if (_updatesInterface) {
+    projectUrl = [_updatesInterface.updateURL absoluteString] ?: @"";
+  }
+
   NSURL *url = [NSURL URLWithString:projectUrl];
   NSString *appId = [[url pathComponents] lastObject];
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
@@ -11,8 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
                                      runtimeVersion:(NSString *)runtimeVersion
                                      installationID:(NSString *)installationID;
 
-+ (NSString *)getUpdatesConfigForKey:(NSString *)key;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -28,22 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
   };
 }
 
-+ (NSString *)getUpdatesConfigForKey:(NSString *)key
-{
-  NSString *value = @"";
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"Expo" ofType:@"plist"];
-
-  if (path != nil) {
-    NSDictionary *expoConfig = [NSDictionary dictionaryWithContentsOfFile:path];
-
-    if (expoConfig != nil) {
-      value = [expoConfig objectForKey:key] ?: @"";
-    }
-  }
-
-  return value;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
 - [iOS] Fix build error on `0.75` because of missing headers. ([#31100](https://github.com/expo/expo/pull/31100) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix a crash on android when calling `setSystemGestureExclusionRects` on apis below 29. ([#31114](https://github.com/expo/expo/pull/31114) by [@alanjhughes](https://github.com/alanjhughes))
+- Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuAppInfo.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuAppInfo.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.ReactHostWrapper
+import expo.modules.manifests.core.ExpoUpdatesManifest
 
 object DevMenuAppInfo {
   fun getAppInfo(reactHost: ReactHostWrapper, reactContext: ReactContext): Bundle {
@@ -14,10 +15,9 @@ object DevMenuAppInfo {
     var appVersion = packageInfo.versionName
     val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
     var appName = packageManager.getApplicationLabel(applicationInfo).toString()
-    val runtimeVersion = getMetadataValue(reactContext, "expo.modules.updates.EXPO_RUNTIME_VERSION")
     val appIcon = getApplicationIconUri(reactContext)
     var hostUrl = reactContext.sourceURL
-
+    var runtimeVersion = ""
     val manifest = DevMenuManager.currentManifest
 
     if (manifest != null) {
@@ -29,6 +29,10 @@ object DevMenuAppInfo {
       val manifestVersion = manifest.getVersion()
       if (manifestVersion != null) {
         appVersion = manifestVersion
+      }
+
+      if (manifest is ExpoUpdatesManifest) {
+        runtimeVersion = manifest.getRuntimeVersion()
       }
     }
 
@@ -51,13 +55,6 @@ object DevMenuAppInfo {
       putString("hostUrl", hostUrl)
       putString("engine", engine)
     }
-  }
-
-  private fun getMetadataValue(reactContext: ReactContext, key: String): String {
-    val packageManager = reactContext.packageManager
-    val packageName = reactContext.packageName
-    val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-    return applicationInfo.metaData?.get(key)?.toString() ?: ""
   }
 
   private fun getApplicationIconUri(reactContext: ReactContext): String {

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -16,7 +16,7 @@
   NSMutableDictionary *appInfo = [NSMutableDictionary new];
 
   NSString *appIcon = [EXDevMenuAppInfo getAppIcon];
-  NSString *runtimeVersion = [EXDevMenuAppInfo getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = @"";
   NSString *appVersion = [EXDevMenuAppInfo getFormattedAppVersion];
   NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleDisplayName"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleExecutable"];
 
@@ -25,6 +25,10 @@
   if (manager.currentManifest != nil) {
     appName = [manager.currentManifest name];
     appVersion = [manager.currentManifest version];
+
+    if ([manager.currentManifest isKindOfClass:[EXManifestsExpoUpdatesManifest class]]) {
+      runtimeVersion = [(EXManifestsExpoUpdatesManifest *)manager.currentManifest runtimeVersion];
+    }
   }
 
   NSString *engine;
@@ -69,22 +73,6 @@
   }
 
   return appIcon;
-}
-
-+(NSString *)getUpdatesConfigForKey:(NSString *)key
-{
-  NSString *value = @"";
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"Expo" ofType:@"plist"];
-
-  if (path != nil) {
-    NSDictionary *expoConfig = [NSDictionary dictionaryWithContentsOfFile:path];
-
-    if (expoConfig != nil) {
-      value = [expoConfig objectForKey:key] ?: @"";
-    }
-  }
-
-  return value;
 }
 
 +(NSString *)getFormattedAppVersion

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.16.2 — 2024-05-09

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -1,6 +1,7 @@
 package expo.modules.updatesinterface
 
 import android.content.Context
+import android.net.Uri
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 
@@ -32,4 +33,7 @@ interface UpdatesInterface {
   fun reset()
   fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback)
   fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean
+
+  fun getRuntimeVersion(context: Context): String?
+  fun getUpdateUrl(context: Context): Uri?
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -24,6 +24,9 @@ public protocol UpdatesExternalInterface {
   @objc weak var updatesExternalInterfaceDelegate: (any UpdatesExternalInterfaceDelegate)? { get set }
   @objc var launchAssetURL: URL? { get }
 
+  @objc var runtimeVersion: String? { get }
+  @objc var updateURL: URL? { get }
+
   @objc func reset()
 
   @objc func fetchUpdate(

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add missing `react` peer dependencies for isolated modules. ([#30488](https://github.com/expo/expo/pull/30488) by [@byCedric](https://github.com/byCedric))
 - Use relative entry point from `@expo/config/paths` with support for server root. ([#30633](https://github.com/expo/expo/pull/30633) by [@byCedric](https://github.com/byCedric))
 - [iOS] Rollback to system SQLite3 and fix incompatible issue when any third-party library uses iOS system SQLite3. ([#30826](https://github.com/expo/expo/pull/30826) by [@kudo](https://github.com/kudo))
+- Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
+import android.net.Uri
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
@@ -106,6 +107,14 @@ class UpdatesDevLauncherController(
 
   override fun reset() {
     launcher = null
+  }
+
+  override fun getRuntimeVersion(context: Context): String? {
+    return updatesConfiguration?.getRuntimeVersion()
+  }
+
+  override fun getUpdateUrl(context: Context): Uri? {
+    return updatesConfiguration?.updateUrl
   }
 
   /**

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -33,6 +33,14 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     launcher?.launchAssetUrl
   }
 
+  public var runtimeVersion: String? {
+    config?.runtimeVersion
+  }
+
+  public var updateURL: URL? {
+    config?.updateUrl
+  }
+
   // swiftlint:disable unavailable_function
   public func start() {
     preconditionFailure("Cannot call start on DevLauncherAppController")


### PR DESCRIPTION
# Why

This adds support for fingerprint runtime versions to dev client.

Closes ENG-12323.
Closes ENG-13390.
Closes https://github.com/expo/eas-cli/issues/2511.

# How

Fingerprint uses a special runtime version (`file:fingeprint`) to direct the code to read the fingerprint from a file. This is so that the fingerprint itself isn't part of the fingeprint.

Dev client was still reading this value from the manifest directly.

# Test Plan

On android, build app with fingeprint and dev client, load on emulator, see correct runtime version. Same with iOS.

![Simulator Screenshot - iPhone 15 Pro - 2024-09-12 at 12.30.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jj2ZqnqdG46xIKpoZK85/a8456d84-262a-4c87-89fe-84a55355c734.png)

![Screenshot 2024-09-12 at 12.02.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jj2ZqnqdG46xIKpoZK85/42b19736-212f-4be6-ba15-1ddb2e74876d.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
