### PR TITLE
fix(cli): add "sticky" resolutions for `react-native` and `/assets-registry`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Added public assets support for DOM components. ([#30975](https://github.com/expo/expo/pull/30975) by [@kudo](https://github.com/kudo))
 - Drop usage of `@react-native-community/cli-server-api` in favor of our own Metro dev middleware. ([#31570](https://github.com/expo/expo/pull/31570) by [@byCedric](https://github.com/byCedric))
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
+- Force-resolve `react-native` and `@react-native/assets-registry` to single packages. ([#31750](https://github.com/expo/expo/pull/31750) by [@byCedric](https://github.com/byCedric))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -118,7 +118,7 @@ describe(withExtendedResolver, () => {
 
     const platform = 'ios';
 
-    modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+    modified.resolver.resolveRequest!(getDefaultRequestContext(), 'expo', platform);
 
     expect(getResolveFunc()).toBeCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
@@ -131,7 +131,7 @@ describe(withExtendedResolver, () => {
         customResolverOptions: {},
         originModulePath: expect.anything(),
       }),
-      'react-native',
+      'expo',
       platform
     );
   });
@@ -912,6 +912,181 @@ describe(withExtendedResolver, () => {
         '/node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js',
         platform
       );
+    });
+  });
+
+  describe('sticky resolutions', () => {
+    const platform = 'ios';
+
+    function getModifiedConfig() {
+      return withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+        tsconfig: {},
+        isTsconfigPathsEnabled: false,
+        isReactCanaryEnabled: true,
+        getMetroBundler: getMetroBundlerGetter() as any,
+      });
+    }
+
+    it('resolves `react-native` as sticky module', () => {
+      const modified = getModifiedConfig();
+
+      // Ensure the sticky module can be resolved
+      getResolveFunc().mockImplementationOnce((_context, moduleImport, _platform) => {
+        assert(moduleImport === 'react-native/package.json');
+        return { type: 'sourceFile', filePath: '/node_modules/react-native/package.json' };
+      });
+
+      // Resolve the sticky module
+      modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+      // Resolution 1 - resolve sticky path of `react-native`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Object),
+        'react-native/package.json',
+        platform
+      );
+      // Resolution 2 - resolve with the sticky path
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Object),
+        '/node_modules/react-native',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(2);
+
+      // Reset the mock's call state
+      getResolveFunc().mockClear();
+      // Resolve the sticky module again
+      modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+      // Resolution 1 - resolve with the cached sticky path
+      expect(getResolveFunc()).toHaveBeenCalledWith(
+        expect.any(Object),
+        '/node_modules/react-native',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves `@react-native/assets-registry` as sticky module', () => {
+      const modified = getModifiedConfig();
+
+      // Ensure the sticky module can be resolved, asset registry relies on react native
+      getResolveFunc()
+        .mockImplementationOnce((_context, moduleImport, _platform) => {
+          assert(moduleImport === 'react-native/package.json');
+          return { type: 'sourceFile', filePath: '/node_modules/react-native/package.json' };
+        })
+        .mockImplementationOnce((_context, moduleImport, _platform) => {
+          assert(moduleImport === '@react-native/assets-registry/package.json');
+          return {
+            type: 'sourceFile',
+            filePath:
+              '/node_modules/react-native/node_modules/@react-native/assets-registry/package.json',
+          };
+        });
+
+      // Resolve the sticky module
+      modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        '@react-native/assets-registry/registry',
+        platform
+      );
+      // Resolution 1 - resolve sticky path of `react-native`, which is used for `@react-native/assets-registry`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Object),
+        'react-native/package.json',
+        platform
+      );
+      // Resolution 2 - resolve sticky path of `@react-native/assets-registry/registry`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ originModulePath: '/node_modules/react-native/package.json' }),
+        '@react-native/assets-registry/package.json',
+        platform
+      );
+      // Resolution 3 - resolve with the sticky path
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        3,
+        expect.any(Object),
+        '/node_modules/react-native/node_modules/@react-native/assets-registry/registry',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(3);
+
+      // Reset the mock's call state
+      getResolveFunc().mockClear();
+      // Resolve the sticky module again
+      modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        '@react-native/assets-registry/registry',
+        platform
+      );
+      // Resolution 1 - resolve with the cached sticky path
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Object),
+        '/node_modules/react-native/node_modules/@react-native/assets-registry/registry',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reuse failed sticky resolutions', () => {
+      const modified = getModifiedConfig();
+
+      // Let the first sticky resolution fail (by not returning a source file)
+      getResolveFunc().mockImplementationOnce((_context, moduleImport, _platform) => ({
+        type: 'empty',
+      }));
+      // Attempt to resolve the sticky module
+      modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+      // Resolution 1 - resolve sticky path of `react-native`, which fails
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Object),
+        'react-native/package.json',
+        platform
+      );
+      // Resolution 2 - resolve normally, without the unresolved sticky path
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Object),
+        'react-native',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(2);
+
+      // Reset the mock's call state
+      getResolveFunc().mockClear();
+      // Let the sticky resolution succeed
+      getResolveFunc().mockImplementationOnce((_context, moduleImport, _platform) => {
+        assert(moduleImport === 'react-native/package.json');
+        return { type: 'sourceFile', filePath: '/node_modules/react-native/package.json' };
+      });
+      // Attempt to resolve the sticky module again, using the same resolver instance
+      modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+      // Resolution 1 - resolve sticky path of `react-native`, which succeeds
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Object),
+        'react-native/package.json',
+        platform
+      );
+      // Resolution 2 - resolve with the sticky path
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Object),
+        '/node_modules/react-native',
+        platform
+      );
+      // Ensure no other calls were made
+      expect(getResolveFunc()).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/createStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createStickyResolver.ts
@@ -1,0 +1,118 @@
+import type { Resolution, ResolutionContext } from 'metro-resolver';
+import path from 'node:path';
+
+import type { ExpoCustomMetroResolver } from './withMetroResolvers';
+
+const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typeof console.log;
+
+type StrictResolver = (moduleName: string) => Resolution;
+type StrictResolverFactory = (
+  context: ResolutionContext,
+  platform: string | null
+) => StrictResolver;
+
+/**
+ * Get the module name that should be handled as sticky import.
+ */
+function getStickyModuleName(moduleImport: string) {
+  if (moduleImport === 'react-native' || moduleImport.startsWith('react-native/')) {
+    return 'react-native';
+  }
+
+  if (
+    moduleImport === '@react-native/assets-registry' ||
+    moduleImport.startsWith('@react-native/assets-registry/')
+  ) {
+    return '@react-native/assets-registry';
+  }
+
+  return null;
+}
+
+/**
+ * The sticky resolver is a resolver that resolves the root location of a module, and use that path for all subsequent resolutions.
+ * It should be primarily used to "deduplicate" packages that are vulnerable to multiple versions being resolved or bundled:
+ *   - `react-native` - When multiple versions are resolved, the app breaks in unexpected ways without clear errors
+ *   - `@react-native/assets-registry` - Installed by `react-native`, this package is stateful - only a single one can exist in the bundle
+ *
+ * @remarks This does NOT follow Node module resolution, and should be used with caution.
+ */
+export function createStickyResolver(
+  getStrictResolver: StrictResolverFactory
+): ExpoCustomMetroResolver {
+  // The root of all sticky modules
+  const moduleRoot: Record<string, string> = {};
+
+  const resolveStickyRoot = (
+    resolve: StrictResolver,
+    moduleName: string,
+    platform: string
+  ): null | string => {
+    // Resolve from the sticky modules cache
+    if (moduleRoot[moduleName] && moduleRoot[moduleName]) {
+      return moduleRoot[moduleName];
+    }
+
+    // Resolve the root module path through `<moduleName>/package.json`
+    const result = resolve(`${moduleName}/package.json`);
+    // Abort when the module is not a source file
+    if (result.type !== 'sourceFile') {
+      return null;
+    }
+
+    // Cache the resolved module path
+    moduleRoot[moduleName] = path.dirname(result.filePath);
+
+    debug(`Sticky resolution for ${platform}: ${moduleName} -> ${moduleRoot[moduleName]}`);
+
+    return moduleRoot[moduleName];
+  };
+
+  return (context, moduleImport, platform) => {
+    // Check if the module import refers to a module that should be handled as sticky, and return the name
+    const moduleName = getStickyModuleName(moduleImport);
+    // Abort if the module is not a sticky module, or no platform was defined
+    if (!platform || !moduleName) {
+      return null;
+    }
+
+    // Resolve from the sticky modules cache directly
+    if (moduleRoot[moduleName]) {
+      return getStrictResolver(
+        context,
+        platform
+      )(moduleImport.replace(moduleName, moduleRoot[moduleName]));
+    }
+
+    // Create the resolver, used to finalize the resolution
+    const resolve = getStrictResolver(context, platform);
+
+    // Resolve `@react-native/assets-registry` from `react-native`
+    if (moduleName === '@react-native/assets-registry') {
+      const reactNativeRoot = resolveStickyRoot(resolve, 'react-native', platform);
+      // Attempt to seed the sticky module root for `@react-native/assets-registry`, from `react-native`
+      if (reactNativeRoot) {
+        resolveStickyRoot(
+          getStrictResolver(createRelativeContext(context, reactNativeRoot), platform),
+          moduleName,
+          platform
+        );
+      }
+    }
+
+    // Try to resolve the sticky module root
+    const stickyModulePath = resolveStickyRoot(resolve, moduleName, platform);
+    if (!stickyModulePath) return null;
+
+    // Return the finalized sticky resolution
+    return resolve(moduleImport.replace(moduleName, stickyModulePath));
+  };
+}
+
+/**
+ * Return a new resolution context where the resolution is relative to the given directory.
+ * Note that the `moduleRoot` is already a directory, that's why we need to add `/.` for Expo's fast resolver.
+ */
+function createRelativeContext<T extends ResolutionContext>(context: T, moduleRoot: string): T {
+  return { ...context, originModulePath: `${moduleRoot}/package.json` };
+}

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -32,6 +32,7 @@ import { loadTsConfigPathsAsync, TsConfigPaths } from '../../../utils/tsconfig/l
 import { resolveWithTsConfigPaths } from '../../../utils/tsconfig/resolveWithTsConfigPaths';
 import { isServerEnvironment } from '../middleware/metroOptions';
 import { PlatformBundlers } from '../platformBundlers';
+import { createStickyResolver } from './createStickyResolver';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -540,6 +541,9 @@ export function withExtendedResolver(
 
       return null;
     },
+
+    // Sticky resolutions, to deduplicate modules that can only exist once in a bundle
+    createStickyResolver(getStrictResolver),
 
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.


### PR DESCRIPTION
# Why

This adds a new "sticky" resolution strategy, applied to only `react-native` and `@react-native/assets-registry`. It generally works by:
1. **Find the package name (and possible package path) of the module import**
  e.g. `@react-native/assets-registry/registry → { name: '@react-native/assets-registry', path: '/registry' }`
  or `react-native -> { name: 'react-native', path: '' }`
  _When the module isn't a sticky module, return `null`_
  e.g. `./some/file -> null`
2. **Resolve the root module dir through `path.dirname(<packageName>/package.json)`**
  e.g. `/path/to/project/node_modules/<packageName>`
3. **Cache the resolved path in-memory**
4. **Resolve the sticky module by rewriting the module import to the resolved root path**
  _For the next resolution request with the same module import, steps 1, 2, and 3 are skipped_.

![image](https://github.com/user-attachments/assets/c40e9533-cfff-4ba0-9016-449364263007)


By applying this strategy to both `react-native` and `@react-native/assets-registry`, we fix a couple of things:
- `@react-native/assets-registry` will always be loaded from `react-native` itself, resolving issues like the "[duplicate asset registries breaking all assets](https://github.com/expo/expo/issues?q=%22%40react-native%2Fassets-registry%22+is%3Aclosed+is%3Aissue+)" and [these](https://twitter.com/DelphineBugner/status/1839291646632145390)
- `react-native` will only be resolved once, which resolves both dependencies requiring different versions of React Native and monorepos having multiple react-native versions installed.

Note, that this method also has some downsides, as it moves away from Node module resolution for these two specific packages. IMHO, it matches React Native autolinking more, as autolinking only "installs" 1 native module per project, while the JS side could bundle multiple installed version of each package, causing version mismatches and unexpected errors all over the place.

One scenario I could think: if a module requires a specific file from a different version of `react-native`, that won't resolve anymore. Although it has a very limited impact / niche scenario, I think it's good to mention this.

# How

- Added `createStickyResolver` as separate resolver
- Added sticky resolver to `withMetroMultiPlatform`, just before the "more complex post-resolution rewrites"
- Added tests for sticky resolutions

# Test Plan

See tests, the easiest way to test this is through:

- `bun create expo ./test-sticky`
- `cd ./test-sticky`
- `bun add @react-native/assets-registry@0.72`
- `bun install --yarn`
- `yarn why @react-native/assets-registry`
  - Should display multiple versions of assets registry
- `DEBUG="expo:start:server:metro:sticky-resolver" expod start`
  - When bundling, should output:
    ```
    expo:start:server:metro:sticky-resolver Sticky resolution for ios: @react-native/assets-registry -> /Users/cedric/Desktop/expo-blank/node_modules/react-native/node_modules/@react-native/assets-registry
    ```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
