### PR TITLE
chore(cli): improve export log format

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### 💡 Others
 
+- improve export log format ([#31476](https://github.com/expo/expo/pull/31476) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce scope of custom transform options in Metro cache. ([#31262](https://github.com/expo/expo/pull/31262) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable experimental features for RSC when `experiments.reactServerComponents` is enabled. ([#30967](https://github.com/expo/expo/pull/30967) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -227,7 +227,7 @@ export async function exportAppAsync(
 
       // build source maps
       if (sourceMaps) {
-        Log.log('Preparing additional debugging files');
+        // TODO: Remove this
         // If we output source maps, then add a debug HTML file which the user can open in
         // the web browser to inspect the output like web.
         files.set('debug.html', {

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import path from 'path';
 
 import { exportAppAsync } from './exportApp';
@@ -26,7 +27,7 @@ export async function exportAsync(projectRoot: string, options: Options) {
   await waitUntilAtlasExportIsReadyAsync(projectRoot);
 
   // Final notes
-  Log.log(`App exported to: ${options.outputDir}`);
+  Log.log(chalk.greenBright`Exported: ${options.outputDir}`);
 
   // Exit the process to stop any hanging processes from reading the app.config.js or server rendering.
   ensureProcessExitsAfterDelay();

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -433,8 +433,6 @@ async function exportApiRoutesAsync({
     platform,
   });
 
-  Log.log(chalk.bold`Exporting ${files.size} API Routes.`);
-
   files.set('_expo/routes.json', {
     contents: JSON.stringify(manifest, null, 2),
     targetDomain: 'server',

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -114,7 +114,7 @@ export class MetroTerminalReporter extends TerminalReporter {
 
   _logInitializing(port: number, hasReducedPerformance: boolean): void {
     // Don't print a giant logo...
-    this.terminal.log('Starting Metro Bundler');
+    this.terminal.log(chalk.dim('Starting Metro Bundler'));
   }
 
   shouldFilterClientLog(event: {


### PR DESCRIPTION
# Why

- Got feedback that the expo export output looks like it failed because there are too many logs. 
- This change will reduce the logging when Expo Router is enabled (all logs will be printed with EXPO_DEBUG=1).
- The format has been updated to look less static.
- Still a bit of work to do here, but this moves the needle a bit.

<img width="1191" alt="Screenshot 2024-09-14 at 11 46 04 AM" src="https://github.com/user-attachments/assets/4e3467d5-3c08-4843-b653-c635af114ac1">
