### PR TITLE
[ios][camera] Remove preferredVideoStabilizationMode

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Updated docs for the `pictureSize` prop. ([#30195](https://github.com/expo/expo/pull/30195) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Migrated cameraview AAR to autolinking and removed related config-plugin about adding the maven repository. ([#30707](https://github.com/expo/expo/pull/30707) by [@kudo](https://github.com/kudo))
 - Remove the dependency on the legacy types from the newer package on web. ([#30952](https://github.com/expo/expo/pull/30952) by [@alanjhughes](https://github.com/alanjhughes))
-- Remove `preferredVideoStabilizationMode` until is is fully supported.
+- Remove `preferredVideoStabilizationMode` until is is fully supported. ([#31514](https://github.com/expo/expo/pull/31514) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Updated docs for the `pictureSize` prop. ([#30195](https://github.com/expo/expo/pull/30195) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Migrated cameraview AAR to autolinking and removed related config-plugin about adding the maven repository. ([#30707](https://github.com/expo/expo/pull/30707) by [@kudo](https://github.com/kudo))
 - Remove the dependency on the legacy types from the newer package on web. ([#30952](https://github.com/expo/expo/pull/30952) by [@alanjhughes](https://github.com/alanjhughes))
+- Remove `preferredVideoStabilizationMode` until is is fully supported.
 
 ### ⚠️ Notices
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -564,12 +564,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     sessionQueue.async {
       if let videoFileOutput = self.videoFileOutput, !videoFileOutput.isRecording && self.videoRecordedPromise == nil {
         if let connection = videoFileOutput.connection(with: .video) {
-          if connection.isVideoStabilizationSupported {
-            connection.preferredVideoStabilizationMode = .auto
-          } else {
-            log.warn("\(#function): Video Stabilization is not supported on this device.")
-          }
-
           let orientation = self.responsiveWhenOrientationLocked ? self.physicalOrientation : UIDevice.current.orientation
           connection.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
           self.setVideoOptions(options: options, for: connection, promise: promise)

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -569,7 +569,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
           self.setVideoOptions(options: options, for: connection, promise: promise)
 
           if connection.isVideoOrientationSupported && self.mirror {
-            connection.preferredVideoStabilizationMode = .auto
             connection.isVideoMirrored = self.mirror
           }
         }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -569,6 +569,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
           self.setVideoOptions(options: options, for: connection, promise: promise)
 
           if connection.isVideoOrientationSupported && self.mirror {
+            connection.preferredVideoStabilizationMode = .auto
             connection.isVideoMirrored = self.mirror
           }
         }


### PR DESCRIPTION
# Why
I've removed setting `preferredVideoStabilizationMode` on iOS. We haven't given a way for users to configure this and setting it adds additional latency and cause ui hitches that are unexpected. I will add it back when we add proper support for it.

# How
Remove setting the property in `record`

# Test Plan
Tested in an example project a user provided to me. The UI hitches are removed.
