### PR TITLE
feature(cli): add `run android --app-id` for custom app ids

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Remove `node-fetch` in favor of `undici` for improved Node 22+ support. ([#29511](https://github.com/expo/expo/pull/29511) by [@byCedric](https://github.com/byCedric))
 - Added support to download template from npm when running prebuild. ([#31195](https://github.com/expo/expo/pull/31195) by [@kudo](https://github.com/kudo))
 - Add an optional New Architecture compatibility check for dependencies added via `install` command. ([#31222](https://github.com/expo/expo/pull/31222) by [@Simek](https://github.com/Simek))
+- Add support in `expo run android` for product flavors with custom app ids. ([#31756](https://github.com/expo/expo/pull/31756) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/__snapshots__/run-android-test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/__snapshots__/run-android-test.ts.snap
@@ -12,7 +12,8 @@ exports[`runs \`npx expo run:android --help\` 1`] = `
     --no-build-cache       Clear the native build cache
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
-    --variant <name>       Build variant. Default: debug
+    --app-id <appId>       Custom Android application ID to launch.
+    --variant <name>       Build variant or product flavor and variant. Default: debug
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. Default: 8081

--- a/packages/@expo/cli/e2e/__tests__/__snapshots__/run-android-test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/__snapshots__/run-android-test.ts.snap
@@ -13,7 +13,7 @@ exports[`runs \`npx expo run:android --help\` 1`] = `
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
     --app-id <appId>       Custom Android application ID to launch.
-    --variant <name>       Build variant or product flavor and variant. Default: debug
+    --variant <name>       Build variant or product flavor and build variant. Default: debug
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. Default: 8081

--- a/packages/@expo/cli/e2e/__tests__/__snapshots__/run-test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/__snapshots__/run-test.ts.snap
@@ -13,7 +13,8 @@ exports[`runs \`npx expo run android --help\` 1`] = `
     --no-build-cache       Clear the native build cache
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
-    --variant <name>       Build variant. Default: debug
+    --app-id <appId>       Custom Android application ID to launch.
+    --variant <name>       Build variant or product flavor and build variant. Default: debug
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. Default: 8081

--- a/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
@@ -31,7 +31,7 @@ describe(resolveLaunchPropsAsync, () => {
       launchActivity: 'com.bacon.mydevicefamilyproject/.MainActivity',
       mainActivity: '.MainActivity',
       packageName: 'com.bacon.mydevicefamilyproject',
-      customAppId: undefined,
+      customAppId: 'com.bacon.mydevicefamilyproject',
     });
   });
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
@@ -6,18 +6,56 @@ import { resolveLaunchPropsAsync } from '../resolveLaunchProps';
 describe(resolveLaunchPropsAsync, () => {
   afterEach(() => vol.reset());
 
-  it(`asserts no android folder`, async () => {
+  it(`throws when /android folder is missing`, async () => {
     vol.fromJSON({}, '/');
-    await expect(resolveLaunchPropsAsync('/')).rejects.toThrow(
+    await expect(resolveLaunchPropsAsync('/', {})).rejects.toThrow(
       /Android project folder is missing in project/
     );
   });
-  it(`resolves launch properties`, async () => {
+
+  it(`resolves standard launch properties`, async () => {
     vol.fromJSON(rnFixture, '/');
-    expect(await resolveLaunchPropsAsync('/')).toEqual({
+    expect(await resolveLaunchPropsAsync('/', {})).toEqual({
       launchActivity: 'com.bacon.mydevicefamilyproject/.MainActivity',
       mainActivity: '.MainActivity',
       packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: undefined,
+    });
+  });
+
+  it(`resolves standard launch properties manual but identical app id`, async () => {
+    vol.fromJSON(rnFixture, '/');
+    expect(
+      await resolveLaunchPropsAsync('/', { appId: 'com.bacon.mydevicefamilyproject' })
+    ).toEqual({
+      launchActivity: 'com.bacon.mydevicefamilyproject/.MainActivity',
+      mainActivity: '.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: undefined,
+    });
+  });
+
+  // See: https://developer.android.com/build/build-variants#change-app-id
+  it(`resolves launch properties with custom suffixed app id`, async () => {
+    vol.fromJSON(rnFixture, '/');
+    expect(
+      await resolveLaunchPropsAsync('/', { appId: 'com.bacon.mydevicefamilyproject.free' })
+    ).toEqual({
+      launchActivity:
+        'com.bacon.mydevicefamilyproject.free/com.bacon.mydevicefamilyproject.MainActivity',
+      mainActivity: '.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: 'com.bacon.mydevicefamilyproject.free',
+    });
+  });
+
+  it(`resolves launch properties with fully custom app id`, async () => {
+    vol.fromJSON(rnFixture, '/');
+    expect(await resolveLaunchPropsAsync('/', { appId: 'dev.expo.test' })).toEqual({
+      launchActivity: 'dev.expo.test/com.bacon.mydevicefamilyproject.MainActivity',
+      mainActivity: '.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: 'dev.expo.test',
     });
   });
 });

--- a/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
@@ -53,12 +53,13 @@ describe(resolveOptionsAsync, () => {
         install: true,
         port: 8081,
         variant: 'firstSecondThird',
+        appId: 'dev.expo.test',
       })
     ).toEqual({
-      apkVariantDirectory: '/android/app/build/outputs/apk/second/third/first',
+      apkVariantDirectory: '/android/app/build/outputs/apk/first/second/third',
       appName: 'app',
       buildCache: true,
-      buildType: 'first',
+      buildType: 'third',
       architectures: '',
       device: {
         device: {
@@ -66,11 +67,12 @@ describe(resolveOptionsAsync, () => {
           pid: '123',
         },
       },
-      flavors: ['second', 'third'],
+      flavors: ['first', 'second'],
       install: true,
-      launchActivity: 'com.bacon.mydevicefamilyproject/.MainActivity',
+      launchActivity: 'dev.expo.test/com.bacon.mydevicefamilyproject.MainActivity',
       mainActivity: '.MainActivity',
       packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: 'dev.expo.test',
       port: 8081,
       shouldStartBundler: true,
       variant: 'firstSecondThird',

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -17,6 +17,7 @@ export const expoRunAndroid: Command = async (argv) => {
     '--no-bundler': Boolean,
     '--variant': String,
     '--binary': String,
+    '--app-id': String,
     // Unstable, temporary fallback to disable active archs only behavior
     // TODO: replace with better fallback option, like free-form passing gradle props
     '--all-arch': Boolean,
@@ -48,7 +49,8 @@ export const expoRunAndroid: Command = async (argv) => {
     --no-build-cache       Clear the native build cache
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
-    --variant <name>       Build variant. {dim Default: debug}
+    --app-id <appId>       Custom Android application ID to launch.
+    --variant <name>       Build variant or product flavor and variant. {dim Default: debug}
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
@@ -75,6 +77,7 @@ export const expoRunAndroid: Command = async (argv) => {
     variant: args['--variant'],
     allArch: args['--all-arch'],
     binary: args['--binary'],
+    appId: args['--app-id'],
     // Custom parsed args
     device: parsed.args['--device'],
   }).catch(logCmdError);

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -50,7 +50,7 @@ export const expoRunAndroid: Command = async (argv) => {
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
     --app-id <appId>       Custom Android application ID to launch.
-    --variant <name>       Build variant or product flavor and variant. {dim Default: debug}
+    --variant <name>       Build variant or product flavor and build variant. {dim Default: debug}
     --binary <path>        Path to existing .apk or .aab to install.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. {dim Default: 8081}

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -11,7 +11,7 @@ export type GradleProps = {
   apkVariantDirectory: string;
   /** Name of the app, used in the `apkVariantDirectory`. */
   appName: string;
-  /** First section of the provided `variant`, indicates the last part of the file name for the output APK. */
+  /** Last section of the provided `variant`, indicates the starting directory of the file name for the output APK. E.g. "debug" or "release" */
   buildType: string;
   /** Used to assemble the APK, also included in the output APK filename. */
   flavors?: string[];
@@ -37,9 +37,13 @@ export async function resolveGradlePropsAsync(
 
   const apkDirectory = path.join(projectRoot, 'android', appName, 'build', 'outputs', 'apk');
 
-  // buildDeveloperTrust -> build, developer, trust (where developer, and trust are flavors).
+  // buildDeveloperTrust -> buildtype: trust, flavors: build, developer
+  // developmentDebug -> buildType: debug, flavors: development
+  // productionRelease -> buildType: release, flavors: production
   // This won't work for non-standard flavor names like "myFlavor" would be treated as "my", "flavor".
-  const [buildType, ...flavors] = variant.split(/(?=[A-Z])/).map((v) => v.toLowerCase());
+  const flavors = variant.split(/(?=[A-Z])/).map((v) => v.toLowerCase());
+  const buildType = flavors.pop() ?? 'debug';
+
   const apkVariantDirectory = path.join(apkDirectory, ...flavors, buildType);
   const architectures = await getConnectedDeviceABIS(buildType, device, options.allArch);
 

--- a/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
+++ b/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
@@ -4,8 +4,27 @@ import { AndroidAppIdResolver } from '../../start/platforms/android/AndroidAppId
 import { CommandError } from '../../utils/errors';
 
 export interface LaunchProps {
+  /**
+   * The "common" Android package name, configured through the app manifest.
+   * @see https://source.android.com/docs/core/architecture/hidl/code-style#package-names
+   */
   packageName: string;
+  /**
+   * Optional customized application ID, used in product flavors.
+   * @see https://developer.android.com/build/build-variants#change-app-id
+   */
+  customAppId?: string;
+  /**
+   * The main activity to launch, by default this is `.MainActivity`.
+   * @see https://github.com/expo/expo/blob/c0aec226a43c0f186258a063a6145c3e52246f8a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml#L22
+   */
   mainActivity: string;
+  /**
+   * The full launch activity reference used in the app intent to launch the app with `adb am start -n <launchActivity>`.
+   * Usually, this is structured as `<package-name>/.<activity-name>`.
+   * For product flavors, this is structured as `<custom-app-id>/<package-name>.<activity-name>`.
+   * @see https://developer.android.com/studio/command-line/adb#IntentSpec
+   */
   launchActivity: string;
 }
 
@@ -25,16 +44,22 @@ async function getMainActivityAsync(projectRoot: string): Promise<string> {
   return activity.$['android:name'];
 }
 
-export async function resolveLaunchPropsAsync(projectRoot: string): Promise<LaunchProps> {
-  // Often this is ".MainActivity"
+export async function resolveLaunchPropsAsync(
+  projectRoot: string,
+  options: { appId?: string }
+): Promise<LaunchProps> {
   const mainActivity = await getMainActivityAsync(projectRoot);
-
   const packageName = await new AndroidAppIdResolver(projectRoot).getAppIdFromNativeAsync();
-  const launchActivity = `${packageName}/${mainActivity}`;
+  const customAppId = options.appId && options.appId !== packageName ? options.appId : undefined;
+
+  const launchActivity = customAppId
+    ? `${customAppId}/${packageName}${mainActivity}`
+    : `${packageName}/${mainActivity}`;
 
   return {
     mainActivity,
     launchActivity,
     packageName,
+    customAppId,
   };
 }

--- a/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
+++ b/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
@@ -50,11 +50,12 @@ export async function resolveLaunchPropsAsync(
 ): Promise<LaunchProps> {
   const mainActivity = await getMainActivityAsync(projectRoot);
   const packageName = await new AndroidAppIdResolver(projectRoot).getAppIdFromNativeAsync();
-  const customAppId = options.appId && options.appId !== packageName ? options.appId : undefined;
+  const customAppId = options.appId;
 
-  const launchActivity = customAppId
-    ? `${customAppId}/${packageName}${mainActivity}`
-    : `${packageName}/${mainActivity}`;
+  const launchActivity =
+    customAppId && customAppId !== packageName
+      ? `${customAppId}/${packageName}${mainActivity}`
+      : `${packageName}/${mainActivity}`;
 
   return {
     mainActivity,

--- a/packages/@expo/cli/src/run/android/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/android/resolveOptions.ts
@@ -13,6 +13,7 @@ export type Options = {
   buildCache?: boolean;
   allArch?: boolean;
   binary?: string;
+  appId?: string;
 };
 
 export type ResolvedOptions = GradleProps &
@@ -23,6 +24,7 @@ export type ResolvedOptions = GradleProps &
     device: AndroidDeviceManager;
     install: boolean;
     architectures?: string;
+    appId?: string;
   };
 
 export async function resolveOptionsAsync(
@@ -35,7 +37,7 @@ export async function resolveOptionsAsync(
   return {
     ...(await resolveBundlerPropsAsync(projectRoot, options)),
     ...(await resolveGradlePropsAsync(projectRoot, options, device.device)),
-    ...(await resolveLaunchPropsAsync(projectRoot)),
+    ...(await resolveLaunchPropsAsync(projectRoot, options)),
     variant: options.variant ?? 'debug',
     // Resolve the device based on the provided device id or prompt
     // from a list of devices (connected or simulated) that are filtered by the scheme.

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -6,6 +6,7 @@ import { resolveInstallApkNameAsync } from './resolveInstallApkName';
 import { Options, ResolvedOptions, resolveOptionsAsync } from './resolveOptions';
 import { exportEagerAsync } from '../../export/embed/exportEager';
 import { Log } from '../../log';
+import type { AndroidOpenInCustomProps } from '../../start/platforms/android/AndroidPlatformManager';
 import { assembleAsync, installAsync } from '../../start/platforms/android/gradle';
 import { CommandError } from '../../utils/errors';
 import { setNodeEnv } from '../../utils/nodeEnv';
@@ -19,7 +20,7 @@ const debug = require('debug')('expo:run:android');
 
 export async function runAndroidAsync(projectRoot: string, { install, ...options }: Options) {
   // NOTE: This is a guess, the developer can overwrite with `NODE_ENV`.
-  const isProduction = options.variant?.toLowerCase() === 'release';
+  const isProduction = options.variant?.toLowerCase().endsWith('release');
   setNodeEnv(isProduction ? 'production' : 'development');
   require('@expo/env').load(projectRoot);
 
@@ -79,10 +80,11 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     await installAppAsync(androidProjectRoot, props);
   }
 
-  await manager.getDefaultDevServer().openCustomRuntimeAsync(
+  await manager.getDefaultDevServer().openCustomRuntimeAsync<AndroidOpenInCustomProps>(
     'emulator',
     {
       applicationId: props.packageName,
+      customAppId: props.customAppId,
     },
     { device: props.device.device }
   );

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -85,6 +85,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     {
       applicationId: props.packageName,
       customAppId: props.customAppId,
+      launchActivity: props.launchActivity,
     },
     { device: props.device.device }
   );

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -123,7 +123,7 @@ export class PlatformManager<
     return { url };
   }
 
-  private async openProjectInCustomRuntimeAsync(
+  protected async openProjectInCustomRuntimeAsync(
     resolveSettings: Partial<IResolveDeviceProps> = {},
     props: Partial<IOpenInCustomProps> = {}
   ): Promise<{ url: string }> {

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -109,10 +109,11 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   /**
    * @param launchActivity Activity to launch `[application identifier]/.[main activity name]`, ex: `com.bacon.app/.MainActivity`
    */
-  async launchActivityAsync(launchActivity: string): Promise<string> {
+  async launchActivityAsync(launchActivity: string, url?: string): Promise<string> {
     try {
       return await AndroidDebugBridge.launchActivityAsync(this.device, {
         launchActivity,
+        url,
       });
     } catch (error: any) {
       let errorMessage = `Couldn't open Android app with activity "${launchActivity}" on device "${this.name}".`;

--- a/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
@@ -2,8 +2,16 @@ import { AndroidAppIdResolver } from './AndroidAppIdResolver';
 import { AndroidDeviceManager } from './AndroidDeviceManager';
 import { Device } from './adb';
 import { startAdbReverseAsync } from './adbReverse';
+import { CommandError } from '../../../utils/errors';
+import { memoize } from '../../../utils/fn';
+import { learnMore } from '../../../utils/link';
+import { hasDirectDevClientDependency } from '../../detectDevClient';
 import { AppIdResolver } from '../AppIdResolver';
 import { BaseOpenInCustomProps, BaseResolveDeviceProps, PlatformManager } from '../PlatformManager';
+
+const debug = require('debug')(
+  'expo:start:platforms:platformManager:android'
+) as typeof console.log;
 
 export interface AndroidOpenInCustomProps extends BaseOpenInCustomProps {
   /**
@@ -21,6 +29,8 @@ export interface AndroidOpenInCustomProps extends BaseOpenInCustomProps {
 export class AndroidPlatformManager extends PlatformManager<Device, AndroidOpenInCustomProps> {
   /** The last used custom launch props, should be reused whenever launching custom runtime without launch props */
   private lastCustomRuntimeLaunchProps?: AndroidOpenInCustomProps;
+  /** Memoized method to detect if dev client is installed */
+  private hasDevClientInstalled: () => boolean;
 
   constructor(
     protected projectRoot: string,
@@ -41,6 +51,8 @@ export class AndroidPlatformManager extends PlatformManager<Device, AndroidOpenI
       ...options,
       resolveDeviceAsync: AndroidDeviceManager.resolveAsync,
     });
+
+    this.hasDevClientInstalled = memoize(hasDirectDevClientDependency.bind(this, projectRoot));
   }
 
   async openAsync(
@@ -60,21 +72,52 @@ export class AndroidPlatformManager extends PlatformManager<Device, AndroidOpenI
         options.props = this.lastCustomRuntimeLaunchProps;
       }
 
-      // Android's adb list packages returns the app id, not the package name.
-      // By default, this app id is identical to the package name.
-      // When using product flavors, the installed app should be refered by the custom app id.
-      if (options.props?.customAppId) {
-        return super.openAsync(
-          {
-            runtime: 'custom',
-            props: { ...options.props, applicationId: options.props.customAppId },
-          },
-          resolveSettings
-        );
-      }
+      // Handle projects that need to launch with a custom app id and launch activity
+      return this.openProjectInCustomRuntimeWithCustomAppIdAsync(options, resolveSettings);
     }
 
     return super.openAsync(options, resolveSettings);
+  }
+
+  /**
+   * Launch the custom runtime project, using the provided custom app id and launch activity.
+   * Instead of "open url", this will launch the activity directly.
+   * If dev client is installed, it will also pass the dev client URL to the activity.
+   */
+  async openProjectInCustomRuntimeWithCustomAppIdAsync(
+    options: { runtime: 'custom'; props?: Partial<AndroidOpenInCustomProps> },
+    resolveSettings?: Partial<BaseResolveDeviceProps<Device>>
+  ) {
+    // Fall back to default dev client URL open behavior if no custom app id or launch activity is provided
+    if (!options.props?.customAppId || !options.props?.launchActivity) {
+      return super.openProjectInCustomRuntimeAsync(resolveSettings, options.props);
+    }
+
+    const { customAppId, launchActivity } = options.props;
+    const url = this.hasDevClientInstalled()
+      ? (this.props.getCustomRuntimeUrl({ scheme: options.props.scheme }) ?? undefined)
+      : undefined;
+
+    debug(`Opening custom runtime using launch activity: ${launchActivity} --`, options.props);
+
+    const deviceManager = (await this.props.resolveDeviceAsync(
+      resolveSettings
+    )) as AndroidDeviceManager;
+
+    if (!(await deviceManager.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(customAppId))) {
+      throw new CommandError(
+        `No development build (${customAppId}) for this project is installed. ` +
+          `Please make and install a development build on the device first.\n${learnMore(
+            'https://docs.expo.dev/development/build/'
+          )}`
+      );
+    }
+
+    deviceManager.logOpeningUrl(url ?? launchActivity);
+    await deviceManager.activateWindowAsync();
+    await deviceManager.launchActivityAsync(launchActivity, url);
+
+    return { url: url ?? launchActivity };
   }
 
   _getAppIdResolver(): AppIdResolver {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -53,6 +53,22 @@ describe('launchActivityAsync', () => {
     });
     await expect(device.launchActivityAsync).rejects.toThrow(/\.\.\./);
   });
+  it(`launches activity with provided props`, async () => {
+    const device = createDevice();
+    await expect(
+      device.launchActivityAsync(
+        'dev.expo.test/.MainActivity',
+        'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081'
+      )
+    ).resolves.toBeUndefined();
+    expect(launchActivityAsync).toBeCalledWith(
+      expect.anything(), // Device context
+      expect.objectContaining({
+        launchActivity: 'dev.expo.test/.MainActivity',
+        url: 'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
+      })
+    );
+  });
 });
 
 describe('openUrlAsync', () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
@@ -99,4 +99,35 @@ describe('openAsync', () => {
       'dev.bacon.app.free'
     );
   });
+
+  it('re-opens with custom runtime props if set', async () => {
+    const platform = new AndroidPlatformManager('/', 8081, {
+      getCustomRuntimeUrl: () => null,
+      getDevServerUrl: () => null,
+      getExpoGoUrl: () => '',
+      getRedirectUrl: () => null,
+    });
+
+    jest.spyOn(platform, '_getAppIdResolver').mockReturnValue({
+      getAppIdAsync: async () => 'dev.bacon.app',
+    } as AndroidAppIdResolver);
+
+    // Open once with custom launch properties
+    expect(
+      await platform.openAsync({
+        runtime: 'custom',
+        props: {
+          launchActivity: 'dev.bacon.app.free/dev.bacon.app.MainActivity',
+          customAppId: 'dev.bacon.app.free',
+        },
+      })
+    ).toStrictEqual({
+      url: 'dev.bacon.app.free/dev.bacon.app.MainActivity',
+    });
+
+    // Ensure these custom launch props are reused when opening again
+    expect(await platform.openAsync({ runtime: 'custom' })).toStrictEqual({
+      url: 'dev.bacon.app.free/dev.bacon.app.MainActivity',
+    });
+  });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
@@ -1,10 +1,12 @@
 import * as Log from '../../../../log';
+import { hasDirectDevClientDependency } from '../../../detectDevClient';
 import { AndroidAppIdResolver } from '../AndroidAppIdResolver';
 import { AndroidDeviceManager } from '../AndroidDeviceManager';
 import { AndroidPlatformManager } from '../AndroidPlatformManager';
 import { startAdbReverseAsync } from '../adbReverse';
 
 jest.mock(`../../../../log`);
+jest.mock('../../../detectDevClient');
 jest.mock('../adb');
 jest.mock('../../ExpoGoInstaller');
 jest.mock('../adbReverse', () => ({
@@ -98,6 +100,39 @@ describe('openAsync', () => {
     expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledWith(
       'dev.bacon.app.free'
     );
+  });
+
+  it('opens devclient with custom runtime, app id, launch activity', async () => {
+    const device = new AndroidDeviceManager({ udid: '123', name: 'Pixel 5' } as any);
+    const platform = new AndroidPlatformManager('/', 8081, {
+      getCustomRuntimeUrl: () => 'exp://dev-client-url',
+      getDevServerUrl: () => null,
+      getExpoGoUrl: () => '',
+      getRedirectUrl: () => null,
+    });
+
+    jest.spyOn(AndroidDeviceManager, 'resolveAsync').mockResolvedValue(device);
+    jest
+      .spyOn(device, 'isAppInstalledAndIfSoReturnContainerPathForIOSAsync')
+      .mockResolvedValue(true);
+    jest.spyOn(platform, '_getAppIdResolver').mockReturnValue({
+      getAppIdAsync: async () => 'dev.bacon.app',
+    } as AndroidAppIdResolver);
+
+    jest.mocked(hasDirectDevClientDependency).mockReturnValue(true);
+
+    expect(
+      await platform.openAsync({
+        runtime: 'custom',
+        props: {
+          launchActivity: 'dev.bacon.app.free/dev.bacon.app.MainActivity',
+          customAppId: 'dev.bacon.app.free',
+        },
+      })
+    ).toStrictEqual({
+      url: 'exp://dev-client-url',
+    });
+    expect(hasDirectDevClientDependency).toHaveBeenCalledWith('/');
   });
 
   it('re-opens with custom runtime props if set', async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -55,7 +55,7 @@ describe(launchActivityAsync, () => {
       })
     ).rejects.toThrow(CommandError);
   });
-  it(`runs`, async () => {
+  it(`launches activity`, async () => {
     jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
     await launchActivityAsync(device, {
       launchActivity: 'dev.bacon.app/.MainActivity',
@@ -70,6 +70,26 @@ describe(launchActivityAsync, () => {
       '0x20000000',
       '-n',
       'dev.bacon.app/.MainActivity',
+    ]);
+  });
+  it(`launches activity with url`, async () => {
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
+    await launchActivityAsync(device, {
+      launchActivity: 'dev.expo.custom.appid/dev.bacon.app.MainActivity',
+      url: 'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
+    });
+    expect(getServer().runAsync).toBeCalledWith([
+      '-s',
+      '123',
+      'shell',
+      'am',
+      'start',
+      '-f',
+      '0x20000000',
+      '-n',
+      'dev.expo.custom.appid/dev.bacon.app.MainActivity',
+      '-d',
+      'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
     ]);
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -103,29 +103,35 @@ export async function isPackageInstalledAsync(
 /**
  * @param device.pid Process ID of the Android device to launch.
  * @param props.launchActivity Activity to launch `[application identifier]/.[main activity name]`, ex: `com.bacon.app/.MainActivity`
+ * @param props.url Optional (dev client) URL to launch
  */
 export async function launchActivityAsync(
   device: DeviceContext,
   {
     launchActivity,
+    url,
   }: {
     launchActivity: string;
+    url?: string;
   }
 ) {
-  return openAsync(
-    adbArgs(
-      device.pid,
-      'shell',
-      'am',
-      'start',
-      // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
-      '-f',
-      '0x20000000',
-      // Activity to open first: com.bacon.app/.MainActivity
-      '-n',
-      launchActivity
-    )
-  );
+  const args: string[] = [
+    'shell',
+    'am',
+    'start',
+    // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
+    '-f',
+    '0x20000000',
+    // Activity to open first: com.bacon.app/.MainActivity
+    '-n',
+    launchActivity,
+  ];
+
+  if (url) {
+    args.push('-d', url);
+  }
+
+  return openAsync(adbArgs(device.pid, ...args));
 }
 
 /**

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -435,9 +435,9 @@ export abstract class BundlerDevServer {
   }
 
   /** Open the dev server in a runtime. */
-  public async openCustomRuntimeAsync(
+  public async openCustomRuntimeAsync<T extends BaseOpenInCustomProps = BaseOpenInCustomProps>(
     launchTarget: keyof typeof PLATFORM_MANAGERS,
-    launchProps: Partial<BaseOpenInCustomProps> = {},
+    launchProps: Partial<T> = {},
     resolver: BaseResolveDeviceProps<any> = {}
   ) {
     const runtime = this.isTargetingNative() ? (this.isDevClient ? 'custom' : 'expo') : 'web';


### PR DESCRIPTION
# Fixes

Fixes #23266, closes #31186 (supersedes)

> [!NOTE]
> This pull request supersedes #31186, adding just the `--appIdSuffix` is not enough when configuring product flavors using a fully different `applicationId`. Thats why this pull request only implements the `--app-id` property.

# Why

This adds basic support for Android's product flavors in `expo run android`, using custom application ids. Having a project with multiple build flavors means that you can build and install the app multiple times with small configuration tweaks, like building with a different application id to install multiple versions side-by-side. Normally, this application id is equal to the package name.

> [!IMPORTANT]
> Even though `expo run android` now supports basic product flavors, it's still customization beyond the default configuration. Its easier to dynamically configure the Android package name through a dynamic app manifest (`app.config.js`). That way, `expo prebuild` works without modification and allows you to customize the package name, slug, and icon to install multiple versions side-by-side.

## Usage

You can use it by defining both the `--variant` (existing) and `--app-id` (new) flags in the `expo run android` command. E.g. you have an Android app configured with product flavors **free** and **paid**, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id) and in the example below, you can switch between the product flavors and build types through:

- `$ expo run android`
  - buildType: **debug**
  - productFlavor: _<default>_
  - launchIntent: **test.expo.flavors/.MainActivity**
- `$ expo run android --variant freeRelease`
  - buildType: **release**
  - productFlavor: **free**
  - launchIntent: **test.expo.flavors/.MainActivity**
- `$ expo run android --variant paidDebug`
  - buildType: **debug**
  - productFlavor: **paid**
  - launchIntent: **test.expo.flavors/.MainActivity**
- `$ expo run android --variant freeRelease --app-id test.expo.flavors.free`
  - buildType: **release**
  - productFlavor: **free**
  - launchIntent: **test.expo.flavors.free/test.expo.flavors.MainActivity**
- `$ expo run android --variant paidRelease --app-id test.expo.flavors.paid`
  - buildType: **release**
  - productFlavor: **paid**
  - launchIntent: **test.expo.flavors.paid/test.expo.flavors.MainActivity**

<details><summary>Example <code>android/app/build.gradle</code> configuration</summary>

```gradle
android {
  // Default build configuration
  defaultConfig {
    applicationId 'test.expo.flavors'
  }
  
  // Default supported build types
  buildTypes {
    debug {
      // ...
    }
    release {
      // ...
    }
  }

  // Customized product flavors
  flavorDimensions "version"
  // See: https://developer.android.com/build/build-variants#change-app-id
  productFlavors {
    free {
      dimension "version"
      // Note, using `applicationId` instead is also supported
      applicationIdSuffix ".free"
      // Customizing the app name is also supported 
      resValue "string", "app_name", "expo test (free)"
    }
    paid {
      dimension "version"
      applicationIdSuffix ".paid"
    }
  }
}
```

</details>

> [!IMPORTANT]
> It is also possible to add a new buildType with a different application id, but that would [break some assumptions](https://github.com/expo/expo/pull/31756/files#diff-386873485613f346961a6c515dae122afec312bf0ec1b8b5d7aa73721e035e28L42-R44) Expo makes to enable debug or release builds. You might ship unoptimized code in your app when using a different build type other than **debug** or **release**.

# How

- Add `--app-id` flag to allow users to configure a custom application id (required when changing app id through product flavors)
- Fixed extraction of build type and product flavors from `--variant` on Android
- Updated and added tests

# Test Plan

- `$ bun create expo ./test-flavors`
- `$ cd ./test-flavors`
- `$ bun expo prebuild --platform android`
- Customize the `android/app/build.gradle` with the example from _usage_.
- Try any of the combinations listed above:
  - Should build the android app once through `expo run android ...`
  - Should support product flavors with `applicationId "..."` and `applicationIdSuffix ".suffix"`
  - Should work with multiple product flavors installed at the same time on a single device

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
