### PR TITLE
docs: rewrite the React Native Debugger documentation to point toward Expo Devtool plugins

### DIFF
--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -205,11 +205,15 @@ Pressing the <kbd>shift</kbd> + <kbd>m</kbd> shortcut will also show installed [
 
 ## React Native Debugger
 
-> **warning** The React Native Debugger does not support apps using Hermes, see the [Chrome DevTools](#debugging-with-chrome-devtools) section.
+> **warning** The React Native Debugger requires Remote JS debugging, which has been deprecated since [React Native 0.73](https://reactnative.dev/docs/other-debugging-methods#remote-javascript-debugging-deprecated).
+The React Native Debugger is a standalone app that wraps the React DevTools, Redux DevTools, and the Chrome DevTools. Unfortunately, [React Native Debugger requires](https://github.com/jhen0409/react-native-debugger/discussions/774) the deprecated Remote JS debugging workflow and is incompatible with Hermes. 
 
-The React Native Debugger includes many tools listed later on this page, all bundled into one, including [React DevTools](#debugging-with-react-devtools) and network request inspection. For this reason, if you use one tool from this page, it should probably be this one.
+If you are using Expo **SDK 50** or **later**, you can use the [Expo Devtool plugins](/debugging/devtools-plugins) equivalents to the React Native Debugger.
+  - [React DevTools](#debugging-with-react-devtools)
+  - [Redux DevTools](/debugging/devtools-plugins/#redux)
+  - [Chrome DevTools](#debugging-with-chrome-devtools)
 
-We'll give a quick look at it here, but check out their [documentation](https://github.com/jhen0409/react-native-debugger#documentation) for a more in-depth look.
+If you are using Expo **SDK 49** or **earlier**, you can use the React Native Debugger. We'll give a quick look at it here, but check out their [documentation](https://github.com/jhen0409/react-native-debugger#documentation) for a more in-depth look.
 
 You can install it via the [release page](https://github.com/jhen0409/react-native-debugger/releases), or if you're on macOS you can run:
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -206,12 +206,13 @@ Pressing the <kbd>shift</kbd> + <kbd>m</kbd> shortcut will also show installed [
 ## React Native Debugger
 
 > **warning** The React Native Debugger requires Remote JS debugging, which has been deprecated since [React Native 0.73](https://reactnative.dev/docs/other-debugging-methods#remote-javascript-debugging-deprecated).
-The React Native Debugger is a standalone app that wraps the React DevTools, Redux DevTools, and the Chrome DevTools. Unfortunately, [React Native Debugger requires](https://github.com/jhen0409/react-native-debugger/discussions/774) the deprecated Remote JS debugging workflow and is incompatible with Hermes. 
+> The React Native Debugger is a standalone app that wraps the React DevTools, Redux DevTools, and the Chrome DevTools. Unfortunately, [React Native Debugger requires](https://github.com/jhen0409/react-native-debugger/discussions/774) the deprecated Remote JS debugging workflow and is incompatible with Hermes.
 
 If you are using Expo **SDK 50** or **later**, you can use the [Expo Devtool plugins](/debugging/devtools-plugins) equivalents to the React Native Debugger.
-  - [React DevTools](#debugging-with-react-devtools)
-  - [Redux DevTools](/debugging/devtools-plugins/#redux)
-  - [Chrome DevTools](#debugging-with-chrome-devtools)
+
+- [React DevTools](#debugging-with-react-devtools)
+- [Redux DevTools](/debugging/devtools-plugins/#redux)
+- [Chrome DevTools](#debugging-with-chrome-devtools)
 
 If you are using Expo **SDK 49** or **earlier**, you can use the React Native Debugger. We'll give a quick look at it here, but check out their [documentation](https://github.com/jhen0409/react-native-debugger#documentation) for a more in-depth look.
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -206,15 +206,16 @@ Pressing the <kbd>shift</kbd> + <kbd>m</kbd> shortcut will also show installed [
 ## React Native Debugger
 
 > **warning** The React Native Debugger requires Remote JS debugging, which has been deprecated since [React Native 0.73](https://reactnative.dev/docs/other-debugging-methods#remote-javascript-debugging-deprecated).
-> The React Native Debugger is a standalone app that wraps the React DevTools, Redux DevTools, and the Chrome DevTools. Unfortunately, [React Native Debugger requires](https://github.com/jhen0409/react-native-debugger/discussions/774) the deprecated Remote JS debugging workflow and is incompatible with Hermes.
 
-If you are using Expo **SDK 50** or **later**, you can use the [Expo Devtool plugins](/debugging/devtools-plugins) equivalents to the React Native Debugger.
+The React Native Debugger is a standalone app that wraps the React DevTools, Redux DevTools, and the Chrome DevTools. Unfortunately, it requires the [deprecated Remote JS debugging workflow](https://github.com/jhen0409/react-native-debugger/discussions/774) and is incompatible with Hermes.
+
+If you are using Expo **SDK 50** or **above**, you can use the [Expo dev tools plugins](/debugging/devtools-plugins) equivalents to the React Native Debugger:
 
 - [React DevTools](#debugging-with-react-devtools)
 - [Redux DevTools](/debugging/devtools-plugins/#redux)
 - [Chrome DevTools](#debugging-with-chrome-devtools)
 
-If you are using Expo **SDK 49** or **earlier**, you can use the React Native Debugger. We'll give a quick look at it here, but check out their [documentation](https://github.com/jhen0409/react-native-debugger#documentation) for a more in-depth look.
+If you are using Expo SDK 49 or below, you can use the React Native Debugger. This section provides quick get started instructions. For in-depth information, check its [documentation](https://github.com/jhen0409/react-native-debugger#documentation).
 
 You can install it via the [release page](https://github.com/jhen0409/react-native-debugger/releases), or if you're on macOS you can run:
 


### PR DESCRIPTION
# Why

Remote JS Debugging has been deprecated since React Native 0.73, and is in a broken state in SDK 51, likely SDK 50, and possibly SDK 49.

We should avoid recommending users try the React Native Debugger.

# How

- Updated documentation with links to relevant info

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
