### PR TITLE
[documentation][modules] In the expo-modules documentation, change the name of the example methods

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -79,13 +79,13 @@ See the [Argument types](#argument-types) section for more details on what types
 <CodeBlocksTable>
 
 ```swift
-Function("syncFunction") { (message: String) in
+Function("mySyncFunction") { (message: String) in
   return message
 }
 ```
 
 ```kotlin
-Function("syncFunction") { message: String ->
+Function("mySyncFunction") { message: String ->
   return@Function message
 }
 ```
@@ -99,7 +99,7 @@ import { requireNativeModule } from 'expo-modules-core';
 const MyModule = requireNativeModule('MyModule');
 
 function getMessage() {
-  return MyModule.syncFunction('bar');
+  return MyModule.mySyncFunction('bar');
 }
 ```
 
@@ -127,27 +127,27 @@ It is recommended to use `AsyncFunction` over `Function` when it:
 <CodeBlocksTable>
 
 ```swift
-AsyncFunction("asyncFunction") { (message: String) in
+AsyncFunction("myAsyncFunction") { (message: String) in
   return message
 }
 
 // or
 
-AsyncFunction("asyncFunction") { (message: String, promise: Promise) in
+AsyncFunction("myAsyncFunction") { (message: String, promise: Promise) in
   promise.resolve(message)
 }
 
 ```
 
 ```kotlin
-AsyncFunction("asyncFunction") { message: String ->
+AsyncFunction("myAsyncFunction") { message: String ->
   return@AsyncFunction message
 }
 
 // or
 
 // Make sure to import `Promise` class from `expo.modules.kotlin` instead of `expo.modules.core`.
-AsyncFunction("asyncFunction") { message: String, promise: Promise ->
+AsyncFunction("myAsyncFunction") { message: String, promise: Promise ->
   promise.resolve(message)
 }
 
@@ -162,7 +162,7 @@ import { requireNativeModule } from 'expo-modules-core';
 const MyModule = requireNativeModule('MyModule');
 
 async function getMessageAsync() {
-  return await MyModule.asyncFunction('bar');
+  return await MyModule.myAsyncFunction('bar');
 }
 ```
 
@@ -171,13 +171,13 @@ It is possible to change the native queue of `AsyncFunction` by calling the `.ru
 <CodeBlocksTable>
 
 ```swift
-AsyncFunction("asyncFunction") { (message: String) in
+AsyncFunction("myAsyncFunction") { (message: String) in
   return message
 }.runOnQueue(.main)
 ```
 
 ```kotlin
-AsyncFunction("asyncFunction") { message: String ->
+AsyncFunction("myAsyncFunction") { message: String ->
   return@AsyncFunction message
 }.runOnQueue(Queues.MAIN)
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When reading the documentation, it was quite unclear for me that asyncFunction and syncFunction were not keywords. I think naming them myAsyncFunction and mySyncFunction would make the comprehension easier.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
