### PR TITLE
[core][iOS] Export a class for `SharedRef`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [Android] The single parameter now can be auto-cast to the list. ([#31290](https://github.com/expo/expo/pull/31290) by [@lukmccall](https://github.com/lukmccall))
 - [Android] `SharedRef` converter now checks the inner ref type. ([#31441](https://github.com/expo/expo/pull/31441) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for changing if functions are enumerable. ([#31495](https://github.com/expo/expo/pull/31495) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) by [@lukmccall](https://github.com/lukmccall))
+- Introduced a base class for all shared refs (`expo.SharedRef`). ([#31513](https://github.com/expo/expo/pull/31513) & [#31706](https://github.com/expo/expo/pull/31706) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Added `onStartListeningToEvent` and `onStopListeningToEvent` to the `SharedObject`. ([#31385](https://github.com/expo/expo/pull/31385) by [@lukmccall](https://github.com/lukmccall))
 - Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -418,6 +418,9 @@ public final class AppContext: NSObject {
     EXJavaScriptRuntimeManager.installSharedObjectClass(runtime) { [weak sharedObjectRegistry] objectId in
       sharedObjectRegistry?.delete(objectId)
     }
+    
+    // Install `global.expo.SharedRef`.
+    EXJavaScriptRuntimeManager.installSharedRefClass(runtime)
 
     // Install `global.expo.NativeModule`.
     EXJavaScriptRuntimeManager.installNativeModuleClass(runtime)

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -20,7 +20,7 @@ public final class ClassDefinition: ObjectDefinition {
   let associatedType: AnyDynamicType?
 
   /**
-    Whetere the associatedType inherits from `SharedRef`.
+   Whether the associatedType inherits from `SharedRef`.
    */
   let isSharedRef: Bool
 
@@ -32,7 +32,7 @@ public final class ClassDefinition: ObjectDefinition {
     self.name = name
     self.constructor = elements.first(where: isConstructor) as? AnySyncFunctionDefinition
     self.associatedType = ~AssociatedObject.self
-    self.isSharedRef = AssociatedObject.self is SharedRerAssociatedObject.Type
+    self.isSharedRef = AssociatedObject.self is SharedRefAssociatedObject.Type
 
     // Constructors can't be passed down to the object definition
     // as we shouldn't override the default `<Class>.prototype.constructor`.
@@ -110,10 +110,10 @@ extension JavaScriptObject: ClassAssociatedObject, AnyArgument, AnyJavaScriptVal
 extension SharedObject: ClassAssociatedObject {}
 
 /**
- A protocol that allows us to detect `SharedRef's`.
+ A protocol that allows us to detect `SharedRef`'s.
  */
-internal protocol SharedRerAssociatedObject {}
-extension SharedRef : SharedRerAssociatedObject {}
+internal protocol SharedRefAssociatedObject {}
+extension SharedRef : SharedRefAssociatedObject {}
 
 // MARK: - Privates
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -39,7 +39,7 @@ extern NSString * _Nonnull const EXGlobalCoreObjectPropertyName;
 + (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser;
 
 /**
- Installs the base class for shared objects, i.e. `global.expo.SharedRef`.
+ Installs the base class for shared refs, i.e. `global.expo.SharedRef`.
  */
 + (void)installSharedRefClass:(nonnull EXRuntime *)runtime;
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -39,6 +39,11 @@ extern NSString * _Nonnull const EXGlobalCoreObjectPropertyName;
 + (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser;
 
 /**
+ Installs the base class for shared objects, i.e. `global.expo.SharedRef`.
+ */
++ (void)installSharedRefClass:(nonnull EXRuntime *)runtime;
+
+/**
  Installs the EventEmitter class in the given runtime as `global.expo.EventEmitter`.
  */
 + (void)installEventEmitterClass:(nonnull EXRuntime *)runtime;

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -10,6 +10,7 @@
 #import <ExpoModulesCore/BridgelessJSCallInvoker.h>
 #import <ExpoModulesCore/LazyObject.h>
 #import <ExpoModulesCore/SharedObject.h>
+#import <ExpoModulesCore/SharedRef.h>
 #import <ExpoModulesCore/EventEmitter.h>
 #import <ExpoModulesCore/NativeModule.h>
 #import <ExpoModulesCore/Swift.h>
@@ -96,6 +97,11 @@ static NSString *modulesHostObjectPropertyName = @"modules";
   expo::SharedObject::installBaseClass(*[runtime get], [releaser](expo::SharedObject::ObjectId objectId) {
     releaser(objectId);
   });
+}
+
++ (void)installSharedRefClass:(nonnull EXRuntime *)runtime
+{
+  expo::SharedRef::installBaseClass(*[runtime get]);
 }
 
 + (void)installEventEmitterClass:(nonnull EXRuntime *)runtime

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -110,6 +110,11 @@ typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, N
 - (nonnull EXJavaScriptObject *)createSharedObjectClass:(nonnull NSString *)name
                                             constructor:(nonnull ClassConstructorBlock)constructor;
 
+#pragma mark - Shared refs
+
+- (nonnull EXJavaScriptObject *)createSharedRefClass:(nonnull NSString *)name
+                                         constructor:(nonnull ClassConstructorBlock)constructor;
+
 #pragma mark - Script evaluation
 
 /**


### PR DESCRIPTION
# Why

Exports a class for `SharedRef's`.
A followup to the https://github.com/expo/expo/pull/31513.

# How

I was able to export and use a new common class for all `SharedRef` that are created by our API.

# Test Plan

<img width="396" alt="Screenshot 2024-09-26 at 12 38 12" src="https://github.com/user-attachments/assets/aa607985-4629-4c2a-9541-90d0358cd670">
