### PR TITLE
[expo-go] remove old android deps

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -143,9 +143,6 @@ dependencies {
   // Expo modules
   api project(':expo')
 
-  // expo-random is no longer a unimodule
-  api project(':expo-random')
-
   // Versioned react native
   // THIS COMMENT IS USED BY android-build-aar.sh DO NOT MODIFY
   // WHEN_VERSIONING_REMOVE_TO_HERE
@@ -206,19 +203,6 @@ dependencies {
 
   // expo-face-detector
   implementation 'com.google.mlkit:face-detection:16.1.5'
-
-  // expo-ads-admob
-  implementation 'com.google.android.gms:play-services-ads:20.5.0'
-  // For apps targeting Android 12, add WorkManager dependency.
-  // See more at https://developers.google.com/admob/android/rel-notes
-  constraints {
-    implementation('androidx.work:work-runtime:2.7.0') {
-      because '''androidx.work:work-runtime:2.1.0 pulled from
-      play-services-ads has a bug using PendingIntent without
-      FLAG_IMMUTABLE or FLAG_MUTABLE and will fail in Apps
-      targeting S+.'''
-    }
-  }
 
   api 'com.google.firebase:firebase-core:21.1.0'
   api 'com.google.firebase:firebase-messaging:22.0.0'

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -35,10 +35,6 @@ project(':packages:react-native:ReactAndroid:hermes-engine').projectDir = new Fi
 include ':expo-modules-test-core'
 project(':expo-modules-test-core').projectDir = new File(rootDir, '../../../packages/expo-modules-test-core/android')
 
-// Include Expo modules that are not unimodules
-include(":expo-random")
-project(":expo-random").projectDir = new File("../../../packages/expo-random/android")
-
 [
     // ADD_NEW_SUPPORTED_ABIS_HERE
 ].forEach({ abiVariant ->


### PR DESCRIPTION
# Why

these are deps no longer present in the expo SDK

# How

remove the deps from gradle config

# Test Plan

builds locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
