### PR TITLE
[expo-updates] Move location of assetPatternsToBeBundled config key

### DIFF
--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -11,11 +11,15 @@ import { CODE } from '~/ui/components/Text';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server. The experimental **asset selection feature** in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
+In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server.
+
+SDK 50 added the experimental **asset selection feature**, which allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
+
+SDK 52 launched this feature to general availability.
 
 ## Using asset selection
 
-To use the asset selection, include the property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
+To use asset selection in SDK 51 and below, include the property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
 
 ```json app.json
   "expo": {
@@ -26,6 +30,19 @@ To use the asset selection, include the property `extra.updates.assetPatternsToB
           "app/images/**/*.png"
         ]
       }
+    }
+  }
+```
+
+To use asset selection in SDK 52 and above, include the property `updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
+
+```json app.json
+  "expo": {
+    /* @hide ... */ /* @end */
+    "updates": {
+      "assetPatternsToBeBundled": [
+        "app/images/**/*.png"
+      ]
     }
   }
 ```

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -81,6 +81,7 @@ If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you wil
 | `updates.fallbackToCacheTimeout`                            | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
 | `updates.codeSigningCertificate`                            | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
 | `updates.codeSigningMetadata`                               | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+| `updates.assetPatternsToBeBundled`                          | (none)   | <NoIcon />  | N/A                               | N/A                                                              | N/A                      |
 
 ## Usage
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Added public assets support for DOM components. ([#30975](https://github.com/expo/expo/pull/30975) by [@kudo](https://github.com/kudo))
 - Added `/expo-dev-plugins/broadcast` WebSocket endpoint in dev server to support devtools plugins. ([#30934](https://github.com/expo/expo/pull/30934) by [@kudo](https://github.com/kudo))
 - Drop usage of `@react-native-community/cli-server-api` in favor of our own Metro dev middleware. ([#31570](https://github.com/expo/expo/pull/31570) by [@byCedric](https://github.com/byCedric))
+- Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
@@ -9,52 +9,103 @@ describe(resolveAssetPatternsToBeBundled, () => {
     const assetPatterns = resolveAssetPatternsToBeBundled('/', exp, []);
     expect(assetPatterns).toBeUndefined();
   });
-  it(`expands bundle patterns`, () => {
-    const exp: any = {
-      name: 'Foo',
-      slug: 'Foo',
-      extra: {
+  describe('previous location of the config key', () => {
+    it(`expands bundle patterns`, () => {
+      const exp: any = {
+        name: 'Foo',
+        slug: 'Foo',
+        extra: {
+          updates: {
+            assetPatternsToBeBundled: ['**/*'],
+          },
+        },
+      };
+      const resultSet = resolveAssetPatternsToBeBundled('/', exp, [
+        {
+          __packager_asset: true,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
+          hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
+          name: 'icon',
+          type: 'png',
+          fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
+        },
+        {
+          __packager_asset: true,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+          hash: 'foobar',
+          name: 'somn',
+          fileHashes: [
+            'foobar',
+            'foobar2',
+            // duplicates are stripped
+            'foobar2',
+          ],
+        },
+        {
+          // Wont match
+          __packager_asset: false,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+          hash: 'foobar',
+          name: 'somn',
+          fileHashes: ['foobar3'],
+        },
+      ]);
+      const result = [...(resultSet ?? new Set())];
+      result.sort();
+      expect(result).toEqual([
+        'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',
+        'asset_foobar',
+        'asset_foobar2',
+      ]);
+    });
+  });
+
+  describe('current location of the config key', () => {
+    it(`expands bundle patterns`, () => {
+      const exp: any = {
+        name: 'Foo',
+        slug: 'Foo',
         updates: {
           assetPatternsToBeBundled: ['**/*'],
         },
-      },
-    };
-    const resultSet = resolveAssetPatternsToBeBundled('/', exp, [
-      {
-        __packager_asset: true,
-        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
-        hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
-        name: 'icon',
-        type: 'png',
-        fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
-      },
-      {
-        __packager_asset: true,
-        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
-        hash: 'foobar',
-        name: 'somn',
-        fileHashes: [
-          'foobar',
-          'foobar2',
-          // duplicates are stripped
-          'foobar2',
-        ],
-      },
-      {
-        // Wont match
-        __packager_asset: false,
-        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
-        hash: 'foobar',
-        name: 'somn',
-        fileHashes: ['foobar3'],
-      },
-    ]);
-    const result = [...(resultSet ?? new Set())];
-    result.sort();
-    expect(result).toEqual([
-      'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',
-      'asset_foobar',
-      'asset_foobar2',
-    ]);
+      };
+      const resultSet = resolveAssetPatternsToBeBundled('/', exp, [
+        {
+          __packager_asset: true,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
+          hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
+          name: 'icon',
+          type: 'png',
+          fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
+        },
+        {
+          __packager_asset: true,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+          hash: 'foobar',
+          name: 'somn',
+          fileHashes: [
+            'foobar',
+            'foobar2',
+            // duplicates are stripped
+            'foobar2',
+          ],
+        },
+        {
+          // Wont match
+          __packager_asset: false,
+          files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+          hash: 'foobar',
+          name: 'somn',
+          fileHashes: ['foobar3'],
+        },
+      ]);
+      const result = [...(resultSet ?? new Set())];
+      result.sort();
+      expect(result).toEqual([
+        'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',
+        'asset_foobar',
+        'asset_foobar2',
+      ]);
+    });
   });
 });

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -18,9 +18,17 @@ function mapAssetHashToAssetString(asset: Asset, hash: string) {
 export function assetPatternsToBeBundled(
   exp: ExpoConfig & { extra?: { updates?: { assetPatternsToBeBundled?: string[] } } }
 ): string[] | undefined {
-  return exp?.extra?.updates?.assetPatternsToBeBundled?.length
-    ? exp?.extra?.updates?.assetPatternsToBeBundled
-    : undefined;
+  // new location for this key
+  if (exp.updates?.assetPatternsToBeBundled?.length) {
+    return exp.updates.assetPatternsToBeBundled;
+  }
+
+  // old, untyped location for this key. we may want to change this to throw in a few SDK versions (deprecated as of SDK 52).
+  if (exp.extra?.updates?.assetPatternsToBeBundled?.length) {
+    return exp.extra.updates.assetPatternsToBeBundled;
+  }
+
+  return undefined;
 }
 
 /**
@@ -90,12 +98,13 @@ export function resolveAssetPatternsToBeBundled<T extends ExpoConfig>(
   exp: T,
   assets: Asset[]
 ): Set<string> | undefined {
-  if (!assetPatternsToBeBundled(exp)) {
+  const assetPatternsToBeBundledForConfig = assetPatternsToBeBundled(exp);
+  if (!assetPatternsToBeBundledForConfig) {
     return undefined;
   }
   const bundledAssets = setOfAssetsToBeBundled(
     assets,
-    assetPatternsToBeBundled(exp) ?? ['**/*'],
+    assetPatternsToBeBundledForConfig,
     projectRoot
   );
   return bundledAssets;

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -205,6 +205,10 @@ export interface ExpoConfig {
         requestHeaders?: {
             [k: string]: any;
         };
+        /**
+         * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
+         */
+        assetPatternsToBeBundled?: string[];
     };
     /**
      * Provide overrides by locale for System Dialog prompts like Permissions Boxes
@@ -303,7 +307,7 @@ export interface Splash {
  */
 export interface IOS {
     /**
-     * The Apple development team ID to use for all build configurations.
+     * The Apple development team ID to use for all native targets. You can find your team ID in [the Apple Developer Portal](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/).
      */
     appleTeamId?: string;
     /**

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -207,6 +207,10 @@ export interface ExpoConfig {
     requestHeaders?: {
       [k: string]: any;
     };
+    /**
+     * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
+     */
+    assetPatternsToBeBundled?: string[];
   };
   /**
    * Provide overrides by locale for System Dialog prompts like Permissions Boxes
@@ -307,7 +311,7 @@ export interface Splash {
  */
 export interface IOS {
   /**
-   * The Apple development team ID to use for all build configurations.
+   * The Apple development team ID to use for all native targets. You can find your team ID in [the Apple Developer Portal](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/).
    */
   appleTeamId?: string;
   /**

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Re-exported `@expo/fingerprint` as `expo-updates/fingerprint`. ([#30757](https://github.com/expo/expo/pull/30757) by [@kudo](https://github.com/kudo))
+- Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/e2e/setup/create-updates-test.ts
+++ b/packages/expo-updates/e2e/setup/create-updates-test.ts
@@ -25,17 +25,12 @@ function transformAppJson(appJson: any, projectName: string, runtimeVersion: str
       ...appJson.expo,
       name: projectName,
       runtimeVersion,
-      extra: {
-        ...appJson.extra,
-        updates: {
-          assetPatternsToBeBundled: ['assetsInUpdates/*'],
-        },
-      },
       updates: {
         ...appJson.expo.updates,
         requestHeaders: {
           'expo-channel-name': 'main',
         },
+        assetPatternsToBeBundled: ['assetsInUpdates/*'],
       },
       android: {
         ...appJson.expo.android,

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -473,11 +473,9 @@ function transformAppJsonForE2E(
       updates: {
         ...appJson.expo.updates,
         url: `http://${process.env.UPDATES_HOST}:${process.env.UPDATES_PORT}/update`,
+        assetPatternsToBeBundled: ['includedAssets/*'],
       },
       extra: {
-        updates: {
-          assetPatternsToBeBundled: ['includedAssets/*'],
-        },
         eas: {
           projectId: '55685a57-9cf3-442d-9ba8-65c7b39849ef',
         },


### PR DESCRIPTION
# Why

This imports this change: https://app.graphite.dev/github/pr/expo/universe/16833/xdl-schema-Add-config-schema-for-updates-assetPatternsToBeBundled

The motivation is that now that this is out of beta (experimental) we should move it to the normal "updates" config key (out of "extra.updates").

We will still read the old location for a while, and then at some point we will change the code to throw if the old location is specified (see inline code comment).

Closes ENG-13557.

# How

Read from new location, update docs.

# Test Plan

Run all tests (e2e tests test this).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
