### PR TITLE
[av][android] Add support for react-native 0.76

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [android] Add support for react-native 0.76 ([#31504](https://github.com/expo/expo/pull/31504) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - [iOS] `loadAsync()` promise never settled when given an invalid file uri ([#30020](https://github.com/expo/expo/pull/30020) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-av/android/CMakeLists.txt
+++ b/packages/expo-av/android/CMakeLists.txt
@@ -43,6 +43,16 @@ target_link_libraries(
         ${LOG_LIB}
         fbjni::fbjni
         ReactAndroid::jsi
-        ReactAndroid::reactnativejni
         android
 )
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  target_link_libraries(
+          ${PACKAGE_NAME}
+          ReactAndroid::reactnative
+  )
+else()
+  target_link_libraries(
+          ${PACKAGE_NAME}
+          ReactAndroid::reactnativejni
+  )
+endif()

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -61,6 +61,7 @@ android {
     // Theses files are intermediated linking files to build reanimated and should not be in final package.
     excludes += [
         "**/libc++_shared.so",
+        "**/libreactnative.so",
         "**/libreactnativejni.so",
         "**/libglog.so",
         "**/libjscexecutor.so",


### PR DESCRIPTION
# Why

Related to ENG-13531

# How

Update expo-av to support react-native 0.76 based on https://github.com/react-native-community/discussions-and-proposals/discussions/816

# Test Plan

Run BareExpo using react-native 0.75 and 0.76

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
