### PR TITLE
chore: fix manual SDK workflow trigger

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.base_ref || github.event.before || 'main' }}:${{ github.base_ref || github.event.before || 'main' }} --depth 100
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'pull_request'
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
# Why

https://github.com/expo/expo/actions/runs/10964654352/job/30448736658

<img width="826" alt="image" src="https://github.com/user-attachments/assets/8a60167d-fdb0-48ec-a932-9022954912f2">


# How

- Skip this step when triggering a manual workflow

# Test Plan

- See GHA

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
