### PR TITLE
feat(template): add auto formatting for vscode in the default template

### DIFF
--- a/templates/expo-template-default/.vscode/settings.json
+++ b/templates/expo-template-default/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
+  }
+}


### PR DESCRIPTION
# Why

- Make it easier for new projects to stay formatted.
