### PR TITLE
[docs] Fix the selection background-color for Safari browser

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -20,7 +20,7 @@ export const globalExtras = css`
   }
 
   ::selection {
-    background-color: ${theme.palette.blue5};
+    background-color: ${theme.palette.blue9};
     color: ${theme.text.default};
   }
 


### PR DESCRIPTION
> [!NOTE]
> This PR address the issue of fixing the contrast of selected text across all docs pages when view in Safari browser.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This PR fixes the text selection contrast issue across all documentation pages when viewed in Safari browser and its confusing the user whether text is selected or not.
Relevant issue link: [issues-31487](https://github.com/expo/expo/issues/31487)

# How

<!--
How did you build this feature or fix this bug and why?
-->
By using another version from the palette color for shade of blue

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Before: Selected text not visible properly whether its selected or not (specially in Safari)
---
Safari:
---
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/f89ec1c7-923d-4d5c-a922-6663959da298">

Chrome:
---
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/3bdf3857-da07-4dbe-931c-c07c8a450db3">


After: Selected text visible properly and tested cross-browser
---
Safari:
---
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/10f12fee-7fa8-48a9-88e9-3d4bfe3e0815">

Chrome:
---
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/456107af-c16a-4e78-a8b1-378d7dd1ecf1">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
