### PR TITLE
[docs] add sdk info to dom components guide

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -6,6 +6,8 @@ description: Learn about rendering React DOM elements in Expo native apps.
 
 import { Terminal } from '~/ui/components/Snippet';
 
+> Experimentally available in **SDK 52 and above**. To try out the latest DOM components features, you can install the [canary release](/versions/unversioned/#canary-releases).
+
 > **warning** **Warning:** DOM components are an experimental feature. The public API (`expo/dom`, `dom` prop), prop transport system, asset handling, and export embedding system are subject to breaking changes. Use `WebViews` directly for a production-ready approach.
 
 Expo offers a novel approach to work with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app by moving on a per-component basis.


### PR DESCRIPTION
# Why

we didn't mention dom components requires sdk 52 or canary.

# How

add the sdk info, not sure whether it's good enough

![Screenshot 2024-09-19 at 2 41 11 AM](https://github.com/user-attachments/assets/12f7dff1-9bd8-449c-91a3-d0ca8c3ca5c6)

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
