### PR TITLE
Remove file with invalid name for windows

### DIFF
--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Remove file that causes expo repo to not be clonable on windows machines ([#31720](https://github.com/expo/expo/pull/31720) by [@acoates-ms](https://github.com/acoates-ms))
 - Update `npm-package-arg@^7` to `npm-package-arg@^11`. ([#30842](https://github.com/expo/expo/pull/30842) by [@kitten](https://github.com/kitten))
 - Simplify workspace root detection with `resolve-workspace-root`. ([#31124](https://github.com/expo/expo/pull/31124) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/package-manager/__mocks__/node:fs.ts
+++ b/packages/@expo/package-manager/__mocks__/node:fs.ts
@@ -1,2 +1,0 @@
-import { fs } from 'memfs';
-module.exports = fs;


### PR DESCRIPTION
# Why

Filenames cannot have `:` in them on windows.  This file means that windows machines cannot clone the expo repo.