### PR TITLE
[core][Android] Set external memory pressure for shared objects

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - Use the `src` folder as the Metro target. ([#30079](https://github.com/expo/expo/pull/30079) by [@tsapeta](https://github.com/tsapeta))
 - Prefer `UIGraphicsImageRenderer` over `UIGraphicsBeginImageContext`. ([#30211](https://github.com/expo/expo/pull/30211) by [@alanjhughes](https://github.com/alanjhughes))
-- Provide image's memory footprint for better garbage collection. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
+- Provide image's memory footprint for better garbage collection. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta) & [#31784](https://github.com/expo/expo/pull/31784) by [@lukmccall](https://github.com/lukmccall))
 
 ## 12.0.5 — 2024-05-13
 

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageRef.kt
@@ -4,4 +4,8 @@ import android.graphics.Bitmap
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.sharedobjects.SharedRef
 
-class ImageRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext)
+class ImageRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext) {
+  override fun getAdditionalMemoryPressure(): Int {
+    return ref.allocationByteCount
+  }
+}

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -25,7 +25,7 @@
 ### 💡 Others
 
 - Use the `src` folder as the Metro target. ([#30665](https://github.com/expo/expo/pull/30665) by [@tsapeta](https://github.com/tsapeta))
-- Provide image's memory footprint for better garbage collection. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta))
+- Provide image's memory footprint for better garbage collection. ([#31168](https://github.com/expo/expo/pull/31168) by [@tsapeta](https://github.com/tsapeta) & [#31784](https://github.com/expo/expo/pull/31784) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/Image.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/Image.kt
@@ -1,6 +1,18 @@
 package expo.modules.image
 
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import expo.modules.kotlin.sharedobjects.SharedRef
 
-class Image(ref: Drawable) : SharedRef<Drawable>(ref)
+class Image(ref: Drawable) : SharedRef<Drawable>(ref) {
+  override fun getAdditionalMemoryPressure(): Int {
+    val ref = ref
+    if (ref is BitmapDrawable) {
+      return ref.getBitmap().allocationByteCount
+    }
+
+    // We can't get the size in bytes of the drawable.
+    // Let's just return the size in pixels for now.
+    return ref.intrinsicWidth * ref.intrinsicHeight
+  }
+}

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Added `onStartListeningToEvent` and `onStopListeningToEvent` to the `SharedObject`. ([#31385](https://github.com/expo/expo/pull/31385) by [@lukmccall](https://github.com/lukmccall))
 - Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))
-- [Android] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data.
+- [Android] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31784](https://github.com/expo/expo/pull/31784) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Android] Add support for react-native 0.76 ([#31580](https://github.com/expo/expo/pull/31580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Added `onStartListeningToEvent` and `onStopListeningToEvent` to the `SharedObject`. ([#31385](https://github.com/expo/expo/pull/31385) by [@lukmccall](https://github.com/lukmccall))
 - Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))
+- [Android] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -37,6 +37,8 @@ void JavaScriptObject::registerNatives() {
                                     JavaScriptObject::defineProperty<jni::alias_ref<JavaScriptObject::javaobject>>),
                    makeNativeMethod("defineNativeDeallocator",
                                     JavaScriptObject::defineNativeDeallocator),
+                   makeNativeMethod("setExternalMemoryPressure",
+                                    JavaScriptObject::setExternalMemoryPressure),
                  });
 }
 
@@ -111,7 +113,8 @@ jni::local_ref<jni::JArrayClass<jstring>> JavaScriptObject::jniGetPropertyNames(
   return paredResult;
 }
 
-jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject> JavaScriptObject::createWeak() {
+jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject>
+JavaScriptObject::createWeak() {
   return JavaScriptWeakObject::newInstance(
     runtimeHolder.getJSIContext(),
     runtimeHolder,
@@ -186,5 +189,10 @@ void JavaScriptObject::defineNativeDeallocator(
       globalRef.reset();
     }
   );
+}
+
+void JavaScriptObject::setExternalMemoryPressure(int size) {
+  auto &jsRuntime = runtimeHolder.getJSRuntime();
+  jsObject->setExternalMemoryPressure(jsRuntime, size);
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -80,6 +80,11 @@ public:
     jni::alias_ref<JNIFunctionBody::javaobject> deallocator
   );
 
+  /**
+   * Sets the memory pressure to inform the GC about how much external memory is associated with that specific JS object.
+  */
+  void setExternalMemoryPressure(int size);
+
 protected:
   WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Object> jsObject;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -68,6 +68,8 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
     }
   }
 
+  external fun setExternalMemoryPressure(size: Int)
+
   fun setProperty(name: String, value: Boolean) = setBoolProperty(name, value)
   operator fun set(name: String, value: Boolean) = setBoolProperty(name, value)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -64,4 +64,14 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
    * Called when the shared object being deallocated.
    */
   open fun deallocate() {}
+
+  /**
+   * Override this function to inform the JavaScript runtime that there is additional
+   * memory associated with a given JavaScript object that is not visible to the GC.
+   * This can be used if an object is known to exclusively retain some native memory,
+   * and may be used to guide decisions about when to run garbage collection.
+   */
+  open fun getAdditionalMemoryPressure(): Int {
+    return 0
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -73,6 +73,13 @@ class SharedObjectRegistry(runtimeContext: RuntimeContext) {
       .jsiContext
       .setNativeStateForSharedObject(id.value, js)
 
+    val size = native.getAdditionalMemoryPressure()
+    // If the size is less or equal to 0, it means that the object doesn't require additional memory pressure.
+    // We can skip the call to the JSI method.
+    if (size > 0) {
+      js.setExternalMemoryPressure(size)
+    }
+
     val jsWeakObject = js.createWeak()
     synchronized(this) {
       pairs[id] = native to jsWeakObject


### PR DESCRIPTION
# Why

A follow up to the https://github.com/expo/expo/pull/31168.

Some shared objects may retain some heavy native data, that the JS engine doesn't know about when considering whether to trigger the GC. Since it's now possible to load and operate on full-sized images, it's considerably easy to cause out of memory crashes.

# How

Took advantage of setExternalMemoryPressure function on jsi::Object and introduced a way for shared object classes to provide their additional memory pressure. As an example, shared refs to images should provide the memory size of their bitmap.

# Test Plan

- bare-expo ✅ 