### PR TITLE
[android][screen-capture] Register Screen Capture callback earlier on Android 14

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Fix `ScreenCaptureModule` was crashing in the dev-client when going back to the home screen. ([#29694](https://github.com/expo/expo/pull/29694) by [@lukmccall](https://github.com/lukmccall))
 - Add missing `react` peer dependencies for isolated modules. ([#30480](https://github.com/expo/expo/pull/30480) by [@byCedric](https://github.com/byCedric))
-- [Android] Fix Screen capture callback was not called on Android 14 when API methods was not being called.
+- [Android] Fix Screen capture callback was not called on Android 14 when API methods was not being called. ([#31702](https://github.com/expo/expo/pull/31702) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix `ScreenCaptureModule` was crashing in the dev-client when going back to the home screen. ([#29694](https://github.com/expo/expo/pull/29694) by [@lukmccall](https://github.com/lukmccall))
 - Add missing `react` peer dependencies for isolated modules. ([#30480](https://github.com/expo/expo/pull/30480) by [@byCedric](https://github.com/byCedric))
+- [Android] Fix Screen capture callback was not called on Android 14 when API methods was not being called.
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -93,10 +93,8 @@ class ScreenCaptureModule : Module() {
       return
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      if (safeCurrentActivity != null) {
-        safeCurrentActivity!!.registerScreenCaptureCallback(currentActivity.mainExecutor, screenCaptureCallback!!)
-        isRegistered = true
-      }
+      safeCurrentActivity?.registerScreenCaptureCallback(currentActivity.mainExecutor, screenCaptureCallback!!) ?: return
+      isRegistered = true
     }
   }
 }


### PR DESCRIPTION
# Why

On Android 14 we're using a new ScreenCapture detection API which requries an extra step in our module to register the callback. Due to a bug in bridgeless mode the activity wasn't ready when the module was created leading to a crash if we tried to register the callback here.

A fix was made in #28244 where the registration code was moved into the API methods for preventing/allowing screen capture. This was fine in the example in our tests since we use these methods in our test code - however in #31678 the example (from documentation) used did not automatically call the required API methods and so the callback was not registered and screen capture notifications was not sent on Android 14.

closes #31678

# How

This PR fixes this by trying to register in the `onCreate` method (testing for null) in addition to also registering in `onActivityEntersForeground` as a fallback.

Registering will no longer be done in the `allowScreenCapture` and `preventScreenCapture` API methods. Registration also has an extra null check.

Related PRs: #28244 which was waiting on #28200 - both merged.

# Test Plan

Tested on BareExpo in both old arch/bridgeless mode without crashing when opening the ScreenCapture test screen.