### PR TITLE
[docs] Point office hours banner to discord

### DIFF
--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -45,13 +45,13 @@ export function DiscoverMore() {
           <OfficeHoursImage />
           <RawH3 className="!text-palette-yellow11 !font-bold">Join us for Office Hours</RawH3>
           <P className="!text-palette-yellow11 !text-xs max-w-[28ch]">
-            Get answers to your questions and get advice from the Expo team.
+            Ask the Expo Team questions on our Discord stage.
           </P>
           <HomeButton
             className="bg-palette-yellow11 border-palette-yellow11 text-palette-yellow2 hocus:bg-palette-yellow11"
-            href="https://us02web.zoom.us/meeting/register/tZcvceivqj0oHdGVOjEeKY0dRxCRPb0HzaAK"
+            href="https://chat.expo.dev"
             rightSlot={<ArrowUpRightIcon className="text-palette-yellow2 icon-md" />}>
-            Register
+            Check Discord for Upcoming Events
           </HomeButton>
         </GridCell>
         <GridCell className="bg-palette-blue3 border-palette-blue6 selection:bg-palette-blue5">


### PR DESCRIPTION
# Why
Office hours are moving to the discord stage.

# How
The best I can seem to do is just link to Discord.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/71c8d8a0-ee34-44d9-adc1-e970d88861d1">


