### PR TITLE
[core] remove submodule imports

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix and update link for `expo-dev-client` in package's README. ([#30162](https://github.com/expo/expo/pull/30162) by [@amandeepmittal](https://github.com/amandeepmittal)).
 - Fixed broken unit test on iOS 17 where `URL()` without scheme returns nil. ([#30178](https://github.com/expo/expo/pull/30178) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import React
 
 @testable import EXDevLauncher
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### 💡 Others
 
+- Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
+
 ### 📚 3rd party library updates
 
 ## 5.0.21 - 2024-08-23

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import Foundation
+import React
 
 class DevMenuPackagerConnectionHandler {
   weak var manager: DevMenuManager?

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import UIKit
+import React
 
 class DevMenuViewController: UIViewController {
   static let JavaScriptDidLoadNotification = Notification.Name("RCTJavaScriptDidLoadNotification")

--- a/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
+++ b/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import Foundation
+import React
 
 class EXDevMenuDevSettings: NSObject {
   static func getDevSettings() -> [String: Bool] {

--- a/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import React
+
 // React navigation uses a safe area providere, but we don't need this.
 // So we can just mock it.
 @objc(MockedRNCSafeAreaProvider)

--- a/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import React
 
 @testable import EXDevMenu
 

--- a/packages/expo-dev-menu/ios/Tests/EXDevMenuAppInfoTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/EXDevMenuAppInfoTest.swift
@@ -1,4 +1,5 @@
- import XCTest
+import XCTest
+import React
 
  @testable import EXDevMenu
 

--- a/packages/expo-dev-menu/ios/UITests/MockedBridges.swift
+++ b/packages/expo-dev-menu/ios/UITests/MockedBridges.swift
@@ -1,5 +1,6 @@
 @testable import EXDevMenu
 @testable import EXDevMenuInterface
+import React
 
 class UIMockedNOOPBridge: RCTBridge {
   override func invalidate() {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -90,6 +90,7 @@
 - [Android] Expose `RuntimeContext.eval()` as `JavaScriptRuntime.eval()` on iOS. ([#31445](https://github.com/expo/expo/pull/31445) by [@kudo](https://github.com/kudo))
 - Removed all `NativeModulesProxy` occurrences. ([#31496](https://github.com/expo/expo/pull/31496) by [@reichhartd](https://github.com/reichhartd))
 - Align web implementation exports as native to support DOM components when using `@expo/dom-webview`. ([#31662](https://github.com/expo/expo/pull/31662) by [@kudo](https://github.com/kudo))
+- Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -2,8 +2,7 @@
 
 #import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
-
-#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+#import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -3,12 +3,7 @@
 #import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
 
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#endif
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -4,8 +4,8 @@
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 #import <ExpoModulesCore/Swift.h>
+#import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
-#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
 #import <ReactCommon/ReactCommon-umbrella.h>
 
 @interface RCTAppDelegate () <RCTTurboModuleManagerDelegate>

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -5,14 +5,8 @@
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 #import <ExpoModulesCore/Swift.h>
 
-#if __has_include(<React-RCTAppDelegate/RCTRootViewFactory.h>)
-#import <React-RCTAppDelegate/RCTRootViewFactory.h>
-#elif __has_include(<React_RCTAppDelegate/RCTRootViewFactory.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTRootViewFactory.h>
-#endif
-
-#import <ReactCommon/RCTTurboModuleManager.h>
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+#import <ReactCommon/ReactCommon-umbrella.h>
 
 @interface RCTAppDelegate () <RCTTurboModuleManagerDelegate>
 @end

--- a/packages/expo-modules-core/ios/AppDelegates/RCTAppDelegateUmbrella.h
+++ b/packages/expo-modules-core/ios/AppDelegates/RCTAppDelegateUmbrella.h
@@ -1,0 +1,24 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ `React-RCTAppDelegate-umbrella.h` requires `USE_HERMES`.
+ This umbrella wrapper lets us import `React-RCTAppDelegate-umbrella.h` in `Expo.h` without requiring `USE_HERMES` from app project settings.
+ */
+
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#ifndef USE_HERMES
+
+#define USE_HERMES 1
+#define INLINE_USE_HERMES 1
+
+#endif // USE_HERMES
+#endif // __has_include(<reacthermes/HermesExecutorFactory.h>)
+
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+
+#if INLINE_USE_HERMES
+
+#undef USE_HERMES
+#undef INLINE_USE_HERMES
+
+#endif // INLINE_USE_HERMES

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
@@ -1,6 +1,6 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
 

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -1,7 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXAppDefines.h>
-#import <React/RCTDefines.h>
+#import <React/React-Core-umbrella.h>
 
 @implementation EXAppDefines
 

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -2,7 +2,7 @@
 
 // Some headers needs to be imported from Objective-C code too.
 // Otherwise they won't be visible in `ExpoModulesCore-Swift.h`.
-#import <React/RCTView.h>
+#import <React/React-Core-umbrella.h>
 
 #if __has_include(<ExpoModulesCore/ExpoModulesCore-umbrella.h>)
 #import <ExpoModulesCore/ExpoModulesCore-umbrella.h>

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -1,9 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-// Some headers needs to be imported from Objective-C code too.
-// Otherwise they won't be visible in `ExpoModulesCore-Swift.h`.
-#import <React/React-Core-umbrella.h>
-
 #if __has_include(<ExpoModulesCore/ExpoModulesCore-umbrella.h>)
 #import <ExpoModulesCore/ExpoModulesCore-umbrella.h>
 #endif

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -3,10 +3,11 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <UIKit/UIKit.h>
-#import <React/RCTView.h>
+#import <React/React-Core-umbrella.h>
 
 #ifdef __cplusplus
-#import <React/RCTViewComponentView.h>
+
+#import <RCTFabric/React-RCTFabric-umbrella.h>
 
 @interface ExpoFabricViewObjC : RCTViewComponentView
 @end

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -7,7 +7,7 @@
 
 #ifdef __cplusplus
 
-#import <RCTFabric/React-RCTFabric-umbrella.h>
+#import <React/RCTViewComponentView.h> // Allows non-umbrella since it's coming from React-RCTFabric
 
 @interface ExpoFabricViewObjC : RCTViewComponentView
 @end

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -10,9 +10,7 @@
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
 #import <ExpoModulesCore/Swift.h>
 
-#import <React/RCTSurfacePresenter.h>
-#import <React/RCTMountingManager.h>
-#import <React/RCTComponentViewRegistry.h>
+#import <React/React-Core-umbrella.h>
 
 #import <string.h>
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
@@ -5,8 +5,8 @@
 #import <Foundation/Foundation.h>
 
 #import <jsi/jsi.h>
-#import <React/RCTBridgeModule.h>
-#import <ReactCommon/CallInvoker.h>
+#import <React/React-Core-umbrella.h>
+#import <ReactCommon/ReactCommon-umbrella.h>
 
 using namespace facebook;
 using namespace react;

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <ReactCommon/TurboModuleUtils.h>
+#import <ReactCommon/ReactCommon-umbrella.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
 #import <ExpoModulesCore/EXJavaScriptWeakObject.h>

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridge.h>
+#import <React/React-Core-umbrella.h>
 
 // Swift classes need forward-declaration in the headers.
 @class EXAppContext;

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -1,9 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#if __has_include(<ReactCommon/RCTRuntimeExecutor.h>)
-#import <ReactCommon/RCTRuntimeExecutor.h>
-#endif // React Native >=0.74
-
+#import <ReactCommon/ReactCommon-umbrella.h>
+#import <React_NativeModulesApple/React-NativeModulesApple-umbrella.h>
 #import <ExpoModulesCore/EXJSIInstaller.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -5,8 +5,8 @@
 #import <functional>
 
 #import <jsi/jsi.h>
-#import <ReactCommon/RCTTurboModule.h>
-#import <ReactCommon/TurboModuleUtils.h>
+#import <React/React-Core-umbrella.h>
+#import <ReactCommon/ReactCommon-umbrella.h>
 #import <ExpoModulesCore/ObjectDeallocator.h>
 
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -2,7 +2,7 @@
 
 #import <sstream>
 
-#import <React/RCTUtils.h>
+#import <React/React-Core-umbrella.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJSIUtils.h>
 #import <ExpoModulesCore/JSIUtils.h>

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -3,10 +3,10 @@
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 
 #ifdef __cplusplus
-#import <ReactCommon/CallInvoker.h>
+#import <ReactCommon/ReactCommon-umbrella.h>
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -2,16 +2,10 @@
 
 #import <jsi/jsi.h>
 
-#if __has_include(<reacthermes/HermesExecutorFactory.h>)
-#import <reacthermes/HermesExecutorFactory.h>
-#elif __has_include(<React-jsc/JSCRuntime.h>)
-// react-native@>=0.71 has a specific React-jsc pod
-#import <React-jsc/JSCRuntime.h>
-// use_frameworks! transforms the dash to underscore
-#elif __has_include(<React_jsc/JSCRuntime.h>)
-#import <React_jsc/JSCRuntime.h>
-#else
-#import <jsi/JSCRuntime.h>
+#if __has_include(<reacthermes/React-hermes-umbrella.h>)
+#import <reacthermes/React-hermes-umbrella.h>
+#elif __has_include(<React_jsc/React-jsc-umbrella.h>)
+#import <React_jsc/React-jsc-umbrella.h>
 #endif
 
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>

--- a/packages/expo-modules-core/ios/Legacy/EXBridgeModule.h
+++ b/packages/expo-modules-core/ios/Legacy/EXBridgeModule.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 
 // Escape hatch for modules that both have to depend on React Native
 // and want to be exported as an internal universal module.

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 
 // An "adapter" over module registry, for given RCTBridge and NSString

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 
 #import <ExpoModulesCore/EXModuleRegistry.h>
 

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.h
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridgeModule.h>
+#import <React/React-Core-umbrella.h>
 
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -2,15 +2,8 @@
 
 #import <objc/runtime.h>
 
-#import <React/RCTLog.h>
-#import <React/RCTUIManager.h>
-#import <React/RCTComponentData.h>
-#import <React/RCTModuleData.h>
-#import <React/RCTEventDispatcherProtocol.h>
-
-#ifdef RCT_NEW_ARCH_ENABLED
-#import <React/RCTComponentViewFactory.h>
-#endif
+#import <React/React-Core-umbrella.h>
+#import <RCTFabric/React-RCTFabric-umbrella.h>
 
 #import <jsi/jsi.h>
 

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -3,7 +3,7 @@
 #import <objc/runtime.h>
 
 #import <React/React-Core-umbrella.h>
-#import <RCTFabric/React-RCTFabric-umbrella.h>
+#import <React/RCTComponentViewFactory.h> // Allows non-umbrella since it's coming from React-RCTFabric
 
 #import <jsi/jsi.h>
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactLogHandler.m
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactLogHandler.m
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTLog.h>
+#import <React/React-Core-umbrella.h>
 
 #import <ExpoModulesCore/EXReactLogHandler.h>
 #import <ExpoModulesCore/EXDefines.h>

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTBridge.h>
+#import <React/React-Core-umbrella.h>
 
 #import <ExpoModulesCore/EXUIManager.h>
 #import <ExpoModulesCore/EXInternalModule.h>

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -2,21 +2,10 @@
 
 #import <JavaScriptCore/JavaScriptCore.h>
 
-#import <React/RCTUIManager.h>
-#import <React/RCTBridge+Private.h>
-#import <React/RCTAppState.h>
-#import <React/RCTImageLoader.h>
-#import <React/RCTUIManagerUtils.h>
-
+#import <React/React-Core-umbrella.h>
+#import <RCTFabric/React-RCTFabric-umbrella.h>
 #import <ExpoModulesCore/EXReactNativeAdapter.h>
-
-#if RCT_NEW_ARCH_ENABLED
-#import <React/RCTComponentViewRegistry.h>
-#import <React/RCTSurfacePresenter.h>
-#import <React/RCTMountingManager.h>
-
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
-#endif
 
 @interface EXReactNativeAdapter ()
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -3,7 +3,6 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 
 #import <React/React-Core-umbrella.h>
-#import <RCTFabric/React-RCTFabric-umbrella.h>
 #import <ExpoModulesCore/EXReactNativeAdapter.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeEventEmitter.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeEventEmitter.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTEventEmitter.h>
+#import <React/React-Core-umbrella.h>
 
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXEventEmitterService.h>

--- a/packages/expo-modules-core/ios/RCTComponentData+Privates.h
+++ b/packages/expo-modules-core/ios/RCTComponentData+Privates.h
@@ -1,7 +1,6 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
-#import <React/RCTComponent.h>
-#import <React/RCTComponentData.h>
+#import <React/React-Core-umbrella.h>
 
 typedef void (^RCTPropBlockAlias)(id<RCTComponent> _Nonnull view, id _Nullable json);
 

--- a/packages/expo-modules-core/ios/RCTComponentData+Privates.m
+++ b/packages/expo-modules-core/ios/RCTComponentData+Privates.m
@@ -1,7 +1,7 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/RCTComponentData+Privates.h>
-#import <React/RCTComponentData.h>
+#import <React/React-Core-umbrella.h>
 
 @implementation RCTComponentDataSwiftAdapter
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
@@ -4,7 +4,7 @@
 
 #import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
-#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+#import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
@@ -4,13 +4,7 @@
 
 #import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
-
-#if __has_include(<React-RCTAppDelegate/RCTRootViewFactory.h>)
-#import <React-RCTAppDelegate/RCTRootViewFactory.h>
-#elif __has_include(<React_RCTAppDelegate/RCTRootViewFactory.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTRootViewFactory.h>
-#endif
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -3,7 +3,7 @@
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
-#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+#import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 @interface RCTRootViewFactory ()
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -3,13 +3,7 @@
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
-
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#endif
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
 
 @interface RCTRootViewFactory ()
 

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
+#import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
@@ -2,12 +2,7 @@
 
 #pragma once
 
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#endif
+#import <React_RCTAppDelegate/React-RCTAppDelegate-umbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
@@ -12,7 +12,7 @@
                             launchOptions:(nullable NSDictionary *)launchOptions
 {
   if (self.bridgelessEnabled) {
-    id reactHost = [self.rootViewFactory valueForKey:@"_reactHost"];
+    id reactHost = self.rootViewFactory.reactHost;
     RCTAssert(reactHost == nil, @"recreateRootViewWithBundleURL: does not support when react instance is created");
   } else {
     RCTAssert(self.rootViewFactory.bridge == nil, @"recreateRootViewWithBundleURL: does not support when react instance is created");


### PR DESCRIPTION
# Why

the `React-Core` in cocoapods had problem of swift integration when we import to clang submodules and we had tricky workaround in cocoapods patcher and the `expo_patch_react_imports!`. without importing submodules, we can prevent the problems.
close ENG-12539

# How

always import from umbrella headers

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
