### PR TITLE
[docs] update macos 14.6 eas build infra

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -277,7 +277,25 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-sonoma-14.5-xcode-15.4` (`latest`, `sdk-51`, `sdk-50`, `sdk-49`)
+#### `macos-sonoma-14.6-xcode-16.0` (`latest`)
+
+<Collapsible summary="Details">
+
+- macOS Sonoma 14.6
+- Xcode 16.0 (16A242d)
+- Node.js 18.18.0
+- Bun 1.1.27
+- Yarn 1.22.21
+- pnpm 9.10.0
+- npm 9.8.1
+- fastlane 2.222.0
+- CocoaPods 1.15.2
+- Ruby 3.2
+- node-gyp 10.2.0
+
+</Collapsible>
+
+#### `macos-sonoma-14.5-xcode-15.4` (`sdk-51`, `sdk-50`, `sdk-49`)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/31725#issuecomment-2378655201

# How

add `macos-sonoma-14.6-xcode-16.0` image info getting from turtle-v2

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
