### PR TITLE
[modules-core][android] Add support for react-native 0.76

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -89,18 +89,25 @@ find_package(fbjni REQUIRED CONFIG)
 
 # includes
 
-get_target_property(INCLUDE_reactnativejni
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  get_target_property(INCLUDE_reactnativejni
+       ReactAndroid::reactnative
+       INTERFACE_INCLUDE_DIRECTORIES)
+else()
+  get_target_property(INCLUDE_reactnativejni
         ReactAndroid::reactnativejni
         INTERFACE_INCLUDE_DIRECTORIES)
+endif()
+
 target_include_directories(
-        ${PACKAGE_NAME}
-        PRIVATE
-        ${INCLUDE_reactnativejni}/react
+       ${PACKAGE_NAME}
+       PRIVATE
+       ${INCLUDE_reactnativejni}/react
 
         # header only imports from turbomodule, e.g. CallInvokerHolder.h
-        "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
-        "${COMMON_DIR}"
-        "${SRC_DIR}/fabric"
+       "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
+       "${COMMON_DIR}"
+       "${SRC_DIR}/fabric"
 )
 
 # linking
@@ -114,15 +121,26 @@ target_compile_options(
 )
 
 target_link_libraries(
-        ${PACKAGE_NAME}
-        CommonSettings
-        ${LOG_LIB}
-        fbjni::fbjni
-        ReactAndroid::jsi
-        ReactAndroid::reactnativejni
-        ReactAndroid::folly_runtime
-        ReactAndroid::react_nativemodule_core
-        android
-        ${JSEXECUTOR_LIB}
-        ${NEW_ARCHITECTURE_DEPENDENCIES}
+  ${PACKAGE_NAME}
+  CommonSettings
+  ${LOG_LIB}
+  fbjni::fbjni
+  ReactAndroid::jsi
+  android
+  ${JSEXECUTOR_LIB}
+  ${NEW_ARCHITECTURE_DEPENDENCIES}
 )
+
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+   target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::reactnative
+   )
+else()
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::reactnativejni
+    ReactAndroid::folly_runtime
+    ReactAndroid::react_nativemodule_core
+  )
+endif()

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -105,6 +105,7 @@ android {
       "**/libhermes.so",
       "**/libjscexecutor.so",
       "**/libjsi.so",
+      "**/libreactnative.so",
       "**/libreactnativejni.so",
       "**/libreact_debug.so",
       "**/libreact_nativemodule_core.so",

--- a/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
+++ b/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
@@ -20,9 +20,15 @@ find_package(ReactAndroid REQUIRED CONFIG)
 
 find_package(fbjni REQUIRED CONFIG)
 
-get_target_property(INCLUDE_fabricjni
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+  get_target_property(INCLUDE_fabricjni
+        ReactAndroid::reactnative
+        INTERFACE_INCLUDE_DIRECTORIES)
+else()
+  get_target_property(INCLUDE_fabricjni
         ReactAndroid::fabricjni
         INTERFACE_INCLUDE_DIRECTORIES)
+endif()
 
 target_include_directories(fabric PRIVATE
   "${REACT_NATIVE_DIR}/ReactCommon"
@@ -33,18 +39,25 @@ target_include_directories(fabric PRIVATE
 target_link_libraries(fabric
   CommonSettings
   fbjni::fbjni
-  ReactAndroid::fabricjni
-  ReactAndroid::folly_runtime
-  ReactAndroid::glog
   ReactAndroid::jsi
-  ReactAndroid::react_debug
-  ReactAndroid::react_render_componentregistry
-  ReactAndroid::react_render_core
-  ReactAndroid::react_render_debug
-  ReactAndroid::react_render_graphics
-  ReactAndroid::react_render_mapbuffer
-  ReactAndroid::react_utils
-  ReactAndroid::rrc_view
-  ReactAndroid::runtimeexecutor
-  ReactAndroid::yoga
 )
+
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+   target_link_libraries(fabric ReactAndroid::reactnative)
+else()
+  target_link_libraries(fabric
+    ReactAndroid::fabricjni
+    ReactAndroid::folly_runtime
+    ReactAndroid::glog
+    ReactAndroid::react_debug
+    ReactAndroid::react_render_componentregistry
+    ReactAndroid::react_render_core
+    ReactAndroid::react_render_debug
+    ReactAndroid::react_render_graphics
+    ReactAndroid::react_render_mapbuffer
+    ReactAndroid::react_utils
+    ReactAndroid::rrc_view
+    ReactAndroid::runtimeexecutor
+    ReactAndroid::yoga
+  )
+endif()

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
@@ -20,7 +20,7 @@ std::unordered_map<std::string, folly::dynamic> propsMapFromProps(const ExpoView
   const auto& dynamicRawProps = static_cast<folly::dynamic>(rawProps);
   for (const auto& propsPair : dynamicRawProps.items()) {
     std::string propName = propsPair.first.getString();
-    propsMap[propName] = (folly::dynamic)propsPair.second;
+    propsMap[propName] = static_cast<folly::dynamic>(propsPair.second);
   }
 
   return propsMap;

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
@@ -19,7 +19,7 @@ std::unordered_map<std::string, folly::dynamic> propsMapFromProps(const ExpoView
   // Note that it contains only updated props.
   const auto& dynamicRawProps = static_cast<folly::dynamic>(rawProps);
   for (const auto& propsPair : dynamicRawProps.items()) {
-    std::string propName = propsPair.first.getString();
+    const auto &propName = propsPair.first.getString();
     propsMap[propName] = static_cast<folly::dynamic>(propsPair.second);
   }
 

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
@@ -17,10 +17,11 @@ std::unordered_map<std::string, folly::dynamic> propsMapFromProps(const ExpoView
 
   // Iterate over values in the raw props object.
   // Note that it contains only updated props.
-  rawProps.iterateOverValues([&propsMap](react::RawPropsPropNameHash hash, const char *name, const react::RawValue &value) {
-    std::string propName(name);
-    propsMap[propName] = (folly::dynamic)value;
-  });
+  const auto& dynamicRawProps = static_cast<folly::dynamic>(rawProps);
+  for (const auto& propsPair : dynamicRawProps.items()) {
+    std::string propName = propsPair.first.getString();
+    propsMap[propName] = (folly::dynamic)propsPair.second;
+  }
 
   return propsMap;
 }


### PR DESCRIPTION
# Why

Related to ENG-13531

# How

Update expo-modules-core to support react-native 0.76 based on https://github.com/react-native-community/discussions-and-proposals/discussions/816

# Test Plan

Run BareExpo using react-native 0.75 and 0.76

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
