### PR TITLE
feat(cli): disable cache reset in CI

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- disable export:embed cache reset when running in CI.
 - add support for css imports from other css files ([#31574](https://github.com/expo/expo/pull/31574) by [@EvanBacon](https://github.com/EvanBacon))
 - server routing and static exports ([#31500](https://github.com/expo/expo/pull/31500) by [@EvanBacon](https://github.com/EvanBacon))
 - Return error UI when an API route throws an error ([#31485](https://github.com/expo/expo/pull/31485) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- disable export:embed cache reset when running in CI.
+- disable export:embed cache reset when running in CI. ([#31663](https://github.com/expo/expo/pull/31663) by [@EvanBacon](https://github.com/EvanBacon))
 - add support for css imports from other css files ([#31574](https://github.com/expo/expo/pull/31574) by [@EvanBacon](https://github.com/EvanBacon))
 - server routing and static exports ([#31500](https://github.com/expo/expo/pull/31500) by [@EvanBacon](https://github.com/EvanBacon))
 - Return error UI when an API route throws an error ([#31485](https://github.com/expo/expo/pull/31485) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -64,6 +64,13 @@ function guessCopiedAppleBundlePath(bundleOutput: string) {
 }
 
 export async function exportEmbedAsync(projectRoot: string, options: Options) {
+  // The React Native build scripts always enable the cache reset but we shouldn't need this in CI environments.
+  // By disabling it, we can eagerly bundle code before the build and reuse the cached artifacts in subsequent builds.
+  if (env.CI && options.resetCache) {
+    debug('CI environment detected, disabling reset cache');
+    options.resetCache = false;
+  }
+
   setNodeEnv(options.dev ? 'development' : 'production');
   require('@expo/env').load(projectRoot);
 

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -67,7 +67,7 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
   // The React Native build scripts always enable the cache reset but we shouldn't need this in CI environments.
   // By disabling it, we can eagerly bundle code before the build and reuse the cached artifacts in subsequent builds.
   if (env.CI && options.resetCache) {
-    debug('CI environment detected, disabling reset cache');
+    debug('CI environment detected, disabling automatic cache reset');
     options.resetCache = false;
   }
 


### PR DESCRIPTION
# Why

The React Native build scripts always enable the cache reset but we shouldn't need this in CI environments. By disabling it, we can eagerly bundle code before the build and reuse the cached artifacts in subsequent builds.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

When CI=1, preserve the export:embed cache. This is primarily designed for local builds where a cache can be preserved between builds and may not update (e.g. when changing the babel config).

