### PR TITLE
[docs] Update private-npm-packages.mdx to include private repo guide

### DIFF
--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -93,13 +93,13 @@ If you or your organisation have packages that reference a private GitHub reposi
 
 <Step label="1">
 
-Generate a [fine-grained personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) with content read permissions for your user/organisation specific repositories you are wanting to install from
+Generate a [fine-grained personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) with content read permissions to install the package from your user/organization specific repositories.
 
 </Step>
 
 <Step label="2">
 
-On the Expo Dashboard [add a secret](/build-reference/variables/#using-secrets-in-environment-variables) called `GITHUB_PAT` and set the token you generated as the value
+On the Expo Dashboard [add a secret](/build-reference/variables/#using-secrets-in-environment-variables) called `GITHUB_PAT` and set the token you generated as the value.
 
 </Step>
 

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -86,3 +86,31 @@ registry=https://registry.johndoe.com/
 ## Submodules in private repositories
 
 If you have a submodule in a private repository, you will need to initialize it by setting up an SSH key. For more information, see [submodules initialization](/build-reference/git-submodules/#submodules-initialization).
+
+## Packages from a private GitHub repository
+
+If you or your organisation have packages that reference a private GitHub repository then you will need to ensure EAS Build can access this by performing the following setup:
+
+<Step label="1">
+
+Generate a [fine-grained personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) with content read permissions for your user/organisation specific repositories you are wanting to install from
+
+</Step>
+
+<Step label="2">
+
+On the Expo Dashboard [add a secret](/build-reference/variables/#using-secrets-in-environment-variables) called `GITHUB_PAT` and set the token you generated as the value
+
+</Step>
+
+<Step label="3">
+
+Add an [`eas-build-pre-install` npm hook](/build-reference/npm-hooks/) to use the PAT in your GitHub requests:
+
+```bash eas-build-pre-install.sh
+#!/usr/bin/env bash
+
+git config --global url."https://${GITHUB_PAT}@github.com/".insteadOf ssh://git@github.com/
+```
+
+</Step>


### PR DESCRIPTION
# Why

Adds some information on how to use EAS to install a package from a private repo which might be common during development and testing of an app. For example, an organisation I work has an in-the-works private package that we didn't want to upload to NPM as a private package and need to be able to create builds on EAS.

# How

Added a basic step-by-step guide which shows how to create the PAT and then configure git on the EAS build server to authenticate properly with GitHub

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
