### PR TITLE
fix(template): perform haptics on iOS only

### DIFF
--- a/templates/expo-template-default/components/HapticTab.tsx
+++ b/templates/expo-template-default/components/HapticTab.tsx
@@ -7,7 +7,7 @@ export function HapticTab(props: BottomTabBarButtonProps) {
     <PlatformPressable
       {...props}
       onPressIn={(ev) => {
-        if (process.env.EXPO_OS !== 'web') {
+        if (process.env.EXPO_OS === 'ios') {
           // Add a soft haptic feedback when pressing down on the tabs.
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         }


### PR DESCRIPTION
# Why

- Apparently many Android devices have subpar haptics, making this feature iOS only for now.
