### PR TITLE
refactor(cli): avoid retrying `development-sessions` requests

### DIFF
--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -260,20 +260,7 @@ export abstract class BundlerDevServer {
       // This URL will be used on external devices so the computer IP won't be relevant.
       this.isTargetingNative()
         ? this.getNativeRuntimeUrl()
-        : this.getDevServerUrl({ hostType: 'localhost' }),
-      () => {
-        // TODO: This appears to be happening consistently after an hour.
-        // We should investigate why this is happening and fix it on our servers.
-        // Log.error(
-        //   chalk.red(
-        //     '\nAn unexpected error occurred while updating the Dev Session API. This project will not appear in the "Development servers" section of the Expo Go app until this process has been restarted.'
-        //   )
-        // );
-        // Log.exception(error);
-        this.devSession?.closeAsync().catch((error) => {
-          debug('[dev-session] error closing: ' + error.message);
-        });
-      }
+        : this.getDevServerUrl({ hostType: 'localhost' })
     );
 
     await this.devSession.startAsync({

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -19,9 +19,7 @@ export class DevelopmentSession {
     /** Project root directory. */
     private projectRoot: string,
     /** Development Server URL. */
-    public url: string | null,
-    /** Catch any errors that may occur during the `startAsync` method. */
-    private onError: (error: Error) => void
+    public url: string | null
   ) {}
 
   /**
@@ -69,7 +67,6 @@ export class DevelopmentSession {
       }
     } catch (error: any) {
       debug(`Error updating development session API: ${error}`);
-      this.onError(error);
     }
   }
 
@@ -102,7 +99,6 @@ export class DevelopmentSession {
       return true;
     } catch (error: any) {
       debug(`Error closing development session API: ${error}`);
-      this.onError(error);
       return false;
     }
   }

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -22,8 +22,7 @@ describe(`startAsync`, () => {
   });
 
   it(`starts a dev session`, async () => {
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
       devices: [{ installationId: '123' }, { installationId: '456' }] as any[],
@@ -35,6 +34,7 @@ describe(`startAsync`, () => {
       description: 'my-foo-bar',
       primaryColor: '#4630eb',
     };
+
     const runtime = 'native';
     const startScope = nock(getExpoApiBaseUrl())
       .post('/v2/development-sessions/notify-alive?deviceId=123&deviceId=456')
@@ -53,37 +53,10 @@ describe(`startAsync`, () => {
     expect(ProjectDevices.getDevicesInfoAsync).toHaveBeenCalledTimes(2);
     expect(startScope.isDone()).toBe(true);
     expect(closeScope.isDone()).toBe(true);
-    expect(onDevSessionError).not.toBeCalled();
-  });
-
-  it(`surfaces exceptions that would otherwise be uncaught`, async () => {
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
-
-    jest
-      .mocked(ProjectDevices.getDevicesInfoAsync)
-      .mockRejectedValueOnce(new Error('predefined error'));
-
-    const exp = {
-      name: 'my-app',
-      slug: 'my-app',
-      description: 'my-foo-bar',
-      primaryColor: '#4630eb',
-    };
-    const runtime = 'native';
-
-    // Does not throw directly
-    await session.startAsync({
-      exp,
-      runtime,
-    });
-
-    expect(onDevSessionError).toHaveBeenCalled();
   });
 
   it(`gracefully handles server outages`, async () => {
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
       devices: [{ installationId: '123' }, { installationId: '456' }] as any[],
@@ -103,19 +76,18 @@ describe(`startAsync`, () => {
       .reply(500, '');
 
     // Does not throw directly
-    await session.startAsync({
-      exp,
-      runtime,
-    });
-
-    expect(onDevSessionError).toHaveBeenCalled();
+    await expect(
+      session.startAsync({
+        exp,
+        runtime,
+      })
+    ).resolves.toBeUndefined();
   });
 
   it('is skipped on CI', async () => {
     process.env.CI = '1';
 
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     const runtime = 'native';
     const exp = {
@@ -143,46 +115,56 @@ describe(`closeAsync`, () => {
     process.env.CI = originalEnvCI;
   });
 
-  it(`surfaces exceptions that would otherwise be uncaught`, async () => {
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
-
-    jest
-      .mocked(ProjectDevices.getDevicesInfoAsync)
-      .mockRejectedValueOnce(new Error('predefined error'));
-
-    // Does not throw directly
-    await expect(session.closeAsync()).resolves.toBe(false);
-
-    // Calls the error handler
-    expect(onDevSessionError).toHaveBeenCalled();
-  });
-
   it(`gracefully handles server outages`, async () => {
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
       devices: [{ installationId: '123' }, { installationId: '456' }] as any[],
     });
 
     // Server is down
-    nock(getExpoApiBaseUrl())
+    const closeScope = nock(getExpoApiBaseUrl())
       .post('/v2/development-sessions/notify-close?deviceId=123&deviceId=456')
       .reply(500, '');
 
+    // Fake the session state
+    Object.assign(session, { hasActiveSession: true });
+
     // Does not throw directly
     await expect(session.closeAsync()).resolves.toBe(false);
+    // Ensure the endpoint is called
+    expect(closeScope.isDone()).toBe(true);
+  });
 
-    // Calls the error handler
-    expect(onDevSessionError).toHaveBeenCalled();
+  it('skips next close call when server is down', async () => { 
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
+
+    jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
+      devices: [{ installationId: '123' }, { installationId: '456' }] as any[],
+    });
+
+    const server = jest.fn(() => '');
+
+    // Server is down
+    nock(getExpoApiBaseUrl())
+      .post('/v2/development-sessions/notify-close?deviceId=123&deviceId=456')
+      .reply(500, server);
+
+    // Fake the session state
+    Object.assign(session, { hasActiveSession: true });
+
+    // Does not throw directly
+    await expect(session.closeAsync()).resolves.toBe(false);
+    await expect(session.closeAsync()).resolves.toBe(false);
+    await expect(session.closeAsync()).resolves.toBe(false);
+
+    expect(server).toHaveBeenCalledTimes(1);
   });
 
   it('is skipped on CI', async () => {
     process.env.CI = '1';
 
-    const onDevSessionError = jest.fn();
-    const session = new DevelopmentSession('/', 'http://localhost:19001/', onDevSessionError);
+    const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     // Does not throw directly
     await expect(session.closeAsync()).resolves.toBe(false);

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -136,7 +136,7 @@ describe(`closeAsync`, () => {
     expect(closeScope.isDone()).toBe(true);
   });
 
-  it('skips next close call when server is down', async () => { 
+  it('skips next close call when server is down', async () => {
     const session = new DevelopmentSession('/', 'http://localhost:19001/');
 
     jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({


### PR DESCRIPTION
# Why

If the server is unavailable, or something else is going wrong in the development session calls, do not retry. It's on a best effort basis, and if it fails, there isn't a lot we can do.

# How

- Dropped `onError` callback in `DevelopmentSession`

# Test Plan

- In `packages/@expo/cli/src/api/updateDevelopmentSession.ts`
- Create a module variable, like `let calledCount = 0;`
- Modify both `updateDevelopmentSessionAsync` and `closeDevelopmentSessionAsync`
  - Add to the top of the function: `if (calledCount <= 50) throw new Error('Test')`
- `DEBUG="expo:start:server:developmentSession" expod start

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
