### PR TITLE
[expo-go] fix benchmarking module resolution

### DIFF
--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -47,6 +47,7 @@ config.watchFolders = [
   path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
   path.join(monorepoRoot, 'react-native-lab'), // Allow Metro to resolve `react-native-lab/react-native` files
   path.join(monorepoRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
+  path.join(monorepoRoot, 'apps/bare-expo/modules/benchmarking'), // Allow Metro to resolve benchmarking folder
 ];
 
 module.exports = config;


### PR DESCRIPTION
# Why

expo go currently won't launch NCL. Metro bundler for NCL will crash with `Unable to resolve "benchmarking" from "apps/native-component-list/src/screens/ModulesCore/ModulesBenchmarksScreen.tsx"` even though it's using `optionalRequire`.

Not that benchmarking screen is not enabled in expo go, it's only enabled / visible in bare expo

# How
 I added a hint for metro on where to find it.

# Test Plan

NCL launches in Expo go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
