### PR TITLE
[expo-go][android] Remove support for multiple SDK versions in Constants

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -29,33 +29,14 @@ public class Constants {
   private static final String TAG = Constants.class.getSimpleName();
 
   public static String VERSION_NAME = null;
-  public static String ABI_VERSIONS;
-  public static String SDK_VERSIONS;
-  public static List<String> SDK_VERSIONS_LIST;
-  public static final String TEMPORARY_SDK_VERSION = ExponentBuildConstants.TEMPORARY_SDK_VERSION;
+  public static String SDK_VERSION = ExponentBuildConstants.TEMPORARY_SDK_VERSION;
   public static final String EMBEDDED_KERNEL_PATH = "assets://kernel.android.bundle";
   public static boolean DISABLE_NUX = false;
   public static int ANDROID_VERSION_CODE;
   public static boolean FCM_ENABLED;
   public static SplashScreenImageResizeMode SPLASH_SCREEN_IMAGE_RESIZE_MODE;
 
-  public static void setSdkVersions(List<String> sdkVersions) {
-    ABI_VERSIONS = TextUtils.join(",", sdkVersions);
-
-    // NOTE: Currently public-facing SDK versions and internal ABI versions are the same, but
-    // eventually we may decouple them
-    SDK_VERSIONS = ABI_VERSIONS;
-    SDK_VERSIONS_LIST = sdkVersions;
-  }
-
   static {
-    List<String> abiVersions = new ArrayList<>();
-    if (TEMPORARY_SDK_VERSION != null) {
-      abiVersions.add(TEMPORARY_SDK_VERSION);
-    }
-
-    setSdkVersions(abiVersions);
-
     try {
       Class appConstantsClass = Class.forName("host.exp.exponent.generated.AppConstants");
       ExpoViewAppConstants appConstants = (ExpoViewAppConstants) appConstantsClass.getMethod("get").invoke(null);
@@ -80,21 +61,6 @@ public class Constants {
   public static final boolean ENABLE_LEAK_CANARY = false;
   public static final boolean WRITE_BUNDLE_TO_LOG = false;
   public static final boolean WAIT_FOR_DEBUGGER = false;
-
-  public static String getVersionName(Context context) {
-    if (VERSION_NAME != null) {
-      // This will be set in shell apps
-      return VERSION_NAME;
-    } else {
-      try {
-        PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-        return pInfo.versionName;
-      } catch (PackageManager.NameNotFoundException e) {
-        EXL.e(TAG, e.toString());
-        return "";
-      }
-    }
-  }
 
   private static boolean sIsTest = false;
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -118,7 +118,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
         this[UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY] = 60000
       }
       this[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders
-      this[UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY] = "exposdk:${Constants.TEMPORARY_SDK_VERSION}"
+      this[UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY] = "exposdk:${Constants.SDK_VERSION}"
       // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates from the multipart manifest response part
       this[UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE] = context.assets.open("expo-root.pem").readBytes().decodeToString()
       this[UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA] = mapOf(
@@ -132,7 +132,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }.toMap()
 
     val configuration = UpdatesConfiguration(null, configMap)
-    val sdkVersionsList = (Constants.SDK_VERSIONS_LIST + listOf(RNObject.UNVERSIONED)).flatMap {
+    val sdkVersionsList = listOf(Constants.SDK_VERSION, RNObject.UNVERSIONED).flatMap {
       listOf(it, "exposdk:$it")
     }
     val selectionPolicy = SelectionPolicy(
@@ -307,7 +307,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
         headers["Exponent-SDK-Version"] = "UNVERSIONED"
       } else {
-        headers["Exponent-SDK-Version"] = Constants.SDK_VERSIONS
+        headers["Exponent-SDK-Version"] = Constants.SDK_VERSION
       }
       return headers
     }
@@ -326,10 +326,8 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     if (RNObject.UNVERSIONED == sdkVersion) {
       return true
     }
-    for (version in Constants.SDK_VERSIONS_LIST) {
-      if (version == sdkVersion) {
-        return true
-      }
+    if (Constants.SDK_VERSION == sdkVersion) {
+      return true
     }
     return false
   }
@@ -340,7 +338,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       errorJson.put("message", "Invalid SDK version")
       if (sdkVersion == null) {
         errorJson.put("errorCode", "NO_SDK_VERSION_SPECIFIED")
-      } else if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSIONS_LIST[0])) {
+      } else if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSION)) {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_TOO_NEW")
       } else {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_OUTDATED")

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
@@ -442,7 +441,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_SDK_VERSION
     // to point to the unversioned code in ReactAndroid.
-    if (Constants.TEMPORARY_SDK_VERSION == sdkVersion) {
+    if (Constants.SDK_VERSION == sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }
 
@@ -450,17 +449,10 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     detachSdkVersion = sdkVersion
 
     if (RNObject.UNVERSIONED != sdkVersion) {
-      var isValidVersion = false
-      for (version in Constants.SDK_VERSIONS_LIST) {
-        if (version == sdkVersion) {
-          isValidVersion = true
-          break
-        }
-      }
+      val isValidVersion = sdkVersion == Constants.SDK_VERSION
       if (!isValidVersion) {
         KernelProvider.instance.handleError(
-          sdkVersion + " is not a valid SDK version. Options are " +
-            TextUtils.join(", ", Constants.SDK_VERSIONS_LIST) + ", " + RNObject.UNVERSIONED + "."
+          sdkVersion + " is not a valid SDK version. Only ${Constants.SDK_VERSION} is supported."
         )
         return
       }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -243,7 +243,7 @@ abstract class ReactNativeActivity :
       return reactRootViewRNClass as Class<out ViewGroup>
     }
     var sdkVersion = manifest.getExpoGoSDKVersion()
-    if (Constants.TEMPORARY_SDK_VERSION == sdkVersion) {
+    if (Constants.SDK_VERSION == sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }
     return RNObject("com.facebook.react.ReactRootView").loadVersion(sdkVersion!!).rnClass() as Class<out ViewGroup>

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -110,20 +110,14 @@ class InternalHeadlessAppLoader(private val context: Context) :
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_SDK_VERSION
     // to point to the unversioned code in ReactAndroid.
-    if (Constants.TEMPORARY_SDK_VERSION == sdkVersion) {
+    if (Constants.SDK_VERSION == sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }
 
     detachSdkVersion = sdkVersion
 
     if (RNObject.UNVERSIONED != sdkVersion) {
-      var isValidVersion = false
-      for (version in Constants.SDK_VERSIONS_LIST) {
-        if (version == sdkVersion) {
-          isValidVersion = true
-          break
-        }
-      }
+      val isValidVersion = sdkVersion == Constants.SDK_VERSION
       if (!isValidVersion) {
         callback!!.onComplete(false, Exception("$sdkVersion is not a valid SDK version."))
         return

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -32,7 +32,7 @@ object ExponentUrls {
     // TODO: set user agent
     val builder = Request.Builder()
       .url(urlString)
-      .header("Exponent-SDK-Version", Constants.SDK_VERSIONS)
+      .header("Exponent-SDK-Version", Constants.SDK_VERSION)
       .header("Exponent-Platform", "android")
     val versionName = ExpoViewKernel.instance.versionName
     if (versionName != null) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
@@ -19,7 +19,7 @@ object KernelNetworkInterceptor {
     sdkVersion = manifest.getExpoGoSDKVersion() ?: throw IllegalArgumentException("Invalid SDK version")
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_SDK_VERSION
     // to point to the unversioned code in ReactAndroid.
-    if (Constants.TEMPORARY_SDK_VERSION == sdkVersion) {
+    if (Constants.SDK_VERSION == sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
@@ -33,7 +33,7 @@ class ExponentKernelModule(reactContext: ReactApplicationContext?) :
 
   override fun getConstants(): Map<String, Any> {
     return mapOf(
-      "sdkVersions" to Constants.SDK_VERSIONS
+      "sdkVersions" to listOf(Constants.SDK_VERSION)
     )
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
@@ -26,7 +26,7 @@ class ConstantsBinding(
       this["manifest"] = manifest.toString()
       this["nativeAppVersion"] = ExpoViewKernel.instance.versionName
       this["nativeBuildVersion"] = Constants.ANDROID_VERSION_CODE
-      this["supportedExpoSdks"] = Constants.SDK_VERSIONS_LIST
+      this["supportedExpoSdks"] = listOf(Constants.SDK_VERSION)
       this["appOwnership"] = "expo"
       this["executionEnvironment"] = executionEnvironment.string
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,7 +1557,7 @@
   resolved "https://registry.yarnpkg.com/@expo/styleguide-native/-/styleguide-native-1.0.1.tgz#b9889266664f885dad15566b5b2956e086b1aa22"
   integrity sha512-VhmMYcOhzQKcng3QH0RBkwK9knhXXFEVzqwjftLK2S4457k6z3OumdyIHp/4P6h5HmfCydtXWvvsFmL7Ui6Pwg==
 
-"@expo/vector-icons@^14.0.0", "@expo/vector-icons@^14.0.4":
+"@expo/vector-icons@^14.0.0":
   version "14.0.4"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.0.4.tgz#fa9d4351877312badf91a806598b2f0bab16039a"
   integrity sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ==


### PR DESCRIPTION
# Why

Re-application of https://github.com/expo/expo/pull/26262 which wasn't landed at the time in order to do some other cleanup first.

Closes ENG-11002.

# How

This mainly just removes a lot of unnecessary constants and creates a new one, `SDK_VERSION`. Assuming that change is sound, the other changes should be as well.

# Test Plan

Build Expo Go. Note that Expo Go currently crashes for me on main so I can't test further.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
