### PR TITLE
[ci] fix android instrumentation test

### DIFF
--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,9 +9,10 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' '^llvm-.*' 'powershell' 'google-chrome-*' 'microsoft-edge-*' 'firefox' 'nginx' 'apache2'
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' '^llvm-.*' 'powershell' 'google-chrome-*' 'microsoft-edge-*' 'firefox' 'nginx' 'apache2' 'ghc' '^ghc-*'
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/.ghcup /opt/ghc
         echo 'Showing Android SDKs'
         ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
         ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall 'ndk;24.0.8215888' 'ndk;25.2.9519653' 'ndk;26.2.11394342'


### PR DESCRIPTION
# Why

fix error of android instrumentation tests, e.g. https://github.com/expo/expo/actions/runs/11103115268
basically it ran out of disk space on ubuntu runner.
```
System.IO.IOException: No space left on device : '/home/runner/runners/2.319.1/_diag/Worker_20240930-091649-utc.log'
```

# How

base on some github discussion to find the installed haskell ghc which takes about ~5GB. this pr removes the ghc packages.
available disk space before this pr: 31GB and after this pr 37GB

# Test Plan

android instrumentation ci passed: https://github.com/expo/expo/actions/runs/11105550196/job/30851958789

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
