### PR TITLE
[Android] fix: crash when reloading an expo update with a video component mounted

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30456](https://github.com/expo/expo/pull/30456) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
 - [Android] Fixed `NullPointerException` in the `installJSIBindings` function. ([#31464](https://github.com/expo/expo/pull/31464) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed crash when reloading an expo update with a video component mounted ([#31540](https://github.com/expo/expo/pull/31540) by [@AbijahKaj](https://github.com/AbijahKaj))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -3,6 +3,7 @@ package expo.modules.av.player;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Looper;
 
 import android.text.TextUtils;
 import android.util.Log;
@@ -89,6 +90,7 @@ class SimpleExoPlayerData extends PlayerData
     mSimpleExoPlayer = new SimpleExoPlayer.Builder(context)
         .setTrackSelector(trackSelector)
         .setBandwidthMeter(bandwidthMeter)
+        .setLooper(Looper.getMainLooper())
         .build();
 
     mSimpleExoPlayer.addListener(this);


### PR DESCRIPTION
# Why

Reopening my previous PR https://github.com/expo/expo/pull/31526 which was reviewed but auto-closed itself when the base brach was changed.

Fix android crash when reloading from an expo update with a video component mounted

The error is:
Player is accessed on the wrong thread.

# How

The solution:
Pass the Looper (from the main thread)
CC: https://developer.android.com/media/media3/exoplayer/hello-world#a-note-on-threading

# Test Plan

- Add a video component
- Publish an expo update
- Add code to download the update and reload the app
- Without this change the android app will crash

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
