### PR TITLE
[templates] Fix: Remove unnecessary space in 'npx expo start' command

### DIFF
--- a/templates/expo-template-default/README.md
+++ b/templates/expo-template-default/README.md
@@ -13,7 +13,7 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 2. Start the app
 
    ```bash
-    npx expo start
+   npx expo start
    ```
 
 In the output, you'll find options to open the app in a


### PR DESCRIPTION
# Why
The documentation contained an unnecessary space before the `npx expo start` command, which could cause confusion for users. This fix improves clarity and consistency in the documentation.

# How

Removed the leading space before the `npx expo start` command in the `templates/expo-template-default/README.md` file.

# Test Plan

To verify the change, you can open the file `templates/expo-template-default/README.md` and ensure that the command `npx expo start` no longer has a leading space. This fix does not require any automated tests since it is a documentation change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
