### PR TITLE
[cli] Ignore /dist folder in default eslint config

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Remove `debug.html` from `npx expo export --source-maps`. ([#31477](https://github.com/expo/expo/pull/31477) by [@EvanBacon](https://github.com/EvanBacon))
-- Ignore /dist folder in the default eslint config
+- Ignore /dist folder in the default eslint config ([#31532](https://github.com/expo/expo/pull/31532) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Remove `debug.html` from `npx expo export --source-maps`. ([#31477](https://github.com/expo/expo/pull/31477) by [@EvanBacon](https://github.com/EvanBacon))
+- Ignore /dist folder in the default eslint config
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/static/template/.eslintrc.js
+++ b/packages/@expo/cli/static/template/.eslintrc.js
@@ -1,4 +1,5 @@
 // https://docs.expo.dev/guides/using-eslint/
 module.exports = {
   extends: 'expo',
+  ignorePatterns: ['/dist/*'],
 };


### PR DESCRIPTION
# Why

By creating a new project, setting up linting and exporting the proejct for deployment, we get a bunch of linting errors.

```sh
# new project
yarn create expo-app my-app
cd my-app

# set up eslint
npx expo lint

# export
npx expo export --platform web

# lint
yarn lint
```

<img width="1297" alt="Screenshot 2024-09-17 at 22 42 51" src="https://github.com/user-attachments/assets/f848e39c-e0cb-4961-815e-03f1459d88e6">



# How

Ignore the `/dist` folder by default.

# Test Plan

Test locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
