### PR TITLE
Add support for `config.resolver.requireCycleIgnorePatterns` in SSR

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 🐛 Bug fixes
 
+- Add support for `config.resolver.requireCycleIgnorePatterns` in SSR bundles.
 - Force DOM components to be minified in production exports. ([#31271](https://github.com/expo/expo/pull/31271) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component re-renders in dev. ([#31259](https://github.com/expo/expo/pull/31259) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component exports in CI. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### 🐛 Bug fixes
 
-- Add support for `config.resolver.requireCycleIgnorePatterns` in SSR bundles.
+- Add support for `config.resolver.requireCycleIgnorePatterns` in SSR bundles. ([#31462](https://github.com/expo/expo/pull/31462) by [@EvanBacon](https://github.com/EvanBacon))
 - Force DOM components to be minified in production exports. ([#31271](https://github.com/expo/expo/pull/31271) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component re-renders in dev. ([#31259](https://github.com/expo/expo/pull/31259) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix DOM component exports in CI. ([#31182](https://github.com/expo/expo/pull/31182) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -101,6 +101,9 @@ export async function loadMetroConfigAsync(
     },
   };
 
+  // @ts-expect-error: Set the global require cycle ignore patterns for SSR bundles. This won't work with custom global prefixes, but we don't use those.
+  globalThis.__requireCycleIgnorePatterns = config.resolver?.requireCycleIgnorePatterns;
+
   if (isExporting) {
     // This token will be used in the asset plugin to ensure the path is correct for writing locally.
     // @ts-expect-error: typed as readonly.


### PR DESCRIPTION
# Why

- Support hiding require cycle messages in SSR bundles.
- fix https://github.com/expo/expo/issues/26613

# How

- Set the `__requireCycleIgnorePatterns` on the CLI global so it gets picked up in the SSR bundles.

<!--
How did you build this feature or fix this bug and why?
-->
