### PR TITLE
[docs] fix DevMenu methods access

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -63,7 +63,8 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import { DevMenu } from 'expo-dev-client';
+import { DevLauncher, DevMenu } from 'expo-dev-client';
 ```
 
 <APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
+<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -63,8 +63,7 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import { DevLauncher, DevMenu } from 'expo-dev-client';
+import { DevMenu } from 'expo-dev-client';
 ```
 
 <APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
-<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -1,7 +1,7 @@
 ---
 title: DevClient
 description: A library that allows creating a development build and includes useful development tools.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-dev-client'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-dev-client'
 packageName: 'expo-dev-client'
 iconUrl: '/static/images/packages/expo-dev-client.png'
 platforms: ['android', 'ios']

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -1,7 +1,7 @@
 ---
 title: DevClient
 description: A library that allows creating a development build and includes useful development tools.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-dev-client'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-dev-client'
 packageName: 'expo-dev-client'
 iconUrl: '/static/images/packages/expo-dev-client.png'
 platforms: ['android', 'ios']
@@ -63,7 +63,8 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import * as DevClient from 'expo-dev-client';
+import { DevLauncher, DevMenu } from 'expo-dev-client';
 ```
 
-<APISection packageName={['expo-dev-menu', 'expo-dev-launcher']} apiName="DevClient" />
+<APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
+<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -63,9 +63,8 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import { DevLauncher, DevMenu } from 'expo-dev-client';
+import { DevMenu } from 'expo-dev-client';
 ```
 
 <APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
-<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />
 

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -63,8 +63,9 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import { DevMenu } from 'expo-dev-client';
+import { DevLauncher, DevMenu } from 'expo-dev-client';
 ```
 
 <APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
+<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />
 

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -63,7 +63,9 @@ You can configure development client launcher using its built-in [config plugin]
 ## API
 
 ```js
-import * as DevClient from 'expo-dev-client';
+import { DevLauncher, DevMenu } from 'expo-dev-client';
 ```
 
-<APISection packageName={['expo-dev-menu', 'expo-dev-launcher']} apiName="DevClient" />
+<APISection packageName={['expo-dev-menu']} apiName="DevMenu" />
+<APISection packageName={['expo-dev-launcher']} apiName="DevLauncher" />
+


### PR DESCRIPTION
# Why

Currently in [documentation of the dev client](https://docs.expo.dev/versions/unversioned/sdk/dev-client/#api), it is said `DevClient.hideMenu` (and other menu methods) are accessible: 

<img width="889" alt="image" src="https://github.com/user-attachments/assets/375c543c-cfb3-45bf-89b4-d63fc90c1ef5">
 
But they are not exposed:
<img width="486" alt="image" src="https://github.com/user-attachments/assets/ce3aec00-e89e-4e7b-b3ff-f7ef9c7d09b4">

We have to use `DevClient.DevMenu.hideMenu()` (same for other methods). 


# How

I modified the doc this way:
<img width="883" alt="image" src="https://github.com/user-attachments/assets/b8b4caf8-0e2b-4f34-a202-4acf596f443f">


- An other option would be to modify `expo-dev-client` to expose directly methods of `DevMenu`, and not modify the doc
- This is what is done for `registerErrorHandlers` and `isDevelopmentBuild`, which are both available from DevClient and DevClient.DevLauncher (is it confusing?)

What do you think is best?


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
