### PR TITLE
[docs][notifications] push notifications will not work in Expo Go

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` is not available in Expo Go as of SDK 52. Using a [development build](/develop/development-builds/introduction/) is required for using push notifications. Scheduled notifications (local notifications) remain available in Expo Go.
+> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` is unavailable in Expo Go from SDK 52. A [development build](/develop/development-builds/introduction/) is required to use push notifications. Scheduled notifications (local notifications) remain available in Expo Go.
 
 ## Features
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> **warning** `expo-notifications` functionality is not fully supported in Expo Go. Instead, we recommend using a [development build](/develop/development-builds/introduction/) to avoid limitations.
+> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` is not available in Expo Go as of SDK 52. Using a [development build](/develop/development-builds/introduction/) is required for using push notifications. Scheduled notifications (local notifications) remain available in Expo Go.
 
 ## Features
 

--- a/docs/pages/versions/v51.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` will not be available in Expo Go as of SDK 52. Using a [development build](/develop/development-builds/introduction/) will be required for using push notifications. Scheduled notifications (local notifications) will remain available in Expo Go.
+> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` will be unavailable in Expo Go from SDK 52. Instead, use a [development build](/develop/development-builds/introduction/). Scheduled notifications (local notifications) will remain available in Expo Go.
 
 ## Features
 

--- a/docs/pages/versions/v51.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> **warning** `expo-notifications` functionality is not fully supported in Expo Go. Instead, we recommend using a [development build](/develop/development-builds/introduction/) to avoid limitations.
+> **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` will not be available in Expo Go as of SDK 52. Using a [development build](/develop/development-builds/introduction/) will be required for using push notifications. Scheduled notifications (local notifications) will remain available in Expo Go.
 
 ## Features
 


### PR DESCRIPTION
# Why

we'll be removing push notifications support from Expo go for several reasons:

- Our goal is to make the transition from Expo Go to development build as smooth as possible. But right now, migrating from Expo Go to dev build breaks push notifications if user has set them up. This is due to the complexities of having Expo Go support push notifications for JS apps that run inside of it. That complexity is inherently there and cannot be avoided.
- related: we're hiding some of that complexity from users. This is nice but only up to a point. Users should understand the necessary minimum of what they're doing when setting up notifications.
- We're already warning people in the current docs that Expo Go's support for notifications is limited. Rather than offering something and saying it's broken under certain scenarios, we're now clearly saying: "Expo Go doesn't work with push. Use dev builds instead."

# How

update docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
