### PR TITLE
[docs] Fix instruction for using Ionicons after preloading

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -390,7 +390,7 @@ export default function RootLayout() {
 }
 ```
 
-Now, you can any icon from the `Ionicons` library in a React component:
+Now, you can use any icon from the `Ionicons` library in a React component:
 
 ```tsx
 <Ionicons name="checkmark-circle" size={32} color="green" />


### PR DESCRIPTION
# Why

This PR fixes a typo in the documentation for handling the initial load of vector icons from @expo/vector-icons. The current example is missing the word "use" in the instruction.

When preloading icons with `useFonts`, it's crucial to have clear instructions. The missing "use" could lead to confusion or errors for developers implementing this technique in their apps. By fixing this typo, I aim to ensure that the documentation clearly communicates how to properly utilize preloaded vector icons, saving developers time and reducing potential frustration.

# How

The change was made directly in the `docs/pages/develop/user-interface/fonts.mdx` file. 

The line:

> ```
> Now, you can any icon from the `Ionicons` library in a React component:
> 

Was updated to:

> ```
> Now, you can use any icon from the `Ionicons` library in a React component:
> 


# Test Plan

This change can be verified by:

1. Checking out this branch locally
2. Navigating to `docs/pages/develop/user-interface/fonts.mdx`
3. Confirming the line now reads: "Now, you can use any icon from the `Ionicons` library in a React component:"
4. Optionally, building the documentation site locally to verify correct rendering

No additional automated tests were necessary for this documentation update.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
