### PR TITLE
[expo-updates][ios] Store strong references to long-lived objects created in procedures

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Use relative entry point from `@expo/config/paths` with support for server root. ([#30633](https://github.com/expo/expo/pull/30633) by [@byCedric](https://github.com/byCedric))
 - [iOS] Rollback to system SQLite3 and fix incompatible issue when any third-party library uses iOS system SQLite3. ([#30826](https://github.com/expo/expo/pull/30826) by [@kudo](https://github.com/kudo))
 - Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
+- [ios] Store strong references to long-lived objects created in procedures ([#31599](https://github.com/expo/expo/pull/31599) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
@@ -13,6 +13,8 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
   private let successBlock: (_ checkForUpdateResult: CheckForUpdateResult) -> Void
   private let errorBlock: (_ error: Exception) -> Void
 
+  private let fileDownloader: FileDownloader
+
   init(
     database: UpdatesDatabase,
     config: UpdatesConfig,
@@ -29,6 +31,8 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
     self.getLaunchedUpdate = getLaunchedUpdate
     self.successBlock = successBlock
     self.errorBlock = errorBlock
+
+    self.fileDownloader = FileDownloader(config: self.config)
   }
 
   func getLoggerTimerLabel() -> String {
@@ -47,7 +51,7 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
         embeddedUpdate: embeddedUpdate
       )
 
-      FileDownloader(config: self.config).downloadRemoteUpdate(
+      self.fileDownloader.downloadRemoteUpdate(
         fromURL: self.config.updateUrl,
         withDatabase: self.database,
         extraHeaders: extraHeaders) { updateResponse in

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -15,6 +15,8 @@ final class FetchUpdateProcedure: StateMachineProcedure {
   private let successBlock: (_ fetchUpdateResult: FetchUpdateResult) -> Void
   private let errorBlock: (_ error: Exception) -> Void
 
+  private let remoteAppLoader: RemoteAppLoader
+
   init(
     database: UpdatesDatabase,
     config: UpdatesConfig,
@@ -35,6 +37,14 @@ final class FetchUpdateProcedure: StateMachineProcedure {
     self.getLaunchedUpdate = getLaunchedUpdate
     self.successBlock = successBlock
     self.errorBlock = errorBlock
+
+    self.remoteAppLoader = RemoteAppLoader(
+      config: self.config,
+      database: self.database,
+      directory: self.updatesDirectory,
+      launchedUpdate: self.getLaunchedUpdate(),
+      completionQueue: controllerQueue
+    )
   }
 
   func getLoggerTimerLabel() -> String {
@@ -43,14 +53,6 @@ final class FetchUpdateProcedure: StateMachineProcedure {
 
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventDownload())
-
-    let remoteAppLoader = RemoteAppLoader(
-      config: self.config,
-      database: self.database,
-      directory: self.updatesDirectory,
-      launchedUpdate: self.getLaunchedUpdate(),
-      completionQueue: controllerQueue
-    )
     remoteAppLoader.loadUpdate(
       fromURL: self.config.updateUrl
     ) { updateResponse in

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -49,6 +49,7 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
   }
 
   private let errorRecovery = ErrorRecovery()
+  private var errorRecoveryRemoteAppLoader: RemoteAppLoader?
   internal func requestStartErrorMonitoring() {
     errorRecovery.startMonitoring()
   }
@@ -250,14 +251,15 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
 
     remoteLoadStatus = .Loading
 
-    let remoteAppLoader = RemoteAppLoader(
+    // swiftlint:disable force_unwrapping
+    errorRecoveryRemoteAppLoader = RemoteAppLoader(
       config: config,
       database: database,
       directory: self.updatesDirectory,
       launchedUpdate: launchedUpdate(),
       completionQueue: controllerQueue
     )
-    remoteAppLoader.loadUpdate(
+    errorRecoveryRemoteAppLoader!.loadUpdate(
       fromURL: config.updateUrl
     ) { updateResponse in
       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
@@ -291,6 +293,7 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
       self.remoteLoadStatus = .Idle
       self.errorRecovery.notify(newRemoteLoadStatus: self.remoteLoadStatus)
     }
+    // swiftlint:enable force_unwrapping
   }
 
   func markFailedLaunchForLaunchedUpdate() {


### PR DESCRIPTION
# Why

We're seeing a bug where a `fetchUpdateAsync` call isn't storing the response metadata. This is because the `RemoteAppLoader` instance reference is weakly held in the `FetchUpdateProcedure` and is deallocated before the success callback is called: https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift#L42

I don't think holding a strong reference to itself in the callback is correct either though since that'd create a retain cycle. Though tbh it's been a while since I dealt with ARC/ref counting/etc on iOS so maybe that's not an issue any more?

# How

This PR fixes the issue detailed above, plus makes the same fix for other potential cases where this could be happening. i.e. make all procedures hold strong references to the classes they use.

# Test Plan

Call `fetchUpdateAsync` in an app, put a breakpoint in the response metadata store method, store see that breakpoint is now hit.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
