### PR TITLE
fi(doc): typo in custom build

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1413,7 +1413,7 @@ build:
     - eas/configure_eas_update
     - eas/configure_ios_credentials
     # @info #
-    - eas/generate_gymfile_template:
+    - eas/generate_gymfile_from_template:
         inputs:
           credentials: ${ eas.job.secrets.buildCredentials }
     # @end #
@@ -1427,7 +1427,7 @@ build:
     - eas/install_node_modules
     - eas/prebuild
     # @info #
-    - eas/generate_gymfile_template
+    - eas/generate_gymfile_from_template
     # @end #
 ```
 
@@ -1448,7 +1448,7 @@ build:
     - eas/configure_eas_update
     - eas/configure_ios_credentials
     # @info #
-    - eas/generate_gymfile_template:
+    - eas/generate_gymfile_from_template:
         inputs:
           credentials: ${ eas.job.secrets.buildCredentials }
           extra:
@@ -1494,7 +1494,7 @@ build:
 
 <BoxLink
   title="eas/generate_gymfile_from_template source code"
-  description="View the source code for the eas/generate_gymfile_template function on GitHub."
+  description="View the source code for the eas/generate_gymfile_from_template function on GitHub."
   Icon={GithubIcon}
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/generateGymfileFromTemplate.ts"
 />
@@ -1519,7 +1519,7 @@ build:
           apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
     - eas/configure_eas_update
     - eas/configure_ios_credentials
-    - eas/generate_gymfile_template:
+    - eas/generate_gymfile_from_template:
         inputs:
           credentials: ${ eas.job.secrets.buildCredentials }
     # @info #
@@ -1535,7 +1535,7 @@ build:
     - eas/install_node_modules
     - eas/prebuild
     - eas/configure_eas_update
-    - eas/generate_gymfile_template
+    - eas/generate_gymfile_from_template
     # @info #
     - eas/run_fastlane
     # @end #
@@ -1568,7 +1568,7 @@ build:
           apple_team_id: ${ steps.resolve_apple_team_id_from_credentials.apple_team_id }
     - eas/configure_eas_update
     - eas/configure_ios_credentials
-    - eas/generate_gymfile_template:
+    - eas/generate_gymfile_from_template:
         inputs:
           credentials: ${ eas.job.secrets.buildCredentials }
     - eas/run_fastlane
@@ -1585,7 +1585,7 @@ build:
     - eas/install_node_modules
     - eas/prebuild
     - eas/configure_eas_update
-    - eas/generate_gymfile_template
+    - eas/generate_gymfile_from_template
     - eas/run_fastlane
     # @info #
     - eas/find_and_upload_build_artifacts


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When I followed the example in the [documentation](https://docs.expo.dev/custom-builds/schema/#easgenerate_gymfile_from_template) below to use a custom build, I encountered the following error:
<img width="660" alt="expo-custom-error" src="https://github.com/user-attachments/assets/c6a3d6e6-d4f6-44c3-9ae5-4fbf4e0017a9">


\# This is snapshot from documentation
<img width="870" alt="image" src="https://github.com/user-attachments/assets/783d486b-c9cc-477c-b264-1bd6ee6c8288">

<!--
How did you build this feature or fix this bug and why?
-->

# How

The correct function name is `generate_gymfile_from_template`.

Renaming it to this would be correct.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
