### PR TITLE
[docs] Add a section about local apps

### DIFF
--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -64,12 +64,12 @@ To compile your app locally for development with Expo CLI, use `npx expo run:and
   href="/guides/local-app-development/"
 />
 
-To create a release build locally you need Android Studio and Xcode installed on your computer. See the following guide for more information:
+To create a production build locally, you need Android Studio and Xcode installed on your computer. See the following guide for more information:
 
 <BoxLink
-  title="Create a release build locally"
+  title="Create a production build locally"
   Icon={BookOpen02Icon}
-  description="Learn how to create a release build for your Expo app locally on your computer."
+  description="Learn how to create a production build for your Expo app locally on your computer."
   href="/guides/local-app-production/"
 />
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -64,13 +64,13 @@ To compile your app locally for development with Expo CLI, use `npx expo run:and
   href="/guides/local-app-development/"
 />
 
-To create a production build locally using Android Studio and Xcode, see:
+To create a release build locally you need Android Studio and Xcode installed on your computer. See the following guide for more information:
 
 <BoxLink
-  title="Create a local production build locally"
+  title="Create a release build locally"
   Icon={BookOpen02Icon}
-  description="Learn how to create a production build for your Expo app locally."
+  description="Learn how to create a release build for your Expo app locally on your computer."
   href="/guides/local-app-production/"
 />
 
-With any of the above approaches, you will not be following the exact process that is run on the cloud with EAS Build &mdash; that is what the `eas build --local` flag is for.
+With any of the above approaches, you'll be following procedures which are different from creating a build on the cloud with EAS Build &mdash; that is what the `eas build --local` flag is for.

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -3,11 +3,12 @@ title: Run builds locally or on your own infrastructure
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that is typically run on the EAS Build servers directly on your machine by using the `eas build --local` flag. This is a useful way to debug build failures that are happening on your cloud builds, which you may not be able to reproduce without running the same set of steps.
-
-> **Note:** To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. With both of these approaches, you will not be following the exact process that is run on the cloud with EAS Build — that is what the `eas build --local` flag is for.
 
 <Terminal
   cmd={['$ eas build --platform android --local', '# or', '$ eas build --platform ios --local']}
@@ -51,3 +52,25 @@ Some of the options available for cloud builds are not available locally. Limita
   - CocoaPods (iOS only)
   - Android SDK and NDK
 - On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds. However, we do not officially test against this platform and do not support Windows for local builds (macOS and Linux are supported).
+
+## Local app compilation for development and production builds
+
+To compile your app locally for development with Expo CLI, use `npx expo run:android` or `npx expo run:ios` commands instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. For more details, see:
+
+<BoxLink
+  title="Local app development"
+  Icon={BookOpen02Icon}
+  description="Learn how to compile and build your Expo app locally."
+  href="/guides/local-app-development/"
+/>
+
+To create a production build locally using Android Studio and Xcode, see:
+
+<BoxLink
+  title="Create a local production build locally"
+  Icon={BookOpen02Icon}
+  description="Learn how to create a production build for your Expo app locally."
+  href="/guides/local-app-production/"
+/>
+
+With any of the above approaches, you will not be following the exact process that is run on the cloud with EAS Build &mdash; that is what the `eas build --local` flag is for.

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -53,7 +53,7 @@ Some of the options available for cloud builds are not available locally. Limita
   - Android SDK and NDK
 - On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds. However, we do not officially test against this platform and do not support Windows for local builds (macOS and Linux are supported).
 
-## Local app compilation for development and production builds
+## App compilation for development and production builds locally
 
 To compile your app locally for development with Expo CLI, use `npx expo run:android` or `npx expo run:ios` commands instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. For more details, see:
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,17 +1,17 @@
 ---
-title: Create a release build locally
-sidebar_title: Release
-description: Learn how to create a release build for your Expo app locally on your computer.
+title: Create a production build locally
+sidebar_title: Production
+description: Learn how to create a production build for your Expo app locally.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-To create your app's release build (also known as production build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
+To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
 
 ## Android
 
-Creating a release build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
+Creating a production build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
 ### Prerequisites
 
@@ -92,7 +92,7 @@ android {
 
 ### Generate release Android Application Bundle (aab)
 
-Create a release build in **.aab** format by running Gradle's `bundleRelease` command:
+Create a production build in **.aab** format by running Gradle's `bundleRelease` command:
 
 <Terminal cmd={['$ ./gradlew app:bundleRelease']} />
 
@@ -102,7 +102,7 @@ This command will generate app-release.aab inside the android/app/build/outputs/
 
 ## iOS
 
-To create an iOS release build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
+To create an iOS production build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
 ### Prerequisites
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,17 +1,17 @@
 ---
-title: Create a local production build locally
-sidebar_title: Production
-description: Learn how to create a production build for your Expo app locally.
+title: Create a release build locally
+sidebar_title: Release
+description: Learn how to create a release build for your Expo app locally on your computer.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps to create a production build for Android and iOS locally.
+To create your app's release build (also known as production build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
 
 ## Android
 
-Creating a local production build for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below to create a production build:
+Creating a release build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
 ### Prerequisites
 
@@ -92,7 +92,7 @@ android {
 
 ### Generate release Android Application Bundle (aab)
 
-Create a production build in **.aab** format by running Gradle's `bundleRelease` command:
+Create a release build in **.aab** format by running Gradle's `bundleRelease` command:
 
 <Terminal cmd={['$ ./gradlew app:bundleRelease']} />
 
@@ -102,7 +102,7 @@ This command will generate app-release.aab inside the android/app/build/outputs/
 
 ## iOS
 
-To create an iOS production build for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
+To create an iOS release build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
 ### Prerequisites
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -231,13 +231,13 @@ The next step to developing an app is to share your app with your team, with bet
 
 If you are using EAS Build, we recommend going through [Internal distribution](/build/internal-distribution/) to learn more about sharing your app for testing.
 
-If you compile your app locally, you can create [release builds locally](/guides/local-app-production/).
+If you compile your app locally, you can create [production builds locally](/guides/local-app-production/).
 
 ## Release app to stores
 
 To release your app on the app stores, you can use [EAS Submit](/submit/introduction/). For more information on using EAS Submit, see [Submit to Google Play Store](/submit/android/) and [Submit to Apple App Store](/submit/ios/).
 
-To create a release build locally, see [release builds locally](/guides/local-app-production/) and then go through the app stores guide to submit your app.
+To create a production build locally, see [release builds locally](/guides/local-app-production/) and then go through the app stores guide to submit your app.
 
 ## Monitor app in production
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -237,7 +237,7 @@ If you compile your app locally, you can create [production builds locally](/gui
 
 To release your app on the app stores, you can use [EAS Submit](/submit/introduction/). For more information on using EAS Submit, see [Submit to Google Play Store](/submit/android/) and [Submit to Apple App Store](/submit/ios/).
 
-To create a production build locally, see [release builds locally](/guides/local-app-production/) and then go through the app stores guide to submit your app.
+To create a production build locally, see the [guide](/guides/local-app-production/) on the same and then go through the app stores guide to submit your app.
 
 ## Monitor app in production
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -231,13 +231,13 @@ The next step to developing an app is to share your app with your team, with bet
 
 If you are using EAS Build, we recommend going through [Internal distribution](/build/internal-distribution/) to learn more about sharing your app for testing.
 
-If you compile your app locally, you can create [release builds locally](/deploy/build-project/#production-builds-locally).
+If you compile your app locally, you can create [release builds locally](/guides/local-app-production/).
 
 ## Release app to stores
 
 To release your app on the app stores, you can use [EAS Submit](/submit/introduction/). For more information on using EAS Submit, see [Submit to Google Play Store](/submit/android/) and [Submit to Apple App Store](/submit/ios/).
 
-To create a release build locally, see [release builds locally](/deploy/build-project/#production-builds-locally) and then go through the app stores guide to submit your app.
+To create a release build locally, see [release builds locally](/guides/local-app-production/) and then go through the app stores guide to submit your app.
 
 ## Monitor app in production
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #31743

Based on a user feedback on how to compile an app locally for development and production.

The existing "Note" in this guide already covered the local development process, but we didn't have steps to link for production. Based on the changes from the PR linked above, we can add a section here to provide context and links to both of the local app guides.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove the note at the top of the page
- Add a section: App compilation for development and production builds locally

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-09-30 at 16 39 44@2x](https://github.com/user-attachments/assets/75f6d29c-a48e-409e-b5fc-9db0c283e31d)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
