### PR TITLE
[expo-file-system] Add `image` sharedRef draft

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.tsx
+++ b/apps/test-suite/tests/FileSystemNext.tsx
@@ -2,11 +2,13 @@
 import * as FS from 'expo-file-system';
 import { File, Directory } from 'expo-file-system/next';
 import { Paths } from 'expo-file-system/src/next';
+import { Image } from 'expo-image';
 import { Platform } from 'react-native';
+import { mountAndWaitFor } from './helpers';
 
 export const name = 'FileSystem@next';
 
-export async function test({ describe, expect, it, ...t }) {
+export async function test({ describe, expect, it, ...t }, { setPortalChild }) {
   const testDirectory = FS.documentDirectory + 'tests/';
   t.beforeEach(async () => {
     try {
@@ -382,6 +384,25 @@ export async function test({ describe, expect, it, ...t }) {
         const file = new File(Paths.document, 'file.txt');
         expect(file.uri).toBe(FS.documentDirectory + 'file.txt');
       });
+    });
+
+    describe('Is compatible with other packages', () => {
+      it('creates a shared ref image', async () => {
+        const url = 'https://picsum.photos/id/237/200/300';
+        const file = new File(testDirectory + 'image.jpeg');
+        const output = await File.downloadFileAsync(url, file);
+        const sharedRef = output.image();
+        console.log(sharedRef);
+        expect(
+          (
+            await mountAndWaitFor(
+              <Image source={sharedRef} style={{ height: 40, width: 40 }} />,
+              'onLoad',
+              setPortalChild
+            )
+          ).source
+        ).toBe(200);
+      }, 10000);
     });
   });
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemFile.kt
@@ -1,8 +1,10 @@
 package expo.modules.filesystem.next
 
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.util.Base64
 import expo.modules.kotlin.apifeatures.EitherType
+import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.typedarray.TypedArray
 import java.io.File
 import java.io.FileOutputStream
@@ -59,6 +61,12 @@ class FileSystemFile(file: File) : FileSystemPath(file) {
   fun text(): String {
     validateType()
     return file.readText()
+  }
+
+  fun image(): SharedRef<Drawable>? {
+    validateType()
+    val drawable = Drawable.createFromPath(file.path) ?: return null
+    return SharedRef(drawable)
   }
 
   fun base64(): String {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -93,6 +93,10 @@ class FileSystemNextModule : Module() {
         file.text()
       }
 
+      Function("image") { file: FileSystemFile ->
+        file.image()
+      }
+
       Function("base64") { file: FileSystemFile ->
         file.base64()
       }

--- a/packages/expo-file-system/src/next/FileSystem.types.ts
+++ b/packages/expo-file-system/src/next/FileSystem.types.ts
@@ -1,3 +1,5 @@
+import { SharedRef } from 'expo-modules-core/types';
+
 /**
  * A string representing a file or directory url.
  */
@@ -89,6 +91,7 @@ export declare class File {
    * @returns The contents of the file as string.
    */
   text(): string;
+  image(): SharedRef<any>;
 
   /**
    * Retrieves content of the file as base64.

--- a/packages/expo-image/src/utils/resolveSources.tsx
+++ b/packages/expo-image/src/utils/resolveSources.tsx
@@ -51,5 +51,10 @@ export function resolveSources(sources?: ImageProps['source']): ImageNativeProps
     // @ts-expect-error
     return sources.__expo_shared_object_id__;
   }
+  // @ts-expect-error
+  if (sources?.__expo_shared_object_id__) {
+    // @ts-expect-error
+    return sources.__expo_shared_object_id__;
+  }
   return [resolveSource(sources)].filter(Boolean) as ImageSource[];
 }


### PR DESCRIPTION
# Why

Would make it possible to do `<Image source={file.image()} />`.
For now blocked on `expo-image` not accepting unwrapped (without a native `ImageRef` class) shared refs as source.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
