### PR TITLE
docs: add `run android --variant --app-id` for custom Android product flavors

### DIFF
--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -77,9 +77,13 @@ To create a development build, you can use [local app compilation](#local-app-co
 
 If you have a custom Android project with multiple product flavors with different application ids, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior when building for Android.
 
-The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with `--variant freeDebug` or `--variant paidDebug`.
+The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
 
-The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run `npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free` to build and launch the correct app.
+<Terminal cmd={['$ npx expo run:android --variant freeDebug', '$ npx expo run:android --variant paidDebug']} />
+
+The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run build and launch the app with:
+
+<Terminal cmd={['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free']} />
 
 > **info** It is also possible to customize the Android build type, but that would break Expo's assumption that the build type **release** is used for production. You might build unoptimized code in your app when using a different build type other than **release** for production.
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -75,19 +75,23 @@ To create a development build, you can use [local app compilation](#local-app-co
 
 > **warning** This feature is only available for SDK 52 and above.
 
-If you have a custom Android project with multiple product flavors using different application ids, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior when building for Android.
+If you have a custom Android project with multiple product flavors using different application IDs, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior.
 
-The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
+The `--variant` flag can switch the Android build type from **debug** to **release**. This flag can also configure a product flavor and build type, when formatted in camelCase. For example, if you have both [**free** and **paid** product flavors](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
 
 <Terminal
-  cmd={['$ npx expo run:android --variant freeDebug', '$ npx expo run:android --variant paidDebug']}
+  cmd={[
+    '$ npx expo run:android --variant freeDebug',
+    '',
+    '$ npx expo run:android --variant paidDebug',
+  ]}
 />
 
 The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run build and launch the app with:
 
 <Terminal cmd={['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free']} />
 
-> **info** It is also possible to customize the Android build type, but that would break Expo's assumption that the build type **release** is used for production. You might build unoptimized code in your app when using a different build type other than **release** for production.
+> **info** Customizing the Android build type is also possible, but that would break Expo's assumption that the build type **release** is used for production. You might build unoptimized code in your app using a different build type instead of **release**.
 
 ## Local builds with EAS
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -75,7 +75,7 @@ To create a development build, you can use [local app compilation](#local-app-co
 
 > **warning** This feature is only available for SDK 52 and above.
 
-If you have a custom Android project with multiple product flavors with different application ids, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior when building for Android.
+If you have a custom Android project with multiple product flavors using different application ids, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior when building for Android.
 
 The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -71,6 +71,18 @@ If you install [`expo-dev-client`](/develop/development-builds/introduction/#wha
 
 To create a development build, you can use [local app compilation](#local-app-compilation) commands (`npx expo run:[android|ios]`) which will create a debug build and start the development server.
 
+## Local builds using Android product flavors
+
+> **warning** This feature is only available for SDK 52 and above.
+
+If you have a custom Android project with multiple product flavors with different application ids, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior when building for Android.
+
+The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with `--variant freeDebug` or `--variant paidDebug`.
+
+The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run `npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free` to build and launch the correct app.
+
+> **info** It is also possible to customize the Android build type, but that would break Expo's assumption that the build type **release** is used for production. You might build unoptimized code in your app when using a different build type other than **release** for production.
+
 ## Local builds with EAS
 
 <BoxLink

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -79,7 +79,9 @@ If you have a custom Android project with multiple product flavors with differen
 
 The `--variant` flag can be used to switch the Android build type from **debug** to **release**. This flag can also be used to configure a product flavor and build typ, formatted in camelCase. For example, if you have both a **free** and **paid** product flavor, as documented on [Android developers](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
 
-<Terminal cmd={['$ npx expo run:android --variant freeDebug', '$ npx expo run:android --variant paidDebug']} />
+<Terminal
+  cmd={['$ npx expo run:android --variant freeDebug', '$ npx expo run:android --variant paidDebug']}
+/>
 
 The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run build and launch the app with:
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -203,6 +203,10 @@ You can debug the native Android project using native debugging tools by opening
 
 <Terminal cmd={['$ open -a /Applications/Android Studio.app android']} />
 
+If you have a customized Android project using different product flavors, you can configure both the flavor and application id using the `--variant` and `--app-id` flags. Learn more in the [local app development](/guides/local-app-development/#local-builds-using-android-product-flavors) guide:
+
+<Terminal cmd={['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free']} />
+
 #### Compiling iOS
 
 An iOS app can have multiple **schemes** for representing different sub-apps like App Clips, watchOS apps, Safari Extensions, and so on. By default, `npx expo run:ios` will choose the scheme for your iOS app. You can pick a custom scheme with the `--scheme <my-scheme>` argument. If you pass in the `--scheme` argument alone, then Expo CLI will prompt you to choose a scheme from the list of available options in your Xcode project.

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -203,9 +203,11 @@ You can debug the native Android project using native debugging tools by opening
 
 <Terminal cmd={['$ open -a /Applications/Android Studio.app android']} />
 
-If you have a customized Android project using different product flavors, you can configure both the flavor and application id using the `--variant` and `--app-id` flags. Learn more in the [local app development](/guides/local-app-development/#local-builds-using-android-product-flavors) guide:
+If you have a customized Android project using different product flavors, you can configure both the flavor and application ID using the `--variant` and `--app-id` flags:
 
 <Terminal cmd={['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free']} />
+
+For more information, see the [Local builds using Android product flavors](/guides/local-app-development/#local-builds-using-android-product-flavors) guide.
 
 #### Compiling iOS
 


### PR DESCRIPTION
# Why

This is a follow-up of #31756 and adds the missing documentation.

# How

- Added a section for Android product flavors to **Local app development** using `--variant` and `--app-id`
- Added a quick example and link to product flavors from Expo CLI

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
