### PR TITLE
[core][Android] Fix `SharedRef` converter for simple types

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.types.NullAwareTypeConverter
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
+import kotlin.reflect.full.isSuperclassOf
 
 class SharedObjectTypeConverter<T : SharedObject>(
   val type: KType
@@ -79,7 +80,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
     val ref = sharedRef.ref ?: return sharedRef
     val sharedRefClass = sharedRefType?.classifier as? KClass<*>
       ?: return sharedRef
-    if (sharedRefClass.java.isAssignableFrom(ref.javaClass)) {
+    if (sharedRefClass.isSuperclassOf(ref.javaClass.kotlin)) {
       return sharedRef
     }
 


### PR DESCRIPTION
# Why

Fixes `SharedRef` converter for simple types like `int` or `double`.

# How

The Java reflection doesn't work when `SharedRef` is used with simple types, and the check inside the converter always fails.

# Test Plan

- actually we have test in our suite that already detected that case ✅ 