### PR TITLE
[core][Android] Unload global java references

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -48,3 +48,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
 #endif
   });
 }
+
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *) {
+  JNIEnv *env = nullptr;
+  jint ret = vm->GetEnv((void**)env, JNI_VERSION_1_6);
+  if (ret != JNI_OK) {
+    return;
+  }
+
+  expo::JCacheHolder::unLoad(env);
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.h
@@ -24,9 +24,7 @@ public:
     PROMISE
   };
 
-  JSReferencesCache() = delete;
-
-  JSReferencesCache(jsi::Runtime &runtime);
+  explicit JSReferencesCache(jsi::Runtime &runtime);
 
   /**
    * Gets a cached object.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -56,10 +56,15 @@ JCache::JCache(JNIEnv *env) {
 #undef REGISTER_CLASS
 }
 
-std::shared_ptr <JCache> JCacheHolder::jCache = nullptr;
+std::shared_ptr<JCache> JCacheHolder::jCache = nullptr;
 
 void JCacheHolder::init(JNIEnv *env) {
   jCache = std::make_shared<JCache>(env);
+}
+
+void JCacheHolder::unLoad(JNIEnv *env) {
+  jCache->unLoad(env);
+  jCache.reset();
 }
 
 JCache &JCacheHolder::get() {
@@ -78,6 +83,27 @@ jclass JCache::getOrLoadJClass(
   }
 
   return result->second;
+}
+
+void JCache::unLoad(JNIEnv *env) {
+  env->DeleteGlobalRef(jDoubleArray);
+  env->DeleteGlobalRef(jBooleanArray);
+  env->DeleteGlobalRef(jIntegerArray);
+  env->DeleteGlobalRef(jLongArray);
+  env->DeleteGlobalRef(jFloatArray);
+  env->DeleteGlobalRef(jCollection);
+  env->DeleteGlobalRef(jMap);
+  env->DeleteGlobalRef(jObject);
+  env->DeleteGlobalRef(jString);
+  env->DeleteGlobalRef(jJavaScriptObject);
+  env->DeleteGlobalRef(jJavaScriptValue);
+  env->DeleteGlobalRef(jJavaScriptTypedArray);
+  env->DeleteGlobalRef(jReadableNativeArray);
+  env->DeleteGlobalRef(jReadableNativeMap);
+  env->DeleteGlobalRef(jWritableNativeArray);
+  env->DeleteGlobalRef(jWritableNativeMap);
+  env->DeleteGlobalRef(jSharedObject);
+  env->DeleteGlobalRef(jJavaScriptModuleObject);
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
@@ -57,6 +57,7 @@ public:
   jclass jSharedObject;
   jclass jJavaScriptModuleObject;
 
+  void unLoad(JNIEnv *env);
 private:
   std::unordered_map<std::string, jclass> jClassRegistry;
 };
@@ -65,6 +66,7 @@ class JCacheHolder {
 public:
   static void init(JNIEnv *env);
 
+  static void unLoad(JNIEnv *env);
   /**
    * Gets a singleton instance
    */


### PR DESCRIPTION
# Why

Unloads global Java references.

# How

It isn't a big deal that we didn't unload those references earlier because in normal app flow, the cpp library isn't unloaded. However, we should probably handle that case. 

# Test Plan

- bare-expo ✅ 