### PR TITLE
fix(template): drop `expo/AppEntry.js` in favor of index file for monorepos

### DIFF
--- a/templates/expo-template-blank-typescript/index.ts
+++ b/templates/expo-template-blank-typescript/index.ts
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -3,7 +3,7 @@
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
   "version": "51.0.27",
-  "main": "expo/AppEntry.js",
+  "main": "index.ts",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/templates/expo-template-blank/index.js
+++ b/templates/expo-template-blank/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -3,7 +3,7 @@
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
   "version": "51.0.27",
-  "main": "expo/AppEntry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
# Why

Expo's devtooling has improved a lot for monorepos in the upcoming SDK. Unfortunately, there is one thing that can't work properly, the `expo/AppEntry.js` entry point.

The reason why this file technically only "sometimes" work is because this file tries to import `import App from '../../App';`. This is only correct if `expo` is installed within the workspace `node_modules`, not the root `node_modules`.

```
Monorepo
├── apps
│   └── awesome-app ➡️ The "awesome app" workspace
│       ├── App.js ➡️ The entry point of the app
│       └── node_modules ➡️ (workspace) - All modules that are specific to "awesome app"
└── node_modules ➡️ (root) - All modules that are shared or only need to install once 
```

## Working scenario

```
Monorepo
└── apps
    └── awesome-app
        ├── App.js
        └── node_modules
            └── expo
                └── AppEntry.js ➡️ `import '../../App'` works, if expo is installed here
```

## Breaking scenario (more common)

```
Monorepo
├── apps
│   └── awesome-app
│       └── App.js
└── node_modules
    └── expo
        └── AppEntry.js ➡️ `import '../../App'` fails, if expo is installed here
```

# How

- Drop (all) usage of `expo/AppEntry.js` in `blank` and `blank-typescript` templates

# Test Plan

- `git clone git@github.com:byCedric/expo-monorepo-example.git ./test-monorepo`
- `cd ./test-monorepo`
- `rm -rf apps packages`
  - Empty the monorepo, using 1 version of `expo` will likely hoist `expo` to `<root>/node_modules/expo`
- `pnpm i`
- `pnpm create expo ./apps/new-project --template blank-typescript`
- `cd ./apps/new-project`
- `pnpm start`
  - Should work without problems

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
