### PR TITLE
test(cli): add tests for devserver `/message` websocket

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
@@ -1,0 +1,205 @@
+import { once } from 'node:events';
+import type { WebSocket } from 'ws';
+
+import { waitForExpect, withMetroServer } from './utils';
+import { Log } from '../../../../../log';
+import { createMessagesSocket } from '../createMessageSocket';
+import { serializeMessage } from '../utils/socketMessages';
+
+jest.mock('../../../../../log');
+
+describe(createMessagesSocket, () => {
+  const { metro, server } = withMetroServer();
+
+  it('handles broadcast socket messages', async () => {
+    const client1 = server.connect('/message');
+    const client2 = server.connect('/message');
+
+    // Wait until the sockets are connected
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    // Add listeners to intercept messages
+    const client1Listener = jest.fn();
+    const client2Listener = jest.fn();
+    client1.on('message', client1Listener);
+    client2.on('message', client2Listener);
+
+    // Create and send the broadcast message from client1
+    const message = serializeMessage({ method: 'reload' });
+    client1.send(message);
+
+    // Ensure both clients received the message
+    await waitForExpect(() => {
+      expect(client2Listener).toHaveBeenCalled();
+      expect(client2Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(client2Listener.mock.calls[0][0].toString()).toBe(message);
+
+      expect(client1Listener).toHaveBeenCalled();
+      expect(client1Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(client1Listener.mock.calls[0][0].toString()).toBe(message);
+    });
+  });
+
+  it('exported broadcast method broadcasts messages', async () => {
+    const client1 = server.connect('/message');
+    const client2 = server.connect('/message');
+
+    // Wait until the sockets are connected
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    // Add listeners to intercept the broadcast
+    const client1Listener = jest.fn();
+    const client2Listener = jest.fn();
+    client1.on('message', client1Listener);
+    client2.on('message', client2Listener);
+
+    // Broadcast a message using the exported method
+    metro.messagesSocket.broadcast('reload', { extra: 'data' });
+
+    // Ensure the receivers received the message
+    await waitForExpect(() => {
+      expect(client1Listener).toHaveBeenCalled();
+      expect(client1Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(JSON.parse(client1Listener.mock.calls[0][0].toString())).toMatchObject({
+        method: 'reload',
+        params: { extra: 'data' },
+      });
+
+      expect(client2Listener).toHaveBeenCalled();
+      expect(client2Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(JSON.parse(client2Listener.mock.calls[0][0].toString())).toMatchObject({
+        method: 'reload',
+        params: { extra: 'data' },
+      });
+    });
+  });
+
+  it('warns when broadcasting to no clients', async () => {
+    // Broadcast a message with no connected clients
+    metro.messagesSocket.broadcast('test');
+
+    // Ensure the warning was logged
+    await waitForExpect(() => {
+      expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('No apps connected'));
+    });
+  });
+
+  it('handles `getid` server request', async () => {
+    const client = server.connect('/message');
+    // Wait until the socket is connected
+    await once(client, 'open');
+    // Request the client ID through the test helper
+    const clientId = await requestClientId(client, 'test#1');
+    // Ensure the client ID is received
+    expect(clientId).toContain('#');
+  });
+
+  it('handles `getpeers` server request', async () => {
+    // Connect clients with different query parameters
+    const client1 = server.connect('/message?test=data');
+    const client2 = server.connect('/message?request=sender');
+    const client3 = server.connect('/message?other=test');
+
+    // Wait until the sockets are connected
+    await Promise.all([once(client1, 'open'), once(client2, 'open'), once(client3, 'open')]);
+
+    // Fetch the client ID of client2, to test if this client is not included in the response
+    const client2Id = await requestClientId(client2);
+    expect(client2Id).toBeDefined();
+
+    // Add listener to client2 for the getpeers response
+    const client2Listener = jest.fn();
+    client2.on('message', client2Listener);
+
+    // Create and send the `getpeers` request from client 2
+    client2.send(serializeMessage({ id: 'testid#2', method: 'getpeers', target: 'server' }));
+
+    // Ensure client2 received the response
+    await waitForExpect(() => {
+      expect(client2Listener).toHaveBeenCalled();
+      expect(client2Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+
+      const message = JSON.parse(client2Listener.mock.calls[0][0].toString());
+      expect(message).toHaveProperty('id', 'testid#2');
+      expect(Object.keys(message.result)).toHaveLength(2);
+      expect(message.result).not.toHaveProperty(client2Id);
+      // TODO: assert the query parameters as result values
+    });
+  });
+
+  it('forwards requests and responses to target clients', async () => {
+    const client1 = server.connect('/message');
+    const client2 = server.connect('/message');
+
+    // Wait until the sockets are connected
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    // Fetch the client IDs of both
+    const [client1Id, client2Id] = await Promise.all([
+      requestClientId(client1, 'requestresponse#client1'),
+      requestClientId(client2, 'requestresponse#client2'),
+    ]);
+
+    // Add listeners to intercept messages
+    const client1Listener = jest.fn();
+    const client2Listener = jest.fn();
+    client1.on('message', client1Listener);
+    client2.on('message', client2Listener);
+
+    // Create and send a request from client1 to client2
+    const request = {
+      id: 'testrequest#1',
+      method: 'testrequest',
+      params: { extra: 'data' },
+      target: client2Id,
+    };
+    client1.send(serializeMessage(request));
+
+    // Ensure client2 received the message
+    await waitForExpect(() => {
+      expect(client2Listener).toHaveBeenCalled();
+      expect(client2Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(JSON.parse(client2Listener.mock.calls[0][0].toString())).toMatchObject({
+        method: request.method,
+        params: request.params,
+        id: expect.objectContaining({
+          requestId: request.id,
+          clientId: client1Id,
+        }),
+      });
+    });
+
+    // Create and send a response from client2 to client1
+    const response = {
+      id: { requestId: request.id, clientId: client1Id },
+      result: { received: 'message' },
+    };
+    client2.send(serializeMessage(response));
+
+    // Ensure client1 received the response
+    await waitForExpect(() => {
+      expect(client1Listener).toHaveBeenCalled();
+      expect(client1Listener.mock.calls[0][0]).toBeInstanceOf(Buffer);
+      expect(JSON.parse(client1Listener.mock.calls[0][0].toString())).toMatchObject({
+        id: response.id.requestId,
+        result: response.result,
+      });
+    });
+  });
+});
+
+async function requestClientId(client: WebSocket, testId = 'requestclientid') {
+  // Send the `getid` server request
+  client.send(serializeMessage({ id: testId, method: 'getid', target: 'server' }));
+
+  // Listen for the client ID response
+  const [data] = await once(client, 'message');
+  const message = JSON.parse(data.toString());
+
+  // Only return the client ID if it matches the test ID
+  if (message.id === testId) {
+    return message.result;
+  }
+
+  throw new Error(`Received unexpected message when fetching client id: ${data}`);
+}

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
@@ -1,0 +1,124 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { parse } from 'node:url';
+import { promisify } from 'node:util';
+import { ClientOptions, WebSocket } from 'ws';
+
+import { createMetroDevMiddleware } from '../createMetroDevMiddleware';
+
+export function withMetroServer(projectRoot = '/project'): {
+  projectRoot: string;
+  metro: ReturnType<typeof createMetroDevMiddleware>;
+  server: ReturnType<typeof createServer> & {
+    fetch: (url: string, init?: RequestInit) => Promise<Response>;
+    connect: (url: string) => WebSocket;
+  };
+} {
+  const metro = createMetroDevMiddleware({ projectRoot });
+  const server = createServer(metro.middleware);
+
+  const closeServer = promisify(server.close.bind(server));
+  const closeSockets = () =>
+    Promise.all(
+      Object.values(metro.websocketEndpoints).map(async (socket) => {
+        socket.clients.forEach((client) => client.terminate());
+
+        // Wait until all clients have been disconnected
+        await waitForExpect(() => expect(socket.clients.size).toBe(0));
+      })
+    );
+
+  // Ensure the websockets can be tested
+  server.on('upgrade', (request, socket, head) => {
+    const { pathname } = parse(request.url!);
+    if (pathname != null && metro.websocketEndpoints[pathname]) {
+      metro.websocketEndpoints[pathname].handleUpgrade(request, socket, head, (ws) => {
+        metro.websocketEndpoints[pathname].emit('connection', ws, request);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  function listen() {
+    return new Promise<void>((resolve) => {
+      server.listen(() => {
+        const address = server.address() as AddressInfo;
+        const hostname = address.family === 'IPv6' ? `[${address.address}]` : address.address;
+
+        Object.defineProperty(server, 'fetch', {
+          value: (url = '', init?: RequestInit) =>
+            fetch(`http://${hostname}:${address.port}${url}`, init),
+        });
+
+        Object.defineProperty(server, 'connect', {
+          value: (url = '', options?: ClientOptions) =>
+            new WebSocket(`ws://${hostname}:${address.port}${url}`),
+        });
+
+        resolve();
+      });
+    });
+  }
+
+  beforeAll(() => listen());
+  afterAll(() => closeSockets().finally(() => closeServer()));
+  afterEach(() => closeSockets());
+
+  return { metro, server: server as any, projectRoot };
+}
+
+/**
+ * Retry a given expect statements a couple of times before failing or passing.
+ * This is useful for async tests that may need to wait a short period of time before the assertion is true.
+ *
+ * @see https://github.com/TheBrainFamily/wait-for-expect/blob/6be6e2ed8e47fd5bc62ab2fc4bd39289c58f2f66/src/index.ts
+ */
+export function waitForExpect(
+  expectation: () => void | Promise<void>,
+  timeout = 4000,
+  interval = 50
+) {
+  const setTimeout = runWithRealTimers(() => globalThis.setTimeout);
+  const triesMaxCount = Math.ceil(timeout / interval);
+  let triesCount = 0;
+
+  return new Promise<void>((resolve, reject) => {
+    const retryOnReject = (error: Error) => {
+      if (triesCount > triesMaxCount) {
+        return reject(error);
+      }
+
+      setTimeout(runExpectation, interval);
+    };
+
+    function runExpectation() {
+      triesCount++;
+
+      try {
+        Promise.resolve(expectation()).then(resolve).catch(retryOnReject);
+      } catch (error) {
+        retryOnReject(error);
+      }
+    }
+
+    runExpectation();
+  });
+}
+
+function runWithRealTimers<T>(callback: () => T): T {
+  const usingJestFakeTimers =
+    (globalThis.setTimeout as any)._isMockFunction && typeof jest !== 'undefined';
+
+  if (usingJestFakeTimers) {
+    jest.useRealTimers();
+  }
+
+  const result = callback();
+
+  if (usingJestFakeTimers) {
+    jest.useFakeTimers();
+  }
+
+  return result;
+}

--- a/packages/@expo/cli/src/start/server/metro/dev-server/utils/createSocketBroadcaster.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/utils/createSocketBroadcaster.ts
@@ -1,9 +1,11 @@
+import type { RawData as WebSocketRawData } from 'ws';
+
 import type { SocketId, SocketMap } from './createSocketMap';
 
 const debug = require('debug')('expo:metro:dev-server:broadcaster') as typeof console.log;
 
 export function createBroadcaster(sockets: SocketMap) {
-  return function broadcast(senderSocketId: SocketId | null, message: string) {
+  return function broadcast(senderSocketId: SocketId | null, message: string | WebSocketRawData) {
     // Ignore if there are no connected sockets
     if (!sockets.size) return;
 


### PR DESCRIPTION
# Why

This is a follow-up from #31570, to ensure the core server features will keep working as expected.

# How

- Kept existing endpoint tests for the Metro dev server core
- Added feature tests for `/message` websocket of the Metro dev server core

# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
