### PR TITLE
[expo-file-system][next] Make move operation change file url

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -206,14 +206,15 @@ export async function test({ describe, expect, it, ...t }) {
         expect(() => src.move(dstFolder)).toThrow();
       });
 
-      it('Copies it to a folder', () => {
+      it('moves it to a folder', () => {
         const src = new File(testDirectory + 'file.txt');
         src.write('Hello world');
         const dstFolder = new Directory(testDirectory + 'destination');
         dstFolder.create();
         src.move(dstFolder);
-        expect(src.exists).toBe(false);
+        expect(src.exists).toBe(true);
         const dst = new File(testDirectory + '/destination/file.txt');
+        expect(src.uri).toBe(dst.uri);
         expect(dst.exists).toBe(true);
         expect(dst.text()).toBe('Hello world');
       });
@@ -225,26 +226,29 @@ export async function test({ describe, expect, it, ...t }) {
         expect(() => file.move(folder)).toThrow();
       });
 
-      it('Copies it to a file', () => {
+      it('moves it to a file', () => {
         const src = new File(testDirectory + 'file.txt');
         src.write('Hello world');
         const dst = new File(testDirectory + 'file2.txt');
         src.move(dst);
         expect(dst.exists).toBe(true);
         expect(dst.text()).toBe('Hello world');
-        expect(src.exists).toBe(false);
+        expect(src.exists).toBe(true);
+        expect(src.uri).toBe(dst.uri);
       });
     });
 
     describe('When moving a directory', () => {
-      it('copies it to a folder', () => {
+      it('moves it to a folder', () => {
         const src = new Directory(testDirectory + 'directory');
         src.create();
         const dstFolder = new Directory(testDirectory + 'destination');
         dstFolder.create();
         src.move(dstFolder);
-        expect(src.exists).toBe(false);
-        expect(new Directory(testDirectory + 'destination/directory').exists).toBe(true);
+        expect(src.exists).toBe(true);
+        const dst = new Directory(testDirectory + 'destination/directory');
+        expect(src.uri).toBe(dst.uri);
+        expect(dst.exists).toBe(true);
       });
 
       it('Throws an error when moving to a nonexistant folder without options', () => {

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [expo-file-system][next] Make move operation change file url. ([#31544](https://github.com/expo/expo/pull/31544) by [@aleqsio](https://github.com/aleqsio))
 - Change `exists()` function to a property. ([#31522](https://github.com/expo/expo/pull/31522) by [@aleqsio](https://github.com/aleqsio))
 - Add path utilities and `parentDirectory`, `extension` fields to the new file system module. ([#31333](https://github.com/expo/expo/pull/31333) by [@aleqsio](https://github.com/aleqsio))
 - Add listing directory contents to the new file system module. ([#31121](https://github.com/expo/expo/pull/31121) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -64,16 +64,21 @@ abstract class FileSystemPath(var file: File) : SharedObject() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       if (to is FileSystemDirectory) {
         file.toPath().moveTo(File(to.file.path, file.name).toPath())
+        file = File(to.file.path, file.name)
       } else {
         file.toPath().moveTo(to.file.toPath())
+        file = to.file
       }
     } else {
       if (to is FileSystemDirectory) {
         file.copyTo(File(to.file.path, file.name))
+        file.delete()
+        file = File(to.file.path, file.name)
       } else {
         file.copyTo(to.file)
+        file.delete()
+        file = to.file
       }
-      file.delete()
     }
   }
 }

--- a/packages/expo-file-system/build/next/FileSystem.types.d.ts
+++ b/packages/expo-file-system/build/next/FileSystem.types.d.ts
@@ -41,7 +41,7 @@ export declare class Directory {
      */
     copy(destination: Directory | File): any;
     /**
-     * Moves a directory.
+     * Moves a directory. The Directory instance now points to the new location.
      */
     move(destination: Directory | File): any;
     /**
@@ -109,7 +109,7 @@ export declare class File {
      */
     copy(destination: Directory | File): any;
     /**
-     * Moves a directory.
+     * Moves a directory. The File instance now points to the new location.
      */
     move(destination: Directory | File): any;
     /**

--- a/packages/expo-file-system/build/next/FileSystem.types.d.ts
+++ b/packages/expo-file-system/build/next/FileSystem.types.d.ts
@@ -41,7 +41,7 @@ export declare class Directory {
      */
     copy(destination: Directory | File): any;
     /**
-     * Moves a directory. The Directory instance now points to the new location.
+     * Moves a directory. Updates the `uri` property that now points to the new location.
      */
     move(destination: Directory | File): any;
     /**
@@ -109,7 +109,7 @@ export declare class File {
      */
     copy(destination: Directory | File): any;
     /**
-     * Moves a directory. The File instance now points to the new location.
+     * Moves a directory. Updates the `uri` property that now points to the new location.
      */
     move(destination: Directory | File): any;
     /**

--- a/packages/expo-file-system/ios/Next/FileSystemPath.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemPath.swift
@@ -2,7 +2,7 @@ import Foundation
 import ExpoModulesCore
 
 internal class FileSystemPath: SharedObject {
-  let url: URL
+  var url: URL
 
   init(url: URL, isDirectory: Bool) {
     let standardizedUrl = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent, isDirectory: isDirectory)
@@ -26,13 +26,16 @@ internal class FileSystemPath: SharedObject {
 
   func move(to destination: FileSystemPath) throws {
     if destination is FileSystemDirectory {
-      try FileManager.default.moveItem(at: url, to: destination.url.appendingPathComponent(url.lastPathComponent))
+      let to = destination.url.appendingPathComponent(url.lastPathComponent, isDirectory: self is FileSystemDirectory)
+      try FileManager.default.moveItem(at: url, to: to)
+      url = to
     }
     if destination is FileSystemFile {
-      guard !url.hasDirectoryPath else {
+      guard self is FileSystemFile else {
         throw MoveDirectoryToFileException()
       }
       try FileManager.default.moveItem(at: url, to: destination.url)
+      url = destination.url
     }
   }
 }

--- a/packages/expo-file-system/src/next/FileSystem.types.ts
+++ b/packages/expo-file-system/src/next/FileSystem.types.ts
@@ -47,7 +47,7 @@ export declare class Directory {
    */
   copy(destination: Directory | File);
   /**
-   * Moves a directory. The Directory instance now points to the new location.
+   * Moves a directory. Updates the `uri` property that now points to the new location.
    */
   move(destination: Directory | File);
   /**
@@ -123,7 +123,7 @@ export declare class File {
   copy(destination: Directory | File);
 
   /**
-   * Moves a directory. The File instance now points to the new location.
+   * Moves a directory. Updates the `uri` property that now points to the new location.
    */
   move(destination: Directory | File);
 

--- a/packages/expo-file-system/src/next/FileSystem.types.ts
+++ b/packages/expo-file-system/src/next/FileSystem.types.ts
@@ -47,7 +47,7 @@ export declare class Directory {
    */
   copy(destination: Directory | File);
   /**
-   * Moves a directory.
+   * Moves a directory. The Directory instance now points to the new location.
    */
   move(destination: Directory | File);
   /**
@@ -123,7 +123,7 @@ export declare class File {
   copy(destination: Directory | File);
 
   /**
-   * Moves a directory.
+   * Moves a directory. The File instance now points to the new location.
    */
   move(destination: Directory | File);
 


### PR DESCRIPTION
# Why

It makes a bit more sense imo to do it this way – the original path will never exist after the `move` operation.

# Test Plan

Updated tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
