### PR TITLE
chore(json-file): update `fs` mocks to also mock `node:fs`

### DIFF
--- a/packages/@expo/config-plugins/__mocks__/fs.ts
+++ b/packages/@expo/config-plugins/__mocks__/fs.ts
@@ -1,2 +1,4 @@
-import { fs } from 'memfs';
-module.exports = fs;
+module.exports = require('memfs').fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/@expo/config/__mocks__/fs.ts
+++ b/packages/@expo/config/__mocks__/fs.ts
@@ -1,2 +1,4 @@
-import { fs } from 'memfs';
-module.exports = fs;
+module.exports = require('memfs').fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/@expo/config/__mocks__/fs.ts
+++ b/packages/@expo/config/__mocks__/fs.ts
@@ -1,4 +1,4 @@
 module.exports = require('memfs').fs;
 
 // NOTE(cedric): workaround to also mock `node:fs`
-jest.mock('node:fs', () => require('memfs').fs);
+jest.mock('node:fs', () => require('fs'));

--- a/packages/@expo/config/src/__tests__/getAccountUsername-test.ts
+++ b/packages/@expo/config/src/__tests__/getAccountUsername-test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync } from 'fs';
+import fs from 'fs';
+import { vol } from 'memfs';
 
 import { getAccountUsername } from '../getAccountUsername';
 import { getExpoHomeDirectory, getUserState } from '../getUserState';
@@ -6,11 +7,15 @@ import { getExpoHomeDirectory, getUserState } from '../getUserState';
 jest.mock('os');
 jest.mock('fs');
 
+// NOTE(cedric): this is a workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('fs'));
+
 describe(getAccountUsername, () => {
   beforeEach(() => {
     delete process.env.EXPO_CLI_USERNAME;
     delete process.env.EAS_BUILD_USERNAME;
   });
+  afterEach(() => vol.reset());
 
   it(`gets the account name from EXPO_CLI_USERNAME`, () => {
     process.env.EXPO_CLI_USERNAME = 'expo-cli-username';
@@ -38,7 +43,7 @@ describe(getAccountUsername, () => {
     // Ensure the test doesn't interact with the developer's state.json
     expect(getExpoHomeDirectory()).toBe('/home/.expo');
     // Ensure the dir exists
-    await mkdirSync(getExpoHomeDirectory(), { recursive: true });
+    fs.mkdirSync(getExpoHomeDirectory(), { recursive: true });
     // Set a username...
     await getUserState().setAsync('auth', { username: 'bacon-boi' });
     // Check the username...

--- a/packages/@expo/fingerprint/__mocks__/fs.ts
+++ b/packages/@expo/fingerprint/__mocks__/fs.ts
@@ -1,2 +1,4 @@
-import { fs } from 'memfs';
-module.exports = fs;
+module.exports = require('memfs').fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/@expo/fingerprint/__mocks__/fs/promises.ts
+++ b/packages/@expo/fingerprint/__mocks__/fs/promises.ts
@@ -1,17 +1,4 @@
-import { fs } from 'memfs';
-import path from 'path';
+module.exports = require('memfs').fs.promises;
 
-/**
- * Further mock `fs.promises` to ensure the parent directory exists.
- * We used to call `fs.promises.mkdtemp(path.join(os.tmpdir(), ...))`, so that we don't have to worry about os.tmpdir() exists.
- */
-const origMkdtemp = fs.promises.mkdtemp;
-fs.promises.mkdtemp = (
-  prefix: string,
-  options?: Parameters<typeof origMkdtemp>[1]
-): ReturnType<typeof origMkdtemp> => {
-  fs.mkdirSync(path.dirname(prefix), { recursive: true });
-  return origMkdtemp(prefix, options);
-};
-
-module.exports = fs.promises;
+// NOTE(cedric): workaround to also mock `node:fs/promises`
+jest.mock('node:fs/promises', () => require('memfs').fs.promises);

--- a/packages/@expo/fingerprint/__mocks__/memfs.ts
+++ b/packages/@expo/fingerprint/__mocks__/memfs.ts
@@ -1,0 +1,17 @@
+const memfs = jest.requireActual('memfs');
+const path = require('path');
+
+/**
+ * Further mock memfs `fs.promises` to ensure the parent directory exists.
+ * We used to call `fs.promises.mkdtemp(path.join(os.tmpdir(), ...))`, so that we don't have to worry about os.tmpdir() exists.
+ */
+const origMkdtemp = memfs.fs.promises.mkdtemp;
+memfs.fs.promises.mkdtemp = (
+  prefix: string,
+  options?: Parameters<typeof origMkdtemp>[1]
+): ReturnType<typeof origMkdtemp> => {
+  memfs.fs.mkdirSync(path.dirname(prefix), { recursive: true });
+  return origMkdtemp(prefix, options);
+};
+
+module.exports = memfs;

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
@@ -24,6 +24,9 @@ jest.mock('fs/promises');
 jest.mock('resolve-from');
 jest.mock('/app/package.json', () => {}, { virtual: true });
 
+// NOTE(cedric): this is a workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);
+
 describe(getEasBuildSourcesAsync, () => {
   afterEach(() => {
     vol.reset();

--- a/packages/@expo/prebuild-config/__mocks__/fs.ts
+++ b/packages/@expo/prebuild-config/__mocks__/fs.ts
@@ -1,2 +1,4 @@
-import { fs } from 'memfs';
-module.exports = fs;
+module.exports = require('memfs').fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/create-expo/src/__mocks__/fs.ts
+++ b/packages/create-expo/src/__mocks__/fs.ts
@@ -1,3 +1,4 @@
-import { fs } from 'memfs';
+module.exports = require('memfs').fs;
 
-module.exports = fs;
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/expo-doctor/__mocks__/fs.js
+++ b/packages/expo-doctor/__mocks__/fs.js
@@ -1,2 +1,4 @@
-import { fs } from 'memfs';
-module.exports = fs;
+module.exports = require('memfs').fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/expo-updates/cli/__mocks__/fs.js
+++ b/packages/expo-updates/cli/__mocks__/fs.js
@@ -1,6 +1,4 @@
-const { fs } = require('memfs');
-
-module.exports = fs;
+module.exports = require('memfs').fs;
 
 // NOTE(cedric): workaround to also mock `node:fs`
 jest.mock('node:fs', () => require('memfs').fs);

--- a/packages/expo-updates/cli/__mocks__/fs.js
+++ b/packages/expo-updates/cli/__mocks__/fs.js
@@ -1,1 +1,6 @@
-module.exports = require('memfs').fs;
+const { fs } = require('memfs');
+
+module.exports = fs;
+
+// NOTE(cedric): workaround to also mock `node:fs`
+jest.mock('node:fs', () => require('memfs').fs);


### PR DESCRIPTION
# Why

In #14297, I used `node:` imports in `@expo/json-file`. Unfortunately, Jest doesn't pick this up when mocking `__mocks__/fs.ts`, it simply loads `node:fs` instead, see: https://github.com/jestjs/jest/pull/14297

# How

- Added `jest.mock('node:fs')` as workaround until Jest has something for `node:` mocking

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
