### PR TITLE
Update stripe.mdx - Explain how to localize PaymentSheet on iOS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -78,7 +78,7 @@ urlScheme:
 
 On Android, the translation of `PaymentSheet` is automatically detected based on a device's language settings.
 
-On iOS, you must enable  `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
+On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
 
 ```app.json
 {

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -80,7 +80,7 @@ On Android, the translation of `PaymentSheet` is automatically detected based on
 
 On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
 
-```app.json
+```json app.json
 {
   "expo": {
     "ios": {

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -76,18 +76,20 @@ urlScheme:
 
 #### PaymentSheet localization on iOS
 
-Translation of PaymentSheet is automatically detected based on device's langage, at least on Android. For this to work on iOS, you must add `CFBundleAllowMixedLocalizations` and `CFBundleLocalizations` declarations in `app.json` (or `app.config.js`, `app.config.ts`). 
+On Android, the translation of `PaymentSheet` is automatically detected based on a device's language settings.
 
-```
+On iOS, you must enable  `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
+
+```app.json
 {
   "expo": {
     "ios": {
       "infoPlist": {
-          "CFBundleAllowMixedLocalizations": true,
-          "CFBundleLocalizations": ['fr']
-          ...
+        "CFBundleAllowMixedLocalizations": true,
+        "CFBundleLocalizations": ["fr"]
+        /* @hide ... */ /* @end */
       }
-      ...
+      /* @hide ... */ /* @end */
     }
   }
 }

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -74,6 +74,25 @@ urlScheme:
 
 [`Linking.createURL()`](/versions/latest/sdk/linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
 
+#### PaymentSheet localization on iOS
+
+Translation of PaymentSheet is automatically detected based on device's langage, at least on Android. For this to work on iOS, you must add `CFBundleAllowMixedLocalizations` and `CFBundleLocalizations` declarations in `app.json` (or `app.config.js`, `app.config.ts`). 
+
+```
+{
+  "expo": {
+    "ios": {
+      "infoPlist": {
+          "CFBundleAllowMixedLocalizations": true,
+          "CFBundleLocalizations": ['fr']
+          ...
+      }
+      ...
+    }
+  }
+}
+```
+
 ## Limitations
 
 ### Google Pay


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

On iOS (not an Android), the PaymentSheet was not localized, as discussed here: https://github.com/stripe/stripe-react-native/issues/243

# How

<!--
How did you build this feature or fix this bug and why?
-->

After reviewing this thread, and successfully tested the solution, i realized this issue should be documented here.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Create an expo app
- Add Stripe RN SDK
- Build development version (Expo GO not supported)
- Set device langage to French (or other than english)
- Open PaymentSheet on Android, notice that it's translated into French
- Open PaymentSheet on iOS, notice that it's not translated into French
- Integrate updates in app.json 
- Re-build development version
- Open PaymentSheet on iOS, **notice that it's now translated into French**
 
![Screenshot 2024-09-24 at 18 22 56](https://github.com/user-attachments/assets/29a0a74f-7ebc-4647-be98-2c9651717e0b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
