### PR TITLE
[expo-updates] Fix E2E

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -22,7 +22,8 @@ function getExpoDependencyChunks({
     ['@expo/config-plugins'],
     ['expo-modules-core'],
     ['@expo/cli', 'expo', 'expo-asset', 'expo-modules-autolinking'],
-    ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants', 'expo-manifests'],
+    ['expo-manifests'],
+    ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants'],
     [
       'babel-preset-expo',
       'expo-application',


### PR DESCRIPTION
# Why

`expo-constants` now directly references `expo-manifest`, so the Updates E2E test setup needs to add `expo-manifest` first when constructing the test project.

# Test Plan

Updates E2E and TV compile tests should pass

