### PR TITLE
[iOS][core] Improve converting function results

### DIFF
--- a/packages/@expo/dom-webview/ios/DomWebView.swift
+++ b/packages/@expo/dom-webview/ios/DomWebView.swift
@@ -68,7 +68,7 @@ internal final class DomWebView: ExpoView, UIScrollViewDelegate, WKUIDelegate, W
     }
 
     if let source,
-      let request = RCTConvert.nsurlRequest(source.toDictionary()),
+      let request = RCTConvert.nsurlRequest(source.toDictionary(appContext: appContext)),
       webView.url?.absoluteURL != request.url {
       webView.load(request)
     }

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -37,11 +37,12 @@ public final class FileSystemModule: Module {
     Events(EVENT_DOWNLOAD_PROGRESS, EVENT_UPLOAD_PROGRESS)
 
     AsyncFunction("getInfoAsync") { (url: URL, options: InfoOptions, promise: Promise) in
+      let optionsDict = options.toDictionary(appContext: appContext)
       switch url.scheme {
       case "file":
-        EXFileSystemLocalFileHandler.getInfoForFile(url, withOptions: options.toDictionary(), resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemLocalFileHandler.getInfoForFile(url, withOptions: optionsDict, resolver: promise.resolver, rejecter: promise.legacyRejecter)
       case "assets-library", "ph":
-        EXFileSystemAssetLibraryHandler.getInfoForFile(url, withOptions: options.toDictionary(), resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemAssetLibraryHandler.getInfoForFile(url, withOptions: optionsDict, resolver: promise.resolver, rejecter: promise.legacyRejecter)
       default:
         throw UnsupportedSchemeException(url.scheme)
       }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -95,6 +95,7 @@
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 - Removed deprecated code for react-native 0.74.0. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -156,35 +156,27 @@ public struct Conversions {
     appContext: AppContext? = nil,
     dynamicType: AnyDynamicType? = nil
   ) -> Any {
+    if let appContext, let result = try? dynamicType?.convertResult(value as Any, appContext: appContext) {
+      return result
+    }
+    return convertFunctionResultInRuntime(value, appContext: appContext)
+  }
+
+  /**
+   Converts the function result to the type that can later be converted to a JS value.
+   As opposed to `convertFunctionResult`, it has no information about the dynamic type,
+   so it is quite limited, e.g. it does not handle shared objects.
+   Currently it is required to handle results of the promise.
+   */
+  static func convertFunctionResultInRuntime<ValueType>(_ value: ValueType?, appContext: AppContext? = nil) -> Any {
     if let value = value as? Record {
-      return value.toDictionary()
+      return value.toDictionary(appContext: appContext)
     }
     if let value = value as? [Record] {
-      return value.map { $0.toDictionary() }
+      return value.map { $0.toDictionary(appContext: appContext) }
     }
     if let value = value as? any Enumerable {
       return value.anyRawValue
-    }
-    if let appContext {
-      if let value = value as? JavaScriptObjectBuilder {
-        // TODO: Handle errors
-        let object = try? value.build(appContext: appContext)
-        return object as Any
-      }
-
-      // If the returned value is a native shared object, create its JS representation and add the pair to the registry of shared objects.
-      if let value = value as? SharedObject, let dynamicType = asDynamicSharedObjectType(dynamicType) {
-        // If the JS object already exists, just return it.
-        if let object = value.getJavaScriptObject() {
-          return object
-        }
-        guard let object = try? appContext.newObject(nativeClassId: dynamicType.typeIdentifier) else {
-          log.warn("Unable to create a JS object for \(dynamicType.description)")
-          return Optional<Any>.none as Any
-        }
-        appContext.sharedObjectRegistry.add(native: value, javaScript: object)
-        return object
-      }
     }
     return value as Any
   }
@@ -297,14 +289,4 @@ public struct Conversions {
       "Provided hex color '\(param)' would result in an overflow"
     }
   }
-}
-
-/**
- Unwraps the dynamic optional type and returns as a dynamic shared object type if possible.
- */
-private func asDynamicSharedObjectType(_ dynamicType: AnyDynamicType?) -> DynamicSharedObjectType? {
-  if let dynamicType = dynamicType as? DynamicOptionalType {
-    return dynamicType.wrappedType as? DynamicSharedObjectType
-  }
-  return dynamicType as? DynamicSharedObjectType
 }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
@@ -29,6 +29,13 @@ public protocol AnyDynamicType: CustomStringConvertible {
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue
+
+  /**
+   Converts function's result to the type that can later be converted to a JS value.
+   For instance, types such as records, enumerables and shared objects need special handling
+   and conversion to simpler types (dictionary, primitive value or specific JS value).
+   */
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any
 }
 
 extension AnyDynamicType {
@@ -44,6 +51,10 @@ extension AnyDynamicType {
     // This conversion isn't the most efficient way to convert Objective-C value to JS value.
     // Better performance should be provided in dynamic type specializations.
     return try JavaScriptValue.from(value, runtime: appContext.runtime)
+  }
+
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    return result
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
@@ -30,6 +30,15 @@ internal struct DynamicArrayType: AnyDynamicType {
     return [try elementType.cast(value, appContext: appContext)]
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    if let result = result as? [Any] {
+      return try result.map({ element in
+        return try elementType.convertResult(element, appContext: appContext)
+      })
+    }
+    return result
+  }
+
   var description: String {
     "[\(elementType.description)]"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -21,6 +21,13 @@ internal struct DynamicConvertibleType: AnyDynamicType {
     return try innerType.convert(from: value, appContext: appContext)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    if let record = result as? Record {
+      return record.toDictionary(appContext: appContext)
+    }
+    return result
+  }
+
   var description: String {
     String(describing: innerType.self)
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -21,6 +21,13 @@ internal struct DynamicEnumType: AnyDynamicType {
     return try innerType.create(fromRawValue: value)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    if let result = result as? any Enumerable {
+      return result.anyRawValue
+    }
+    return result
+  }
+
   var description: String {
     "Enum<\(innerType)>"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
@@ -35,6 +35,11 @@ internal struct DynamicOptionalType: AnyDynamicType {
     return try wrappedType.cast(value, appContext: appContext)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    // Delegate the conversion to the wrapped type
+    return try wrappedType.convertResult(result, appContext: appContext)
+  }
+
   var description: String {
     "\(wrappedType)?"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
@@ -31,6 +31,15 @@ internal struct DynamicRawType<InnerType>: AnyDynamicType {
     throw Conversions.CastingException<InnerType>(value)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    // TODO: Definitions and JS object builders should have its own dynamic type.
+    // We use `DynamicRawType` for this only temporarily.
+    if let objectBuilder = result as? JavaScriptObjectBuilder {
+      return try objectBuilder.build(appContext: appContext) as Any
+    }
+    return result
+  }
+
   var description: String {
     String(describing: innerType.self)
   }

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -64,7 +64,7 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
     let promise = Promise { value in
-      callback(.success(Conversions.convertFunctionResult(value)))
+      callback(.success(Conversions.convertFunctionResult(value, appContext: appContext)))
     } rejecter: { exception in
       callback(.failure(exception))
     }

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -20,7 +20,7 @@ public protocol Record: Convertible {
   /**
    Converts the record back to the dictionary. Only members wrapped by `@Field` will be set in the dictionary.
    */
-  func toDictionary() -> Dict
+  func toDictionary(appContext: AppContext?) -> Dict
 }
 
 /**
@@ -58,9 +58,11 @@ public extension Record {
     }
   }
 
-  func toDictionary() -> Dict {
+  func toDictionary(appContext: AppContext? = nil) -> Dict {
     return fieldsOf(self).reduce(into: Dict()) { result, field in
-      result[field.key!] = Conversions.convertFunctionResult(field.get())
+      if let key = field.key {
+        result[key] = Conversions.convertFunctionResult(field.get(), appContext: appContext)
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

To move function result conversion to respective dynamic types. This reduces a number of runtime checks and allows us to do more complex conversions, e.g. an array of shared objects, records with shared objects inside.

# How

- Introduced `convertResult(_:appContext:)` to dynamic types. It's now called by `Conversions.convertFunctionResult` in the first place.
- Updated `toDictionary` function on records so it can take an app context.

# Test Plan

- Native unit tests are passing
- Went through some tests and demos in NCL
- Confirmed that returning an array of shared objects works (previously it was returning an array of nulls)