### PR TITLE
[iOS][core] Don't convert convertibles if the value is already converted

### DIFF
--- a/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
@@ -13,6 +13,9 @@ import CoreGraphics
 extension URL: Convertible {
   public static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     guard let value = value as? String else {
+      if let url = value as? URL {
+        return url
+      }
       throw Conversions.ConvertingException<URL>(value)
     }
 
@@ -66,6 +69,9 @@ extension CGSize: Convertible {
       let args = try Conversions.pickValues(from: value, byKeys: ["width", "height"], as: Double.self)
       return CGSize(width: args[0], height: args[1])
     }
+    if let size = value as? CGSize {
+      return size
+    }
     throw Conversions.ConvertingException<CGSize>(value)
   }
 }
@@ -79,6 +85,9 @@ extension CGVector: Convertible {
       let args = try Conversions.pickValues(from: value, byKeys: ["dx", "dy"], as: Double.self)
       return CGVector(dx: args[0], dy: args[1])
     }
+    if let vector = value as? CGVector {
+      return vector
+    }
     throw Conversions.ConvertingException<CGVector>(value)
   }
 }
@@ -91,6 +100,9 @@ extension CGRect: Convertible {
     if let value = value as? [String: Any] {
       let args = try Conversions.pickValues(from: value, byKeys: ["x", "y", "width", "height"], as: Double.self)
       return CGRect(x: args[0], y: args[1], width: args[2], height: args[3])
+    }
+    if let rect = value as? CGRect {
+      return rect
     }
     throw Conversions.ConvertingException<CGRect>(value)
   }
@@ -109,6 +121,9 @@ extension Date: Convertible {
     // For converting the value from `Date.now()`
     if let value = value as? Int {
       return Date(timeIntervalSince1970: Double(value) / 1000.0)
+    }
+    if let date = value as? Date {
+      return date
     }
     throw Conversions.ConvertingException<Date>(value)
   }

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -70,6 +70,9 @@ extension UIColor: Convertible {
         return color as! Self
       }
     }
+    if let color = value as? Self {
+      return color
+    }
     throw Conversions.ConvertingException<UIColor>(value)
     // swiftlint:enable force_cast
   }

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -31,6 +31,11 @@ public extension Record {
     if let value = value as? Dict {
       return try Self(from: value, appContext: appContext)
     }
+    // It's possible that the current implementation tries to convert a value that is already of the desired type.
+    // Handle that gracefully instead of throwing an exception.
+    if let record = value as? Self {
+      return record
+    }
     throw Conversions.ConvertingException<Self>(value)
   }
 


### PR DESCRIPTION
# Why

One of my PRs that changed how we convert arguments seemed to introduce a regression that causes the `Convertible.convert` function being called twice in constructors and async functions.

This PR is not solving the issue entirely as we should also prevent it from being called twice, but this seems like a bit more work. Anyway, in my opinion convertibles should check if the value is already converted.

# How

Added `if`s to convertibles in the core so that the second call just returns the passed value

# Test Plan

Constructing the video player works as expected, I also tested some async functions (such as `openAuthSessionAsync` that Alan reported to me while working on Expo Go migration)