### PR TITLE
Update sending-notifications-custom.mdx. Added notification section t…

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -70,6 +70,11 @@ async function sendFCMv1Notification() {
         scopeKey: '@yourExpoUsername/yourProjectSlug',
         experienceId: '@yourExpoUsername/yourProjectSlug',
       },
+      //optional: to display notification in status bar or at the lock screen - add notification section to message payload
+      notification: {
+        title: 'This is an FCM notification message',
+        body: 'Testing'
+      }
     },
   };
 


### PR DESCRIPTION
…o properly display notification bar and message

# Why

Notification sent is correct, message ID obtains well, but notification doesn't show at status bar or on the lock screen.

# How
"expo-notifications": "~0.28.17"
"expo": "~51.0.34"

Found that notification never appears without that section when app is in background.

# Test Plan

Try to obtain device token via getDevicePushTokenAsync, configure FCM V1 according to Expo doc.
Write simple nodejs server to send push notifications via FCM v1. Nothing appears, but message ID is received.
Add notification section to message payload.
Notification apears.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
