### PR TITLE
[expo-go][android] Fix expo-updates app loader status callback

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -72,7 +72,11 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
   var isUpToDate = true
     private set
   var status: AppLoaderStatus? = null
-    private set
+    private set(value) {
+      field = value
+      callback.updateStatus(value)
+    }
+
   var shouldShowAppLoaderStatus = true
     private set
   private var isStarted = false
@@ -82,7 +86,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     fun onManifestCompleted(manifest: Manifest)
     fun onBundleCompleted(localBundlePath: String)
     fun emitEvent(params: JSONObject)
-    fun updateStatus(status: AppLoaderStatus)
+    fun updateStatus(status: AppLoaderStatus?)
     fun onError(e: Exception)
   }
 
@@ -91,11 +95,6 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
 
   lateinit var launcher: Launcher
     private set
-
-  private fun updateStatus(status: AppLoaderStatus) {
-    this.status = status
-    callback.updateStatus(status)
-  }
 
   fun start(context: Context) {
     check(!isStarted) { "AppLoader for $manifestUrl was started twice. AppLoader.start() may only be called once per instance." }
@@ -216,7 +215,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
           }
           setShouldShowAppLoaderStatus(update.manifest)
           callback.onOptimisticManifest(update.manifest)
-          updateStatus(AppLoaderStatus.DOWNLOADING_NEW_UPDATE)
+          status = AppLoaderStatus.DOWNLOADING_NEW_UPDATE
         }
 
         override fun onSuccess(launcher: Launcher, isUpToDate: Boolean) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -197,7 +197,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
             emitUpdatesEvent(params)
           }
 
-          override fun updateStatus(status: AppLoaderStatus) {
+          override fun updateStatus(status: AppLoaderStatus?) {
             setLoadingProgressStatusIfEnabled(status)
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -89,7 +89,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
         }
 
         override fun emitEvent(params: JSONObject) {}
-        override fun updateStatus(status: AppLoaderStatus) {}
+        override fun updateStatus(status: AppLoaderStatus?) {}
         override fun onError(e: Exception) {
           Exponent.instance.runOnUiThread { this@InternalHeadlessAppLoader.callback!!.onComplete(false, Exception(e.message)) }
         }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -689,7 +689,7 @@ class Kernel : KernelInterface() {
             }
           }
 
-          override fun updateStatus(status: AppLoaderStatus) {
+          override fun updateStatus(status: AppLoaderStatus?) {
             if (optimisticActivity != null) {
               optimisticActivity!!.setLoadingProgressStatusIfEnabled(status)
             }


### PR DESCRIPTION
# Why

It seems that status is only being reported via the callback for the download. This change makes it so that all status updates are reported back.

Closes ENG-13693.

# How

Call the callback on property set.

# Test Plan

Compile. Still can't launch Expo Go due to a hard crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
