### PR TITLE
[docs] Removes fingerprintExperimental documentation

### DIFF
--- a/docs/pages/eas-update/deployment-patterns.mdx
+++ b/docs/pages/eas-update/deployment-patterns.mdx
@@ -136,7 +136,7 @@ This flow is for projects that need to build and update their Android and iOS ap
 
 This flow is an example of a flow for managing versioned releases.
 
-> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, `"nativeVersion"` and `"fingerprintExperimental"`). You will need to [manually specify](/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
+> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, `"nativeVersion"` and `"fingerprint"`). You will need to [manually specify](/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
 
 Here are the parts of the deployment process above that make up this flow:
 

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -121,24 +121,6 @@ We provide the `"fingerprint"` runtime version policy for Expo projects that aut
 
 This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
 
-### `"fingerprintExperimental"` runtime version policy
-
-> **warning** `fingerprintExperimental`is deprecated and is removed from SDK 51 onwards.
-
-We provide the `"fingerprintExperimental"` runtime version policy for a project that has custom native code that may change between builds:
-
-```json
-{
-  "expo": {
-    "runtimeVersion": {
-      "policy": "fingerprintExperimental"
-    }
-  }
-}
-```
-
-This policy is well-suited for projects incorporating custom native code that require safe updates without native conflicts. Unlike the `"nativeVersion"` policy, the `"fingerprintExperimental"` option automatically scans your project's native dependencies to update the `"runtimeVersion"` accordingly.
-
 Enabling fingerprinting may lengthen build times, as the fingerprinting process can be resource-intensive.
 
 ### `"sdkVersion"` runtime version policy (deprecated)


### PR DESCRIPTION
# Why

The `fingerprintExperimental` runtime version policy does not appear to be valid anymore. This PR removes it from the docs.

# Screenshots

Inside a code editor:
<img width="877" alt="Screenshot 2024-09-20 at 10 27 30 AM" src="https://github.com/user-attachments/assets/e85d4994-21ce-4a24-889d-ca1b1b795855">

Running `eas update`
<img width="694" alt="Screenshot 2024-09-20 at 10 28 03 AM" src="https://github.com/user-attachments/assets/8d5df18a-b42e-412b-90fd-96a1cdc58cd2">

# Test Plan

- Make sure that the runtime version policy is actually not supported and that these docs still read correctly and are accurate.
