### PR TITLE
[docs] alternate fix for Safari selection color

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -20,8 +20,12 @@ export const globalExtras = css`
   }
 
   ::selection {
-    background-color: ${theme.palette.blue5};
+    background-color: rgb(from ${theme.palette.blue5} r g b / 80%);
     color: ${theme.text.default};
+  }
+
+  ::-moz-selection {
+    background-color: ${theme.palette.blue5};
   }
 
   ::-webkit-scrollbar {


### PR DESCRIPTION
# Why

Refs:
* #31606

Fixes:
* #31487

# How

An alternate fix for he Safari text selection color issue in dark mode.

There is a workaround to force Safari to display the correct shade by adding an alpha channel to the used color.

Unfortunately, Firefox does not like the semi-transparent colors, hence dedicated overwrite.

# Test Plan

The change have been tested locally using Safari, Firefox and Chrome.

# Preview

# Safari

![Screenshot 2024-09-22 at 20 09 01](https://github.com/user-attachments/assets/759c0898-776a-410b-8b22-d74b2f5471bc)

# Firefox

![Screenshot 2024-09-22 at 20 11 33](https://github.com/user-attachments/assets/9f38b047-a365-4ea9-b2f9-a97ef0eebb92)

# Chrome

![Screenshot 2024-09-22 at 20 11 54](https://github.com/user-attachments/assets/3955c823-2415-41b6-811f-e613b8d2ad84)
