### PR TITLE
[core] add appGroups support

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -120,7 +120,8 @@ final class VersionManager: EXVersionManagerObjC {
     }
     return AppContextConfig(
       documentDirectory: URL(fileURLWithPath: documentDirectory),
-      cacheDirectory: URL(fileURLWithPath: cacheDirectory)
+      cacheDirectory: URL(fileURLWithPath: cacheDirectory),
+      appGroups: nil
     )
   }
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Android] Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Added `onStartListeningToEvent` and `onStopListeningToEvent` to the `SharedObject`. ([#31385](https://github.com/expo/expo/pull/31385) by [@lukmccall](https://github.com/lukmccall))
+- Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/AppCodeSignEntitlements.swift
+++ b/packages/expo-modules-core/ios/Core/AppCodeSignEntitlements.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ App code signing entitlements passed from autolinking
+ */
+public struct AppCodeSignEntitlements: Codable {
+  /**
+   https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups
+   */
+  var appGroups: [String]?
+
+  /**
+   Create an instance from JSON string.
+   If passing an invalid JSON string, it creates default empty entitlements instead.
+   */
+  public static func from(json: String) -> AppCodeSignEntitlements {
+    guard let data = json.data(using: .utf8) else {
+      log.error("Invalid string encoding")
+      return AppCodeSignEntitlements()
+    }
+
+    do {
+      return try JSONDecoder().decode(AppCodeSignEntitlements.self, from: data)
+    } catch {
+      log.error("Unable to decode entitlement JSON data: \(error.localizedDescription)")
+      return AppCodeSignEntitlements()
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/AppCodeSignEntitlements.swift
+++ b/packages/expo-modules-core/ios/Core/AppCodeSignEntitlements.swift
@@ -7,7 +7,7 @@ public struct AppCodeSignEntitlements: Codable {
   /**
    https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups
    */
-  var appGroups: [String]?
+  public var appGroups: [String]?
 
   /**
    Create an instance from JSON string.

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -34,7 +34,15 @@ public final class AppContext: NSObject {
    The legacy module registry with modules written in the old-fashioned way.
    */
   @objc
-  public weak var legacyModuleRegistry: EXModuleRegistry?
+  public weak var legacyModuleRegistry: EXModuleRegistry? {
+    didSet {
+      if let registry = legacyModuleRegistry,
+        let legacyModule = registry.getModuleImplementingProtocol(EXFileSystemInterface.self) as? EXFileSystemInterface,
+        let fileSystemLegacyModule = legacyModule as? FileSystemLegacyUtilities {
+        fileSystemLegacyModule.maybeInitAppGroupSharedDirectories(self.config.appGroupSharedDirectories)
+      }
+    }
+  }
 
   @objc
   public weak var legacyModulesProxy: LegacyNativeModulesProxy?
@@ -188,11 +196,7 @@ public final class AppContext: NSObject {
    Provides access to the file system manager from legacy module registry.
    */
   public var fileSystem: EXFileSystemInterface? {
-    let legacyFileSystemModule: EXFileSystemInterface? = legacyModule(implementing: EXFileSystemInterface.self)
-    if let appGroups = appCodeSignEntitlements.appGroups {
-      (legacyFileSystemModule as? FileSystemLegacyUtilities)?.maybeInitAppGroupSharedDirectories(appGroups: appGroups)
-    }
-    return legacyFileSystemModule
+    return legacyModule(implementing: EXFileSystemInterface.self)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/AppContextConfig.swift
+++ b/packages/expo-modules-core/ios/Core/AppContextConfig.swift
@@ -1,13 +1,20 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 public struct AppContextConfig {
-  public static var `default` = AppContextConfig()
-
   public let documentDirectory: URL?
   public let cacheDirectory: URL?
+  public let appGroupSharedDirectories: [URL]
 
-  public init(documentDirectory: URL? = nil, cacheDirectory: URL? = nil) {
+  public init(documentDirectory: URL?, cacheDirectory: URL?, appGroups: [String]?) {
     self.documentDirectory = documentDirectory ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
     self.cacheDirectory = cacheDirectory ?? FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+
+    var sharedDirectories: [URL] = []
+    for appGroup in appGroups ?? [] {
+      if let directory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+        sharedDirectories.append(directory)
+      }
+    }
+    self.appGroupSharedDirectories = sharedDirectories
   }
 }

--- a/packages/expo-modules-core/ios/Core/ModulesProvider.swift
+++ b/packages/expo-modules-core/ios/Core/ModulesProvider.swift
@@ -16,6 +16,8 @@ public protocol ModulesProviderProtocol {
    Returns an array of `ExpoReactDelegateHandlerTupleType` for `ReactDelegate` to hook React instance creation.
    */
   func getReactDelegateHandlers() -> [ExpoReactDelegateHandlerTupleType]
+
+  func getAppCodeSignEntitlements() -> AppCodeSignEntitlements
 }
 
 /**
@@ -36,5 +38,9 @@ open class ModulesProvider: NSObject, ModulesProviderProtocol {
 
   open func getReactDelegateHandlers() -> [ExpoReactDelegateHandlerTupleType] {
     return []
+  }
+
+  open func getAppCodeSignEntitlements() -> AppCodeSignEntitlements {
+    return AppCodeSignEntitlements()
   }
 }

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
@@ -123,15 +123,13 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
     return filePermissions
   }
 
-  internal func maybeInitAppGroupSharedDirectories(appGroups: [String]) {
+  internal func maybeInitAppGroupSharedDirectories(_ directories: [URL]) {
     if appGroupSharedDirectories != nil {
       return
     }
     var appGroupSharedDirectories: [String] = []
-    for appGroup in appGroups {
-      if let directory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
-        appGroupSharedDirectories.append(directory.standardized.path)
-      }
+    for directory in directories {
+      appGroupSharedDirectories.append(directory.standardized.path)
     }
     self.appGroupSharedDirectories = appGroupSharedDirectories
   }

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
@@ -64,7 +64,7 @@ public struct FileSystemUtilities {
       return [.none]
     }
 
-    let scopedDirs = [appContext.config.cacheDirectory, appContext.config.documentDirectory]
+    let scopedDirs = [appContext.config.cacheDirectory, appContext.config.documentDirectory] + appContext.config.appGroupSharedDirectories
     let standardizedPath = url.standardized.path
 
     for dir in scopedDirs {
@@ -96,5 +96,16 @@ public struct FileSystemUtilities {
     }
 
     return filePermissions
+  }
+
+  private static func getAppGroupSharedDirectories(_ appContext: AppContext) -> [String] {
+    let appGroups = appContext.appCodeSignEntitlements.appGroups ?? []
+    var appGroupSharedDirectories: [String] = []
+    for appGroup in appGroups {
+      if let directory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+        appGroupSharedDirectories.append(directory.standardized.path)
+      }
+    }
+    return appGroups
   }
 }

--- a/packages/expo-modules-core/ios/Tests/AppCodeSignEntitlementsSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/AppCodeSignEntitlementsSpec.swift
@@ -1,0 +1,42 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class AppCodeSignEntitlementsSpec: ExpoSpec {
+  override class func spec() {
+    describe("AppCodeSignEntitlements") {
+      it("should have a nil appGroups array when initialized with default init") {
+        let entitlements = AppCodeSignEntitlements()
+        expect(entitlements.appGroups).to(beNil())
+      }
+
+      it("should parse valid JSON and set appGroups correctly") {
+        let jsonString = """
+          {
+            "appGroups": ["group.com.example.app"]
+          }
+          """
+        let entitlements = AppCodeSignEntitlements.from(json: jsonString)
+        expect(entitlements.appGroups).to(equal(["group.com.example.app"]))
+      }
+
+      it("should return nil appGroups when initialized with invalid JSON") {
+        let jsonString = "{\"foo\"}"
+        let entitlements = AppCodeSignEntitlements.from(json: jsonString)
+        expect(entitlements.appGroups).to(beNil())
+      }
+
+      it("should return nil appGroups when JSON structure is incorrect") {
+        let jsonString = """
+          {
+            "incorrectKey": ["group.com.example.app"]
+          }
+          """
+        let entitlements = AppCodeSignEntitlements.from(json: jsonString)
+        expect(entitlements.appGroups).to(beNil())
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

add [shared app group support](https://developer.apple.com/documentation/xcode/configuring-app-groups) to file system utilities. this is a follow up for https://github.com/expo/expo/pull/31278#discussion_r1761193997

# How

- parse appGroups from the generated `ExpoModulesProvider.swift`
- add `AppCodeSignEntitlements` class
- add `AppContext.appCodeSignEntitlements` for clients to retrieve the app group ids
- add the shared app group container path as internal directories into both `FileSystemUtilities` and `FileSystemLegacyUtilities`

# Test Plan

- ci passed
- add the following code to **apps/bare-expo/ios/BareExpo/BareExpo.entitlements** and check if the `AppCodeSignEntitlements` has valid appGroups
```diff
--- a/apps/bare-expo/ios/BareExpo/BareExpo.entitlements
+++ b/apps/bare-expo/ios/BareExpo/BareExpo.entitlements
@@ -8,5 +8,9 @@
     <array>
       <string>Default</string>
     </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.dev.expo.Payments</string>
+    </array>
   </dict>
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---------

Co-authored-by: Igor Khramtsov <igor.khramtsov@proton.me>