### PR TITLE
refactor(ci): improve `router-e2e` installation time by caching Yarns global cache

### DIFF
--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -3,6 +3,7 @@ name: Router Maestro E2E
 on:
   pull_request:
     paths:
+      - .github/workflows/router-e2e.yml
       - packages/@expo/cli/**
       - packages/expo-router/**
 

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -21,11 +21,18 @@ jobs:
         with:
           node-version: '20.x'
 
-      - name: Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
+      # Find and restore Yarn's global cache
+      # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: 🔍 Find Yarn Cache
+        id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: ♻️ Restore Yarn Cache
+        uses: actions/cache@v4
         with:
-          yarn-workspace: 'true'
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: YARN_IGNORE_SCRIPTS=true yarn --frozen-lockfile

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-cache-
 
       - name: Install dependencies
         run: YARN_IGNORE_SCRIPTS=true yarn --frozen-lockfile


### PR DESCRIPTION
# Why

I was merging the stacked PRs related to telemetry, but had to wait quite long. So I had time to improve the installation time of the Expo Router E2E Maestro workflow.

# How

- Followed [best-practices](https://github.com/actions/cache/blob/main/examples.md#node---yarn) to restore the Yarn cache in GitHub Actions

# Test Plan

See CI

Previous timings ([run](https://github.com/expo/expo/actions/runs/11032871089/job/30642749180))
  - Restore Cache - **51s**
  - Install dependencies - **3m18s**
  - Fix expo-linking - **3m31s**
  - _Total: **11m35s**_

New timings ([run](https://github.com/expo/expo/actions/runs/11033957517/job/30647692764))
  - Restore Cache - **1m40s**
  - Install dependencies - **58s**
  - Fix expo-linking - **2m27s**
  - _Total: **7m58s**_

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
