### PR TITLE
[babel-preset] fix dom component crash for React import

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix JSC builds. ([#30763](https://github.com/expo/expo/pull/30763) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
+- Fixed `ReferenceError: Property 'React' doesn't exist.` crash when a DOM component includes `import React from 'react';`. ([#31469](https://github.com/expo/expo/pull/31469) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.js
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.js
@@ -52,8 +52,8 @@ function expoUseDomDirectivePlugin(api) {
                 }
                 const outputKey = url_1.default.pathToFileURL(filePath).href;
                 const proxyModule = [
-                    `import React from 'react';
-import { WebView } from 'expo/dom/internal';`,
+                    `import React from 'react';`,
+                    `import { WebView } from 'expo/dom/internal';`,
                 ];
                 if (isProduction) {
                     // MUST MATCH THE EXPORT COMMAND!
@@ -78,6 +78,16 @@ import { WebView } from 'expo/dom/internal';`,
 export default React.forwardRef((props, ref) => {
   return React.createElement(WebView, { ref, ...props, source });
 });`);
+                // Removes all imports using babel API, that will disconnect import bindings from the program.
+                // plugin-transform-typescript TSX uses the bindings to remove type imports.
+                // If the DOM component has `import React from 'react';`,
+                // the plugin-transform-typescript treats it as an typed import and removes it.
+                // That will futher cause undefined `React` error.
+                path.traverse({
+                    ImportDeclaration(path) {
+                        path.remove();
+                    },
+                });
                 // Clear the body
                 path.node.body = [];
                 path.node.directives = [];

--- a/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
+++ b/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
@@ -64,8 +64,8 @@ export function expoUseDomDirectivePlugin(api: ConfigAPI): babel.PluginObj {
         const outputKey = url.pathToFileURL(filePath).href;
 
         const proxyModule: string[] = [
-          `import React from 'react';
-import { WebView } from 'expo/dom/internal';`,
+          `import React from 'react';`,
+          `import { WebView } from 'expo/dom/internal';`,
         ];
 
         if (isProduction) {
@@ -96,12 +96,20 @@ export default React.forwardRef((props, ref) => {
 });`
         );
 
+        // Removes all imports using babel API, that will disconnect import bindings from the program.
+        // plugin-transform-typescript TSX uses the bindings to remove type imports.
+        // If the DOM component has `import React from 'react';`,
+        // the plugin-transform-typescript treats it as an typed import and removes it.
+        // That will futher cause undefined `React` error.
+        path.traverse({
+          ImportDeclaration(path) {
+            path.remove();
+          },
+        });
         // Clear the body
         path.node.body = [];
         path.node.directives = [];
-
         path.pushContainer('body', template.ast(proxyModule.join('\n')));
-
         assertExpoMetadata(state.file.metadata);
 
         // Save the client reference in the metadata.

--- a/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
+++ b/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
@@ -109,7 +109,9 @@ export default React.forwardRef((props, ref) => {
         // Clear the body
         path.node.body = [];
         path.node.directives = [];
+
         path.pushContainer('body', template.ast(proxyModule.join('\n')));
+
         assertExpoMetadata(state.file.metadata);
 
         // Save the client reference in the metadata.


### PR DESCRIPTION
# Why

fix release crash when a DOM component has `import React from 'react';` import. the crash is about `ReferenceError: Property 'React' doesn't exist`.
for example, the DOM component. (the filename should be `*.tsx`)
```tsx
// dom.tsx
'use dom';
import React from 'react';

export default function DOM() {
  return <div />;
}
```

close ENG-13506

# How

when the file is `*.tsx`, the `plugin-transform-typescript` + `TSX: true` plugin will be used. the plugin by default will remove [type only imports](https://github.com/babel/babel/blob/2ee26be1bf1d11c75bec8ba66d4aa7f7ba1b85ec/packages/babel-plugin-transform-typescript/src/index.ts#L723-L757). since the transformed code has `import React from 'react';` and no JSX, the import will be treated as type only import and removed further.

the pr tries to use the babel API to remove all imports. that will also disconnect the import bindings from the program. `plugin-transform-typescript` uses the bindings to [get some information](https://github.com/babel/babel/blob/2ee26be1bf1d11c75bec8ba66d4aa7f7ba1b85ec/packages/babel-plugin-transform-typescript/src/index.ts#L332-L353). the trick prevents `plugin-transform-typescript` to remove the React import for us.

# Test Plan

- adding unit test
- check the transformed code.
  ```sh
  $ cd apps/router-e2e
  $ cat > dom.tsx << EOF
  'use dom';
  import React from 'react';
  
  export default function DOM() {
    return <div />;
  }
  EOF
  
  # before the fix
  $ bunx @babel/cli dom.tsx
  Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _internal=require("expo/dom/internal");var source={uri:new URL("/_expo/@dom/dom.tsx?file="+"file:///Users/kudo/expo/expo/apps/router-e2e/dom.tsx",require("react-native/Libraries/Core/Devtools/getDevServer")().url).toString()};var _default=exports.default=React.forwardRef(function(props,ref){return React.createElement(_internal.WebView,Object.assign({ref:ref},props,{source:source}));});
  
  # after the fix
  $ bunx @babel/cli dom.tsx
  var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _react=_interopRequireDefault(require("react"));var _internal=require("expo/dom/internal");var source={uri:new URL("/_expo/@dom/dom.tsx?file="+"file:///Users/kudo/expo/expo/apps/router-e2e/dom.tsx",require("react-native/Libraries/Core/Devtools/getDevServer")().url).toString()};var _default=exports.default=_react.default.forwardRef(function(props,ref){return _react.default.createElement(_internal.WebView,Object.assign({ref:ref},props,{source:source}));});
  ```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
