### PR TITLE
[tools] Update SwiftLint to 0.57.0

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
       ### To update SwiftLint, uncomment steps below, download the artifact and update that package.
       # - name: 👷 Build and install SwiftLint
       #   run: |
-      #     git clone https://github.com/realm/SwiftLint.git --branch 0.52.2 --depth 1
+      #     git clone https://github.com/realm/SwiftLint.git --branch 0.57.0 --depth 1
       #     cd SwiftLint
       #     swift build -c release
       #     cp .build/release/swiftlint /usr/local/bin/
@@ -40,6 +40,7 @@ jobs:
       #   with:
       #     name: swiftlint
       #     path: SwiftLint/.build
+      #     include-hidden-files: true
 
       - name: 🔬 Reviewing a pull request
         run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,7 +31,6 @@ excluded:
 
 # Enable rules that are turned off by default. Run `swiftlint rules` to see what's available to opt-in.
 opt_in_rules:
-  - anyobject_protocol
   - array_init
   - closure_body_length
   - closure_end_indentation
@@ -51,6 +50,7 @@ opt_in_rules:
   - identical_operands
   - implicitly_unwrapped_optional
   - indentation_width
+  - legacy_objc_type
   - literal_expression_end_indentation
   - local_doc_comment
   - lower_acl_than_parent
@@ -88,9 +88,6 @@ analyzer_rules:
   - capture_variable
   - unused_declaration
   - unused_import
-
-# Prefer using AnyObject over class for class-only protocols.
-anyobject_protocol: warning
 
 # Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array.
 array_init: warning

--- a/tools/package.json
+++ b/tools/package.json
@@ -30,7 +30,7 @@
     "@expo/multipart-body-parser": "^1.1.0",
     "@expo/plist": "^0.0.20",
     "@expo/spawn-async": "^1.7.0",
-    "@expo/swiftlint": "^0.52.4",
+    "@expo/swiftlint": "^0.57.1",
     "@expo/xcodegen": "2.18.0-patch.1",
     "@expo/xdl": "^59.2.1",
     "@linear/sdk": "^2.6.0",

--- a/tools/src/linting/SwiftLint.ts
+++ b/tools/src/linting/SwiftLint.ts
@@ -108,7 +108,6 @@ export async function lintStringAsync(str: string): Promise<LintViolation[]> {
   } catch {
     logger.error(`SwiftLint resulted with the following stderr: \n${stderr}`);
     // Return no violations in case of any errors.
-    // TODO: We should migrate to this action instead: https://github.com/marketplace/actions/github-action-for-swiftlint
     return [];
   }
 }

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -1823,10 +1823,10 @@
   dependencies:
     cross-spawn "^7.0.3"
 
-"@expo/swiftlint@^0.52.4":
-  version "0.52.4"
-  resolved "https://registry.yarnpkg.com/@expo/swiftlint/-/swiftlint-0.52.4.tgz#ee9dd44fd654f5d48d69442727543e1fc5089ee3"
-  integrity sha512-B73P7P6hV1V3dVRMaljtVdf6Ndh3zeLxB5lIytDaXQF8k0lWlKTYHnfKTxA59TJSdDl0pgF7bakVxPFTzwnW+A==
+"@expo/swiftlint@^0.57.1":
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/@expo/swiftlint/-/swiftlint-0.57.1.tgz#0805182db600d3ab51d5eefa377a1c95abe8649d"
+  integrity sha512-7hCDABeIPrNOIn/fYC7cKYRo1kAXvQpYiKvIG9LZKv3iMNZmDpo7n9BcBvMHnpbUGsaHKPJC5VbiTcVsRx4t5Q==
   dependencies:
     "@expo/spawn-async" "^1.5.0"
 


### PR DESCRIPTION
# Why

Trying to solve issues with SwiftLint on our CI. Currently it's failing with the following stderr:
```
/home/runner/work/expo/expo/tools/node_modules/@expo/swiftlint/bin/linux-x64/swiftlint: symbol lookup error: /home/runner/work/expo/expo/tools/node_modules/@expo/swiftlint/bin/linux-x64/swiftlint: undefined symbol: $s10Foundation4UUIDVSEAAMc
```

# How

- Temporarily uncommented steps to build SwiftLint in a `code-review.yml` workflow
- Downloaded the artifact and copied the `release/swiftlint` binary to `tools/node_modules/@expo/swiftlint/bin/linux-x64`
- Built from sources on the macOS machine, using the same commands as in the workflow file and copied the binary to `tools/node_modules/@expo/swiftlint/bin/darwin-x64`
- `chmod +x` on both executable files
- `cd tools/node_modules/@expo/swiftlint` then updated version in `package.json` to `0.57.1` and ran `npm publish`
- Updated the dependency on `@expo/swiftlint` in `tools/package.json`
- Commented SwiftLint building steps in `code-review.yml`
- Addressed some necessary changes in the SwiftLint config, i.e. removed a deprecated rule and opted into a rule that was previously enabled by default

# Test Plan

Checked that the code review workflow works as expected by manually dispatching the workflow