### PR TITLE
Adds more context to build and update docs on home page

### DIFF
--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -10,14 +10,56 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-To submit your app to the app stores, you'll need to create a production build. This build is optimized for performance and size, and it includes all the necessary assets and configurations for the app stores.
+To submit your app to the app stores, you'll need to create a production build of your Expo or React Native project. A production build is optimized for performance and size, and it includes all the necessary assets and configurations for the app stores.
+
+## Quick start
+
+To get started quickly, run the following [EAS CLI](#) command:
+
+<Terminal cmd={['$ eas build --profile production']} />
+
+This will create a production build of your project that is ready for the app stores. If you prefer to build locally with Android Studio and Xcode, see [our guide](#).
+
+## Guides
+
+You can do a lot more with EAS Build. See the following guides to learn more:
+
+<BoxLink
+  title="Configure eas.json"
+  description="Control how EAS builds your project."
+  Icon={BookOpen02Icon}
+  href="/guides/eas-build"
+/>
+
+<BoxLink
+  title="Automate app store submissions"
+  description="Automate the submission of your builds to the app stores."
+  Icon={BookOpen02Icon}
+  href="/guides/eas-build"
+/>
+
+<BoxLink
+  title="Build automatically on Git push"
+  description="Set up continuous integration to build your project automatically on Git push."
+  Icon={BookOpen02Icon}
+  href="/guides/eas-build"
+/>
+
+There's a lot more you can do with EAS Build. See all of the [build guides](#) for more information.
 
 ## Prerequisites
 
 Paid developer accounts are required to submit builds to the app stores. You will need the following:
 
+Required:
+
 - A [Google Play Developer](https://play.google.com/apps/publish/signup/) membership ($25 one-time fee)
 - An [Apple Developer Program](https://developer.apple.com/programs) membership ($99 per year)
+
+Optional:
+
+- Install EAS CLI and log in...TODO
+- Configure over-the-air updates...TODO
 
 <Collapsible summary="Optional: Configure over-the-air updates">
 Over-the-air updates allow you to send critical bug fixes and improvements to your users. To set it up, run the following [EAS CLI](/develop/tools/#eas-cli) command:

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -64,7 +64,7 @@ You can build and sign your app using EAS Build, but you can't upload it to the 
 
 <Collapsible summary="Apple Developer Program membership is required to build for the Apple App Store.">
 
-If you are going to use EAS Build to create release builds for the Apple App Store, you need access to an account with a $99 USD [Apple Developer Program](https://developer.apple.com/programs) membership.
+If you are going to use EAS Build to create production builds for the Apple App Store, you need access to an account with a $99 USD [Apple Developer Program](https://developer.apple.com/programs) membership.
 
 </Collapsible>
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -21,7 +21,7 @@ Production builds must be installed through their respective app stores. You can
 
 ### `eas.json` configuration
 
-A minimal configuration for building a production build in **eas.json** that is already created when you create your first build:
+A minimal configuration for building a production build in **eas.json** is already created when you create your first build:
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -47,7 +47,7 @@ To create a production build, run the following command for a platform:
   </Tab>
 </Tabs>
 
-> You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the website. It comes in handy when you want to leave a note with the purpose of the build for your team.
+> You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the Expo dashboard. It comes in handy when you want to specify the purpose of the build for your team.
 > Alternatively, you can use `--platform all` option to build for Android and iOS at the same time:
 
 <Terminal cmd={['$ eas build --platform all']} />
@@ -70,23 +70,23 @@ If you are going to use EAS Build to create release builds for the Apple App Sto
 
 ## App signing credentials
 
-Before the build process can start for app stores, you will need to have a store developer account and generate or provide app signing credentials.
+Before the build process can start for app stores, you need a store developer account and generate or provide app signing credentials.
 
-Whether you have experience with generating app signing credentials or not, EAS CLI does the heavy lifting. You can opt-in for EAS CLI to handle the app signing credentials process.
+Whether you have experience with generating app signing credentials or not, EAS CLI can do the heavy lifting. You can opt-in for EAS CLI to handle the app signing credentials process.
 
 ### Android app signing credentials
 
-- If you have not yet generated a keystore for your app, you can let EAS CLI take care of that for you by selecting `Generate new keystore`, and then you are done. The keystore is stored securely on EAS servers.
+- If you have not yet generated a keystore for your app, use EAS CLI by selecting `Generate new keystore`, and then you are done. The keystore is stored securely on EAS servers.
 - If you want to manually generate your keystore, see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
 
 ### iOS app signing credentials
 
-- If you have not generated a provisioning profile and/or distribution certificate yet, you can let EAS CLI take care of that for you by signing in to your Apple Developer Program account and following the prompts.
+- If you have not generated a provisioning profile and/or distribution certificate yet, use EAS CLI by signing in to your Apple Developer Program account and following the prompts.
 - If you want to manually generate your credentials, see the [manual iOS credentials guide](/app-signing/local-credentials#ios-credentials) for more information.
 
 ## Wait for the build to complete
 
-By default, the `eas build` command will wait for your build to complete, but you can interrupt it if you prefer not to wait. Monitor the progress and read the logs by following the link to the build details page that EAS CLI prompts once the build process gets started. You can also find this page by visiting [your build dashboard](https://expo.dev/builds) or running the following command:
+By default, the `eas build` command will wait for your build to complete, but you can interrupt it if you prefer not to wait. Instead, use the builds details page link prompted by EAS CLI to monitor the build progress and read the build logs. You can also find this page by visiting [your build dashboard](https://expo.dev/builds) or running the following command:
 
 <Terminal cmd={['$ eas build:list']} />
 
@@ -94,7 +94,7 @@ If you are a member of an organization and your build is on its behalf, you will
 
 ## Production builds locally
 
-To create a production build locally, see the following React Native guides for more information on the necessary steps that are required for Android and iOS.
+To create a production build locally, see the following React Native guides for more information on the necessary steps for Android and iOS.
 
 These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories before following the guides.
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -17,7 +17,7 @@ Production builds are submitted to app stores for release to the general public 
 
 ## Production builds using EAS
 
-Production builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
+Production builds must be installed through their respective app stores. You cannot install them directly on your Android Emulator, iOS Emulator, or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
 
 ### `eas.json` configuration
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build your project for app stores
-description: Learn how to create production builds of your project that are ready for the app stores.
-sidebar_title: Build for app stores
+description: Learn how to create a production build for your app that is ready to be submitted to app stores from the command line using EAS Build.
+sidebar_title: Build project for app stores
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -9,77 +9,96 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-To submit your app to the app stores, you'll need to create a production build of your Expo or React Native project. A production build is optimized for performance and size, and it includes all the necessary assets and configurations for the app stores.
+Whether you have built a native app binary using [EAS](/build/setup/) or [locally](/guides/local-app-development/), the next step in your app development journey is to submit your app to the stores. To do so, you need to create a **production build**.
 
-## Quick start
+Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight. This guide explains how to create production builds with [EAS](#production-builds-using-eas) and [locally](#production-builds-locally). It is also possible to create production builds for Expo apps with any CI service capable of compiling Android and iOS apps.
 
-To get started quickly, run the following [EAS CLI](#) command:
+## Production builds using EAS
 
-<Terminal cmd={['$ eas build --profile production']} />
+Production builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
 
-This will create a production build of your project that is ready for the app stores. If you prefer to build locally with Android Studio and Xcode, see [our guide](#).
+### `eas.json` configuration
 
-## Guides
+A minimal configuration for building a production build in **eas.json** that is already created when you create your first build:
 
-You can do a lot more with EAS Build. See the following guides to learn more:
+{/* prettier-ignore */}
+```json eas.json
+{
+  "build": {
+    /* @hide ... */ /* @end */
+    "production": {}
+    /* @hide ... */ /* @end */
+  }
+}
+```
 
-<BoxLink
-  title="Configure eas.json"
-  description="Control how EAS builds your project."
-  Icon={BookOpen02Icon}
-  href="/guides/eas-build"
-/>
+### Create a production build
 
-<BoxLink
-  title="Automate app store submissions"
-  description="Automate the submission of your builds to the app stores."
-  Icon={BookOpen02Icon}
-  href="/guides/eas-build"
-/>
+To create a production build, run the following command for a platform:
 
-<BoxLink
-  title="Build automatically on Git push"
-  description="Set up continuous integration to build your project automatically on Git push."
-  Icon={BookOpen02Icon}
-  href="/guides/eas-build"
-/>
+<Tabs tabs={['Android', 'iOS']}>
+  <Tab>
+    <Terminal cmd={['$ eas build --platform android']} />
+  </Tab>
+  <Tab>
+    <Terminal cmd={['$ eas build --platform ios']} />
+  </Tab>
+</Tabs>
 
-There's a lot more you can do with EAS Build. See all of the [build guides](#) for more information.
+> You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the website. It comes in handy when you want to leave a note with the purpose of the build for your team.
+> Alternatively, you can use `--platform all` option to build for Android and iOS at the same time:
 
-## Prerequisites
+<Terminal cmd={['$ eas build --platform all']} />
 
-Paid developer accounts are required to submit builds to the app stores. You will need the following:
+## Developer account
 
-Required:
+You will need to have a developer account for the app store you want to submit your app.
 
-- A [Google Play Developer](https://play.google.com/apps/publish/signup/) membership ($25 one-time fee)
-- An [Apple Developer Program](https://developer.apple.com/programs) membership ($99 per year)
+<Collapsible summary="Google Play Developer membership is required to distribute to the Google Play Store.">
 
-Optional:
+You can build and sign your app using EAS Build, but you can't upload it to the Google Play Store unless you have a membership, a one-time $25 USD fee.
 
-- Install EAS CLI and log in...TODO
-- Configure over-the-air updates...TODO
-
-<Collapsible summary="Optional: Configure over-the-air updates">
-Over-the-air updates allow you to send critical bug fixes and improvements to your users. To set it up, run the following [EAS CLI](/develop/tools/#eas-cli) command:
-
-<Terminal cmd={['$ eas update:configure']} />
 </Collapsible>
 
-## Create a production build with EAS
+<Collapsible summary="Apple Developer Program membership is required to build for the Apple App Store.">
 
-To create a production build, run the following [EAS CLI](/develop/tools/#eas-cli) command:
+If you are going to use EAS Build to create release builds for the Apple App Store, you need access to an account with a $99 USD [Apple Developer Program](https://developer.apple.com/programs) membership.
 
-<Terminal cmd={['$ eas build --profile production']} />
+</Collapsible>
 
-## Create a production build locally
+## App signing credentials
 
-To create a production build locally with Android Studio and Xcode, see the following guides.
+Before the build process can start for app stores, you will need to have a store developer account and generate or provide app signing credentials.
 
-These guides assume your project has **android** and/or **ios** directories containing native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories.
+Whether you have experience with generating app signing credentials or not, EAS CLI does the heavy lifting. You can opt-in for EAS CLI to handle the app signing credentials process.
 
-> **Note**: When following the guides below, in step four, when you build the release **.aab** for Android, run `./gradlew app:bundleRelease` from the **android** directory instead of `npx react-native build-android --mode=release`.
+### Android app signing credentials
+
+- If you have not yet generated a keystore for your app, you can let EAS CLI take care of that for you by selecting `Generate new keystore`, and then you are done. The keystore is stored securely on EAS servers.
+- If you want to manually generate your keystore, see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
+
+### iOS app signing credentials
+
+- If you have not generated a provisioning profile and/or distribution certificate yet, you can let EAS CLI take care of that for you by signing in to your Apple Developer Program account and following the prompts.
+- If you want to manually generate your credentials, see the [manual iOS credentials guide](/app-signing/local-credentials#ios-credentials) for more information.
+
+## Wait for the build to complete
+
+By default, the `eas build` command will wait for your build to complete, but you can interrupt it if you prefer not to wait. Monitor the progress and read the logs by following the link to the build details page that EAS CLI prompts once the build process gets started. You can also find this page by visiting [your build dashboard](https://expo.dev/builds) or running the following command:
+
+<Terminal cmd={['$ eas build:list']} />
+
+If you are a member of an organization and your build is on its behalf, you will find the build details on [the build dashboard for that account](https://expo.dev/accounts/[account]/builds).
+
+## Production builds locally
+
+To create a production build locally, see the following React Native guides for more information on the necessary steps that are required for Android and iOS.
+
+These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories before following the guides.
+
+> **Note**: Following the guide below, in step four, when you build the release **.aab** for Android, run `./gradlew app:bundleRelease` from the **android** directory instead of `npx react-native build-android --mode=release`.
 
 <BoxLink
   title="Publishing to Google Play Store"
@@ -95,6 +114,11 @@ These guides assume your project has **android** and/or **ios** directories cont
   href="https://reactnative.dev/docs/publishing-to-app-store"
 />
 
-## Learn more
+## Next step
 
-You can learn how to [automate submissions](/build/automate-submissions/), automate [app version management](/build-reference/app-versions/), and more with our [build guides](/build/introduction/).
+<BoxLink
+  title="App stores best practices"
+  description="Learn about the best practices for submitting your app to app stores."
+  Icon={BookOpen02Icon}
+  href="/distribution/app-stores/"
+/>

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -47,8 +47,9 @@ To create a production build, run the following command for a platform:
   </Tab>
 </Tabs>
 
-> You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the Expo dashboard. It comes in handy when you want to specify the purpose of the build for your team.
-> Alternatively, you can use `--platform all` option to build for Android and iOS at the same time:
+You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the Expo dashboard. It comes in handy when you want to specify the purpose of the build for your team.
+
+Alternatively, you can use `--platform all` option to build for Android and iOS at the same time:
 
 <Terminal cmd={['$ eas build --platform all']} />
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -4,6 +4,10 @@ description: Learn how to create production builds of your project that are read
 sidebar_title: Build for app stores
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
 To submit your app to the app stores, you'll need to create a production build. This build is optimized for performance and size, and it includes all the necessary assets and configurations for the app stores.
@@ -15,14 +19,40 @@ Paid developer accounts are required to submit builds to the app stores. You wil
 - A [Google Play Developer](https://play.google.com/apps/publish/signup/) membership ($25 one-time fee)
 - An [Apple Developer Program](https://developer.apple.com/programs) membership ($99 per year)
 
-## Configure over-the-air updates
-
+<Collapsible summary="Optional: Configure over-the-air updates">
 Over-the-air updates allow you to send critical bug fixes and improvements to your users. To set it up, run the following [EAS CLI](/develop/tools/#eas-cli) command:
 
 <Terminal cmd={['$ eas update:configure']} />
+</Collapsible>
 
-## Create a production build
+## Create a production build with EAS
 
 To create a production build, run the following [EAS CLI](/develop/tools/#eas-cli) command:
 
 <Terminal cmd={['$ eas build --profile production']} />
+
+## Create a production build locally
+
+To create a production build locally with Android Studio and Xcode, see the following guides.
+
+These guides assume your project has **android** and/or **ios** directories containing native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories.
+
+> **Note**: When following the guides below, in step four, when you build the release **.aab** for Android, run `./gradlew app:bundleRelease` from the **android** directory instead of `npx react-native build-android --mode=release`.
+
+<BoxLink
+  title="Publishing to Google Play Store"
+  description="Learn how to publish an app to Google Play Store by following the necessary steps manually."
+  Icon={BookOpen02Icon}
+  href="https://reactnative.dev/docs/signed-apk-android"
+/>
+
+<BoxLink
+  title="Publishing to Apple App Store"
+  description="Learn how to publish an app to Apple App Store by following the necessary steps manually."
+  Icon={BookOpen02Icon}
+  href="https://reactnative.dev/docs/publishing-to-app-store"
+/>
+
+## Learn more
+
+You can learn how to [automate submissions](/build/automate-submissions/), automate [app version management](/build-reference/app-versions/), and more with our [build guides](/build/introduction/).

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -26,3 +26,7 @@ To send an update, run the following [EAS CLI](/develop/tools/#eas-cli) command:
 This command will create an update and make it available to builds of your app that are configured to receive updates on the `production` channel. This channel is defined in [**eas.json**](/eas/json/#channel).
 
 You can verify the update works by force closing the app and reopening it two times. The update should be applied on the second launch.
+
+## Learn more
+
+You can learn how to [rollout an update](/eas-update/rollouts/), [optimize assets](/eas-update/optimize-assets/), and more with our [update guides](/eas-update/introduction/).


### PR DESCRIPTION
# Why

@brentvatne mentioned that the build project and over-the-air update doc could be improved with more content. As a result of that conversation, this PR:

- Makes the "configure updates" section of the build-project doc collapsible and clearly labels it as optional
- Adds documentation on how to build locally without EAS CLI.
- Adds a "Learn more" section to the bottom of both docs that links to their sections in /guides. I didn't use the "Next Step" header since there are buttons that invite users to the next doc as the next step, and I'd like to have one primary next step on each doc. To make the "Learn more" a bit more juicy, I added some suggestions on things you can learn if you go there.

# Test Plan

Read the docs and let me know what you think. I am open to feedback!

I am assuming that the majority of users reading these are closer to the "trying to get something done" part of the spectrum rather than the "understanding how everything works" part of the spectrum. They are newer to Expo's tools and looking for which commands they'll need to run. --With that, we want them to know there's a lot you can do with Expo, which we have many detailed guides on.

- /deploy/build-project/
- /deploy/send-over-the-air-updates/