### PR TITLE
[expo] Bump recommended @sentry/react-native version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,5 +101,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "1.3.11",
   "@shopify/flash-list": "1.6.4",
-  "@sentry/react-native": "~5.22.0"
+  "@sentry/react-native": "~5.33.1"
 }


### PR DESCRIPTION
# Why

Due to compatibility issues with Xcode 16 (https://github.com/getsentry/sentry-react-native/issues/4100#issuecomment-2358977520), It is now recommended to use the newer version of Sentry to build.

[Related issue](https://github.com/expo/expo/issues/30117)

Running expo-doctor we get:
```
The following packages should be updated for best compatibility with the installed expo version:
  @sentry/react-native@5.33.1 - expected version: ~5.22.0
```

# How

created a dev build project and built with Xcode, Android Studio and EAS

# Test Plan

---

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
