### PR TITLE
[docs] Add a Local app production and create a Local app section

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -136,7 +136,6 @@ const general = [
   makeSection('Development process', [
     makePage('workflow/overview.mdx'),
     makePage('workflow/configuration.mdx'),
-    makePage('guides/local-app-development.mdx'),
     makePage('workflow/using-libraries.mdx'),
     makePage('guides/apple-privacy.mdx'),
     makePage('guides/permissions.mdx'),
@@ -152,6 +151,13 @@ const general = [
         makePage('guides/adopting-prebuild.mdx'),
       ],
       { expanded: false }
+    ),
+    makeGroup(
+      'Local app',
+      [makePage('guides/local-app-development.mdx'), makePage('guides/local-app-production.mdx')],
+      {
+        expanded: false,
+      }
     ),
     makeGroup(
       'Web',

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -3,11 +3,12 @@ title: Run builds locally or on your own infrastructure
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that is typically run on the EAS Build servers directly on your machine by using the `eas build --local` flag. This is a useful way to debug build failures that are happening on your cloud builds, which you may not be able to reproduce without running the same set of steps.
-
-> **Note:** To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. With both of these approaches, you will not be following the exact process that is run on the cloud with EAS Build — that is what the `eas build --local` flag is for.
 
 <Terminal
   cmd={['$ eas build --platform android --local', '# or', '$ eas build --platform ios --local']}
@@ -51,3 +52,25 @@ Some of the options available for cloud builds are not available locally. Limita
   - CocoaPods (iOS only)
   - Android SDK and NDK
 - On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds. However, we do not officially test against this platform and do not support Windows for local builds (macOS and Linux are supported).
+
+## App compilation for development and production builds locally
+
+To compile your app locally for development with Expo CLI, use `npx expo run:android` or `npx expo run:ios` commands instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. For more details, see:
+
+<BoxLink
+  title="Local app development"
+  Icon={BookOpen02Icon}
+  description="Learn how to compile and build your Expo app locally."
+  href="/guides/local-app-development/"
+/>
+
+To create a production build locally, you need Android Studio and Xcode installed on your computer. See the following guide for more information:
+
+<BoxLink
+  title="Create a production build locally"
+  Icon={BookOpen02Icon}
+  description="Learn how to create a production build for your Expo app locally on your computer."
+  href="/guides/local-app-production/"
+/>
+
+With any of the above approaches, you'll be following procedures which are different from creating a build on the cloud with EAS Build &mdash; that is what the `eas build --local` flag is for.

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -1,6 +1,7 @@
 ---
 title: Local app development
-description: Learn how to compile and build your app locally when using Expo.
+sidebar_title: Development
+description: Learn how to compile and build your Expo app locally.
 ---
 
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
@@ -36,7 +37,7 @@ The above commands compile your project, using your locally installed Android SD
 
 - These compilation commands initially run `npx expo prebuild` to generate native directories (**android** and **ios**) before building, if they do not exist yet. If they already exist, this will be skipped.
 - You can also add the `--device` flag to select a device to run the app on — you can select a physically connected device or emulator/simulator.
-- You can pass in `--variant release` (Android) or `--configuration Release` (iOS) to build a [production version of your app](/deploy/build-project/#production-builds-locally).
+- You can pass in `--variant release` (Android) or `--configuration Release` (iOS) to build a [production build of your app](/deploy/build-project/#production-builds-locally). Note that these builds are not signed and you cannot submit them to app stores. To sign your production build, see [Local app production](/guides/local-app-production/).
 
 To modify your project's configuration or native code after the first build, you will have to rebuild your project. Running `npx expo prebuild` again layers the changes on top of existing files. It may also produce different results after the build.
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -4,6 +4,7 @@ sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -21,6 +22,17 @@ Creating a production build locally for Android requires signing it with an [upl
 <Step label="1">
 
 ### Create an upload key
+
+<Collapsible summary="Already created a build with EAS Build? Download your credentials and skip to the next step.">
+
+If you've already created a build with EAS Build, follow the steps below to download the credentials, which contains the upload key and its password, key alias, and key password:
+
+1. In your terminal, run `eas credentials -p android` and select the build profile.
+2. Select **credentials.json** > **Download credentials from EAS to credentials.json**.
+3. Move the downloaded **keystore.jks** file to the **android/app** directory.
+4. Copy the values for the upload keystore password, key alias, and key password from the **credentials.json** as you will need them in the next step.
+
+</Collapsible>
 
 Inside your Expo project directory, run the following `keytool` command to create an upload key:
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create a local production build locally
+title: Create a production build locally
 sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---
@@ -7,11 +7,11 @@ description: Learn how to create a production build for your Expo app locally.
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps to create a production build for Android and iOS locally.
+To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
 
 ## Android
 
-Creating a local production build for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below to create a production build:
+Creating a production build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
 ### Prerequisites
 
@@ -102,7 +102,7 @@ This command will generate app-release.aab inside the android/app/build/outputs/
 
 ## iOS
 
-To create an iOS production build for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
+To create an iOS production build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
 ### Prerequisites
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,0 +1,159 @@
+---
+title: Local app production
+sidebar_title: Production
+description: Learn how to create a production build for your Expo app locally.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps to create a production build for Android and iOS locally.
+
+## Android
+
+Creating a local production build for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below to create a production build:
+
+### Prerequisites
+
+- [OpenJDK distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk) installed to access the `keytool` command
+- **android** directory generated. If you are using [CNG](/workflow/continuous-native-generation/), then run `npx expo prebuild` to generate it.
+
+<Step label="1">
+
+### Create an upload key
+
+Inside your Expo project directory, run the following `keytool` command to create an upload key:
+
+<Terminal
+  cmd={[
+    '$ sudo keytool -genkey -v -keystore my-upload-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000',
+  ]}
+/>
+
+After running this command, you will be prompted to enter a password for the keystore. This password will protect the upload key. Remember the password you enter here, as you'll need it in the next step.
+
+This command also generates the keystore file named **my-upload-key.keystore** in your project directory. Move it to the **android/app** directory.
+
+> **warning** If you commit the **android** directory to a version control system like Git, don't commit this keystore file. It contains your upload key and should be kept private.
+
+</Step>
+
+<Step label="2">
+
+### Update gradle variables
+
+Open **android/gradle.properties** file and add the following gradle variables at the end of the file. These variables contain information about your upload key:
+
+```groovy android/gradle.properties
+MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias
+MYAPP_UPLOAD_STORE_PASSWORD=*****
+MYAPP_UPLOAD_KEY_PASSWORD=*****
+```
+
+> **warning** If you commit the **android** directory to a version control system like Git, don't commit the above information. Instead, create a **~/.gradle/gradle.properties** file on your computer and add the above variables to this file.
+
+</Step>
+
+<Step label="3">
+
+### Add signing config to build.gradle
+
+Open **android/build.gradle** file and add the following configuration:
+
+```diff android/build.gradle
+android {
+  signingConfigs {
+    // ...
++   release {
++     if (project.hasProperty('MYAPP_UPLOAD_STORE_FILE')) {
++         storeFile file(MYAPP_UPLOAD_STORE_FILE)
++         storePassword MYAPP_UPLOAD_STORE_PASSWORD
++         keyAlias MYAPP_UPLOAD_KEY_ALIAS
++         keyPassword MYAPP_UPLOAD_KEY_PASSWORD
++     }
+    }
+  }
+  buildTypes {
+    // ...
+    release {
+      signingConfig signingConfigs.debug
++     signingConfig signingConfigs.release
+      minifyEnabled false
+      // ...
+    }
+  }
+}
+```
+
+</Step>
+
+<Step label="4">
+
+### Generate release Android Application Bundle (aab)
+
+Create a production build in **.aab** format by running Gradle's `bundleRelease` command:
+
+<Terminal cmd={['$ ./gradlew app:bundleRelease']} />
+
+This command will generate app-release.aab inside the android/app/build/outputs/bundle/release directory.
+
+</Step>
+
+## iOS
+
+To create an iOS production build for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
+
+### Prerequisites
+
+- Paid Apple Developer membership
+- [Xcode installed](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman) on your computer
+- **ios** directory generated. If you are using [CNG](/workflow/continuous-native-generation/), then run `npx expo prebuild` to generate it.
+
+<Step label="1">
+
+### Open iOS workspace in Xcode
+
+Inside your Expo project directory, run the following command to open `your-project.xcworkspace` in Xcode:
+
+<Terminal cmd={['$ xed ios']} />
+
+After opening the iOS project in Xcode:
+
+1. From the sidebar on the left, select your app's workspace.
+2. Go to **Signing & Capabilities** > **All** or **Release**.
+3. Under **Signing** > **Team**, ensure your Apple Developer team is selected. Xcode will generate an automatically managed Provisioning Profile and Signing Certificate.
+
+</Step>
+
+<Step label="2">
+
+### Configure a release scheme
+
+To configure your app's release scheme:
+
+1. From the menu bar, open **Product** > **Scheme** > **Edit Scheme**.
+2. Select **Run** from the sidebar, then set the **Build configuration** to **Release** using the dropdown.
+
+</Step>
+
+<Step label="3">
+
+### Build app for release
+
+To build your app for release, From the menu bar, open **Product** > **Build**. This step will build your app binary for release.
+
+</Step>
+
+<Step label="4">
+
+### App submission using App Store Connect
+
+Once the build is complete, you can distribute your app to TestFlight or submit it to the App Store using App Store Connect:
+
+1. From the menu bar, open **Product** > **Archive**.
+2. Under **Archives**, click **Distribute App** from the right sidebar.
+3. Click **App Store Connect** and follow the prompts shown in the window. This step will create an app store record and upload your app to the App Store.
+4. Now you can go to your App Store Connect account, select your app under Apps, and submit it for testing using TestFlight or prepare it for final release by following the steps in the App Store Connect dashboard.
+
+</Step>

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,5 +1,5 @@
 ---
-title: Local app production
+title: Create a local production build locally
 sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -121,7 +121,7 @@ Inside your Expo project directory, run the following command to open `your-proj
 After opening the iOS project in Xcode:
 
 1. From the sidebar on the left, select your app's workspace.
-2. Go to **Signing & Capabilities** > **All** or **Release**.
+2. Go to **Signing & Capabilities** and select **All** or **Release**.
 3. Under **Signing** > **Team**, ensure your Apple Developer team is selected. Xcode will generate an automatically managed Provisioning Profile and Signing Certificate.
 
 </Step>

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -231,13 +231,13 @@ The next step to developing an app is to share your app with your team, with bet
 
 If you are using EAS Build, we recommend going through [Internal distribution](/build/internal-distribution/) to learn more about sharing your app for testing.
 
-If you compile your app locally, you can create [release builds locally](/deploy/build-project/#production-builds-locally).
+If you compile your app locally, you can create [production builds locally](/guides/local-app-production/).
 
 ## Release app to stores
 
 To release your app on the app stores, you can use [EAS Submit](/submit/introduction/). For more information on using EAS Submit, see [Submit to Google Play Store](/submit/android/) and [Submit to Apple App Store](/submit/ios/).
 
-To create a release build locally, see [release builds locally](/deploy/build-project/#production-builds-locally) and then go through the app stores guide to submit your app.
+To create a production build locally, see the [guide](/guides/local-app-production/) on the same and then go through the app stores guide to submit your app.
 
 ## Monitor app in production
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @brentvatne on a missing in-detailed guide that covers steps on how to create a code signed production build for Android and iOS.

This new guide can be backlinked from other documents (like Deploy > Build a project from https://github.com/expo/expo/pull/31674) help us avoid explaining these steps. It also covers some Gradle specific configuration for Android which slightly differs from React Native's Android guide on the same subject.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Creates a sub-section under Guides > Development Process called "Local app"
- Adds a new guide named "Create a local production build locally"
  - This guide covers steps to create a code signed production build for Android and iOS based on the steps from React Native's [Android](https://reactnative.dev/docs/signed-apk-android) and [iOS](https://reactnative.dev/docs/publishing-to-app-store) guides but cover the differences for an Expo project (only applied to Android). iOS steps are the same.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
