### PR TITLE
[notifications][android] fix notifications actions not being presented

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] fix notifications actions not being presented ([#31795](https://github.com/expo/expo/pull/31795) by [@vonovak](https://github.com/vonovak))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30478](https://github.com/expo/expo/pull/30478) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
@@ -24,7 +24,7 @@ import kotlin.math.min
  */
 open class ExpoNotificationBuilder(context: Context?) : ChannelAwareNotificationBuilder(context) {
   override suspend fun build(): Notification {
-    val builder = super.createBuilder()
+    val builder = createBuilder()
     builder.setSmallIcon(icon)
     builder.setPriority(priority)
 


### PR DESCRIPTION
# Why

closes #31710

Note: this will be cherry picked for a bugfix release.

# How

`ExpoNotificationBuilder.build` would call `ChannelAwareNotificationBuilder.createBuilder` instead of `CategoryAwareNotificationBuilder.createBuilder`

# Test Plan

tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
