### PR TITLE
[android][image-picker] Removed android permissions to comply with Google's guidelines

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 💡 Others
 
+- Removed android permissions to comply with Google's guidelines ([#31801](https://github.com/expo/expo/pull/31801) by [@JulianDueck](https://github.com/JulianDueck))
 - Refactored the code on iOS and made promise resolution faster. ([#30896](https://github.com/expo/expo/pull/30896) by [@tsapeta](https://github.com/tsapeta))
 
 ## 15.0.7 - 2024-07-03

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 💡 Others
 
-- Removed android permissions to comply with Google's guidelines ([#31801](https://github.com/expo/expo/pull/31801) by [@JulianDueck](https://github.com/JulianDueck))
+- [Android] Removed android permissions to comply with Google's guidelines ([#31801](https://github.com/expo/expo/pull/31801) by [@JulianDueck](https://github.com/JulianDueck))
 - Refactored the code on iOS and made promise resolution faster. ([#30896](https://github.com/expo/expo/pull/30896) by [@tsapeta](https://github.com/tsapeta))
 
 ## 15.0.7 - 2024-07-03

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
   <!-- Required for picking images from camera roll -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
   <application>
     <service


### PR DESCRIPTION
[expo-image-picker]
To comply with Google's policies and guidelines, I removed the READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions from the AndroidManifest.xml as per [Google's request](https://support.google.com/googleplay/android-developer/answer/14115180) to do so. Since this library is already using Google's recommended [Android photo picker](https://developer.android.com/training/data-storage/shared/photopicker), these permissions are not required for that photo picker and can therefore be removed from the Manifest.

I removed the 2 lines in the AndroidManifest.xml containing the READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions