### PR TITLE
chore(expo-cli): only ping dev session once on start when authenticated

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ### 💡 Others
 
-- Reduce the number of dev session calls by 3x. ([#31717](https://github.com/expo/expo/pull/31717) by [@EvanBacon](https://github.com/EvanBacon))
+- Stop pinging dev session with updates. ([#31717](https://github.com/expo/expo/pull/31717) by [@EvanBacon](https://github.com/EvanBacon))
 - improve export log format ([#31476](https://github.com/expo/expo/pull/31476) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce scope of custom transform options in Metro cache. ([#31262](https://github.com/expo/expo/pull/31262) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ### 💡 Others
 
-- Reduce the number of dev session calls by 3x.
+- Reduce the number of dev session calls by 3x. ([#31717](https://github.com/expo/expo/pull/31717) by [@EvanBacon](https://github.com/EvanBacon))
 - improve export log format ([#31476](https://github.com/expo/expo/pull/31476) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce scope of custom transform options in Metro cache. ([#31262](https://github.com/expo/expo/pull/31262) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ### 💡 Others
 
+- Reduce the number of dev session calls by 3x.
 - improve export log format ([#31476](https://github.com/expo/expo/pull/31476) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce scope of custom transform options in Metro cache. ([#31262](https://github.com/expo/expo/pull/31262) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactor web hydration to use `globalThis.__EXPO_ROUTER_HYDRATE__` instead of `process.env.EXPO_PUBLIC_USE_STATIC`. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -255,7 +255,6 @@ export abstract class BundlerDevServer {
   protected async startDevSessionAsync() {
     // This is used to make Expo Go open the project in either Expo Go, or the web browser.
     // Must come after ngrok (`startTunnelAsync`) setup.
-    this.devSession?.stopNotifying?.();
     this.devSession = new DevelopmentSession(
       this.projectRoot,
       // This URL will be used on external devices so the computer IP won't be relevant.

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -10,15 +10,11 @@ import * as ProjectDevices from '../project/devices';
 
 const debug = require('debug')('expo:start:server:developmentSession') as typeof console.log;
 
-const UPDATE_FREQUENCY = 60 * 1000; // 60 seconds
-
 async function isAuthenticatedAsync(): Promise<boolean> {
   return !!(await getUserAsync().catch(() => null));
 }
 
 export class DevelopmentSession {
-  protected timeout: NodeJS.Timeout | null = null;
-
   constructor(
     /** Project root directory. */
     private projectRoot: string,
@@ -31,8 +27,6 @@ export class DevelopmentSession {
   /**
    * Notify the Expo servers that a project is running, this enables the Expo Go app
    * and Dev Clients to offer a "recently in development" section for quick access.
-   *
-   * This method starts an interval that will continue to ping the servers until we stop it.
    *
    * @param projectRoot Project root folder, used for retrieving device installation IDs.
    * @param props.exp Partial Expo config with values that will be used in the Expo Go app.
@@ -52,7 +46,6 @@ export class DevelopmentSession {
             ? 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in CI.'
             : 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in offline-mode.'
         );
-        this.stopNotifying();
         return;
       }
 
@@ -62,13 +55,11 @@ export class DevelopmentSession {
         debug(
           'Development session will not ping because the user is not authenticated and there are no devices.'
         );
-        this.stopNotifying();
         return;
       }
 
       if (this.url) {
-        // debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
-
+        debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
         await updateDevelopmentSessionAsync({
           url: this.url,
           runtime,
@@ -76,13 +67,8 @@ export class DevelopmentSession {
           deviceIds,
         });
       }
-
-      this.stopNotifying();
-
-      this.timeout = setTimeout(() => this.startAsync({ exp, runtime }), UPDATE_FREQUENCY);
     } catch (error: any) {
       debug(`Error updating development session API: ${error}`);
-      this.stopNotifying();
       this.onError(error);
     }
   }
@@ -93,18 +79,8 @@ export class DevelopmentSession {
     return devices.map(({ installationId }) => installationId);
   }
 
-  /** Stop notifying the Expo servers that the development session is running. */
-  public stopNotifying() {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-    }
-    this.timeout = null;
-  }
-
   /** Try to close any pending development sessions, but always resolve */
   public async closeAsync(): Promise<boolean> {
-    this.stopNotifying();
-
     if (env.CI || env.EXPO_OFFLINE) {
       return false;
     }

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -10,7 +10,7 @@ import * as ProjectDevices from '../project/devices';
 
 const debug = require('debug')('expo:start:server:developmentSession') as typeof console.log;
 
-const UPDATE_FREQUENCY = 60 * 1000; // 20 seconds
+const UPDATE_FREQUENCY = 60 * 1000; // 60 seconds
 
 async function isAuthenticatedAsync(): Promise<boolean> {
   return !!(await getUserAsync().catch(() => null));

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -10,7 +10,7 @@ import * as ProjectDevices from '../project/devices';
 
 const debug = require('debug')('expo:start:server:developmentSession') as typeof console.log;
 
-const UPDATE_FREQUENCY = 20 * 1000; // 20 seconds
+const UPDATE_FREQUENCY = 60 * 1000; // 20 seconds
 
 async function isAuthenticatedAsync(): Promise<boolean> {
   return !!(await getUserAsync().catch(() => null));

--- a/packages/@expo/cli/src/start/server/__mocks__/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/__mocks__/DevelopmentSession.ts
@@ -5,6 +5,5 @@ export class DevelopmentSession {
   ) {}
 
   startAsync = jest.fn(async () => ({}));
-  stopNotifying = jest.fn();
   closeAsync = jest.fn(async () => ({}));
 }

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -79,9 +79,6 @@ describe(`startAsync`, () => {
     });
 
     expect(onDevSessionError).toHaveBeenCalled();
-
-    // Did not repeat the cycle
-    expect(session['timeout']).toBe(null);
   });
 
   it(`gracefully handles server outages`, async () => {
@@ -112,9 +109,6 @@ describe(`startAsync`, () => {
     });
 
     expect(onDevSessionError).toHaveBeenCalled();
-
-    // Did not repeat the cycle
-    expect(session['timeout']).toBe(null);
   });
 
   it('is skipped on CI', async () => {
@@ -136,8 +130,6 @@ describe(`startAsync`, () => {
 
     // Did not load the current device info
     expect(ProjectDevices.getDevicesInfoAsync).not.toHaveBeenCalled();
-    // Did not repeat the cycle
-    expect(session['timeout']).toBe(null);
   });
 });
 


### PR DESCRIPTION
# Why

- The dev session is polled on the native-side and only needs polling on the CLI-side to update minor settings and metadata. More efficient to only ping once on project start.
