### PR TITLE
[docs] Change docs rendering for getters

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -181,6 +181,7 @@ export type PropData = {
   flags?: TypePropertyDataFlags;
   defaultValue?: string;
   signatures?: MethodSignatureData[];
+  getSignature?: MethodSignatureData;
   overwrites?: TypeDefinitionData;
   implementationOf?: TypeDefinitionData;
   inheritedFrom?: InheritedFromData;

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -48,14 +48,15 @@ const CLASSES_TO_IGNORE_INHERITED_PROPS = [
 ] as const;
 
 const isProp = (child: PropData) =>
-  child.kind === TypeDocKind.Property &&
+  child.kind &&
+  [TypeDocKind.Property, TypeDocKind.Accessor].includes(child.kind) &&
   !child.overwrites &&
   !child.name.startsWith('_') &&
   !child.implementationOf;
 
 const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   child.kind &&
-  [TypeDocKind.Method, TypeDocKind.Function, TypeDocKind.Accessor].includes(child.kind) &&
+  [TypeDocKind.Method, TypeDocKind.Function].includes(child.kind) &&
   (allowOverwrites || !child.overwrites) &&
   !child.name.startsWith('_') &&
   !child?.implementationOf;

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -103,11 +103,12 @@ const renderProps = (
 };
 
 export const renderProp = (
-  { comment, name, type, flags, signatures }: PropData,
+  propData: PropData,
   sdkVersion: string,
   defaultValue?: string,
   { exposeInSidebar, ...options }: RenderPropOptions = {}
 ) => {
+  const { comment, name, type, flags, signatures } = { ...propData, ...propData.getSignature };
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
   const HeaderComponent = getH3CodeWithBaseNestingLevel(baseNestingLevel);
   const extractedSignatures = signatures || type?.declaration?.signatures;


### PR DESCRIPTION
# Why

It changes how getters render in expo-file-system@next.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
