### PR TITLE
[core][Android] Stop recreating react context

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -31,9 +31,7 @@ class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) 
           }
         })
         appRecords[params.appScopeKey] = reactInstanceManager
-        if (reactInstanceManager.hasStartedCreatingInitialContext()) {
-          reactInstanceManager.recreateReactContextInBackground()
-        } else {
+        if (!reactInstanceManager.hasStartedCreatingInitialContext()) {
           reactInstanceManager.createReactContextInBackground()
         }
       } else {


### PR DESCRIPTION
# Why

Fixes:
```
Cannot install JSI interop: java.lang.IllegalArgumentException: The module wasn't created! You can't access the app context
```
caused by task manager

# How

It seems strange that we are reloading context that has already been created. This change, as far as I know, shouldn't affect the general behavior.


# Test Plan

-  https://github.com/kuczi55/TaskManagerCrash ✅ 
 
Flow like this isn't crashing anymore:

https://github.com/user-attachments/assets/88f26e1d-fc73-4d6b-bf58-bfdb1fb77120


