### PR TITLE
refactor(cli): trim down the built-in Metro dev server

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { bin, ensurePortFreeAsync, setupTestProjectWithOptionsAsync } from './utils';
 
-describe('bunding code', () => {
+describe('bundling code', () => {
   const metro = withMetroServer('metro-server-bundle-code', 'with-blank');
 
   it('bundles the app entry point', async () => {

--- a/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
@@ -1,0 +1,118 @@
+import execa from 'execa';
+import fs from 'fs-extra';
+import assert from 'node:assert';
+import path from 'node:path';
+
+import { bin, ensurePortFreeAsync, setupTestProjectWithOptionsAsync } from './utils';
+
+describe('bunding code', () => {
+  const metro = withMetroServer('metro-server-bundle-code', 'with-blank');
+
+  it('bundles the app entry point', async () => {
+    const response = await metro.fetch('/App.bundle?platform=ios');
+    expect(response).toMatchObject({ status: 200 });
+    expect(response.headers.get('Content-Type')).toContain('application/javascript');
+  });
+});
+
+describe('serving assets', () => {
+  const metro = withMetroServer('metro-server-bundle-asset', 'with-assets');
+
+  it('serves assets using url pathname references', async () => {
+    const response = await metro.fetch('/assets/assets/icon.png');
+    expect(response).toMatchObject({ status: 200 });
+    expect(response.headers.get('Content-Type')).toContain('image/png');
+  });
+
+  it('serves assets using unstable_path references', async () => {
+    const response = await metro.fetch(
+      `/assets?unstable_path=${encodeURIComponent('./assets/icon.png')}`
+    );
+    expect(response).toMatchObject({ status: 200 });
+    expect(response.headers.get('Content-Type')).toContain('image/png');
+  });
+
+  it('serves assets from public folder', async () => {
+    const response = await metro.fetch('/favicon.ico');
+    expect(response).toMatchObject({ status: 200 });
+    expect(response.headers.get('Content-Type')).toContain('image/x-icon');
+  });
+});
+
+function withMetroServer(testName: string, fixtureName = 'with-blank') {
+  // Could take 45s depending on how fast npm installs
+  jest.setTimeout(120 * 1000);
+
+  let projectRoot: string | null = null;
+  // Keep track of the Metro server process
+  let metroProcess: execa.ExecaChildProcess<string> | null = null;
+
+  // Ensure the test project is set up before the tests start
+  beforeAll(() => setupServer());
+  // Ensure the Metro server is active before each test, even when closed manually
+  beforeEach(() => startServer());
+  // Ensure the Metro server is killed after all tests
+  afterAll(() => killServer());
+
+  async function setupServer() {
+    // Prepare the test project
+    projectRoot = await setupTestProjectWithOptionsAsync(testName, fixtureName);
+    // Ensure no .expo directory / previous state is present
+    await fs.remove(path.join(projectRoot, '.expo'));
+  }
+
+  async function killServer() {
+    await ensurePortFreeAsync(8081);
+    metroProcess = null;
+  }
+
+  async function stopServer() {
+    if (!metroProcess) return;
+    metroProcess.kill('SIGTERM');
+    await metroProcess;
+    metroProcess = null;
+  }
+
+  async function startServer() {
+    assert(projectRoot !== null, 'Metro server project is not set up yet');
+    if (metroProcess) return;
+
+    console.log('Starting server');
+
+    metroProcess = execa('node', [bin, 'start'], {
+      cwd: projectRoot!,
+      env: {
+        ...process.env,
+        EXPO_USE_FAST_RESOLVER: 'true',
+      },
+    });
+
+    // Wait until the server crashed or is up and running
+    await new Promise<void>((resolve, reject) => {
+      assert(metroProcess, 'Metro server is not started yet');
+
+      metroProcess.on('close', (code: number) => {
+        reject(
+          code === 0
+            ? 'Server closed too early. Run `kill -9 $(lsof -ti:8081)` to kill the orphaned process.'
+            : code
+        );
+      });
+
+      metroProcess.stdout?.on('data', (data) => {
+        const stdout = data.toString();
+        console.log('output:', stdout);
+        if (stdout.includes('Logs for your project')) {
+          resolve();
+        }
+      });
+    });
+  }
+
+  return {
+    startServer,
+    stopServer,
+    killServer,
+    fetch: (path: string, init?: RequestInit) => fetch(`http://localhost:8081${path}`, init),
+  };
+}

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -66,6 +66,7 @@
     "cacache": "^18.0.2",
     "chalk": "^4.0.0",
     "ci-info": "^3.3.0",
+    "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
     "env-editor": "^0.4.1",

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -1,10 +1,10 @@
 import { withMetroServer } from './utils';
 import { openInEditorAsync } from '../../../../../utils/editor';
-import { createMetroDevMiddleware } from '../createMetroDevMiddleware';
+import { createMetroMiddleware } from '../createMetroMiddleware';
 
 jest.mock('../../../../../utils/editor');
 
-describe(createMetroDevMiddleware, () => {
+describe(createMetroMiddleware, () => {
   const { metro, server, projectRoot } = withMetroServer();
 
   it('disables cache on all requests', async () => {

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
@@ -4,17 +4,17 @@ import { parse } from 'node:url';
 import { promisify } from 'node:util';
 import { ClientOptions, WebSocket } from 'ws';
 
-import { createMetroDevMiddleware } from '../createMetroDevMiddleware';
+import { createMetroMiddleware } from '../createMetroMiddleware';
 
 export function withMetroServer(projectRoot = '/project'): {
   projectRoot: string;
-  metro: ReturnType<typeof createMetroDevMiddleware>;
+  metro: ReturnType<typeof createMetroMiddleware>;
   server: ReturnType<typeof createServer> & {
     fetch: (url: string, init?: RequestInit) => Promise<Response>;
     connect: (url: string) => WebSocket;
   };
 } {
-  const metro = createMetroDevMiddleware({ projectRoot });
+  const metro = createMetroMiddleware({ projectRoot });
   const server = createServer(metro.middleware);
 
   const closeServer = promisify(server.close.bind(server));

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createEventSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createEventSocket.ts
@@ -13,6 +13,10 @@ type EventsSocketOptions = {
   broadcast: ReturnType<typeof createMessagesSocket>['broadcast'];
 };
 
+/**
+ * Metro events server that dispatches all Metro events to connected clients.
+ * This includes logs, errors, bundling progression, etc.
+ */
 export function createEventsSocket(options: EventsSocketOptions) {
   const clients = createSocketMap();
   const broadcast = createBroadcaster(clients.map);

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createEventSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createEventSocket.ts
@@ -51,7 +51,14 @@ export function createEventsSocket(options: EventsSocketOptions) {
   return {
     endpoint: '/events' as const,
     server: new WebSocketServer({ noServer: true }),
-    reportMetroEvent: (event: any) => broadcast(null, serializeMetroEvent(event)),
+    reportMetroEvent: (event: any) => {
+      // Avoid serializing data if there are no clients
+      if (!clients.map.size) {
+        return;
+      }
+
+      return broadcast(null, serializeMetroEvent(event));
+    },
   };
 }
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -11,6 +11,10 @@ type MessageSocketOptions = {
   };
 };
 
+/**
+ * Client "command" server that dispatches basic commands to connected clients.
+ * This basic client to client communication, reload, or open dev menu cli commands.
+ */
 export function createMessagesSocket(options: MessageSocketOptions) {
   const clients = createSocketMap();
   const broadcast = createBroadcaster(clients.map);

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -6,7 +6,7 @@ import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
 
-export function createMetroDevMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
+export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
   const messages = createMessagesSocket({ logger: Log });
   const events = createEventsSocket(messages);
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -6,12 +6,15 @@ import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
 
+const compression = require('compression');
+
 export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
   const messages = createMessagesSocket({ logger: Log });
   const events = createEventsSocket(messages);
 
   const middleware = connect()
     .use(noCacheMiddleware)
+    .use(compression())
     // Support opening stack frames from clients directly in the editor
     .use('/open-stack-frame', rawBodyMiddleware)
     .use('/open-stack-frame', metroOpenStackFrameMiddleware)

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -17,7 +17,7 @@ import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { attachAtlasAsync } from './debugging/attachAtlas';
 import { createDebugMiddleware } from './debugging/createDebugMiddleware';
-import { createMetroDevMiddleware } from './dev-server/createMetroDevMiddleware';
+import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
 import { runServer } from './runServer-fork';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
 import { Log } from '../../../log';
@@ -184,7 +184,7 @@ export async function instantiateMetroAsync(
 
   // Create the core middleware stack for Metro, including websocket listeners
   const { middleware, messagesSocket, eventsSocket, websocketEndpoints } =
-    createMetroDevMiddleware(metroConfig);
+    createMetroMiddleware(metroConfig);
 
   if (!isExporting) {
     // Enable correct CORS headers for Expo Router features
@@ -195,16 +195,6 @@ export async function instantiateMetroAsync(
     Object.assign(websocketEndpoints, debugWebsocketEndpoints);
     middleware.use(debugMiddleware);
     middleware.use('/_expo/debugger', createJsInspectorMiddleware());
-
-    // TODO: We can probably drop this now.
-    const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
-    // @ts-expect-error: can't mutate readonly config
-    metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: Metro.Server) => {
-      if (customEnhanceMiddleware) {
-        metroMiddleware = customEnhanceMiddleware(metroMiddleware, server);
-      }
-      return middleware.use(metroMiddleware);
-    };
   }
 
   // Attach Expo Atlas if enabled

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -193,6 +193,18 @@ export async function instantiateMetroAsync(
     Object.assign(websocketEndpoints, debugWebsocketEndpoints);
     middleware.use(debugMiddleware);
     middleware.use('/_expo/debugger', createJsInspectorMiddleware());
+
+    // TODO(cedric): `enhanceMiddleware` is deprecated, but is currently used to unify the middleware stacks
+    // See: https://github.com/facebook/metro/commit/22e85fde85ec454792a1b70eba4253747a2587a9
+    // See: https://github.com/facebook/metro/commit/d0d554381f119bb80ab09dbd6a1d310b54737e52
+    const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
+    // @ts-expect-error: can't mutate readonly config
+    metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: Metro.Server) => {
+      if (customEnhanceMiddleware) {
+        metroMiddleware = customEnhanceMiddleware(metroMiddleware, server);
+      }
+      return middleware.use(metroMiddleware);
+    };
   }
 
   // Attach Expo Atlas if enabled

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import { getMetroServerRoot } from '@expo/config/paths';
 import { getDefaultConfig, LoadOptions } from '@expo/metro-config';
 import chalk from 'chalk';
-import http, { ServerResponse } from 'http';
+import http from 'http';
 import type Metro from 'metro';
 import Bundler from 'metro/src/Bundler';
 import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
@@ -10,7 +10,6 @@ import MetroHmrServer from 'metro/src/HmrServer';
 import { loadConfig, resolveConfig, ConfigT } from 'metro-config';
 import { Terminal } from 'metro-core';
 import util from 'node:util';
-import { URL } from 'url';
 
 import { createDevToolsPluginWebsocketEndpoint } from './DevToolsPluginWebsocketEndpoint';
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
@@ -27,7 +26,6 @@ import { createCorsMiddleware } from '../middleware/CorsMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
 import { getPlatformBundlers } from '../platformBundlers';
-import { ServerNext, ServerRequest } from '../middleware/server.types';
 
 // From expo/dev-server but with ability to use custom logger.
 type MessageSocket = {
@@ -251,19 +249,6 @@ export async function instantiateMetroAsync(
       fileBuffer
     );
   };
-
-  prependMiddleware(middleware, (req: ServerRequest, res: ServerResponse, next: ServerNext) => {
-    // If the URL is a Metro asset request, then we need to skip all other middleware to prevent
-    // the community CLI's serve-static from hosting `/assets/index.html` in place of all assets if it exists.
-    // /assets/?unstable_path=.
-    if (req.url) {
-      const url = new URL(req.url!, 'http://localhost:8000');
-      if (url.pathname.match(/^\/assets\/?/) && url.searchParams.get('unstable_path') != null) {
-        return metro.processRequest(req, res, next);
-      }
-    }
-    return next();
-  });
 
   setEventReporter(eventsSocket.reportMetroEvent);
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, getConfig } from '@expo/config';
 import { getMetroServerRoot } from '@expo/config/paths';
 import { getDefaultConfig, LoadOptions } from '@expo/metro-config';
 import chalk from 'chalk';
-import http from 'http';
+import http, { ServerResponse } from 'http';
 import type Metro from 'metro';
 import Bundler from 'metro/src/Bundler';
 import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
@@ -26,8 +26,8 @@ import { CommandError } from '../../../utils/errors';
 import { createCorsMiddleware } from '../middleware/CorsMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
-import { ServerNext, ServerRequest, ServerResponse } from '../middleware/server.types';
 import { getPlatformBundlers } from '../platformBundlers';
+import { ServerNext, ServerRequest } from '../middleware/server.types';
 
 // From expo/dev-server but with ability to use custom logger.
 type MessageSocket = {
@@ -188,7 +188,7 @@ export async function instantiateMetroAsync(
 
   if (!isExporting) {
     // Enable correct CORS headers for Expo Router features
-    middleware.use(createCorsMiddleware(exp));
+    prependMiddleware(middleware, createCorsMiddleware(exp));
 
     // Enable debug middleware for CDP-related debugging
     const { debugMiddleware, debugWebsocketEndpoints } = createDebugMiddleware(metroBundler);


### PR DESCRIPTION
# Why

This is a follow-up PR from #31570, adding more tests and removing extraneous modifications we made to the Metro dev server from RNC cli server API.

It's a small finishing touch on the current setup, without trying to refactor the middleware getting added in `MetroBundlerDevServer`. This would be the next future step, unifying these and simplifying our middleware mutations.

# How

- Moved the CORS middleware as prepended middleware
- Added back `compression` - Bundles seem to get enough compressed that it makes it faster to load compared to uncompressed, even on the same machine through localhost 🤷
- Dropped asset middleware workaround - We don't serve all watch folders statically anymore, so we don't need this workaround.
- Avoid serializing Metro events when no client is listening

# Test Plan

See added Metro e2e test for basic metro functionality (like bundling code and assets).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
