### PR TITLE
[iOS] Fixed `No space left on device` when saving persistent log

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [Android] Fixed `CodedException.getCode()` crash when R8 is enabled. ([#31392](https://github.com/expo/expo/pull/31392) by [@kudo](https://github.com/kudo))
 - [Android] Fixed getter for the third parameter of `Either`. ([#31443](https://github.com/expo/expo/pull/31443) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
+- [iOS] Fixed `No space left on device` on PersistentFileLog.swift ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -54,7 +54,7 @@
 - [Android] Fixed `CodedException.getCode()` crash when R8 is enabled. ([#31392](https://github.com/expo/expo/pull/31392) by [@kudo](https://github.com/kudo))
 - [Android] Fixed getter for the third parameter of `Either`. ([#31443](https://github.com/expo/expo/pull/31443) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
-- [iOS] Fixed `No space left on device` on PersistentFileLog.swift ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
+- [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -56,8 +56,12 @@ public class PersistentFileLog {
   public func appendEntry(entry: String, _ completionHandler: PersistentFileLogCompletionHandler? = nil) {
     PersistentFileLog.serialQueue.async {
       self.ensureFileExists()
-      self.appendTextToFile(text: entry + "\n")
-      completionHandler?(nil)
+      do {
+        try self.appendTextToFile(text: entry + "\n")
+        completionHandler?(nil)
+      } catch {
+        completionHandler?(error)
+      }
     }
   }
 
@@ -110,11 +114,11 @@ public class PersistentFileLog {
     }
   }
 
-  private func appendTextToFile(text: String) {
+  private func appendTextToFile(text: String) throws {
     if let data = text.data(using: .utf8) {
       if let fileHandle = FileHandle(forWritingAtPath: filePath) {
         fileHandle.seekToEndOfFile()
-        fileHandle.write(data)
+        try fileHandle.write(data)
         fileHandle.closeFile()
       }
     }


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/31582

# How

Adding a try-catch to avoid crash when the device has no space left.

# Test Plan

1. Add an exception to simulate a device without space left.
2. Patch: https://gist.github.com/RodolfoGS/e179fe4d049753d648f651e090964c49
3. Execute the `appendEntry` function.

Please test it since I'm not sure how to use the `PersistentFileLog` class.

I previously reported a similar issue on Android, which was resolved by simply adding a try-catch (https://github.com/expo/expo/pull/24247), this is the same situation on iOS.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
