### PR TITLE
[config-plugins] Remove post_integrate step from the snapshot

### DIFF
--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -288,14 +288,6 @@ target 'HelloWorld' do
       end
     end
   end
-
-  post_integrate do |installer|
-    begin
-      expo_patch_react_imports!(installer)
-    rescue => e
-      Pod::UI.warn e
-    end
-  end
 end
 "
 `;


### PR DESCRIPTION
# Why

Bring SDK checks back to green (https://github.com/expo/expo/actions/runs/11093272691/job/30819360061)
The issue seems to be introduced by https://github.com/expo/expo/pull/31699

# How

Updated a snapshot in `@expo/config-plugins` by removing the `post_integrate` step that was removed from the template in https://github.com/expo/expo/pull/31699

# Test Plan

`et check-packages @expo/config-plugins` passes now