### PR TITLE
[expo] Bump `androix.test.*` libraries

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -194,10 +194,10 @@ dependencies {
         implementation jscFlavor
     }
 
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.5.1')
-    androidTestImplementation('androidx.test:runner:1.5.2')
-    androidTestImplementation('androidx.test:rules:1.5.0')
-    androidTestImplementation('androidx.test.ext:junit-ktx:1.1.5')
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.6.1')
+    androidTestImplementation('androidx.test:runner:1.6.2')
+    androidTestImplementation('androidx.test:rules:1.6.1')
+    androidTestImplementation('androidx.test.ext:junit-ktx:1.2.1')
 }
 
 class ExecuteSetupAndroidProject implements Plugin<Project> {

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -47,13 +47,13 @@ dependencies {
   androidTestImplementation 'com.facebook.react:react-android'
   androidTestImplementation 'com.facebook.react:hermes-android'
 
-  androidTestImplementation('androidx.test.espresso:espresso-core:3.4.0')
-  androidTestImplementation('androidx.test:core:1.4.0')
-  androidTestImplementation('androidx.test:core-ktx:1.4.0')
-  androidTestImplementation('androidx.test.ext:junit:1.1.3')
-  androidTestImplementation('androidx.test.ext:junit-ktx:1.1.3')
-  androidTestImplementation('androidx.test:runner:1.4.0')
-  androidTestImplementation('androidx.test:rules:1.4.0')
+  androidTestImplementation('androidx.test.espresso:espresso-core:3.6.1')
+  androidTestImplementation('androidx.test:core:1.6.1')
+  androidTestImplementation('androidx.test:core-ktx:1.6.1')
+  androidTestImplementation('androidx.test.ext:junit:1.2.1')
+  androidTestImplementation('androidx.test.ext:junit-ktx:1.2.1')
+  androidTestImplementation('androidx.test:runner:1.6.2')
+  androidTestImplementation('androidx.test:rules:1.6.1')
 
   androidTestImplementation 'org.webkit:android-jsc:+'
 
@@ -63,10 +63,10 @@ dependencies {
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
 
-  androidTestImplementation "androidx.appcompat:appcompat:1.1.0"
+  androidTestImplementation "androidx.appcompat:appcompat:1.7.0"
 
   androidTestImplementation "com.google.truth:truth:1.1.2"
-  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+  androidTestImplementation 'io.mockk:mockk-android:1.13.11'
 
   // Fixes "e: java.lang.AssertionError: No such enum entry LIBRARY_GROUP_PREFIX in org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl@b254b575"
   // According to the https://stackoverflow.com/a/67736351

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-  api 'androidx.test:core:1.5.0'
+  api 'androidx.test:core:1.6.1'
   api 'junit:junit:4.13.2'
   api('io.mockk:mockk:1.13.5') {
     // jupiter is junit 5 which we don't use
@@ -47,9 +47,9 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion()}"
 
   // instrumented testing dependencies
-  api 'androidx.test.ext:junit:1.1.5'
-  api 'androidx.test:runner:1.5.2'
-  api 'androidx.test:rules:1.5.0'
+  api 'androidx.test.ext:junit:1.2.1'
+  api 'androidx.test:runner:1.6.2'
+  api 'androidx.test:rules:1.6.1'
   api "com.google.truth:truth:1.1.2"
   api "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 }


### PR DESCRIPTION
# Why

Bumps `androidx.text.*` libraries to the newest version.
Should fix:
```
java.lang.NoSuchMethodError: No virtual method setFuture(Lcom/google/common/util/concurrent/p;)Z in class Landroidx/concurrent/futures/d; or its super classes (declaration of 'androidx.concurrent.futures.d' appears in /data/app/~~ohm8V3riLuv_5F0LSeHW9w==/dev.expo.payments-J4_-C4M-wwCuQSh3w5TFsw==/base.apk)
	at androidx.test.core.app.DeviceCapture$forceRedrawGlobalWindowViews$1.run(DeviceCapture.kt:168)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7924)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```
https://github.com/expo/expo/actions/runs/10955112326/job/30419016124

# Test Plan

- CI ✅ 