### PR TITLE
[docs] Add common questions section in Existing React Native apps overview and other related changes

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -1,7 +1,7 @@
 ---
-title: Install expo-dev-client in a bare React Native project
+title: Install expo-dev-client in an existing React Native project
 sidebar_title: Install expo-dev-client
-description: Learn how to install and configure expo-dev-client in bare React Native projects.
+description: Learn how to install and configure expo-dev-client in your existing React Native project.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -1,7 +1,7 @@
 ---
-title: Install expo-updates in a bare React Native project
+title: Install expo-updates in an existing React Native project
 sidebar_title: Install expo-updates
-description: Learn how to install and configure expo-updates in bare React Native projects.
+description: Learn how to install and configure expo-updates in your existing React Native project.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -180,7 +180,7 @@ Expo solves these problems by providing a set of primitives and helping you (the
 
 <Collapsible summary="Do I have to get rid of my native projects to use Expo?">
 
-By default, Expo projects created with `create-expo-app` use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) and do not contain android and ios native directories. If you incrementally adopt Expo in your existing React Native app, you don't have to remove these directories. You can continue with `npx expo run:[android|ios]` as alternates to commands offered by `@react-native-community/cli` to compile your app locally and keep the configuration of your native projects.
+By default, Expo projects created with `create-expo-app` use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) and do not contain android and ios native directories. If you incrementally adopt Expo in your existing React Native app, you don't have to remove these directories. You can use `npx expo run:[android|ios]` as an alternative to commands offered by `@react-native-community/cli` to compile your app locally and keep the configuration of your native projects.
 
 </Collapsible>
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -152,7 +152,7 @@ Adopting Expo doesn't have to be done in one step. You can start with the _quick
 
 <Collapsible summary="What will I gain from using Expo in my React Native app?">
 
-Adopting Expo tools in your existing React Native app will help you maintain long-term maintenance support, easier native upgrades, and a better developer experience.
+Adopting Expo tools in your existing React Native app can help you develop faster with the [Expo SDK](/versions/latest/), streamline native code maintenance and upgrades with [CNG](/workflow/continuous-native-generation/), deploy faster with [EAS Update](/eas-update/introduction/), and more.
 
 </Collapsible>
 
@@ -164,9 +164,7 @@ Expo is used by top companies worldwide that serve millions of end users. For mo
 
 <Collapsible summary="What impact will adopting Expo have on my app's size?">
 
-The `expo` package has a small footprint since it only includes a minimal set of modules required in every app with autolinking infrastructure and other Expo SDK libraries that are built-in.
-
-Including `expo` package in your app adds 1 MB to the final size of apps on app stores. This package has a marginal cost. For example, on Android, it only adds 150 Kib and the rest of the size comes from the language runtime (Kotlin).
+The `expo` package has a small footprint since it only includes a minimal set of modules required in every app with autolinking infrastructure and other Expo SDK libraries that are built-in. For more information on how to determine the actual size of your app, see [Understanding app size](/distribution/app-size/).
 
 </Collapsible>
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -28,7 +28,9 @@ There's so much more to explore, and the links below will help you to explore th
 
 ## Incremental adoption steps
 
-There are four steps of incremental adoption to help you get started.
+Below are four suggested phases of incremental adoption. These phases generally progress from quick changes to improve developer experience, to more significant workflow and codebase optimizations.
+
+Only the first phase &mdhash; prerequisites &mdhash; is required by other phases. After following its instructions, you can skip to the tools and services that are most relevant to your goals in adopting Expo.
 
 ### Prerequisites
 
@@ -39,8 +41,8 @@ These first steps are required to later adopt Expo tools and services:
   Icon={Rocket02Icon}
   description={
     <>
-      To unlock Expo capabilities, you need to install the <CODE>expo</CODE> package in your project in
-      your existing React Native project. This guide provides both automated and manual installation
+      To unlock Expo capabilities, you need to install the <CODE>expo</CODE> package in your
+      existing React Native project. This guide provides both automated and manual installation
       steps.
     </>
   }
@@ -52,9 +54,10 @@ These first steps are required to later adopt Expo tools and services:
   Icon={BookOpen02Icon}
   description={
     <>
-      Migration to Expo CLI provides many benefits over <CODE>@react-native-community/cli</CODE>.
-      This guide explains these benefits and provides compilation commands to start your development
-      server after installing <CODE>expo</CODE> package.
+      Migration to Expo CLI is a drop-in replacement for <CODE>@react-native-community/cli</CODE>.
+      It provides full compatibility with all Expo tools and services. This guide explains the
+      benefits and provides compilation commands to start your development server after installing
+      <CODE>expo</CODE> package.
     </>
   }
   href="/bare/using-expo-cli/"
@@ -197,7 +200,7 @@ Although we recommend using EAS for a smooth collaboration with your teammates a
 
 <Collapsible summary="Can I install third-party native libraries in my code?">
 
-Yes, you can install and use third-party libraries that require native projects (**android** and **ios**) configuration with [development builds](/workflow/overview/#development-builds). See [Using Third-Party libraries](/workflow/using-libraries/#third-party-libraries) for more information.
+Yes, you can install and use third-party libraries that require native projects (**android** and **ios**) configuration or provides a [config plugin](/config-plugins/introduction/) with [development builds](/workflow/overview/#development-builds). See [Using Third-Party libraries](/workflow/using-libraries/#third-party-libraries) for more information.
 
 </Collapsible>
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -32,14 +32,14 @@ There are four steps of incremental adoption to help you get started.
 
 ### Prerequisites
 
-Required to use Expo tools:
+These first steps are required to later adopt Expo tools and services:
 
 <BoxLink
   title="Install Expo modules"
   Icon={Rocket02Icon}
   description={
     <>
-      To unlock Expo capabilities, you need to install <CODE>expo</CODE> package in your project in
+      To unlock Expo capabilities, you need to install the <CODE>expo</CODE> package in your project in
       your existing React Native project. This guide provides both automated and manual installation
       steps.
     </>
@@ -121,7 +121,7 @@ Once your app has `expo` package installed, you can submit your app to app store
   href="/bare/installing-updates/"
 />
 
-### New mindset
+### New mindsets
 
 The following helps with your project's long term maintainability, native code maintenance, and easier upgrades:
 
@@ -143,11 +143,11 @@ The following helps with your project's long term maintainability, native code m
 
 <Collapsible summary="How long will it take to adopt Expo in my existing React Native project?">
 
-Adopting Expo doesn't have to be done in one step. You can start with _quick wins_ and then move to tackle more complex parts. You can also pick and choose which features you want to adopt at the beginning of this process.
+Adopting Expo doesn't have to be done in one step. You can start with the _quick wins_ and then move on to more complex parts. You can also pick and choose which features you want to adopt based on what is most helpful for your project.
 
 </Collapsible>
 
-<Collapsible summary="What will I gain from using Expo in my React Native App?">
+<Collapsible summary="What will I gain from using Expo in my React Native app?">
 
 Adopting Expo tools in your existing React Native app will help you maintain long-term maintenance support, easier native upgrades, and a better developer experience.
 
@@ -183,7 +183,7 @@ By default, Expo projects created with `create-expo-app` use [Continuous Native 
 
 <Collapsible summary="I use CodePush. Can I continue using it with Expo?">
 
-CodePush will retire in March 2025 and is incompatible with React Native's New Architecture. Instead, we recommend using the `expo-updates` library to manage remote updates to your app's code.
+CodePush will be retired in March 2025 and is incompatible with React Native's New Architecture, so, in the long run, we recommend switching to EAS Update to manage remote updates to your app's code. However, you can start using Expo tools in your CodePush enabled app today, including the Expo SDK, Expo CLI, EAS Build, and more.
 
 </Collapsible>
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: Learn how to use Expo tools and services with existing React Native apps.
 ---
 
-import { DocsLogo } from '@expo/styleguide';
+import { DocsLogo, RouterLogo } from '@expo/styleguide';
 import { BuildArtifactIcon } from '@expo/styleguide-icons/custom/BuildArtifactIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { ChevronUpDoubleIcon } from '@expo/styleguide-icons/outline/ChevronUpDoubleIcon';
@@ -32,7 +32,7 @@ There are four steps of incremental adoption to help you get started.
 
 ### Prerequisites
 
-Required to use Expo tools and services:
+Required to use Expo tools:
 
 <BoxLink
   title="Install Expo modules"
@@ -52,7 +52,7 @@ Required to use Expo tools and services:
   Icon={BookOpen02Icon}
   description={
     <>
-      Migrating to Expo CLI provides many benefits over <CODE>@react-native-community/cli</CODE>.
+      Migration to Expo CLI provides many benefits over <CODE>@react-native-community/cli</CODE>.
       This guide explains these benefits and provides compilation commands to start your development
       server after installing <CODE>expo</CODE> package.
     </>
@@ -114,7 +114,8 @@ Once your app has `expo` package installed, you can submit your app to app store
   Icon={BuildArtifactIcon}
   description={
     <>
-      Learn how to install and configure <CODE>expo-updates</CODE> to manage remote updates.
+      Learn how to install and configure <CODE>expo-updates</CODE> to manage remote updates and
+      enable PR previews.
     </>
   }
   href="/bare/installing-updates/"
@@ -128,7 +129,14 @@ The following helps with your project's long term maintainability, native code m
   title="Adopt Prebuild"
   Icon={RefreshCw02Icon}
   description="Learn how to simplify maintaining your native projects by generating them on demand from configuration."
-  href="/guides/adopting-prebuild"
+  href="/guides/adopting-prebuild/"
+/>
+
+<BoxLink
+  title="Expo Router"
+  Icon={RouterLogo}
+  description="Expo Router is a file-based routing library that offers advantages such as organized navigation hierarchy, automatic deep linking support, and more."
+  href="/router/introduction/"
 />
 
 ## Common questions

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Overview of using Expo with existing React Native apps
 sidebar_title: Overview
-hideTOC: true
 description: Learn how to use Expo tools and services with existing React Native apps.
 ---
 
@@ -14,6 +13,7 @@ import { RefreshCw02Icon } from '@expo/styleguide-icons/outline/RefreshCw02Icon'
 import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
 import { CODE } from '~/ui/components/Text';
 
 If you have a React Native app that doesn't use any Expo tools, you might be wondering what Expo can provide for you, why you might want to use Expo tools and services, and how to get started.
@@ -28,7 +28,7 @@ There's so much more to explore, and the links below will help you to explore th
 
 ## Incremental adoption steps
 
-There are four steps of incremental adoption to help you get started with:
+There are four steps of incremental adoption to help you get started.
 
 ### Prerequisites
 
@@ -130,3 +130,71 @@ The following helps with your project's long term maintainability, native code m
   description="Learn how to simplify maintaining your native projects by generating them on demand from configuration."
   href="/guides/adopting-prebuild"
 />
+
+## Common questions
+
+<Collapsible summary="How long will it take to adopt Expo in my existing React Native project?">
+
+Adopting Expo doesn't have to be done in one step. You can start with _quick wins_ and then move to tackle more complex parts. You can also pick and choose which features you want to adopt at the beginning of this process.
+
+</Collapsible>
+
+<Collapsible summary="What will I gain from using Expo in my React Native App?">
+
+Adopting Expo tools in your existing React Native app will help you maintain long-term maintenance support, easier native upgrades, and a better developer experience.
+
+</Collapsible>
+
+<Collapsible summary="Who uses Expo?">
+
+Expo is used by top companies worldwide that serve millions of end users. For more information, see our [Expo showcase](https://expo.dev/customers).
+
+</Collapsible>
+
+<Collapsible summary="What impact will adopting Expo have on my app's size?">
+
+The `expo` package has a small footprint since it only includes a minimal set of modules required in every app with autolinking infrastructure and other Expo SDK libraries that are built-in.
+
+Including `expo` package in your app adds 1 MB to the final size of apps on app stores. This package has a marginal cost. For example, on Android, it only adds 150 Kib and the rest of the size comes from the language runtime (Kotlin).
+
+</Collapsible>
+
+<Collapsible summary="Why did React Native recommend using Expo?">
+
+Most React Native developers solve common problems when building an app, such as implementing navigation, accessing Native APIs, upgrading to new versions, and more. This requires using a specific set of tools and libraries to build and maintain your app &mdash; which means you are creating your own framework.
+
+Expo solves these problems by providing a set of primitives and helping you (the developer) to focus on building your app. It also offers tools to iterate faster in development. For more information, see [Why React Native recommends using a framework](https://reactnative.dev/blog/2024/06/25/use-a-framework-to-build-react-native-apps).
+
+</Collapsible>
+
+<Collapsible summary="Do I have to get rid of my native projects to use Expo?">
+
+By default, Expo projects created with `create-expo-app` use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) and do not contain android and ios native directories. If you incrementally adopt Expo in your existing React Native app, you don't have to remove these directories. You can continue with `npx expo run:[android|ios]` as alternates to commands offered by `@react-native-community/cli` to compile your app locally and keep the configuration of your native projects.
+
+</Collapsible>
+
+<Collapsible summary="I use CodePush. Can I continue using it with Expo?">
+
+CodePush will retire in March 2025 and is incompatible with React Native's New Architecture. Instead, we recommend using the `expo-updates` library to manage remote updates to your app's code.
+
+</Collapsible>
+
+<Collapsible summary="Do I have to build with EAS?">
+
+[Expo Application Services (EAS)](/eas/) are deeply integrated cloud services for Expo and React Native apps that provide tools to build, test, and deploy your app.
+
+Although we recommend using EAS for a smooth collaboration with your teammates and fast distribution, you can compile your app locally, on your CI, or any other way you prefer.
+
+</Collapsible>
+
+<Collapsible summary="Can I install third-party native libraries in my code?">
+
+Yes, you can install and use third-party libraries that require native projects (**android** and **ios**) configuration with [development builds](/workflow/overview/#development-builds). See [Using Third-Party libraries](/workflow/using-libraries/#third-party-libraries) for more information.
+
+</Collapsible>
+
+<Collapsible summary="I use React Navigation. Do I have to use Expo Router?">
+
+You can continue using any navigation library in your project. However, we recommend using Expo Router for all the benefits [described here](/router/introduction).
+
+</Collapsible>

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -66,14 +66,13 @@ The following helps improving development experience and requires configuration:
 
 <BoxLink
   title="Use Expo SDK"
+  description="Use one of the many libraries provided by the Expo SDK, an extensive set of libraries that provide access to native APIs."
   Icon={DocsLogo}
-  description="Use one of the many libraries provided by the Expo SDK &mdash; an extensive set of libraries that provide access to native APIs."
   href="/versions/"
 />
 
 <BoxLink
   title="Install expo-dev-client"
-  Icon={BookOpen02Icon}
   description={
     <>
       <CODE>expo-dev-client</CODE> provides access to Expo Go-style app launcher interface into your
@@ -81,6 +80,7 @@ The following helps improving development experience and requires configuration:
       project.
     </>
   }
+  Icon={BookOpen02Icon}
   href="/bare/install-dev-builds-in-bare/"
 />
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -5,6 +5,7 @@ hideTOC: true
 description: Learn how to use Expo tools and services with existing React Native apps.
 ---
 
+import { DocsLogo } from '@expo/styleguide';
 import { BuildArtifactIcon } from '@expo/styleguide-icons/custom/BuildArtifactIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { ChevronUpDoubleIcon } from '@expo/styleguide-icons/outline/ChevronUpDoubleIcon';
@@ -25,52 +26,107 @@ If you've ever written a native module for React Native, you'll be surprised how
 
 There's so much more to explore, and the links below will help you to explore the options available to you.
 
-## Next Steps
+## Incremental adoption steps
+
+There are four steps of incremental adoption to help you get started with:
+
+### Prerequisites
+
+Required to use Expo tools and services:
 
 <BoxLink
   title="Install Expo modules"
   Icon={Rocket02Icon}
   description={
     <>
-      If you have already initialized a React Native app without <CODE>create-expo-app</CODE>, learn
-      how to install the Expo module library.
+      To unlock Expo capabilities, you need to install <CODE>expo</CODE> package in your project in
+      your existing React Native project. This guide provides both automated and manual installation
+      steps.
     </>
   }
   href="/bare/installing-expo-modules"
 />
+
+<BoxLink
+  title="Use Expo CLI"
+  Icon={BookOpen02Icon}
+  description={
+    <>
+      Migrating to Expo CLI provides many benefits over <CODE>@react-native-community/cli</CODE>.
+      This guide explains these benefits and provides compilation commands to start your development
+      server after installing <CODE>expo</CODE> package.
+    </>
+  }
+  href="/bare/using-expo-cli/"
+/>
+
+### Quick wins
+
+The following helps improving development experience and requires configuration:
+
 <BoxLink
   title="Use Expo SDK"
-  Icon={BookOpen02Icon}
-  description="Use one of the many libraries provided by the Expo SDK, an extensive set of libraries that provide access to native APIs."
+  Icon={DocsLogo}
+  description="Use one of the many libraries provided by the Expo SDK &mdash; an extensive set of libraries that provide access to native APIs."
   href="/versions/"
 />
+
+<BoxLink
+  title="Install expo-dev-client"
+  Icon={BookOpen02Icon}
+  description={
+    <>
+      <CODE>expo-dev-client</CODE> provides access to Expo Go-style app launcher interface into your
+      debug app variants. Learn how to install and configure it in your existing React Native
+      project.
+    </>
+  }
+  href="/bare/install-dev-builds-in-bare/"
+/>
+
 <BoxLink
   title="Write native modules"
   description="Use the Expo Modules API to write native modules using Swift and Kotlin."
   Icon={Lightbulb01Icon}
   href="/modules/overview/"
 />
-<BoxLink
-  title="Use Expo CLI"
-  Icon={BookOpen02Icon}
-  description="Learn about the many benefits Expo CLI provides over @react-native-community/cli."
-  href="/bare/using-expo-cli/"
-/>
+
 <BoxLink
   title="Native project upgrade helper"
   Icon={ChevronUpDoubleIcon}
   description="View file-by-file diffs of all the changes you need to make to your native projects to upgrade them to the next Expo SDK and React Native version."
   href="/bare/upgrade/"
 />
+
+### New workflows
+
+Once your app has `expo` package installed, you can submit your app to app stores with a single command or update configure `expo-updates` library to manage remote updates to you app's code:
+
+<BoxLink
+  title="App distribution"
+  Icon={BuildArtifactIcon}
+  description="Build and submit your app to app stores with a single command."
+  href="/distribution/introduction"
+/>
+
+<BoxLink
+  title="Install expo-updates"
+  Icon={BuildArtifactIcon}
+  description={
+    <>
+      Learn how to install and configure <CODE>expo-updates</CODE> to manage remote updates.
+    </>
+  }
+  href="/bare/installing-updates/"
+/>
+
+### New mindset
+
+The following helps with your project's long term maintainability, native code maintenance, and easier upgrades:
+
 <BoxLink
   title="Adopt Prebuild"
   Icon={RefreshCw02Icon}
   description="Learn how to simplify maintaining your native projects by generating them on demand from configuration."
   href="/guides/adopting-prebuild"
-/>
-<BoxLink
-  title="App distribution"
-  Icon={BuildArtifactIcon}
-  description="Build and submit your app to the app store with a single command."
-  href="/distribution/introduction"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add a common questions section in using Expo with existing React Native apps overview page.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Adds a "Common questions" section in Overview page
- Updates "Next steps" to "Incremental adoption steps" which relates to how @keith-kurak is approaching this in his blog post
  - This section also adds new sub-sections based on the terminology from the blog post
- Updates outdated page titles and descriptions to use "existing React Native apps" instead of "bare React Native apps"


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: /bare/overview/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).