### PR TITLE
[docs] Fix minor issues such as typos and grammatical errors in multiple docs

### DIFF
--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -15,7 +15,7 @@ When you run `eas build`, you will be prompted to generate credentials if you ha
 
 Generating your iOS credentials (distribution certificate, provisioning profile, and push key) requires you to sign in with an [Apple Developer Program](https://developer.apple.com/programs) membership.
 
-> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, please refer to the ["Security"](/app-signing/security) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials/) instead.
+> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, see [Security](/app-signing/security) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials/) instead.
 
 ### Push notification credentials
 

--- a/docs/pages/archive/push-notifications/notification-channels.mdx
+++ b/docs/pages/archive/push-notifications/notification-channels.mdx
@@ -3,7 +3,7 @@ title: Notification Channels
 hideFromSearch: true
 ---
 
-> **warning** This page is archived. Please refer to the [Push Notifications guide](/push-notifications/overview/) for up-to-date information.
+> **warning** This page is archived. See [Push Notifications guide](/push-notifications/overview/) for up-to-date information.
 
 Notification channels are a new feature in Android Oreo that give users more control over the notifications they receive. Starting in Android Oreo, every local and push notification must be assigned to a single channel. Users can see all notification channels in their OS Settings, and they can customize the behavior of alerts on a per-channel basis.
 

--- a/docs/pages/archive/push-notifications/sending-notifications-custom-fcm-legacy.mdx
+++ b/docs/pages/archive/push-notifications/sending-notifications-custom-fcm-legacy.mdx
@@ -4,7 +4,7 @@ hideFromSearch: true
 description: Learn how to send notifications with FCM legacy server.
 ---
 
-> **warning** This page is archived. Please refer to the [Push Notifications guide](/push-notifications/overview/) for up-to-date information.
+> **warning** This page is archived. See [Push Notifications guide](/push-notifications/overview/) for up-to-date information.
 
 > **info** For documentation on communicating with the newer FCMv1 service, see [Send notifications with FCMv1 and APNs](/push-notifications/sending-notifications-custom/). This guide is based on [Google's documentation](https://firebase.google.com/docs/cloud-messaging/http-server-ref), and this section covers the basics to get you started.
 

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ignoring files in .easignore
+title: Ignore files in .easignore
 description: Learn how to configure EAS to ignore unnecessary files during the build process.
 hideTOC: true
 ---

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ignore files in .easignore
+title: Ignore files via .easignore
 description: Learn how to configure EAS to ignore unnecessary files during the build process.
 hideTOC: true
 ---

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -24,6 +24,7 @@ All apps that include the `expo-updates` library have the ability to receive upd
 <ContentSpotlight
   alt="Updates JS API"
   src="/static/images/eas-update/frontpage/critical-update.png"
+  className="max-w-[480px]"
 />
 
 The updates [JavaScript API](/versions/unversioned/sdk/updates/) includes a React hook called `useUpdates()`. This hook provides detailed information about the currently running update and any new updates that are available or have been downloaded. In addition, you can view any errors that were encountered during the update process to help you debug any issues while the app is attempting to update.
@@ -35,6 +36,7 @@ The API also provides methods such as `checkForUpdateAsync()` and `fetchUpdateAs
 <ContentSpotlight
   alt="Website dashboard deployment insights"
   src="/static/images/eas-update/frontpage/insights.png"
+  className="max-w-[640px]"
 />
 
 You'll get a [deployments dashboard](https://expo.dev/accounts/[account]/projects/[project]/deployments) that helps visualize which updates are being sent to builds. Updates work in concert with [insights](/eas-insights/introduction/) to provide data on the adoption rates of your updates with your users.
@@ -44,6 +46,7 @@ You'll get a [deployments dashboard](https://expo.dev/accounts/[account]/project
 <ContentSpotlight
   alt="Republishing button on an update"
   src="/static/images/eas-update/frontpage/republish.png"
+  className="max-w-[480px]"
 />
 
 If an update isn't performing as expected, you can [republish](/eas-update/eas-cli/#republish-a-previous-update-within-a-branch) a previous, stable version on top of the problematic one, much like a new "commit" in version control systems.

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -5,7 +5,7 @@ description: Rollback a branch to a previous update or the embedded update.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
+> **info** Available from SDK 50 and [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 and above.
 
 There are two types of rollbacks supported by EAS Update:
 

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -5,7 +5,7 @@ description: Rollback a branch to a previous update or the embedded update.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available from SDK 50 and [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 and above.
+> **info** Available from SDK 50 using [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 or above.
 
 There are two types of rollbacks supported by EAS Update:
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -5,7 +5,7 @@ description: Incrementally deploy updates on a new branch to a channel.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
+> **info** Available from SDK 50 and [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 and above.
 
 Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, you can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -5,7 +5,7 @@ description: Incrementally deploy updates on a new branch to a channel.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available from SDK 50 and [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 and above.
+> **info** Available from SDK 50 using [`expo-updates`](/versions/latest/sdk/updates/) 0.23.0 or above.
 
 Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, you can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -123,7 +123,7 @@ This policy works for both projects with and without custom native code. It work
 
 ### `"fingerprintExperimental"` runtime version policy
 
-> **warning** `fingerprintExperimental`is deprecated and is removed from SDK 51 onwards.
+> **warning** `fingerprintExperimental` is deprecated and is removed from SDK 51 onwards.
 
 We provide the `"fingerprintExperimental"` runtime version policy for a project that has custom native code that may change between builds:
 

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -40,9 +40,9 @@ One way to think of local-first tools is to group them by the following categori
 
 ### Legend-State
 
-[Legend-State](https://legendapp.com/open-source/state/v3/) is a super fast all-in-one state and sync library that lets you write less code to make faster apps. Legend-State has four primary goals:
+[Legend-State](https://legendapp.com/open-source/state/v3/) is a super fast all-in-one state and sync library that lets you write less code to make faster apps. It has the following primary goals:
 
-- The fastest React state library
+- Faster state management for React apps
 - Fine-grained reactivity for minimal renders
 - Powerful sync and persistence (with Supabase support built-in)
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -197,7 +197,7 @@ use_expo_modules!({
 
 ### How to set up the autolinking in my app?
 
-All projects created with the `npx create-expo-app` command are already configured to use Expo Autolinking. If your project was created using different tools, please refer to [Installing Expo modules](/bare/installing-expo-modules) to make sure your project includes all necessary changes.
+All projects created with the `npx create-expo-app` command are already configured to use Expo Autolinking. If your project was created using a different tool, see [Installing Expo modules](/bare/installing-expo-modules) to make sure your project includes all necessary changes.
 
 ### What do I need to have in my module to make it autolinkable?
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -330,8 +330,6 @@ View(TextView::class) {
 
 > **Info** Support for rendering SwiftUI views is planned. For now, you can use [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) and add its content view to your UIKit view.
 
-> **Info** View functions are available as of SDK 49.
-
 </APIBox>
 <APIBox header="Prop">
 
@@ -747,8 +745,6 @@ Function("mutateMe") { jsObject: JavaScriptObject ->
 ```
 
 </CodeBlocksTable>
-
-> **Info** JavaScript types are available as of SDK 49.
 
 </APIBox>
 

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -34,7 +34,7 @@ Look at your logs before this error message to see what may have caused it. A fr
 
 Another possibility is that there is a mismatch between the `AppKey` being provided to [`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent), and the `AppKey` being registered on the native iOS or Android side.
 
-In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, please refer to the [registerRootComponent](/versions/latest/sdk/register-root-component) API reference.
+In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, see [registerRootComponent](/versions/latest/sdk/register-root-component) API reference.
 
 In projects with native code, you will see something like this in your **index.js** by default:
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -50,7 +50,7 @@ Under the hood, that example connects to [this Glitch server code](https://glitc
 
 ## Usage
 
-For usage information and detailed documentation, please refer to:
+For usage information and detailed documentation, see the following resources:
 
 - [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
 - [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
-For more information on Apple's new App Tracking Transparency framework, please refer to their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
+For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/stripe.mdx
@@ -52,7 +52,7 @@ Under the hood, that example connects to [this Glitch server code](https://glitc
 
 ## Usage
 
-For usage information and detailed documentation, please refer to:
+For usage information and detailed documentation, see the following resources:
 
 - [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
 - [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)

--- a/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
-For more information on Apple's new App Tracking Transparency framework, please refer to their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
+For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 
 <PlatformsSection ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/stripe.mdx
@@ -52,7 +52,7 @@ Under the hood, that example connects to [this Glitch server code](https://glitc
 
 ## Usage
 
-For usage information and detailed documentation, please refer to:
+For usage information and detailed documentation, see the following resources:
 
 - [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
 - [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
-For more information on Apple's new App Tracking Transparency framework, please refer to their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
+For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v51.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/stripe.mdx
@@ -50,7 +50,7 @@ Under the hood, that example connects to [this Glitch server code](https://glitc
 
 ## Usage
 
-For usage information and detailed documentation, please refer to:
+For usage information and detailed documentation, see the following resources:
 
 - [Stripe's React Native SDK reference](https://stripe.dev/stripe-react-native/api-reference/index.html)
 - [Stripe's React Native GitHub repo](https://github.com/stripe/stripe-react-native)

--- a/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
-For more information on Apple's new App Tracking Transparency framework, please refer to their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
+For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 
 ## Installation
 

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -60,7 +60,7 @@ export function DiscoverMore() {
           </div>
           <RawH3 className="!text-palette-blue11 !font-bold">Chat with the community</RawH3>
           <P className="!text-palette-blue11 !text-xs max-w-[32ch]">
-            Join over 20,000 other developers
+            Join over 40,000 other developers
             <br />
             on the Expo Community Discord.
           </P>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through our documentation, I've found some issues (typos, formatting nits, and grammatical errors) on multiple pages.

Also, found out that on our home page, the number of Discount community members we reference is outdated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix issues in multiple docs
- Update community members count for "Chat with the community" under Discover more section on home page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By going through issues and fixing them manually in each doc. To see the changes, use the diff to compare.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
