### PR TITLE
[sqlite] fix prebuild error from undefined props

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30483](https://github.com/expo/expo/pull/30483) by [@byCedric](https://github.com/byCedric))
 - Fixed build errors on iOS if other third-party libraries building with iOS system SQLite. ([#30824](https://github.com/expo/expo/pull/30824) by [@kudo](https://github.com/kudo))
 - Fixed build error when using `incremental_installation` mode in CocoaPods. ([#30918](https://github.com/expo/expo/pull/30918) by [@kudo](https://github.com/kudo))
+- Fixed prebuild error when `app.json` doesn't specify any plugin properties for `expo-sqlite`. ([#31672](https://github.com/expo/expo/pull/31672) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/plugin/build/withSQLite.js
+++ b/packages/expo-sqlite/plugin/build/withSQLite.js
@@ -9,9 +9,9 @@ const withSQLite = (config, props) => {
 };
 const withSQLiteAndroidProps = (config, props) => {
     return (0, config_plugins_1.withGradleProperties)(config, (config) => {
-        const customBuildFlags = props.android?.customBuildFlags ?? props.customBuildFlags;
-        const enableFTS = props.android?.enableFTS ?? props.enableFTS;
-        const useSQLCipher = props.android?.useSQLCipher ?? props.useSQLCipher;
+        const customBuildFlags = props?.android?.customBuildFlags ?? props?.customBuildFlags;
+        const enableFTS = props?.android?.enableFTS ?? props?.enableFTS;
+        const useSQLCipher = props?.android?.useSQLCipher ?? props?.useSQLCipher;
         config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.customBuildFlags', customBuildFlags);
         config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.enableFTS', enableFTS);
         config.modResults = updateAndroidBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.useSQLCipher', useSQLCipher);
@@ -20,9 +20,9 @@ const withSQLiteAndroidProps = (config, props) => {
 };
 const withSQLiteIOSProps = (config, props) => {
     return (0, config_plugins_1.withPodfileProperties)(config, (config) => {
-        const customBuildFlags = props.ios?.customBuildFlags ?? props.customBuildFlags;
-        const enableFTS = props.ios?.enableFTS ?? props.enableFTS;
-        const useSQLCipher = props.ios?.useSQLCipher ?? props.useSQLCipher;
+        const customBuildFlags = props?.ios?.customBuildFlags ?? props?.customBuildFlags;
+        const enableFTS = props?.ios?.enableFTS ?? props?.enableFTS;
+        const useSQLCipher = props?.ios?.useSQLCipher ?? props?.useSQLCipher;
         config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.customBuildFlags', customBuildFlags);
         config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.enableFTS', enableFTS);
         config.modResults = updateIOSBuildPropertyIfNeeded(config.modResults, 'expo.sqlite.useSQLCipher', useSQLCipher);

--- a/packages/expo-sqlite/plugin/src/withSQLite.ts
+++ b/packages/expo-sqlite/plugin/src/withSQLite.ts
@@ -32,9 +32,9 @@ const withSQLite: ConfigPlugin<Props> = (config, props) => {
 
 const withSQLiteAndroidProps: ConfigPlugin<Props> = (config, props) => {
   return withGradleProperties(config, (config) => {
-    const customBuildFlags = props.android?.customBuildFlags ?? props.customBuildFlags;
-    const enableFTS = props.android?.enableFTS ?? props.enableFTS;
-    const useSQLCipher = props.android?.useSQLCipher ?? props.useSQLCipher;
+    const customBuildFlags = props?.android?.customBuildFlags ?? props?.customBuildFlags;
+    const enableFTS = props?.android?.enableFTS ?? props?.enableFTS;
+    const useSQLCipher = props?.android?.useSQLCipher ?? props?.useSQLCipher;
 
     config.modResults = updateAndroidBuildPropertyIfNeeded(
       config.modResults,
@@ -57,9 +57,9 @@ const withSQLiteAndroidProps: ConfigPlugin<Props> = (config, props) => {
 
 const withSQLiteIOSProps: ConfigPlugin<Props> = (config, props) => {
   return withPodfileProperties(config, (config) => {
-    const customBuildFlags = props.ios?.customBuildFlags ?? props.customBuildFlags;
-    const enableFTS = props.ios?.enableFTS ?? props.enableFTS;
-    const useSQLCipher = props.ios?.useSQLCipher ?? props.useSQLCipher;
+    const customBuildFlags = props?.ios?.customBuildFlags ?? props?.customBuildFlags;
+    const enableFTS = props?.ios?.enableFTS ?? props?.enableFTS;
+    const useSQLCipher = props?.ios?.useSQLCipher ?? props?.useSQLCipher;
 
     config.modResults = updateIOSBuildPropertyIfNeeded(
       config.modResults,


### PR DESCRIPTION
# Why

@betomoedano caught a nice issue when running prebuild without any expo-sqlite plugin configurations
```
✖ Prebuild failed
TypeError: [ios.podfileProperties]: withIosPodfilePropertiesBaseMod: Cannot read properties of undefined (reading 'ios')
    at /Users/kudo/sdkcanary2/node_modules/expo-sqlite/plugin/build/withSQLite.js:25:40
    at action (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/withMod.js:199:29)
    at interceptingMod (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/withMod.js:104:27)
    at action (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/withMod.js:204:14)
    at async interceptingMod (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/withMod.js:104:21)
    at async action (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/createBaseMod.js:60:21)
    at async interceptingMod (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/withMod.js:104:21)
    at async evalModsAsync (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/mod-compiler.js:206:25)
    at async compileModsAsync (/Users/kudo/sdkcanary2/node_modules/@expo/config-plugins/build/plugins/mod-compiler.js:123:10)
    at async configureProjectAsync (/Users/kudo/sdkcanary2/node_modules/@expo/cli/build/src/prebuild/configureProjectAsync.js:88:14)
```

# How

we should consider if the `props=undefined` in the expo-sqlite plugin. namely:
```json
{
  "expo": {
    "plugins": [
      "expo-sqlite"
    ]
  }
}
```

# Test Plan

```sh
$ bunx create-expo-app -t blank@canary sdkcanary
$ npx expo install expo-sqlite
$ npx expo prebuild -p ios --clean
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
