### PR TITLE
[core][Android] Reduce number of fbjni references

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -10,7 +10,10 @@ namespace react = facebook::react;
 namespace expo {
 
 jni::local_ref<jni::JObject>
-JNIFunctionBody::invoke(jobjectArray args) {
+JNIFunctionBody::invoke(
+  jobject self,
+  jobjectArray args
+) {
   // Do NOT use getClass here!
   // Method obtained from `getClass` will point to the overridden version of the method.
   // Because of that, it can't be cached - we will try to invoke the nonexistent method
@@ -22,12 +25,13 @@ JNIFunctionBody::invoke(jobjectArray args) {
       "([Ljava/lang/Object;)Ljava/lang/Object;"
     );
 
-  auto result = jni::Environment::current()->CallObjectMethod(this->self(), method.getId(), args);
+  auto result = jni::Environment::current()->CallObjectMethod(self, method.getId(), args);
   throwPendingJniExceptionAsCppException();
   return jni::adopt_local(static_cast<jni::JniType<jni::JObject>>(result));
 }
 
 void JNIAsyncFunctionBody::invoke(
+  jobject self,
   jobjectArray args,
   jobject promise
 ) {
@@ -44,7 +48,7 @@ void JNIAsyncFunctionBody::invoke(
       "([Ljava/lang/Object;Lexpo/modules/kotlin/jni/PromiseImpl;)V"
     );
 
-  jni::Environment::current()->CallVoidMethod(this->self(), method.getId(), args, promise);
+  jni::Environment::current()->CallVoidMethod(self, method.getId(), args, promise);
   throwPendingJniExceptionAsCppException();
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
@@ -23,7 +23,8 @@ public:
    * @param args
    * @return result of the Kotlin function
    */
-  jni::local_ref<jni::JObject> invoke(
+  static jni::local_ref<jni::JObject> invoke(
+    jobject self,
     jobjectArray args
   );
 };
@@ -42,7 +43,8 @@ public:
    * @param args
    * @param promise that will be resolve or rejected in the Kotlin's implementation
    */
-  void invoke(
+  static void invoke(
+    jobject self,
     jobjectArray args,
     jobject promise
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -182,7 +182,7 @@ void JavaScriptObject::defineNativeDeallocator(
         JavaReferencesCache::instance()->getJClass("java/lang/Object").clazz,
         nullptr
       );
-      globalRef->invoke(args);
+      JNIFunctionBody::invoke(globalRef.get(), args);
       globalRef.reset();
     }
   );

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -182,13 +182,7 @@ jni::local_ref<jobject> MethodMetadata::callJNISync(
   }
 
   auto convertedArgs = convertJSIArgsToJNI(env, rt, thisValue, args, count);
-
-  // Cast in this place is safe, cause we know that this function is promise-less.
-  auto syncFunction = jni::static_ref_cast<JNIFunctionBody>(this->jBodyReference);
-  auto result = syncFunction->invoke(
-    convertedArgs
-  );
-
+  auto result = JNIFunctionBody::invoke(this->jBodyReference.get(), convertedArgs);
   env->DeleteLocalRef(convertedArgs);
   return result;
 }
@@ -344,12 +338,7 @@ jsi::Function MethodMetadata::createPromiseBody(
         javaCallback
       );
 
-      // Cast in this place is safe, cause we know that this function expects promise.
-      auto asyncFunction = jni::static_ref_cast<JNIAsyncFunctionBody>(this->jBodyReference);
-      asyncFunction->invoke(
-        globalArgs,
-        promise
-      );
+      JNIAsyncFunctionBody::invoke(this->jBodyReference.get(), globalArgs, promise);
 
       // We have to remove the local reference to the promise object.
       // It doesn't mean that the promise will be deallocated, but rather that we move

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -56,7 +56,7 @@ jsi::Value convert(
   // Which is actually slow. We can use some pointer magic to avoid it.
 #define CAST_AND_RETURN(type, classId) \
   if (env->IsInstanceOf(unpackedValue, cache->getJClass(#classId).clazz)) { \
-     return convertToJS(env, rt, *((jni::local_ref<type>*)((void*)&value))); \
+    return convertToJS(env, rt, *((jni::local_ref<type>*)((void*)&value))); \
   }
 #define COMMA ,
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -52,9 +52,11 @@ jsi::Value convert(
   auto unpackedValue = value.get();
   auto cache = JavaReferencesCache::instance();
 
+  // We could use jni::static_ref_cast here. It will lead to the creation of a new local reference.
+  // Which is actually slow. We can use some pointer magic to avoid it.
 #define CAST_AND_RETURN(type, classId) \
   if (env->IsInstanceOf(unpackedValue, cache->getJClass(#classId).clazz)) { \
-    return convertToJS(env, rt, jni::static_ref_cast<type>(value)); \
+     return convertToJS(env, rt, *((jni::local_ref<type>*)((void*)&value))); \
   }
 #define COMMA ,
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -97,12 +97,27 @@ struct deref<jni::local_ref<T>> {
 };
 
 template<typename T>
+struct deref<jni::local_ref<T>&> {
+  typedef T type;
+};
+
+template<typename T>
 struct deref<jni::global_ref<T>> {
   typedef T type;
 };
 
 template<typename T>
+struct deref<jni::global_ref<T>&> {
+  typedef T type;
+};
+
+template<typename T>
 struct deref<jni::alias_ref<T>> {
+  typedef T type;
+};
+
+template<typename T>
+struct deref<jni::alias_ref<T>&> {
   typedef T type;
 };
 


### PR DESCRIPTION
# Why

Reduces number of fbjni references created during sync and async calls.

# How

By not using `fbjni` in some places, I improved function calls by about `20%` in production builds. Creating new references is quite expensive. Also, I wasn't aware that `jni::static_ref_cast` produces a new reference. We used it on global refs, where it was a costly operation.

# Test Plan

Before:

<image src="https://github.com/user-attachments/assets/ad95ef58-29fd-4ae3-a5d1-e7606f5da709" height="800"/>

After:

<image src="https://github.com/user-attachments/assets/d1c81b85-0b50-476a-9be3-3c4caef9b1f3" height="800"/>

