### PR TITLE
docs: Replace `justifyContext` typo with correct `justifyContent` in RTL guide

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
 
 ### Layouts and views
 
-You don't need to manually adjust `<View>` styling properties based on locale. You can use properties like `justifyContext`, `alignItems`, and others. Their property values change behavior as required.
+You don't need to manually adjust `<View>` styling properties based on locale. You can use properties like `justifyContent`, `alignItems`, and others. Their property values change behavior as required.
 
 - On LTR locales, `start` and `end` are the same as `left` and `right`.
 - On RTL locales, `start` and `end` are the same as `right` and `left`.


### PR DESCRIPTION
# Why

Typo

