### PR TITLE
[core] cleanup rn 0.74 todos

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 💡 Others
 
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
+- Removed deprecated code for SDK 49. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-menu/ios/DevClientAppDelegate.h
+++ b/packages/expo-dev-menu/ios/DevClientAppDelegate.h
@@ -14,20 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)initRootViewFactory;
 
-#pragma mark - Remove these method when we drop SDK 49
-
-// These methods are backward compatible layer to define nonnull `RCTAppDelegate`,
-// which is landed after React Native 0.74:
-// https://github.com/facebook/react-native/commit/a7c5c2821c39a7bf653919353897d27d29a64068
-
-- (UIView *)createRootViewWithBridge:(RCTBridge *)bridge
-                          moduleName:(NSString *)moduleName
-                           initProps:(NSDictionary *)initProps;
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge;
-- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
-- (BOOL)bridge:(RCTBridge *)bridge didNotFindModule:(NSString *)moduleName;
-
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-menu/ios/DevClientAppDelegate.h
+++ b/packages/expo-dev-menu/ios/DevClientAppDelegate.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)initRootViewFactory;
 
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Removed all `NativeModulesProxy` occurrences. ([#31496](https://github.com/expo/expo/pull/31496) by [@reichhartd](https://github.com/reichhartd))
 - Align web implementation exports as native to support DOM components when using `@expo/dom-webview`. ([#31662](https://github.com/expo/expo/pull/31662) by [@kudo](https://github.com/kudo))
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
+- Removed deprecated code for react-native 0.74.0. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -58,26 +58,7 @@ class CoreModule : Module() {
 
     AsyncFunction("reloadAppAsync") { _: String ->
       val reactActivity = appContext.throwingActivity as? ReactActivity ?: return@AsyncFunction
-
-      // TODO(kudo): Use ReactActivity.getReactDelegate() after react-native 0.74.1
-      // reactActivity.getReactDelegate()
-      val reactActivityDelegateField = ReactActivity::class.java.getDeclaredField("mDelegate")
-        .apply { isAccessible = true }
-      val reactActivityDelegate = reactActivityDelegateField[reactActivity]
-      val getReactDelegateMethod = reactActivityDelegate.javaClass.getDeclaredMethod("getReactDelegate")
-        .apply { isAccessible = true }
-      val reactDelegate = getReactDelegateMethod.invoke(reactActivityDelegate) as? ReactDelegate
-        ?: return@AsyncFunction
-      if (!ReactFeatureFlags.enableBridgelessArchitecture) {
-        val reactInstanceManager = reactDelegate.reactInstanceManager
-        if (reactInstanceManager.devSupportManager is ReleaseDevSupportManager) {
-          UiThreadUtil.runOnUiThread {
-            reactInstanceManager.recreateReactContextInBackground()
-          }
-          return@AsyncFunction
-        }
-      }
-
+      val reactDelegate = reactActivity.reactDelegate ?: return@AsyncFunction
       reactDelegate.reload()
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -1,10 +1,6 @@
 package expo.modules.kotlin.defaultmodules
 
 import com.facebook.react.ReactActivity
-import com.facebook.react.ReactDelegate
-import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.config.ReactFeatureFlags
-import com.facebook.react.devsupport.ReleaseDevSupportManager
 import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -7,8 +7,11 @@
 #import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 #import <ReactCommon/ReactCommon-umbrella.h>
+#import <React/RCTComponentViewFactory.h> // Allows non-umbrella since it's coming from React-RCTFabric
+#import <ReactCommon/RCTHost.h> // Allows non-umbrella because the header is not inside a clang module
 
-@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate>
+
+@interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider, RCTHostDelegate>
 @end
 
 @interface RCTRootViewFactoryConfiguration ()
@@ -95,11 +98,47 @@
     return [weakSelf createBridgeWithDelegate:delegate launchOptions:launchOptions];
   };
 
-  // TODO(kudo,20240706): Remove respondsToSelector and set the property directly when we upgrade to react-native 0.75
-  if ([configuration respondsToSelector:@selector(setCustomizeRootView:)]) {
-    [configuration setCustomizeRootView:^(UIView *_Nonnull rootView) {
-      [weakSelf customizeRootView:(RCTRootView *)rootView];
-    }];
+  configuration.customizeRootView = ^(UIView *_Nonnull rootView) {
+    [weakSelf customizeRootView:(RCTRootView *)rootView];
+  };
+
+  configuration.sourceURLForBridge = ^NSURL *_Nullable(RCTBridge *_Nonnull bridge)
+  {
+    return [weakSelf sourceURLForBridge:bridge];
+  };
+
+  configuration.hostDidStartBlock = ^(RCTHost *_Nonnull host) {
+    [weakSelf hostDidStart:host];
+  };
+
+  configuration.hostDidReceiveJSErrorStackBlock =
+      ^(RCTHost *_Nonnull host,
+        NSArray<NSDictionary<NSString *, id> *> *_Nonnull stack,
+        NSString *_Nonnull message,
+        NSUInteger exceptionId,
+        BOOL isFatal) {
+        [weakSelf host:host didReceiveJSErrorStack:stack message:message exceptionId:exceptionId isFatal:isFatal];
+      };
+
+  if ([self respondsToSelector:@selector(extraModulesForBridge:)]) {
+    configuration.extraModulesForBridge = ^NSArray<id<RCTBridgeModule>> *_Nonnull(RCTBridge *_Nonnull bridge)
+    {
+      return [weakSelf extraModulesForBridge:bridge];
+    };
+  }
+
+  if ([self respondsToSelector:@selector(extraLazyModuleClassesForBridge:)]) {
+    configuration.extraLazyModuleClassesForBridge =
+        ^NSDictionary<NSString *, Class> *_Nonnull(RCTBridge *_Nonnull bridge)
+    {
+      return [weakSelf extraLazyModuleClassesForBridge:bridge];
+    };
+  }
+
+  if ([self respondsToSelector:@selector(bridge:didNotFindModule:)]) {
+    configuration.bridgeDidNotFindModule = ^BOOL(RCTBridge *_Nonnull bridge, NSString *_Nonnull moduleName) {
+      return [weakSelf bridge:bridge didNotFindModule:moduleName];
+    };
   }
 
   return [[EXReactRootViewFactory alloc] initWithReactDelegate:self.reactDelegate configuration:configuration turboModuleManagerDelegate:self];
@@ -110,5 +149,26 @@
   [_expoAppDelegate customizeRootView:rootView];
 }
 #endif // !TARGET_OS_OSX
+
+#pragma mark - RCTComponentViewFactoryComponentProvider
+
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
+{
+  return @{};
+}
+
+#pragma mark - RCTHostDelegate
+
+- (void)hostDidStart:(RCTHost *)host
+{
+}
+
+- (void)host:(RCTHost *)host
+    didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
+                   message:(NSString *)message
+               exceptionId:(NSUInteger)exceptionId
+                   isFatal:(BOOL)isFatal
+{
+}
 
 @end

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -102,10 +102,8 @@
     [weakSelf customizeRootView:(RCTRootView *)rootView];
   };
 
-  configuration.sourceURLForBridge = ^NSURL *_Nullable(RCTBridge *_Nonnull bridge)
-  {
-    return [weakSelf sourceURLForBridge:bridge];
-  };
+  // NOTE(kudo): `sourceURLForBridge` is not referenced intentionally because it does not support New Architecture.
+  configuration.sourceURLForBridge = nil;
 
   configuration.hostDidStartBlock = ^(RCTHost *_Nonnull host) {
     [weakSelf hostDidStart:host];


### PR DESCRIPTION
# Why

cleanup some todos from react-native 0.74

# How

- [android] use upstream reload
- [ios] remove `respondsToSelector` todo and sync 0.75 `createRCTRootViewFactory` [changes](https://github.com/facebook/react-native/blob/893a4b30b1596fff1a85e66139ec697674673034/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L238-L304)

# Test Plan

- ci passed
- run NCL ModulesCore `reloadAppAsync` on bare-expo android debug/release build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
