### PR TITLE
[ci] Use expo-modules-autolinking to display React Native config

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -46,7 +46,7 @@ jobs:
       - name: ⚙️ Setup react-native nightly
         run: et setup-react-native-nightly
       - name: ⚛️ Display React Native config
-        run: yarn react-native config
+        run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
       - name: 🌳 Display pod environment
         run: pod env
@@ -166,7 +166,7 @@ jobs:
       - name: ⚙️ Setup react-native nightly
         run: et setup-react-native-nightly
       - name: ⚛️ Display React Native config
-        run: yarn react-native config
+        run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
       - name: 🛠️ Generate dynamic macros
         run: expotools android-generate-dynamic-macros --configuration release --bare

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: apps/bare-expo/ios
         continue-on-error: true
       - name: ⚛️ Display React Native config
-        run: yarn react-native config
+        run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
       - name: 🌳 Display pod environment
         run: pod env
@@ -186,7 +186,7 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: ⚛️ Display React Native config
-        run: yarn react-native config
+        run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
       - name: 🛠️ Generate dynamic macros
         run: expotools android-generate-dynamic-macros --configuration release --bare


### PR DESCRIPTION
# Why

In react-native 0.76 the command `yarn react-native config` no longer works without listing `@react-native-community/cli` as a direct dependency. We can use instead our own `expo-modules-autolinking` CLI to the React Native config. More details in https://github.com/facebook/react-native/pull/45464

Related to ENG-13531

# How

Update workflows to use `expo-modules-autolinking` CLI instead of the community CLI to display React Native config

# Test Plan

The `⚛️ Display React Native config` step of CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
