### PR TITLE
[updates] use iphone 16 for e2e testing

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
@@ -36,7 +36,7 @@
       "type": "ios.simulator",
       "headless": true,
       "device": {
-        "type": "iPhone 15"
+        "type": "iPhone 16"
       }
     },
     "emulator": {


### PR DESCRIPTION
# Why

fixed broken updates e2e https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/982aff7f-846c-4a76-a691-93359110936c
```
  ● Test suite failed to run
    DetoxRuntimeError: Failed to find a device by type = "iPhone 15"
```

# How

we use the latest eas image which now has xcode 16. we should also use `iPhone 16` to run e2e tests

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
