### PR TITLE
Render code output fields as text in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,11 +59,13 @@ body:
     attributes:
       label: Environment
       description: Run the `npx expo-env-info` command and paste its output in the field below.
+      render: text
     validations:
       required: true
   - type: textarea
     attributes:
       label: Expo Doctor Diagnostics
       description: Run the `npx expo-doctor@latest` command on your minimal reproduction and paste its output in the field below. If Doctor reports any errors, fix them before submitting the issue.
+      render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -36,6 +36,7 @@ body:
     attributes:
       label: Environment
       description: Run the `npx expo-env-info` command and paste its output in the field below.
+      render: text
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_router.yml
@@ -54,5 +54,6 @@ body:
     attributes:
       label: Environment
       description: Run the `npx expo-env-info` command and paste its output in the field below.
+      render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -49,6 +49,7 @@ body:
     attributes:
       label: Environment
       description: Run the `npx expo-env-info` command and paste its output in the field below.
+      render: text
     validations:
       required: true
   - type: textarea
@@ -69,6 +70,7 @@ body:
     attributes:
       label: Stacktrace (if a crash is involved)
       description: If your issue involves a crash, please provide the native stacktrace if you are able to.
+      render: text
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
# Why

Issue templates where I'm supposed to paste terminal output render like markdown. This MR change it to be rendered like raw text similar to how `react-native` core repo does it. 

# How

Changing the `render` attribute in issue templates. 

# Test Plan

N/A

# Checklist

N/A
