### PR TITLE
[core][Android] Rename `UseExperimentalConverter` to follow naming convention

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ExperimentalConverterTest.kt
@@ -7,11 +7,11 @@ class ExperimentalConverterTest {
   @Test
   fun list_should_be_convertible() = withSingleModule({
     Function<_>("simpleList") { listOf(1, 2, 3, 4, 5, 6) }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
     Function<_>("listWithMixedData") { listOf(1, 2, 3, "string", "expo" to "modules") }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
     Function<_>("complexList") { listOf(listOf(1, 2, "string"), listOf("expo", "modules"), listOf(listOf(1, 2, 3))) }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
   }) {
     val simpleList = call("simpleList").getArray().map { it.getInt() }
     val listWithMixedData = call("listWithMixedData").getArray()
@@ -44,11 +44,11 @@ class ExperimentalConverterTest {
   @Test
   fun maps_should_be_convertible() = withSingleModule({
     Function<_>("simpleMap") { mapOf("expo" to "modules", "foo" to "bar") }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
     Function<_>("nestedMap") { mapOf("inner" to mapOf("foo" to "bar"), "expo" to "modules") }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
     Function<_>("mapWithList") { mapOf("list" to listOf(1, 2, 3)) }
-      .UseExperimentalConverter()
+      .useExperimentalConverter()
   }) {
     val simpleMap = call("simpleMap").getObject()
     val nestedMap = call("nestedMap").getObject()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -19,8 +19,7 @@ class SyncFunctionComponent(
 ) : AnyFunction(name, argTypes) {
   private var shouldUseExperimentalConverter = false
 
-  @Suppress("FunctionName")
-  fun UseExperimentalConverter(shouldUse: Boolean = true) = apply {
+  fun useExperimentalConverter(shouldUse: Boolean = true) = apply {
     shouldUseExperimentalConverter = shouldUse
   }
 


### PR DESCRIPTION
# Why

Renames `UseExperimentalConverter` -> `useExperimentalConverter`.
See: https://github.com/expo/expo/pull/31495#discussion_r1761262104

