### PR TITLE
[core][Android] Add support for changing if functions are enumerable

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [iOS] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added support for changing if functions are enumerable.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,7 +26,7 @@
 - [iOS] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Added support for changing if functions are enumerable.
+- [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -54,16 +54,16 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
   size_t count
 ) {
   // This function takes the owner, so the args number is higher because we have access to the thisValue.
-  if (takesOwner) {
+  if (info.takesOwner) {
     count++;
   }
 
   // The `count < argTypes.size()` case is handled by the Kotlin part
-  if (count > argTypes.size()) {
+  if (count > info.argTypes.size()) {
     throwNewJavaException(
       InvalidArgsNumberException::create(
         count,
-        argTypes.size()
+        info.argTypes.size()
       ).get()
     );
   }
@@ -75,7 +75,7 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
   );
 
 
-  const auto getCurrentArg = [&thisValue, args, takesOwner = takesOwner](
+  const auto getCurrentArg = [&thisValue, args, takesOwner = info.takesOwner](
     size_t index
   ) -> const jsi::Value & {
     if (!takesOwner) {
@@ -90,7 +90,7 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
 
   for (size_t argIndex = 0; argIndex < count; argIndex++) {
     const jsi::Value &arg = getCurrentArg(argIndex);
-    auto &type = argTypes[argIndex];
+    auto &type = info.argTypes[argIndex];
 
     if (type->converter->canConvert(rt, arg)) {
       auto converterValue = type->converter->convert(rt, env, arg);
@@ -104,7 +104,7 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
       auto stringRepresentation = arg.toString(rt).utf8(rt);
       throwNewJavaException(
         UnexpectedException::create(
-          "[" + this->name + "] Cannot convert '" + stringRepresentation +
+          "[" + this->info.name + "] Cannot convert '" + stringRepresentation +
           "' to a Kotlin type.").get()
       );
     }
@@ -114,35 +114,9 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
 }
 
 MethodMetadata::MethodMetadata(
-  std::string name,
-  bool takesOwner,
-  bool isAsync,
-  jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  Info info,
   jni::global_ref<jobject> &&jBodyReference
-) : name(std::move(name)),
-    takesOwner(takesOwner),
-    isAsync(isAsync),
-    jBodyReference(std::move(jBodyReference)) {
-  size_t argsSize = expectedArgTypes->size();
-  argTypes.reserve(argsSize);
-  for (size_t i = 0; i < argsSize; i++) {
-    auto expectedType = expectedArgTypes->getElement(i);
-    argTypes.push_back(
-      std::make_unique<AnyType>(std::move(expectedType))
-    );
-  }
-}
-
-MethodMetadata::MethodMetadata(
-  std::string name,
-  bool takesOwner,
-  bool isAsync,
-  std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
-  jni::global_ref<jobject> &&jBodyReference
-) : name(std::move(name)),
-    takesOwner(takesOwner),
-    isAsync(isAsync),
-    argTypes(std::move(expectedArgTypes)),
+) : info(std::move(info)),
     jBodyReference(std::move(jBodyReference)) {
 }
 
@@ -154,7 +128,7 @@ std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
       return nullptr;
     }
 
-    if (isAsync) {
+    if (info.isAsync) {
       body = std::make_shared<jsi::Function>(toAsyncFunction(runtime));
     } else {
       body = std::make_shared<jsi::Function>(toSyncFunction(runtime));
@@ -170,8 +144,8 @@ jsi::Function MethodMetadata::toSyncFunction(
   auto weakThis = weak_from_this();
   return jsi::Function::createFromHostFunction(
     runtime,
-    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, name),
-    argTypes.size(),
+    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, info.name),
+    info.argTypes.size(),
     [weakThis = std::move(weakThis)](
       jsi::Runtime &rt,
       const jsi::Value &thisValue,
@@ -234,7 +208,7 @@ jsi::Value MethodMetadata::callSync(
   jni::JniLocalScope scope(env, (int) count);
 
   auto result = this->callJNISync(env, rt, thisValue, args, count);
-  return convert(env, rt, std::move(result));
+  return convert(env, rt, result);
 }
 
 jsi::Function MethodMetadata::toAsyncFunction(
@@ -243,8 +217,8 @@ jsi::Function MethodMetadata::toAsyncFunction(
   auto weakThis = weak_from_this();
   return jsi::Function::createFromHostFunction(
     runtime,
-    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, name),
-    argTypes.size(),
+    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, info.name),
+    info.argTypes.size(),
     [weakThis = std::move(weakThis)](
       jsi::Runtime &rt,
       const jsi::Value &thisValue,

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -27,36 +27,33 @@ class JSIContext;
  */
 class MethodMetadata : public std::enable_shared_from_this<MethodMetadata> {
 public:
-  /**
-   * Function name
-   */
-  std::string name;
-  /**
-   * Whether this function takes owner
-   */
-  bool takesOwner;
-  /**
-   * Whether this function is async
-   */
-  bool isAsync;
-  /**
-   * Representation of expected argument types.
-   */
-  std::vector<std::unique_ptr<AnyType>> argTypes;
+  struct Info {
+    /**
+     * Function name
+     */
+    const std::string name;
+    /**
+     * Whether this function takes owner
+     */
+    const bool takesOwner = false;
+    /**
+     * Whether this function is async
+     */
+    const bool isAsync = false;
+    /**
+    * Whether this function is enumerable
+    */
+    const bool enumerable = true;
+    /**
+     * Representation of expected argument types.
+     */
+    std::vector<std::unique_ptr<AnyType>> argTypes;
+  };
+
+  Info info;
 
   MethodMetadata(
-    std::string name,
-    bool takesOwner,
-    bool isAsync,
-    jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-    jni::global_ref<jobject> &&jBodyReference
-  );
-
-  MethodMetadata(
-    std::string name,
-    bool takesOwner,
-    bool isAsync,
-    std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
+    Info info,
     jni::global_ref<jobject> &&jBodyReference
   );
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -32,6 +32,7 @@ void JSDecoratorsBridgingObject::registerNatives() {
 void JSDecoratorsBridgingObject::registerSyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
+  jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
@@ -39,12 +40,13 @@ void JSDecoratorsBridgingObject::registerSyncFunction(
     functionDecorator = std::make_unique<JSFunctionsDecorator>();
   }
 
-  functionDecorator->registerSyncFunction(name, takesOwner, expectedArgTypes, body);
+  functionDecorator->registerSyncFunction(name, takesOwner, enumerable, expectedArgTypes, body);
 }
 
 void JSDecoratorsBridgingObject::registerAsyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
+  jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
 ) {
@@ -52,7 +54,7 @@ void JSDecoratorsBridgingObject::registerAsyncFunction(
     functionDecorator = std::make_unique<JSFunctionsDecorator>();
   }
 
-  functionDecorator->registerAsyncFunction(name, takesOwner, expectedArgTypes, body);
+  functionDecorator->registerAsyncFunction(name, takesOwner, enumerable, expectedArgTypes, body);
 }
 
 void JSDecoratorsBridgingObject::registerProperty(

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -44,6 +44,7 @@ public:
   void registerSyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
+    jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
@@ -51,6 +52,7 @@ public:
   void registerAsyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
+    jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
   );

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JSFunctionsDecorator.h"
+#include "JSIUtils.h"
 
 #include <jsi/jsi.h>
 
@@ -8,40 +9,79 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 
+std::vector<std::unique_ptr<AnyType>> JSFunctionsDecorator::mapConverters(
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes
+) {
+  size_t argsSize = expectedArgTypes->size();
+  std::vector<std::unique_ptr<AnyType>> argTypes;
+  argTypes.reserve(argsSize);
+  for (size_t i = 0; i < argsSize; i++) {
+    auto expectedType = expectedArgTypes->getElement(i);
+    argTypes.push_back(
+      std::make_unique<AnyType>(std::move(expectedType))
+    );
+  }
+  return argTypes;
+}
+
+void JSFunctionsDecorator::registerFunction(
+  const std::string &name,
+  bool takesOwner,
+  bool enumerable,
+  bool isAsync,
+  std::vector<std::unique_ptr<AnyType>> &&argTypes,
+  jni::global_ref<jobject> body
+) {
+  MethodMetadata::Info info{
+    .name = name,
+    .takesOwner = takesOwner,
+    .isAsync = isAsync,
+    .enumerable = enumerable,
+    .argTypes = std::move(argTypes)
+  };
+  auto methodMetadata = std::make_shared<MethodMetadata>(
+    std::move(info),
+    std::move(body)
+  );
+  methodsMetadata.insert_or_assign(name, std::move(methodMetadata));
+}
+
 void JSFunctionsDecorator::registerSyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
+  jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
-  std::string cName = name->toStdString();
-  auto methodMetadata = std::make_shared<MethodMetadata>(
-    cName,
-    takesOwner &
-    0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(expectedArgTypes),
+  registerFunction(
+    name->toStdString(),
+    static_cast<bool>(
+      takesOwner & 0x1
+    ), // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    enumerable,
+    /*isAsync=*/false,
+    mapConverters(expectedArgTypes),
     jni::make_global(body)
   );
-  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
 }
 
 void JSFunctionsDecorator::registerAsyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
+  jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
 ) {
-  std::string cName = name->toStdString();
-  auto methodMetadata = std::make_shared<MethodMetadata>(
-    cName,
-    takesOwner &
-    0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    true,
-    jni::make_local(expectedArgTypes),
+  registerFunction(
+    name->toStdString(),
+    static_cast<bool>(
+      takesOwner & 0x1
+    ), // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    enumerable,
+    /*isAsync=*/true,
+    mapConverters(expectedArgTypes),
     jni::make_global(body)
   );
-  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
 }
 
 void JSFunctionsDecorator::decorate(
@@ -49,11 +89,20 @@ void JSFunctionsDecorator::decorate(
   jsi::Object &jsObject
 ) {
   for (auto &[name, method]: this->methodsMetadata) {
-    jsObject.setProperty(
-      runtime,
-      jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *method->toJSFunction(runtime))
-    );
+    if (method->info.enumerable) {
+      jsObject.setProperty(
+        runtime,
+        jsi::String::createFromUtf8(runtime, name),
+        jsi::Value(runtime, *method->toJSFunction(runtime))
+      );
+    } else {
+      common::PropertyDescriptor descriptor{
+        .enumerable = false,
+        .value = jsi::Value(runtime, *method->toJSFunction(runtime))
+      };
+
+      defineProperty(runtime, &jsObject, name.c_str(), descriptor);
+    }
   }
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
@@ -24,6 +24,7 @@ public:
   void registerSyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
+    jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
@@ -31,6 +32,7 @@ public:
   void registerAsyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
+    jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
   );
@@ -40,11 +42,22 @@ public:
     jsi::Object &jsObject
   ) override;
 
+  static std::vector<std::unique_ptr<AnyType>> mapConverters(jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes);
+
 private:
   /**
   * Metadata map that stores information about all available methods on this module.
   */
   std::unordered_map<std::string, std::shared_ptr<MethodMetadata>> methodsMetadata;
+
+  void registerFunction(
+    const std::string &name,
+    bool takesOwner,
+    bool enumerable,
+    bool isAsync,
+    std::vector<std::unique_ptr<AnyType>> &&argTypes,
+    jni::global_ref<jobject> body
+  );
 };
 
 }

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
@@ -3,7 +3,7 @@
 #include "JSPropertiesDecorator.h"
 #include "../JavaScriptObject.h"
 #include "JSIUtils.h"
-
+#include "JSFunctionsDecorator.h"
 
 #include <jsi/jsi.h>
 
@@ -21,22 +21,29 @@ void JSPropertiesDecorator::registerProperty(
   jni::alias_ref<JNIFunctionBody::javaobject> setter
 ) {
   auto cName = name->toStdString();
-
-  auto getterMetadata = make_shared<MethodMetadata>(
-    cName,
-    getterTakesOwner &
-    0x1, // We're unsure if getterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(getterExpectedArgsTypes),
+  MethodMetadata::Info getterInfo {
+    .name = cName,
+    // We're unsure if getterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    .takesOwner = static_cast<bool>(getterTakesOwner & 0x1),
+    .isAsync = false,
+    .enumerable = true,
+    .argTypes = JSFunctionsDecorator::mapConverters(getterExpectedArgsTypes)
+  };
+  auto getterMetadata = std::make_shared<MethodMetadata>(
+    std::move(getterInfo),
     jni::make_global(getter)
   );
 
-  auto setterMetadata = make_shared<MethodMetadata>(
-    cName,
-    setterTakesOwner &
-    0x1, // We're unsure if setterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(setterExpectedArgsTypes),
+  MethodMetadata::Info setterInfo {
+    .name = cName,
+    // We're unsure if setterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    .takesOwner = static_cast<bool>(setterTakesOwner & 0x1),
+    .isAsync = false,
+    .enumerable = true,
+    .argTypes = JSFunctionsDecorator::mapConverters(setterExpectedArgsTypes)
+  };
+  auto setterMetadata = std::make_shared<MethodMetadata>(
+    std::move(setterInfo),
     jni::make_global(setter)
   );
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -30,6 +30,8 @@ abstract class AnyFunction(
   @PublishedApi
   internal var ownerType: KType? = null
 
+  internal var isEnumerable: Boolean = true
+
   internal val takesOwner: Boolean
     get() {
       if (canTakeOwner) {
@@ -121,5 +123,10 @@ abstract class AnyFunction(
 
   fun getCppRequiredTypes(): List<ExpectedType> {
     return desiredArgsTypes.map { it.getCppRequiredTypes() }
+  }
+
+  @Suppress("FunctionName")
+  fun Enumerable(isEnumerable: Boolean = true) = apply {
+    this.isEnumerable = isEnumerable
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -125,8 +125,7 @@ abstract class AnyFunction(
     return desiredArgsTypes.map { it.getCppRequiredTypes() }
   }
 
-  @Suppress("FunctionName")
-  fun Enumerable(isEnumerable: Boolean = true) = apply {
+  fun enumerable(isEnumerable: Boolean = true) = apply {
     this.isEnumerable = isEnumerable
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -59,6 +59,7 @@ abstract class AsyncFunction(
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
+      isEnumerable,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, promiseImpl ->
       if (BuildConfig.DEBUG) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -53,6 +53,7 @@ class SuspendFunctionComponent(
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
+      isEnumerable,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, promiseImpl ->
       if (BuildConfig.DEBUG) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -52,6 +52,7 @@ class SyncFunctionComponent(
     jsObject.registerSyncFunction(
       name,
       takesOwner,
+      isEnumerable,
       getCppRequiredTypes().toTypedArray(),
       getJNIFunctionBody(moduleName, appContext)
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -31,6 +31,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
   external fun registerSyncFunction(
     name: String,
     takesOwner: Boolean,
+    enumerable: Boolean,
     desiredTypes: Array<ExpectedType>,
     body: JNIFunctionBody
   )
@@ -38,6 +39,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
   external fun registerAsyncFunction(
     name: String,
     takesOwner: Boolean,
+    enumerable: Boolean,
     desiredTypes: Array<ExpectedType>,
     body: JNIAsyncFunctionBody
   )


### PR DESCRIPTION
# Why

Adds support for changing if functions are enumerable.
It can be done using `Enumerable` method like this:
```kt
Function("f") { -> }
  .enumerable(false)
```

# How

For non enumerable functions, we can use define property to change visibility. It'll be primary used to hide internal functions like `startObserving`. 

# Test Plan

- bare-expo ✅ 

