### PR TITLE
fix(cli): check for `cause` in network errors to detect and auto-enable offline mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads. ([#30424](https://github.com/expo/expo/pull/30424) by [@byCedric](https://github.com/byCedric))
 - Fixed the `CorsMiddleware` is a not registered since react-native 0.75. ([#30752](https://github.com/expo/expo/pull/30752) by [@kudo](https://github.com/kudo))
 - Detect workspace root for monorepos using pnpm. ([#31124](https://github.com/expo/expo/pull/31124) by [@byCedric](https://github.com/byCedric))
+- Detect network issues and enable offline mode with Undici errors.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -49,7 +49,7 @@
 - Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads. ([#30424](https://github.com/expo/expo/pull/30424) by [@byCedric](https://github.com/byCedric))
 - Fixed the `CorsMiddleware` is a not registered since react-native 0.75. ([#30752](https://github.com/expo/expo/pull/30752) by [@kudo](https://github.com/kudo))
 - Detect workspace root for monorepos using pnpm. ([#31124](https://github.com/expo/expo/pull/31124) by [@byCedric](https://github.com/byCedric))
-- Detect network issues and enable offline mode with Undici errors.
+- Detect network issues and enable offline mode with Undici errors. ([#31517](https://github.com/expo/expo/pull/31517) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -112,8 +112,11 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
 
       return response;
     } catch (error: any) {
-      // Specifically, when running `npx expo start` and the wifi is connected but not really (public wifi, airplanes, etc).
-      if ('code' in error && error.code === 'ENOTFOUND') {
+      // When running `expo start`, but wifi or internet has issues
+      if (
+        ('code' in error && error.code === 'ENOTFOUND') || // node-fetch error handling
+        ('cause' in error && 'code' in error.cause && error.cause.code === 'ENOTFOUND') // undici error handling
+      ) {
         disableNetwork();
 
         throw new CommandError(


### PR DESCRIPTION
# Why

`undici` throws errors slightly different compared to `node-fetch`. Instead of throwing the actual "error cause", they throw a generic "TypeError: fetch failed" error with a `cause` property containing the actual fetch error.

This updates the auto-offline network detection to account for that.

# How

- Also check `error.cause.code === 'ENOTFOUND'` when fetch errors fail (and enable offline mode)
- Add tests for both `node-fetch` and `undici`-styled errors

# Test Plan

- `$ bun create expo ./test-undici-offline`
- `$ cd ./test-undici-offline`
- Disable network on your computer
- `$ expod start`
- Should start normally in offline mode, without throwing `TypeError: fetch failed`

<details><summary>Example output <b>with</b> the fix (and wifi disabled)</summary>

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/a61d9ccb-9b04-4813-8e25-2168211faced">

</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
