### PR TITLE
[video][android] Add @UnstableReactNativeAPI annotation to classes

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Bump media3 version to 1.4.0. ([#31239](https://github.com/expo/expo/pull/31239) by [@behenate](https://github.com/behenate))
 - [Android] The media will now be buffered even when the player is unmounted to match iOS behavior. ([#30626](https://github.com/expo/expo/pull/30626) by [@behenate](https://github.com/behenate))
+- [Android] Add @UnstableReactNativeAPI annotation to classes ([#31549](https://github.com/expo/expo/pull/31549) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### ⚠️ Notices
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -8,6 +8,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
 import androidx.media3.common.Timeline
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.ViewProps
@@ -24,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
+@UnstableReactNativeAPI
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class VideoModule : Module() {
   override fun definition() = ModuleDefinition {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -15,6 +15,7 @@ import android.widget.FrameLayout
 import android.widget.ImageButton
 import androidx.fragment.app.FragmentActivity
 import androidx.media3.ui.PlayerView
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.Spacing
@@ -55,6 +56,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
 
   private val outlineProvider = OutlineProvider(context)
 
+  @UnstableReactNativeAPI
   private val borderDrawableLazyHolder = lazy {
     ReactViewBackgroundDrawable(context).apply {
       callback = this@VideoView
@@ -72,6 +74,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     }
   }
 
+  @UnstableReactNativeAPI
   private val borderDrawable
     get() = borderDrawableLazyHolder.value
 
@@ -284,6 +287,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     applyRectHint()
   }
 
+  @UnstableReactNativeAPI
   override fun draw(canvas: Canvas) {
     // When the border-radii are not all the same, a convex-path
     // is used for the Outline. Unfortunately clipping is not supported
@@ -330,6 +334,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     }
   }
 
+  @UnstableReactNativeAPI
   internal fun setBorderRadius(position: Int, borderRadius: Float) {
     val isInvalidated = outlineProvider.setBorderRadius(borderRadius, position)
     if (isInvalidated) {
@@ -354,21 +359,25 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     }
   }
 
+  @UnstableReactNativeAPI
   internal fun setBorderWidth(position: Int, width: Float) {
     borderDrawable.setBorderWidth(position, width)
     shouldInvalided = true
   }
 
+  @UnstableReactNativeAPI
   internal fun setBorderColor(position: Int, rgb: Float, alpha: Float) {
     borderDrawable.setBorderColor(position, rgb, alpha)
     shouldInvalided = true
   }
 
+  @UnstableReactNativeAPI
   internal fun setBorderStyle(style: String?) {
     borderDrawable.setBorderStyle(style)
     shouldInvalided = true
   }
 
+  @UnstableReactNativeAPI
   fun didUpdateProps() {
     val hasBorder = if (borderDrawableLazyHolder.isInitialized()) {
       val spacings = listOf(

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -44,7 +44,11 @@ class ExpoVideoPlaybackService : MediaSessionService() {
     .build()
 
   fun setShowNotification(showNotification: Boolean, player: ExoPlayer) {
-    val sessionExtras = mediaSessions[player]?.sessionExtras?.deepCopy() ?: Bundle()
+    val sessionExtras = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      mediaSessions[player]?.sessionExtras?.deepCopy() ?: Bundle()
+    } else {
+      Bundle()
+    }
     sessionExtras.putBoolean(SESSION_SHOW_NOTIFICATION, showNotification)
     mediaSessions[player]?.let {
       it.sessionExtras = sessionExtras


### PR DESCRIPTION
# Why

In react-native 0.76 CSSBackgroundDrawable is marked as `@UnstableReactNativeAPI` requiring us to add the same annotation in our libs 

Related to ENG-13531

# How

Add @UnstableReactNativeAPI annotation to expo-video classes on Android

# Test Plan

Run BareExpo on Android using 0.75 and 0.76

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
