### PR TITLE
[core][Android] Make `getCppRequiredTypes` internal

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -22,8 +22,6 @@ abstract class AnyFunction(
   protected val name: String,
   protected val desiredArgsTypes: Array<AnyType>
 ) {
-  internal val argsCount get() = desiredArgsTypes.size
-
   @PublishedApi
   internal var canTakeOwner: Boolean = false
 
@@ -121,7 +119,7 @@ abstract class AnyFunction(
    */
   abstract fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String)
 
-  fun getCppRequiredTypes(): List<ExpectedType> {
+  internal fun getCppRequiredTypes(): List<ExpectedType> {
     return desiredArgsTypes.map { it.getCppRequiredTypes() }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -46,10 +46,10 @@ class PropertyComponent(
 
     jsObject.registerProperty(
       name,
-      getter?.takesOwner ?: false,
+      getter?.takesOwner == true,
       getter?.getCppRequiredTypes()?.toTypedArray() ?: emptyArray(),
       jniGetter,
-      setter?.takesOwner ?: false,
+      setter?.takesOwner == true,
       setter?.getCppRequiredTypes()?.toTypedArray() ?: emptyArray(),
       jniSetter
     )


### PR DESCRIPTION
# Why

The `getCppRequiredTypes` shouldn't be public. 
I've also removed `argsCount` parameter that isn't used anymore.

# Tests

- unit tests ✅ 