### PR TITLE
[AV][Android] Fix `NPE` in `installJSIBindings`

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix unhandled promise rejection when start recording fails [#29826](https://github.com/expo/expo/pull/29826) by [@anirudhsama](https://github.com/anirudhsama)
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30456](https://github.com/expo/expo/pull/30456) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
+- [Android] Fixed `NullPointerException` in the `installJSIBindings` function.
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fix unhandled promise rejection when start recording fails [#29826](https://github.com/expo/expo/pull/29826) by [@anirudhsama](https://github.com/anirudhsama)
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30456](https://github.com/expo/expo/pull/30456) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
-- [Android] Fixed `NullPointerException` in the `installJSIBindings` function.
+- [Android] Fixed `NullPointerException` in the `installJSIBindings` function. ([#31464](https://github.com/expo/expo/pull/31464) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/cpp/JAVManager.cpp
+++ b/packages/expo-av/android/src/main/cpp/JAVManager.cpp
@@ -43,8 +43,11 @@ namespace expo {
     void JAVManager::installJSIBindings(jlong jsRuntimePointer,
                                         jni::alias_ref<facebook::react::CallInvokerHolder::javaobject> jsCallInvokerHolder) {
       auto &runtime = *reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
-      auto callInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
-
+      auto callInvokerHolder = jsCallInvokerHolder->cthis();
+      if (callInvokerHolder == nullptr) {
+        jni::throwNewJavaException("java/lang/IllegalStateException", "CallInvokerHolder is null");
+      }
+      auto callInvoker = callInvokerHolder->getCallInvoker();
       auto function = [this, callInvoker](jsi::Runtime &runtime,
                                           const jsi::Value &thisValue,
                                           const jsi::Value *args,

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -192,7 +192,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   private void installBindings() {
     final JavaScriptContextProvider jsContextProvider = mModuleRegistry.getModule(JavaScriptContextProvider.class);
     final long jsContextRef = jsContextProvider.getJavaScriptContextRef();
-    if (jsContextRef <= 0) {
+    if (jsContextRef != 0) {
       Log.e("AVManager", "Cannot install JSI bindings for AV module because JS context is not available");
       return;
     }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -14,9 +14,11 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.util.Log;
 
 import com.facebook.jni.HybridData;
 
+import androidx.annotation.OptIn;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;
 import expo.modules.core.arguments.ReadableArguments;
@@ -44,6 +46,7 @@ import expo.modules.av.video.VideoView;
 import expo.modules.interfaces.permissions.Permissions;
 import expo.modules.interfaces.permissions.PermissionsResponseListener;
 
+import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 
 import static android.media.MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED;
@@ -146,6 +149,8 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @SuppressWarnings("JavaJniMissingFunction")
   private native HybridData initHybrid();
+
+  @OptIn(markerClass = FrameworkAPI.class)
   @SuppressWarnings("JavaJniMissingFunction")
   private native void installJSIBindings(long jsRuntimePointer, CallInvokerHolderImpl jsCallInvokerHolder);
 
@@ -179,13 +184,29 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       final UIManager uiManager = getUIManager();
 
       uiManager.registerLifecycleEventListener(this);
-      uiManager.runOnClientCodeQueueThread(() -> {
-        final JavaScriptContextProvider jsContextProvider = mModuleRegistry.getModule(JavaScriptContextProvider.class);
-        final long jsContextRef = jsContextProvider.getJavaScriptContextRef();
-        if (jsContextRef != 0) {
-          installJSIBindings(jsContextRef, jsContextProvider.getJSCallInvokerHolder());
-        }
-      });
+      uiManager.runOnClientCodeQueueThread(this::installBindings);
+    }
+  }
+
+  @OptIn(markerClass = FrameworkAPI.class)
+  private void installBindings() {
+    final JavaScriptContextProvider jsContextProvider = mModuleRegistry.getModule(JavaScriptContextProvider.class);
+    final long jsContextRef = jsContextProvider.getJavaScriptContextRef();
+    if (jsContextRef <= 0) {
+      Log.e("AVManager", "Cannot install JSI bindings for AV module because JS context is not available");
+      return;
+    }
+
+    CallInvokerHolderImpl callInvokerHolder = jsContextProvider.getJSCallInvokerHolder();
+    if (callInvokerHolder == null) {
+      Log.e("AVManager", "Cannot install JSI bindings for AV module because JS call invoker holder is not available");
+      return;
+    }
+
+    try {
+      installJSIBindings(jsContextRef, callInvokerHolder);
+    } catch (Exception e) {
+      Log.e("AVManager", "Cannot install JSI bindings for AV module", e);
     }
   }
 
@@ -760,10 +781,10 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   @Override
   public void getCurrentInput(final Promise promise) {
     AudioDeviceInfo deviceInfo = null;
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.P){
+    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.P) {
       promise.reject("E_AUDIO_VERSIONINCOMPATIBLE", "Getting current audio input is not supported on devices running Android version lower than Android 9.0");
       return;
-    } else  {
+    } else {
 
       try {
         // getRoutedDevice() is the most reliable way to return the actual mic input, however it


### PR DESCRIPTION
# Why

(Probably) fixes:
![image](https://github.com/user-attachments/assets/c667e9d7-77c6-4334-85a9-222cee4ad76c)
I couldn't reproduce this bug, but it definitely occurs during the app's startup reload.

# How

Added more checks to ensure `installJSIBindings` will finished without crashing whole app. 

# Test Plan

- none :/