### PR TITLE
chore: remove old api @available checks

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -59,8 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadApp:(NSURL *)expoUrl withProjectUrl:(NSURL  * _Nullable)projectUrl onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError;
 
-- (NSDictionary *)recentlyOpenedApps;
-
 - (void)clearRecentlyOpenedApps;
 
 - (NSDictionary *)getLaunchOptions;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -324,9 +324,7 @@
   self.manifest = nil;
   self.manifestURL = nil;
 
-  if (@available(iOS 12, *)) {
-    [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
-  }
+  [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
 
   [self _removeInitModuleObserver];
 
@@ -420,11 +418,7 @@
 
 - (BOOL)isEASUpdateURL:(NSURL *)url
 {
-  if ([url.host isEqual: @"u.expo.dev"]) {
-    return true;
-  }
-
-  return false;
+  return [url.host isEqualToString:@"u.expo.dev"];
 }
 
 -(void)loadApp:(NSURL *)url onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError
@@ -536,16 +530,14 @@
   };
 
   [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:^(NSError * _Nonnull error) {
-    if (@available(iOS 14, *)) {
-      // Try to retry if the network connection was rejected because of the luck of the lan network permission.
-      static BOOL shouldRetry = true;
-      NSString *host = expoUrl.host;
+    // Try to retry if the network connection was rejected because of the lack of the lan network permission.
+    static BOOL shouldRetry = true;
+    NSString *host = expoUrl.host;
 
-      if (shouldRetry && ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."])) {
-        shouldRetry = false;
-        [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
-        return;
-      }
+    if (shouldRetry && ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."])) {
+      shouldRetry = false;
+      [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
+      return;
     }
 
     onError(error);
@@ -583,19 +575,15 @@
     }
 #endif
 
-    if (@available(iOS 12, *)) {
-      UIUserInterfaceStyle userInterfaceStyle = [EXDevLauncherManifestHelper exportManifestUserInterfaceStyle:manifest.userInterfaceStyle];
-      [self _applyUserInterfaceStyle:userInterfaceStyle];
+    UIUserInterfaceStyle userInterfaceStyle = [EXDevLauncherManifestHelper exportManifestUserInterfaceStyle:manifest.userInterfaceStyle];
+    [self _applyUserInterfaceStyle:userInterfaceStyle];
 
-      // Fix for the community react-native-appearance.
-      // RNC appearance checks the global trait collection and doesn't have another way to override the user interface.
-      // So we swap `currentTraitCollection` with one from the root view controller.
-      // Note that the root view controller will have the correct value of `userInterfaceStyle`.
-      if (@available(iOS 13.0, *)) {
-        if (userInterfaceStyle != UIUserInterfaceStyleUnspecified) {
-          UITraitCollection.currentTraitCollection = [self.window.rootViewController.traitCollection copy];
-        }
-      }
+    // Fix for the community react-native-appearance.
+    // RNC appearance checks the global trait collection and doesn't have another way to override the user interface.
+    // So we swap `currentTraitCollection` with one from the root view controller.
+    // Note that the root view controller will have the correct value of `userInterfaceStyle`.
+    if (userInterfaceStyle != UIUserInterfaceStyleUnspecified) {
+      UITraitCollection.currentTraitCollection = [self.window.rootViewController.traitCollection copy];
     }
 
     [self _addInitModuleObserver];
@@ -647,7 +635,7 @@
   });
 }
 
-- (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle API_AVAILABLE(ios(12.0))
+- (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle
 {
   NSString *colorSchema = nil;
   if (userInterfaceStyle == UIUserInterfaceStyleDark) {
@@ -724,7 +712,7 @@
 
 -(void)copyToClipboard:(NSString *)content {
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
-  clipboard.string = (content ? : @"");
+  clipboard.string = (content ?: @"");
 }
 
 - (void)setDevMenuAppBridge

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -58,7 +58,6 @@ public class EXDevLauncherManifestHelper: NSObject {
   }
 
   @objc
-  @available(iOS 12.0, *)
   public static func exportManifestUserInterfaceStyle(_ userInterfaceStyle: String?) -> UIUserInterfaceStyle {
     switch userInterfaceStyle {
       case "light":


### PR DESCRIPTION
# Why

Came to this file to check on something and just made a few simplifying changes.

Unrelated, I'm seeing this:

<img width="873" alt="Screenshot 2024-09-17 at 12 06 05" src="https://github.com/user-attachments/assets/dc58b442-18b3-444b-9afc-64dbf827b10c">

edit: fixed by removing recentlyOpenedApps from header file

# How

remove a few `@available(iOS 12, *)` and `@available(iOS 14, *)` checks

# Test Plan

CI passes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
