### PR TITLE
[cli] only prebuild for platforms specified in app.json

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Enable inverse dependency stack trace (`EXPO_METRO_UNSTABLE_ERRORS`) for Metro bundling errors by default ([#38296](https://github.com/expo/expo/pull/38296) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Fix duplicate code frames printed in transformation error ([#38288](https://github.com/expo/expo/pull/38288) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Fix processing circular dependencies for inverse dependency resolver stack trace ([#38414](https://github.com/expo/expo/pull/38414) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Run prebuild only for the platforms specified in app config (if listed). ([#31752](https://github.com/expo/expo/pull/31752) by [@prathameshmm02](https://github.com/prathameshmm02))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,7 +28,6 @@
 - Enable inverse dependency stack trace (`EXPO_METRO_UNSTABLE_ERRORS`) for Metro bundling errors by default ([#38296](https://github.com/expo/expo/pull/38296) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Fix duplicate code frames printed in transformation error ([#38288](https://github.com/expo/expo/pull/38288) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Fix processing circular dependencies for inverse dependency resolver stack trace ([#38414](https://github.com/expo/expo/pull/38414) by [@krystofwoldrich](https://github.com/krystofwoldrich))
-- Run prebuild only for the platforms specified in app config (if listed). ([#31752](https://github.com/expo/expo/pull/31752) by [@prathameshmm02](https://github.com/prathameshmm02))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -73,7 +73,7 @@ export async function prebuildAsync(
       options.platforms = finalPlatforms;
     } else {
       Log.warn(
-        chalk`⚠️ No platforms to prebuild, skipping. Provided platforms not present in app.json.`
+        chalk`⚠️ No platforms to prebuild, skipping. ${options.platforms.join(', ')} not present in app config.`
       );
       return null;
     }

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config';
+import { ExpoConfig, getConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
 import chalk from 'chalk';
 
@@ -65,6 +65,19 @@ export async function prebuildAsync(
   setNodeEnv('development');
   require('@expo/env').load(projectRoot);
 
+  const { platforms } = getConfig(projectRoot).exp;
+  if (platforms?.length) {
+    // Filter out platforms that aren't in the app.json.
+    const finalPlatforms = options.platforms.filter((platform) => platforms.includes(platform));
+    if (finalPlatforms.length > 0) {
+      options.platforms = finalPlatforms;
+    } else {
+      Log.warn(
+        chalk`⚠️ No platforms to prebuild, skipping. Provided platforms not present in app.json.`
+      );
+      return null;
+    }
+  }
   if (options.clean) {
     const { maybeBailOnGitStatusAsync } = await import('../utils/git.js');
     // Clean the project folders...

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -72,10 +72,10 @@ export async function prebuildAsync(
     if (finalPlatforms.length > 0) {
       options.platforms = finalPlatforms;
     } else {
+      const requestedPlatforms = options.platforms.join(', ');
       Log.warn(
-        chalk`⚠️ No platforms to prebuild, skipping. ${options.platforms.join(', ')} not present in app config.`
+        chalk`⚠️  Requested prebuild for "${requestedPlatforms}", but only "${platforms.join(', ')}" is present in app config ("expo.platforms" entry). Continuing with "${requestedPlatforms}".`
       );
-      return null;
     }
   }
   if (options.clean) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/18386. Expo prebuild was being run for a platform even if the platform is not specified in `platforms` field of `app.json`. Now prebuild will ignore platforms which are not present in `app.json`.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Added a filter to exclude platforms not present in app.json before proceeding with the prebuild process.

# Test Plan
The following scenarios were tested to verify the changes:

1. With `"platforms": ["ios"]` in `app.json`:
a. Running `npx expo prebuild` only executes prebuild for iOS.
b. Running `npx expo prebuild -p android` skips prebuild and displays a warning.

2. With `"platforms": ["android"]` in `app.json`:
a. Running `npx expo prebuild` only executes prebuild for Android.
b. Running `npx expo prebuild -p ios` skips prebuild and displays a warning.

3. Without `platforms` field in `app.json`:
a. Running `npx expo prebuild` executes prebuild for all platforms.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
