### PR TITLE
[docs] Fix code block and section title in E2E tests guide

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -52,9 +52,9 @@ The following command creates a new project on Expo servers for your app and cre
 
 <Step label="3">
 
-## Disable Android Build Infrastructure
+## Disable New Android Builds Infrastructure
 
-Go to [**Project settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.
+Go to [**Project settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Builds Infrastructure**.
 
 Unfortunately, the new build infrastructure is incompatible with E2E tests due to the lack of virtualization support required to start Android Emulator. We are working on better solutions for running various tests on EAS.
 
@@ -176,8 +176,8 @@ To learn more about Maestro flows and how to write them, see the [Maestro docume
 
 If you encounter the following error message when starting an Android Emulator for E2E tests on EAS Build:
 
-```
+```text
 Failed to configure emulator: emulator with required ID not found.
 ```
 
-This is likely because the New Build Infrastructure is enabled for your project. Go to [**Project Settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Build Infrastructure**.
+This is likely because the New Build Infrastructure is enabled for your project. Go to [**Project Settings**](https://expo.dev/accounts/[account]/projects/[project]/settings) and disable **New Android Builds Infrastructure**.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1726594055466809)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding the `text` as the code block language to display the error message code block.
- Update the section title and other references to reflect the correct settings name (New Android Builds Infrastructure) from expo.dev > Project settings dashboard

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-09-17 at 23 12 39@2x](https://github.com/user-attachments/assets/4b332297-5f10-4d1f-9956-5a6c3cb13b8a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
