### PR TITLE
[docs] Revamp the "Add custom native code" docs page

### DIFF
--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -3,73 +3,92 @@ title: Add custom native code
 description: Learn how to add custom native code to your Expo project.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-Expo projects can use both third-party React Native libraries with native code and your own custom native code. Creating a [development build](/workflow/overview/#development-builds) allows you to include your specific native dependencies and customizations and not only what comes with the latest [Expo SDK](/versions/latest/). These native customizations can be any React Native library or your own custom native code.
+You can add custom native code by using one or both of the following approaches:
 
-For most third-party native libraries, [autolinking](/modules/autolinking/) makes it easy. All you have to do is install the npm package and run [prebuild](/workflow/prebuild/) to use the module. Some modules might also need a [config-plugin](/config-plugins/introduction) for additional native customizations. When adding your own custom native code, the approach varies based on how you want to work with native code.
+- Using libraries that include native code
+- Writing native code
 
-## Create a local module with the Expo Modules API
+## Using libraries that include native code
 
-By default, Expo projects use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation). This means that projects do not have **android** and **ios** directories containing the native code and configuration. Instead, the native directories are generated right before building the app and are based on your [app config](/workflow/configuration) and native modules in **package.json**. This simplifies the management and upgrading of native code.
+Expo and React Native developers typically spend the vast majority of their time writing JavaScript code and using native APIs and components that are made available through libraries like `expo-camera`, `react-native-safe-area-context`, and `react-native` itself. These libraries allow developers to access and use device features (such as Camera) from their JavaScript code. They may also provide access to a third-party service SDK that is implemented in native code (such as @sentry/react-native, which provides bindings to the Sentry native SDK for Android and iOS). 
 
-It might seem you cannot add custom native code to a project using CNG. However, you can still add that by [creating a local Expo module](/modules/get-started/#creating-the-local-expo-module).
+If you are using the sandbox app, Expo Go, you can only access native libraries that are included in the Expo SDK, or libraries that do not include any custom native code. In contrast, by [creating a development build](https://docs.expo.dev/develop/development-builds/introduction/), you can control any part of your app. You can change the native code or configuration that is possible in any other native app. For more details on how to determine if a third-party library depends on custom code, see https://docs.expo.dev/workflow/using-libraries/#third-party-libraries.
 
-Local Expo Modules function similarly to [Expo Modules](/modules/overview/) used by library developers and within the Expo SDK. They are not published to npm. Instead, you create them directly inside your project.
+### Installing libraries with custom native code in development builds
 
-Creating a local module allows you to write custom Swift and Kotlin code that you can interact with from your JavaScript code. It is also included in the development builds and production apps automatically when you build with [EAS Build](/build/introduction) or when you [compile your app locally](/guides/local-app-development/#local-app-compilation).
+When using [development builds](/develop/development-builds/introduction/), using libraries with custom native code is straightforward:
 
-## Manage custom native projects
+- Install the library with npm, for example: `npx expo install react-native-localize`
+- If the library includes a [config plugin](/config-plugins/introduction/), you can specify your preferred configuration in your app config.
+- Create a new development build (either [locally](/guides/local-app-development/) or with [EAS](/develop/development-builds/create-a-build/)).
 
-You can opt out of CNG and directly manage the code and configuration inside your **android** and **ios** directories. To generate these directories, run `npx expo prebuild` or [compile your app locally](/guides/local-app-development/#local-app-compilation) (`npx expo run:android` or `npx expo run:ios`). You can also create a development build before compiling your app locally. To do so, run `npx expo install expo-dev-client` before `prebuild` or `run`.
+You can now use the library in your application code.
 
-<Terminal
-  cmd={[
-    '# Build your native Android project',
-    '$ npx expo run:android',
-    '',
-    '# Build your native iOS project',
-    '$ npx expo run:ios',
-  ]}
-  cmdCopy="npx expo run:android && npx expo run:ios"
+<Collapsible summary="Key concepts and core development">
+    
+[The development overview](/workflow/overview/) provides details on key concepts for developing an app with Expo and the flow of the core development loop.
+
+</Collapsible>
+
+## Writing native code
+
+It's common to encounter situations where a library doesn't help you get your job done. For example, the library might not provide access to a specific platform feature, or a third-party library might not provide bindings for React Native. To solve this, you can write Kotlin (or Java) and/or Swift (or Objective-C) code to add any native functionality to your app directly, or to provide bindings to your JavaScript code. There are different tools you can use for this in React Native, and we typically recommend using the Expo Modules API. If you intend to write C++ code, you may want to explore the [Turbo Modules API](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md) provided by React Native.
+
+### Using the Expo Modules API
+
+The Expo Modules API allows you to write Swift and Kotlin to add new capabilities to your app with native modules and views. We believe that using the Expo Modules API makes building and maintaining nearly all kinds of React Native modules about as easy as it can be. We think that the Expo Modules API is the best choice for most developers building native modules for their apps.
+
+<BoxLink
+  title="Expo Modules API: Overview"
+  description="An overview of the APIs and utilities provided by Expo to develop native modules."
+  href="/modules/overview/"
+  Icon={BookOpen02Icon}
 />
 
-- `npx expo run:android` requires Android Studio and the Android SDK to be installed. See how to [setup environment](/guides/local-app-development/#android).
-- `npx expo run:ios` requires Xcode (macOS only) installed on your computer. See how to [setup environment](/guides/local-app-development/#ios).
-
-The `run` commands will [prebuild](/workflow/prebuild/) your project to generate all the native code within your project directory. If you manually modify the **android** or **ios** directory, you cannot re-run `npx expo prebuild` safely, as this may overwrite your changes.
-
-If you install a library with Expo [config plugin](/config-plugins/introduction/), you'll need to follow a few steps:
-
-- Add the plugin to the [`plugins`](/versions/latest/config/app/#plugins) array in the project's app config.
-- Re-run `npx expo prebuild` to sync the changes before rebuilding the native app. This process often involves tasks like adding required permissions to the **AndroidManifest.xml** or **Info.plist**.
-- For complex plugins, consider running `npx expo prebuild --clean`. This command will delete and re-generate the native directories from scratch.
-
-### Manual changes to the native project files
-
-If you manually modify the **android** and **ios** directories, you must set up new libraries manually. Running `npx expo prebuild` may not work as expected because the project is now in an unpredictable state (think of this like running `yarn` after manually modifying your **node_modules** directory).
-
-If you want to make static changes to your native project files, such as **AndroidManifest.xml** or **Info.plist**, and still have access to prebuilding, then create a [config plugin](/config-plugins/plugins-and-mods/#create-a-plugin) to see how you can hook into the prebuild process to make those changes.
-
-### Revert changes from `npx expo run:[android|ios]`
-
-Suppose you have decided to roll your app back to being fully managed (no **android** or **ios** directories in your project directory). In that case, you can check out your most recent commit before executing `npx expo run:[android|ios]`, then run `npm install` again to restore the state of your **node_modules** directory.
-
-### Develop apps with custom native code
-
-Once you have customized the native code in your project, you can use the [`expo-dev-client`](/develop/development-builds/introduction/#what-is-an-expo-dev-client) library to [create a development build](/develop/development-builds/create-a-build/) and retain the convenience of working with JavaScript or TypeScript in Expo Go.
-
-## Release apps with custom native code to production
-
-When you're ready to ship your app, you can [build it with EAS Build](/build/introduction) the same as you were building it before adding custom native code. Alternatively, you can archive and sign it locally. Unsurprisingly, we recommend EAS Build!
-
-<Terminal
-  cmd={['# Install the CLI', '$ npm i -g eas-cli', '', '# Build your app!', '$ eas build -p all']}
-  cmdCopy="npm i -g eas-cli && eas build -p all"
+<BoxLink
+  title="Tutorial: Creating a native module"
+  description="A tutorial on creating a native module that persists settings with the Expo Modules API."
+  href="/modules/native-module-tutorial/"
+  Icon={BookOpen02Icon}
 />
 
-## Create reusable native modules
+<BoxLink
+  title="Tutorial: Creating a native view"
+  description="A tutorial on creating a native view that renders a native WebView component with the Expo Modules API."
+  href="/modules/native-view-tutorial/"
+  Icon={BookOpen02Icon}
+/>
 
-Apart from adding custom native code to a project, the [Expo Modules API](/modules/overview) enables developers to build reusable modules for Expo and React Native projects using Swift, Kotlin, and TypeScript. These modules are often published to npm. They can also be included as separate packages within a [monorepo](/guides/monorepos/). We use the Expo Modules API for most modules in the [Expo SDK](/versions/latest).
+### Creating a local module
 
-Another option is to use [React Native's Core Native Modules API](https://reactnative.dev/docs/native-modules-intro), which may require some C++ knowledge in addition to Objective-C and Java. Most React Native modules in the ecosystem are built using this API because it is and always has been part of React Native. The Expo Module API is new and intends to solve many of the pain points of using the core API.
+If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a “local” Expo module](https://docs.expo.dev/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](https://docs.expo.dev/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project. 
+
+Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
+
+<Terminal cmd={['npx create-expo-module@latest --local', 'npx expo run']} />
+
+### Sharing a module with multiple apps
+
+If you intend to use your native module with multiple apps, then use `npx create-expo-module@latest,` leave out the `--local` flag, and [create a standalone module](https://docs.expo.dev/modules/use-standalone-expo-module-in-your-project/). You can publish your package to npm, or you can put it in a packages directory in your [monorepo](https://docs.expo.dev/guides/monorepos/) (if you have one) to use it in [a similar way to local modules](https://docs.expo.dev/modules/use-standalone-expo-module-in-your-project/).
+
+### Considerations when using Continuous Native Generation (CNG)
+
+The following suggestions are most important when using CNG, but are good guidelines even if you don’t use it.
+
+### Build locally for the best debugging experience and fast feedback
+
+By default, Expo projects created with `create-expo-app` use CNG and do not contain **android** or **ios** native directories until you've run the `npx expo prebuild` command in your project. When using CNG, developers typically do not commit the **android** and **ios** directories to source control and do not generate them locally, since EAS Build will do it automatically during the build process. That said, it is common to generate native directories and build locally with `npx expo run` when writing custom native code, to have a fast feedback loop and to have full access to native debugging tools in Android Studio / Xcode.
+
+### Use config plugins for native project configuration
+
+If your native code requires that you make changes to your project configuration, such as modifying the project's **AndroidManifest.xml** or **Info.plist**, [you should apply these hanges through a config plugin](https://docs.expo.dev/modules/config-plugin-and-native-module-tutorial/) rather than by modifying the files directly in the **android** and **ios** directories. Remember that changes made directly to native project directories will be lost the next time you run prebuild when you use CNG.
+
+### Use event subscribers to hook into app lifecycle events
+
+Additionally, if you need to hook into Android lifecycle events or `AppDelegate` methods, use the APIs provided by Expo Modules for [Android](https://docs.expo.dev/modules/android-lifecycle-listeners/) and [iOS](https://docs.expo.dev/modules/appdelegate-subscribers/) to accomplish this rather than modifying the source files in your native project directories directly or using a config plugin to add the code, which does not compose well with other plugins.

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -71,23 +71,23 @@ If you intend to use your native module in a single app (you can always change y
 
 Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
 
-<Terminal cmd={['npx create-expo-module@latest --local', 'npx expo run']} />
+<Terminal cmd={['$ npx create-expo-module@latest --local', '$ npx expo run']} />
 
 ### Sharing a module with multiple apps
 
 If you intend to use your native module with multiple apps, then use `npx create-expo-module@latest,` leave out the `--local` flag, and [create a standalone module](/modules/use-standalone-expo-module-in-your-project/). You can publish your package to npm, or you can put it in a packages directory in your [monorepo](/guides/monorepos/) (if you have one) to use it in [a similar way to local modules](/modules/use-standalone-expo-module-in-your-project/).
 
-### Considerations when using Continuous Native Generation (CNG)
+## Considerations when using Continuous Native Generation (CNG)
 
 The following suggestions are most important when using CNG, but are good guidelines even if you don't use it.
 
 ### Build locally for the best debugging experience and fast feedback
 
-By default, Expo projects created with `create-expo-app` use CNG and do not contain **android** or **ios** native directories until you've run the `npx expo prebuild` command in your project. When using CNG, developers typically do not commit the **android** and **ios** directories to source control and do not generate them locally, since EAS Build will do it automatically during the build process. That said, it is common to generate native directories and build locally with `npx expo run` when writing custom native code, to have a fast feedback loop and to have full access to native debugging tools in Android Studio / Xcode.
+By default, Expo projects created with `create-expo-app` use CNG and do not contain **android** or **ios** native directories until you've run the `npx expo prebuild` command in your project. When using CNG, developers typically do not commit the **android** and **ios** directories to source control and do not generate them locally, since EAS Build will do it automatically during the build process. That said, it is common to generate native directories and build locally with `npx expo run` when writing custom native code, to have a fast feedback loop and full access to native debugging tools in Android Studio / Xcode.
 
 ### Use config plugins for native project configuration
 
-If your native code requires that you make changes to your project configuration, such as modifying the project's **AndroidManifest.xml** or **Info.plist**, [you should apply these hanges through a config plugin](/modules/config-plugin-and-native-module-tutorial/) rather than by modifying the files directly in the **android** and **ios** directories. Remember that changes made directly to native project directories will be lost the next time you run prebuild when you use CNG.
+If your native code requires that you make changes to your project configuration, such as modifying the project's **AndroidManifest.xml** or **Info.plist**, [you should apply these changes through a config plugin](/modules/config-plugin-and-native-module-tutorial/) rather than by modifying the files directly in the **android** and **ios** directories. Remember that changes made directly to native project directories will be lost the next time you run prebuild when you use CNG.
 
 ### Use event subscribers to hook into app lifecycle events
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -67,7 +67,7 @@ The Expo Modules API allows you to write Swift and Kotlin to add new capabilitie
 
 ### Creating a local module
 
-If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a “local” Expo module](/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project.
+If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a "local" Expo module](/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project.
 
 Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
 
@@ -79,7 +79,7 @@ If you intend to use your native module with multiple apps, then use `npx create
 
 ### Considerations when using Continuous Native Generation (CNG)
 
-The following suggestions are most important when using CNG, but are good guidelines even if you don’t use it.
+The following suggestions are most important when using CNG, but are good guidelines even if you don't use it.
 
 ### Build locally for the best debugging experience and fast feedback
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -16,9 +16,9 @@ You can add custom native code by using one or both of the following approaches:
 
 ## Using libraries that include native code
 
-Expo and React Native developers typically spend the vast majority of their time writing JavaScript code and using native APIs and components that are made available through libraries like `expo-camera`, `react-native-safe-area-context`, and `react-native` itself. These libraries allow developers to access and use device features (such as Camera) from their JavaScript code. They may also provide access to a third-party service SDK that is implemented in native code (such as @sentry/react-native, which provides bindings to the Sentry native SDK for Android and iOS). 
+Expo and React Native developers typically spend the vast majority of their time writing JavaScript code and using native APIs and components that are made available through libraries like `expo-camera`, `react-native-safe-area-context`, and `react-native` itself. These libraries allow developers to access and use device features (such as Camera) from their JavaScript code. They may also provide access to a third-party service SDK that is implemented in native code (such as `@sentry/react-native`, which provides bindings to the Sentry native SDK for Android and iOS).
 
-If you are using the sandbox app, Expo Go, you can only access native libraries that are included in the Expo SDK, or libraries that do not include any custom native code. In contrast, by [creating a development build](https://docs.expo.dev/develop/development-builds/introduction/), you can control any part of your app. You can change the native code or configuration that is possible in any other native app. For more details on how to determine if a third-party library depends on custom code, see https://docs.expo.dev/workflow/using-libraries/#third-party-libraries.
+If you are using the sandbox app, Expo Go, you can only access native libraries that are included in the Expo SDK, or libraries that do not include any custom native code. In contrast, by [creating a development build](/develop/development-builds/introduction/), you can control any part of your app. You can change the native code or configuration that is possible in any other native app. For more details on how to determine if a third-party library depends on custom code, see [Using third party libraries](/workflow/using-libraries/#third-party-libraries).
 
 ### Installing libraries with custom native code in development builds
 
@@ -67,7 +67,7 @@ The Expo Modules API allows you to write Swift and Kotlin to add new capabilitie
 
 ### Creating a local module
 
-If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a “local” Expo module](https://docs.expo.dev/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](https://docs.expo.dev/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project. 
+If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a “local” Expo module](/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project.
 
 Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
 
@@ -75,7 +75,7 @@ Creating a local module scaffolds a Swift and Kotlin module inside the `modules`
 
 ### Sharing a module with multiple apps
 
-If you intend to use your native module with multiple apps, then use `npx create-expo-module@latest,` leave out the `--local` flag, and [create a standalone module](https://docs.expo.dev/modules/use-standalone-expo-module-in-your-project/). You can publish your package to npm, or you can put it in a packages directory in your [monorepo](https://docs.expo.dev/guides/monorepos/) (if you have one) to use it in [a similar way to local modules](https://docs.expo.dev/modules/use-standalone-expo-module-in-your-project/).
+If you intend to use your native module with multiple apps, then use `npx create-expo-module@latest,` leave out the `--local` flag, and [create a standalone module](/modules/use-standalone-expo-module-in-your-project/). You can publish your package to npm, or you can put it in a packages directory in your [monorepo](/guides/monorepos/) (if you have one) to use it in [a similar way to local modules](/modules/use-standalone-expo-module-in-your-project/).
 
 ### Considerations when using Continuous Native Generation (CNG)
 
@@ -87,8 +87,8 @@ By default, Expo projects created with `create-expo-app` use CNG and do not cont
 
 ### Use config plugins for native project configuration
 
-If your native code requires that you make changes to your project configuration, such as modifying the project's **AndroidManifest.xml** or **Info.plist**, [you should apply these hanges through a config plugin](https://docs.expo.dev/modules/config-plugin-and-native-module-tutorial/) rather than by modifying the files directly in the **android** and **ios** directories. Remember that changes made directly to native project directories will be lost the next time you run prebuild when you use CNG.
+If your native code requires that you make changes to your project configuration, such as modifying the project's **AndroidManifest.xml** or **Info.plist**, [you should apply these hanges through a config plugin](/modules/config-plugin-and-native-module-tutorial/) rather than by modifying the files directly in the **android** and **ios** directories. Remember that changes made directly to native project directories will be lost the next time you run prebuild when you use CNG.
 
 ### Use event subscribers to hook into app lifecycle events
 
-Additionally, if you need to hook into Android lifecycle events or `AppDelegate` methods, use the APIs provided by Expo Modules for [Android](https://docs.expo.dev/modules/android-lifecycle-listeners/) and [iOS](https://docs.expo.dev/modules/appdelegate-subscribers/) to accomplish this rather than modifying the source files in your native project directories directly or using a config plugin to add the code, which does not compose well with other plugins.
+Additionally, if you need to hook into Android lifecycle events or `AppDelegate` methods, use the APIs provided by Expo Modules for [Android](/modules/android-lifecycle-listeners/) and [iOS](/modules/appdelegate-subscribers/) to accomplish this rather than modifying the source files in your native project directories directly or using a config plugin to add the code, which does not compose well with other plugins.


### PR DESCRIPTION
# Why

The current one isn't clear enough

# How

Worked with @amandeepmittal on Notion on rewriting it