### PR TITLE
[notifications] rename NotificationContent to LocalNotificationContent

### DIFF
--- a/packages/expo-notifications/android/src/androidTest/kotlin/expo/modules/notifications/ExpoNotificationBuilderTest.kt
+++ b/packages/expo-notifications/android/src/androidTest/kotlin/expo/modules/notifications/ExpoNotificationBuilderTest.kt
@@ -9,7 +9,7 @@ import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.notifications.notifications.enums.NotificationPriority
 import expo.modules.notifications.notifications.interfaces.INotificationContent
-import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.LocalNotificationContent
 import expo.modules.notifications.notifications.model.NotificationRequest
 import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder
 import kotlinx.coroutines.runBlocking
@@ -45,7 +45,7 @@ class ExpoNotificationBuilderTest {
 
   @Test
   fun buildMethodCreatesNotificationWithCorrectProperties() = runBlocking {
-    val notificationContent = NotificationContent.Builder()
+    val localNotificationContent = LocalNotificationContent.Builder()
       .setTitle("Test Title")
       .setSubtitle("Test Subtitle")
       .setText("Test Text")
@@ -57,7 +57,7 @@ class ExpoNotificationBuilderTest {
       .setPriority(NotificationPriority.HIGH)
       .setVibrationPattern(longArrayOf(100, 200, 300, 400))
       .build()
-    val androidNotification = createTestNotificationBuilder(notificationContent).build()
+    val androidNotification = createTestNotificationBuilder(localNotificationContent).build()
 
     // Verify the notification properties
     assertNotNull(androidNotification)
@@ -89,8 +89,8 @@ class ExpoNotificationBuilderTest {
 
   @Test
   fun buildMethodCreatesEmptyNotification() = runBlocking {
-    val notificationContent = NotificationContent.Builder().build()
-    val androidNotification = createTestNotificationBuilder(notificationContent).build()
+    val localNotificationContent = LocalNotificationContent.Builder().build()
+    val androidNotification = createTestNotificationBuilder(localNotificationContent).build()
 
     // Verify the notification properties
     assertNotNull(androidNotification)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/ArgumentsNotificationContentBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/ArgumentsNotificationContentBuilder.java
@@ -14,9 +14,9 @@ import java.util.Map;
 import androidx.annotation.Nullable;
 import expo.modules.notifications.notifications.channels.InvalidVibrationPatternException;
 import expo.modules.notifications.notifications.enums.NotificationPriority;
-import expo.modules.notifications.notifications.model.NotificationContent;
+import expo.modules.notifications.notifications.model.LocalNotificationContent;
 
-public class ArgumentsNotificationContentBuilder extends NotificationContent.Builder {
+public class ArgumentsNotificationContentBuilder extends LocalNotificationContent.Builder {
   private static final String TITLE_KEY = "title";
   private static final String SUBTITLE_KEY = "subtitle";
   private static final String TEXT_KEY = "body";
@@ -36,7 +36,7 @@ public class ArgumentsNotificationContentBuilder extends NotificationContent.Bui
     mSoundResolver = new SoundResolver(context);
   }
 
-  public NotificationContent.Builder setPayload(ReadableArguments payload) {
+  public LocalNotificationContent.Builder setPayload(ReadableArguments payload) {
     this.setTitle(payload.getString(TITLE_KEY))
       .setSubtitle(payload.getString(SUBTITLE_KEY))
       .setText(payload.getString(TEXT_KEY))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/LocalNotificationContent.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/LocalNotificationContent.java
@@ -28,12 +28,12 @@ import kotlin.coroutines.Continuation;
 
 /**
  * A POJO representing a local notification content: title, message, body, etc. Instances
- * should be created using {@link NotificationContent.Builder}.
+ * should be created using {@link LocalNotificationContent.Builder}.
  *
  * Note that it implements {@link Serializable} interfaces to store the object in the SharedPreferences.
  * Refactoring this class may require a migration strategy for the data stored in SharedPreferences.
  */
-public class NotificationContent implements Parcelable, Serializable, INotificationContent {
+public class LocalNotificationContent implements Parcelable, Serializable, INotificationContent {
   private String mTitle;
   private String mText;
   private String mSubtitle;
@@ -49,18 +49,18 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
   private String mCategoryId;
   private boolean mSticky;
 
-  protected NotificationContent() {
+  protected LocalNotificationContent() {
   }
 
-  public static final Creator<NotificationContent> CREATOR = new Creator<NotificationContent>() {
+  public static final Creator<LocalNotificationContent> CREATOR = new Creator<LocalNotificationContent>() {
     @Override
-    public NotificationContent createFromParcel(Parcel in) {
-      return new NotificationContent(in);
+    public LocalNotificationContent createFromParcel(Parcel in) {
+      return new LocalNotificationContent(in);
     }
 
     @Override
-    public NotificationContent[] newArray(int size) {
-      return new NotificationContent[size];
+    public LocalNotificationContent[] newArray(int size) {
+      return new LocalNotificationContent[size];
     }
   };
 
@@ -156,7 +156,7 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
     return 0;
   }
 
-  protected NotificationContent(Parcel in) {
+  protected LocalNotificationContent(Parcel in) {
     mTitle = in.readString();
     mText = in.readString();
     mSubtitle = in.readString();
@@ -370,8 +370,8 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
       return this;
     }
 
-    public NotificationContent build() {
-      NotificationContent content = new NotificationContent();
+    public LocalNotificationContent build() {
+      LocalNotificationContent content = new LocalNotificationContent();
       content.mTitle = mTitle;
       content.mSubtitle = mSubtitle;
       content.mText = mText;

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.kt
@@ -16,7 +16,7 @@ import expo.modules.notifications.notifications.ArgumentsNotificationContentBuil
 import expo.modules.notifications.notifications.NotificationSerializer
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
-import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.LocalNotificationContent
 import expo.modules.notifications.notifications.model.NotificationRequest
 import expo.modules.notifications.notifications.triggers.ChannelAwareTrigger
 import expo.modules.notifications.notifications.triggers.DailyTrigger
@@ -223,7 +223,7 @@ open class NotificationScheduler : Module() {
 
   protected open fun createNotificationRequest(
     identifier: String,
-    content: NotificationContent,
+    content: LocalNotificationContent,
     notificationTrigger: NotificationTrigger?
   ): NotificationRequest {
     return NotificationRequest(identifier, content, notificationTrigger)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
@@ -16,7 +16,7 @@ import expo.modules.notifications.notifications.SoundResolver
 import expo.modules.notifications.notifications.enums.NotificationPriority
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationBehavior
-import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.LocalNotificationContent
 import expo.modules.notifications.notifications.model.NotificationRequest
 import expo.modules.notifications.notifications.presentation.builders.CategoryAwareNotificationBuilder
 import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder
@@ -183,7 +183,7 @@ open class ExpoPresentationDelegate(
     // We weren't able to reconstruct the notification from our data, which means
     // it's either not our notification or we couldn't have unmarshaled it from
     // the byte array. Let's do what we can.
-    val content = NotificationContent.Builder()
+    val content = LocalNotificationContent.Builder()
       .setTitle(notification.extras.getString(android.app.Notification.EXTRA_TITLE))
       .setText(notification.extras.getString(android.app.Notification.EXTRA_TEXT))
       .setSubtitle(notification.extras.getString(android.app.Notification.EXTRA_SUB_TEXT)) // using deprecated field

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/LocalNotificationContentSerializationTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/LocalNotificationContentSerializationTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import java.io.*
 import org.json.JSONObject
 import expo.modules.notifications.notifications.enums.NotificationPriority
-import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.LocalNotificationContent
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -15,7 +15,7 @@ import org.junit.Before
 
 const val mockData = "{\"key\":\"value\"}"
 
-class NotificationContentSerializationTest {
+class LocalNotificationContentSerializationTest {
 
   @Before
   fun setup() {
@@ -29,7 +29,7 @@ class NotificationContentSerializationTest {
 
   @Test
   fun testSerializationWithNullValues() {
-    val originalContent = NotificationContent.Builder()
+    val originalContent = LocalNotificationContent.Builder()
       .setTitle(null)
       .setText(null)
       .setSubtitle(null)
@@ -53,7 +53,7 @@ class NotificationContentSerializationTest {
     val base64EncodedSerialized = "rO0ABXNyAEJleHBvLm1vZHVsZXMubm90aWZpY2F0aW9ucy5ub3RpZmljYXRpb25zLm1vZGVsLk5vdGlmaWNhdGlvbkNvbnRlbnQFhMvjE97pQgMADloADG1BdXRvRGlzbWlzc1oAF21TaG91bGRQbGF5RGVmYXVsdFNvdW5kWgAhbVNob3VsZFVzZURlZmF1bHRWaWJyYXRpb25QYXR0ZXJuWgAHbVN0aWNreUwAC21CYWRnZUNvdW50dAASTGphdmEvbGFuZy9OdW1iZXI7TAAFbUJvZHl0ABVMb3JnL2pzb24vSlNPTk9iamVjdDtMAAttQ2F0ZWdvcnlJZHQAEkxqYXZhL2xhbmcvU3RyaW5nO0wABm1Db2xvcnEAfgABTAAJbVByaW9yaXR5dABFTGV4cG8vbW9kdWxlcy9ub3RpZmljYXRpb25zL25vdGlmaWNhdGlvbnMvZW51bXMvTm90aWZpY2F0aW9uUHJpb3JpdHk7TAAGbVNvdW5kdAARTGFuZHJvaWQvbmV0L1VyaTtMAAltU3VidGl0bGVxAH4AA0wABW1UZXh0cQB+AANMAAZtVGl0bGVxAH4AA1sAEW1WaWJyYXRpb25QYXR0ZXJudAACW0p4cHQAClRlc3QgVGl0bGV0AAlUZXN0IFRleHR0AA1UZXN0IFN1YnRpdGxlc3IAEWphdmEubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAV3AQB0AAdVcmkoIzIpdyUAAAAABAAAAAAAAAAAAAAAAAAAAMgAAAAAAAAAyAAAAAAAAADIdAAPeyJrZXkiOiJ2YWx1ZSJ9c3EAfgALAAAAAXNxAH4ACwD/AAB3AQF0AA10ZXN0X2NhdGVnb3J5dwEAeA=="
     val serializedContent = java.util.Base64.getDecoder().decode(base64EncodedSerialized)
     val deserializedContent = ObjectInputStream(ByteArrayInputStream(serializedContent)).use {
-      it.readObject() as NotificationContent
+      it.readObject() as LocalNotificationContent
     }
 
     assertNotificationContentEquals(createSampleNotificationContent(), deserializedContent)
@@ -70,8 +70,8 @@ class NotificationContentSerializationTest {
     assertNotificationContentEquals(originalContent, deserializedContent)
   }
 
-  private fun createSampleNotificationContent(): NotificationContent {
-    return NotificationContent.Builder()
+  private fun createSampleNotificationContent(): LocalNotificationContent {
+    return LocalNotificationContent.Builder()
       .setTitle("Test Title")
       .setText("Test Text")
       .setSubtitle("Test Subtitle")
@@ -87,15 +87,15 @@ class NotificationContentSerializationTest {
       .build()
   }
 
-  private fun serializeAndDeserialize(content: NotificationContent): NotificationContent {
+  private fun serializeAndDeserialize(content: LocalNotificationContent): LocalNotificationContent {
     val byteArrayOutputStream = ByteArrayOutputStream()
     ObjectOutputStream(byteArrayOutputStream).use { it.writeObject(content) }
     return ObjectInputStream(ByteArrayInputStream(byteArrayOutputStream.toByteArray())).use {
-      it.readObject() as NotificationContent
+      it.readObject() as LocalNotificationContent
     }
   }
 
-  private fun assertNotificationContentEquals(expected: NotificationContent, actual: NotificationContent) {
+  private fun assertNotificationContentEquals(expected: LocalNotificationContent, actual: LocalNotificationContent) {
     assertEquals(expected.title, actual.title)
     assertEquals(expected.text, actual.text)
     assertEquals(expected.subtitle, actual.subtitle)

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegateTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegateTest.kt
@@ -5,7 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import expo.modules.notifications.notifications.NotificationManager
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 import expo.modules.notifications.notifications.model.Notification
-import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.LocalNotificationContent
 import expo.modules.notifications.notifications.model.NotificationRequest
 import expo.modules.notifications.service.NotificationsService
 import io.mockk.every
@@ -98,7 +98,7 @@ class ExpoHandlingDelegateTest {
     return Notification(
       NotificationRequest(
         "identifier",
-        NotificationContent.Builder().setTitle(title).setText(text).setBody(body).build(),
+        LocalNotificationContent.Builder().setTitle(title).setText(text).setBody(body).build(),
         object : NotificationTrigger {
           override fun describeContents(): Int = -1
           override fun writeToParcel(dest: Parcel, flags: Int) {}


### PR DESCRIPTION
# Why

There's already `RemoteNotificationContent` and it makes sense to do this distinction

# How

rename

# Test Plan

app builds, tests for(de) serialization pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
