### PR TITLE
[core][updates] fix ios reload crash in new arch mode

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [Android] Fixed getter for the third parameter of `Either`. ([#31443](https://github.com/expo/expo/pull/31443) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
+- Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -45,7 +45,9 @@ internal final class CoreModule: Module {
     }
 
     AsyncFunction("reloadAppAsync") { (reason: String) in
-      RCTTriggerReloadCommandListeners(reason)
+      DispatchQueue.main.async {
+        RCTTriggerReloadCommandListeners(reason)
+      }
     }
   }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Use relative entry point from `@expo/config/paths` with support for server root. ([#30633](https://github.com/expo/expo/pull/30633) by [@byCedric](https://github.com/byCedric))
 - [iOS] Rollback to system SQLite3 and fix incompatible issue when any third-party library uses iOS system SQLite3. ([#30826](https://github.com/expo/expo/pull/30826) by [@kudo](https://github.com/kudo))
 - Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
+- Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
@@ -25,7 +25,7 @@ final class RecreateReactContextProcedure: StateMachineProcedure {
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventRestart())
 
-    DispatchQueue(label: "expo.procedure.RecreateReactContextProcedureQueue").async {
+    DispatchQueue.main.async {
       RCTTriggerReloadCommandListeners(self.triggerReloadCommandListenersReason)
       self.successBlock()
       // Reset the state machine


### PR DESCRIPTION
# Why

fix ios reload crash, e.g. `Updates.reloadAsync()` on new architecture mode.
close ENG-13646

# How

fundamentally, the issue is from react-native core and could relate to https://github.com/facebook/react-native/issues/44755. this pr is trying to send `RCTTriggerReloadCommandListeners` from main thread. that would highly reduce the possibility of having the crash. 

# Test Plan

- ci passed
- try the repro from https://github.com/brentvatne/delay-loading-ux/tree/%40brent/075-new-arch
 
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
