### PR TITLE
[iOS][dev-menu] Fix obtaining the packager host when it's not running

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -75,10 +75,12 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
       return nil
     }
     // Return `nil` if the content is not a valid URL.
-    guard let content = try? String(contentsOfFile: packagerHostPath, encoding: String.Encoding.utf8).trimmingCharacters(in: CharacterSet.newlines),
-      let url = URL(string: "http://\(content)") else {
+    guard let content = try? String(contentsOfFile: packagerHostPath, encoding: .utf8).trimmingCharacters(in: .newlines) else {
       return nil
     }
-    return "\(url.host ?? ""):\(url.port ?? 8081)"
+    guard let url = URL(string: "http://\(content)"), let host = url.host else {
+      return nil
+    }
+    return "\(host):\(url.port ?? 8081)"
   }
 }


### PR DESCRIPTION
# Why

Fixes the missing host parameter error when launching bare-expo on iOS. It also affected other issues I noticed on the new architecture (while working on #31171).

![Screenshot 2024-09-25 at 18 22 05](https://github.com/user-attachments/assets/e24edfea-fedc-4a18-83bc-7302a30644c2)

# How

The root cause is quite weird to me and I'm not sure what introduced it. We were assuming that if `URL(string:)` can construct the URL instance from the contents of `dev-menu-packager-host` file then the dev menu should be loaded from the running bundler (instead of already prebuilt bundle). The default contents of that file is just a [comment](https://github.com/expo/expo/blob/main/packages/expo-dev-menu/assets/dev-menu-packager-host) but it turned out that `URL(string:)` constructor is passing now, with the url that has no host. To improve the assumption, we should also check if the host is present.

# Test Plan

Running bare-expo without running the bundler for dev menu launches correctly and without the above error.