### PR TITLE
[core][Android] Introduce a base class for all shared refs

### DIFF
--- a/apps/native-component-list/src/screens/ModulesCore/ExpoModulesScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ExpoModulesScreen.tsx
@@ -22,7 +22,7 @@ export default function ExpoModulesScreen() {
       <CheckIfPresent name="modules" />
 
       <HeadingText>Exported classes</HeadingText>
-      {['EventEmitter', 'SharedObject', 'SharedRef'].map((className) => (
+      {['EventEmitter', 'SharedObject', 'SharedRef', 'NativeModule'].map((className) => (
         <CheckIfPresent key={className} name={className} />
       ))}
 

--- a/apps/native-component-list/src/screens/ModulesCore/ExpoModulesScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ExpoModulesScreen.tsx
@@ -8,6 +8,10 @@ const customJsonReplacer = (_: string, value: any) => {
   return typeof value === 'function' ? value.toString().replace(/\s+/g, ' ') : value;
 };
 
+function CheckIfPresent({ name }: { name: string }) {
+  return <MonoText>{`'${name}' in globalThis.expo => ${name in globalThis.expo!}`}</MonoText>;
+}
+
 export default function ExpoModulesScreen() {
   const modules = { ...globalThis.expo?.modules };
   const moduleNames = Object.keys(modules);
@@ -15,7 +19,12 @@ export default function ExpoModulesScreen() {
   return (
     <ScrollView style={styles.scrollView}>
       <HeadingText>Host object is installed</HeadingText>
-      <MonoText>{`'modules' in globalThis.expo => ${'modules' in globalThis.expo!}`}</MonoText>
+      <CheckIfPresent name="modules" />
+
+      <HeadingText>Exported classes</HeadingText>
+      {['EventEmitter', 'SharedObject', 'SharedRef'].map((className) => (
+        <CheckIfPresent key={className} name={className} />
+      ))}
 
       <HeadingText>Available Expo modules</HeadingText>
       <MonoText>

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Introduced a base class for all shared refs (`expo.SharedRef`).
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Introduced a base class for all shared refs (`expo.SharedRef`).
+- [Android] Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -5,6 +5,7 @@
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
 #include "SharedObject.h"
+#include "SharedRef.h"
 #include "NativeModule.h"
 
 #include <fbjni/detail/Meta.h>
@@ -111,7 +112,6 @@ void JSIContext::prepareRuntime() noexcept {
   runtimeHolder->installMainObject();
 
   EventEmitter::installClass(runtime);
-
   SharedObject::installBaseClass(
     runtime,
     // We can't predict the order of deallocation of the JSIContext and the SharedObject.
@@ -122,7 +122,7 @@ void JSIContext::prepareRuntime() noexcept {
       });
     }
   );
-
+  SharedRef::installBaseClass(runtime);
   NativeModule::installClass(runtime);
 
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
@@ -3,6 +3,7 @@
 #include "JSClassesDecorator.h"
 
 #include "SharedObject.h"
+#include "SharedRef.h"
 #include "JSDecoratorsBridgingObject.h"
 #include "../JavaReferencesCache.h"
 #include "../JSIContext.h"
@@ -16,6 +17,7 @@ void JSClassesDecorator::registerClass(
   jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> prototypeDecorator,
   jboolean takesOwner,
   jni::alias_ref<jclass> ownerClass,
+  jboolean isSharedRef,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
@@ -34,9 +36,11 @@ void JSClassesDecorator::registerClass(
   );
 
   ClassEntry classTuple{
-    prototypeDecorator->cthis()->bridge(),
-    std::move(constructor),
-    jni::make_global(ownerClass)
+    .prototypeDecorators = prototypeDecorator->cthis()->bridge(),
+    .constructor = std::move(constructor),
+    .ownerClass = jni::make_global(ownerClass),
+    // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    .isSharedRef = static_cast<bool>(isSharedRef & 0x1)
   };
 
   classes.try_emplace(
@@ -50,67 +54,69 @@ void JSClassesDecorator::decorate(
   jsi::Object &jsObject
 ) {
   for (auto &[name, classInfo]: classes) {
-    auto &[prototypeDecorators, constructor, ownerClass] = classInfo;
+    auto &[prototypeDecorators, constructor, ownerClass, isSharedRef] = classInfo;
 
     auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
-    auto klass = SharedObject::createClass(
-      runtime,
-      name.c_str(),
-      [weakConstructor = std::move(weakConstructor)](
-        jsi::Runtime &runtime,
-        const jsi::Value &thisValue,
-        const jsi::Value *args,
-        size_t count
-      ) -> jsi::Value {
-        // We need to check if the constructor is still alive.
-        // If not we can just ignore the call. We're destroying the module.
-        auto ctr = weakConstructor.lock();
-        if (ctr == nullptr) {
-          return jsi::Value::undefined();
-        }
-
-        auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
-
-        try {
-          JNIEnv *env = jni::Environment::current();
-          /**
-          * This will push a new JNI stack frame for the LocalReferences in this
-          * function call. When the stack frame for this lambda is popped,
-          * all LocalReferences are deleted.
-          */
-          jni::JniLocalScope scope(env, (int) count);
-          auto result = ctr->callJNISync(
-            env,
-            runtime,
-            thisValue,
-            args,
-            count
-          );
-          if (result == nullptr) {
-            return {runtime, thisValue};
-          }
-          jobject unpackedResult = result.get();
-          jclass resultClass = env->GetObjectClass(unpackedResult);
-          if (env->IsAssignableFrom(
-            resultClass,
-            JavaReferencesCache::instance()->getJClass(
-              "expo/modules/kotlin/sharedobjects/SharedObject").clazz
-          )) {
-            JSIContext *jsiContext = getJSIContext(runtime);
-            auto jsThisObject = JavaScriptObject::newInstance(
-              jsiContext,
-              jsiContext->runtimeHolder,
-              thisObject
-            );
-            jsiContext->registerSharedObject(result, jsThisObject);
-          }
-          return {runtime, thisValue};
-        } catch (jni::JniException &jniException) {
-          rethrowAsCodedError(runtime, jniException);
-        }
+    expo::common::ClassConstructor jsConstructor = [weakConstructor = std::move(weakConstructor)](
+      jsi::Runtime &runtime,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      // We need to check if the constructor is still alive.
+      // If not we can just ignore the call. We're destroying the module.
+      auto ctr = weakConstructor.lock();
+      if (ctr == nullptr) {
+        return jsi::Value::undefined();
       }
-    );
 
+      auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
+
+      try {
+        JNIEnv *env = jni::Environment::current();
+        /**
+        * This will push a new JNI stack frame for the LocalReferences in this
+        * function call. When the stack frame for this lambda is popped,
+        * all LocalReferences are deleted.
+        */
+        jni::JniLocalScope scope(env, (int) count);
+        auto result = ctr->callJNISync(
+          env,
+          runtime,
+          thisValue,
+          args,
+          count
+        );
+        if (result == nullptr) {
+          return {runtime, thisValue};
+        }
+        jobject unpackedResult = result.get();
+        jclass resultClass = env->GetObjectClass(unpackedResult);
+        if (env->IsAssignableFrom(
+          resultClass,
+          JavaReferencesCache::instance()->getJClass(
+            "expo/modules/kotlin/sharedobjects/SharedObject").clazz
+        )) {
+          JSIContext *jsiContext = getJSIContext(runtime);
+          auto jsThisObject = JavaScriptObject::newInstance(
+            jsiContext,
+            jsiContext->runtimeHolder,
+            thisObject
+          );
+          jsiContext->registerSharedObject(result, jsThisObject);
+        }
+        return {runtime, thisValue};
+      } catch (jni::JniException &jniException) {
+        rethrowAsCodedError(runtime, jniException);
+      }
+    };
+
+    auto klass = createClass(
+      runtime,
+      name,
+      isSharedRef,
+      std::move(jsConstructor)
+    );
     auto klassSharedPtr = std::make_shared<jsi::Function>(std::move(klass));
 
     JSIContext *jsiContext = getJSIContext(runtime);
@@ -140,6 +146,27 @@ void JSClassesDecorator::decorate(
       decorator->decorate(runtime, klassPrototype);
     }
   }
+}
+
+jsi::Function JSClassesDecorator::createClass(
+  jsi::Runtime &runtime,
+  const std::string &className,
+  bool isSharedRef,
+  common::ClassConstructor constructor
+) {
+  if (!isSharedRef) {
+    return SharedObject::createClass(
+      runtime,
+      className.c_str(),
+      std::move(constructor)
+    );
+  }
+
+  return SharedRef::createClass(
+    runtime,
+    className.c_str(),
+    std::move(constructor)
+  );
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -9,6 +9,7 @@
 #include "JSDecorator.h"
 #include "../MethodMetadata.h"
 #include "../JNIFunctionBody.h"
+#include "JSIUtils.h"
 
 namespace jni = facebook::jni;
 
@@ -23,6 +24,7 @@ public:
     jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> prototypeDecorator,
     jboolean takesOwner,
     jni::alias_ref<jclass> ownerClass,
+    jboolean isSharedRef,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
@@ -37,7 +39,15 @@ private:
     std::vector<std::unique_ptr<JSDecorator>> prototypeDecorators;
     std::shared_ptr<MethodMetadata> constructor;
     jni::global_ref<jclass> ownerClass;
+    bool isSharedRef;
   };
+
+  static jsi::Function createClass(
+    jsi::Runtime &runtime,
+    const std::string &className,
+    bool isSharedRef,
+    common::ClassConstructor constructor
+  );
 
   std::unordered_map<
     std::string,

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -105,6 +105,7 @@ void JSDecoratorsBridgingObject::registerClass(
   jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
   jboolean takesOwner,
   jni::alias_ref<jclass> ownerClass,
+  jboolean isSharedRef,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
@@ -117,6 +118,7 @@ void JSDecoratorsBridgingObject::registerClass(
     jsDecoratorsBridgingObject,
     takesOwner,
     ownerClass,
+    isSharedRef,
     expectedArgTypes,
     body
   );

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -69,6 +69,7 @@ public:
     jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
     jboolean takesOwner,
     jni::alias_ref<jclass> ownerClass,
+    jboolean isSharedRef,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -74,6 +74,7 @@ class ModuleHolder<T : Module>(val module: T) {
             prototypeDecorator,
             constructor.takesOwner,
             ownerClass,
+            clazz.isSharedRef,
             constructor.getCppRequiredTypes().toTypedArray(),
             constructor.getJNIFunctionBody(clazz.name, appContext)
           )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -31,7 +31,8 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     }
 
     val hasSharedObject = ownerClass !== Unit::class // TODO: Add an empty constructor that throws when called from JS
-    if (hasSharedObject && constructor == null && !ownerClass.isSubclassOf(SharedRef::class)) {
+    val isSharedRef = ownerClass.isSubclassOf(SharedRef::class)
+    if (hasSharedObject && constructor == null && !isSharedRef) {
       throw IllegalArgumentException("constructor cannot be null")
     }
 
@@ -41,7 +42,8 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     return ClassDefinitionData(
       name,
       constructor,
-      objectData
+      objectData,
+      isSharedRef
     )
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
@@ -6,5 +6,6 @@ import expo.modules.kotlin.objects.ObjectDefinitionData
 class ClassDefinitionData(
   val name: String,
   val constructor: SyncFunctionComponent,
-  val objectDefinition: ObjectDefinitionData
+  val objectDefinition: ObjectDefinitionData,
+  val isSharedRef: Boolean
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -64,6 +64,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
     prototypeDecorator: JSDecoratorsBridgingObject,
     takesOwner: Boolean,
     ownerClass: Class<*>?,
+    isSharedRef: Boolean,
     desiredTypes: Array<ExpectedType>,
     body: JNIFunctionBody
   )

--- a/packages/expo-modules-core/common/cpp/SharedRef.cpp
+++ b/packages/expo-modules-core/common/cpp/SharedRef.cpp
@@ -1,0 +1,25 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#include "SharedRef.h"
+
+namespace expo::SharedRef {
+
+void installBaseClass(jsi::Runtime &runtime) {
+  jsi::Function baseClass = SharedObject::getBaseClass(runtime);
+  jsi::Function klass = expo::common::createInheritingClass(runtime, "SharedRef", baseClass);
+
+  common::getCoreObject(runtime)
+    .setProperty(runtime, "SharedRef", klass);
+}
+
+jsi::Function getBaseClass(jsi::Runtime &runtime) {
+  return common::getCoreObject(runtime)
+    .getPropertyAsFunction(runtime, "SharedRef");
+}
+
+jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::ClassConstructor constructor) {
+  jsi::Function baseSharedObjectClass = getBaseClass(runtime);
+  return common::createInheritingClass(runtime, className, baseSharedObjectClass, std::move(constructor));
+}
+
+} // namespace expo::SharedRef

--- a/packages/expo-modules-core/common/cpp/SharedRef.h
+++ b/packages/expo-modules-core/common/cpp/SharedRef.h
@@ -1,0 +1,32 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include "SharedObject.h"
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo::SharedRef {
+
+/**
+ Installs a base JavaScript class for all shared references.
+ */
+void installBaseClass(jsi::Runtime &runtime);
+
+/**
+ Returns the base JavaScript class for all shared refs, i.e. `global.expo.SharedRef`.
+ */
+jsi::Function getBaseClass(jsi::Runtime &runtime);
+
+/**
+ Creates a concrete shared ref class with the given name and constructor.
+ */
+jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::ClassConstructor constructor);
+
+} // namespace expo::SharedRef
+
+#endif // __cplusplus


### PR DESCRIPTION
# Why

Introduces a base class for all shared refs and use it when creating a new js shared ref. 

# How

Similarly to `SharedObject`, I've exported new js prototype for `SharedRef`.

# Test Plan

![image](https://github.com/user-attachments/assets/7dc7bc71-8f28-4b94-9b2c-5d43cb643705)