### PR TITLE
[docs] Fix button overflow on Expo Office Hours banner

### DIFF
--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -45,13 +45,13 @@ export function DiscoverMore() {
           <OfficeHoursImage />
           <RawH3 className="!text-palette-yellow11 !font-bold">Join us for Office Hours</RawH3>
           <P className="!text-palette-yellow11 !text-xs max-w-[28ch]">
-            Ask the Expo Team questions on our Discord stage.
+            Check our Discord events for the next live Q&A session.
           </P>
           <HomeButton
             className="bg-palette-yellow11 border-palette-yellow11 text-palette-yellow2 hocus:bg-palette-yellow11"
             href="https://chat.expo.dev"
             rightSlot={<ArrowUpRightIcon className="text-palette-yellow2 icon-md" />}>
-            Check Discord for Upcoming Events
+            Go to Discord
           </HomeButton>
         </GridCell>
         <GridCell className="bg-palette-blue3 border-palette-blue6 selection:bg-palette-blue5">


### PR DESCRIPTION
# Why

New design on #31572 didn't get applied. It should have been this:

<img width="606" alt="image" src="https://github.com/user-attachments/assets/8c465dc8-47a0-4b6f-b120-0bcbb0722fd5">

