### PR TITLE
[docs] Fix redirect URL for EAS Update getting started guide

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -180,7 +180,7 @@ redirects[eas-update/custom-updates-server]=versions/latest/sdk/updates
 redirects[distribution/custom-updates-server]=versions/latest/sdk/updates
 redirects[bare/error-recovery]=eas-update/error-recovery
 redirects[deploy/instant-updates]=eas-update/send-over-the-air-updates
-redirects[eas-update/publish]=eas-update/get-started
+redirects[eas-update/publish]=eas-update/getting-started
 redirects[eas-update/debug-advanced]=eas-update/debug
 
 # Redirects for Expo Router docs

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -34,7 +34,7 @@ When using the `expo-updates` library inside a development build, the **Extensio
 
 <Step label="1">
 
-Make non-native changes locally in your project and then [publish them using `eas update`](/eas-update/publish/). The update will be published on a branch.
+Make non-native changes locally in your project and then [publish them using `eas update`](/eas-update/getting-started/#publish-an-update). The update will be published on a branch.
 
 </Step>
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -32,7 +32,7 @@ All apps that include the `expo-updates` library have the ability to receive upd
 <BoxLink
   title="Publish an update"
   description="Learn how to publish an update to a specific branch with EAS Update."
-  href="/eas-update/publish/"
+  href="/eas-update/getting-started/#publish-an-update"
   Icon={LayersTwo02Icon}
 />
 

--- a/docs/pages/review/with-orbit.mdx
+++ b/docs/pages/review/with-orbit.mdx
@@ -30,7 +30,7 @@ If you don't have any development builds available, either because they have all
   caption="Expo Orbit launching an update directly from Expo dashboard to an iOS Simulator."
 />
 
-Previewing with Expo Orbit requires you to have an update published. If you haven't published an update, see [Publish an update](/eas-update/publish/) before following the steps in the next section.
+Previewing with Expo Orbit requires you to have an update published. If you haven't published an update, see [Publish an update](/eas-update/getting-started/#publish-an-update) before following the steps in the next section.
 
 ### Install and launch the update
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -130,11 +130,11 @@ You can configure your app to check for updates manually by doing the following 
 
 Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
-**To test the content of an update in a development build**, run [`eas update`](/eas-update/publish/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
+**To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 
 **To test updates in a release build**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test). The full [Updates API](#api) is available in a release build.
 
-**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/publish/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
+**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1727278593323759)

With EAS Update section organization, we recently removed the publish guide and added it as a section to EAS Update > Getting started guide.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the typo in the server-side redirect file (deploy.sh) and update all references of the removed `eas-update/publish` in our docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
