### PR TITLE
Update `react-native-pager-view` to 6.4.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1905,7 +1905,7 @@ PODS:
     - Yoga
   - react-native-netinfo (11.3.1):
     - React-Core
-  - react-native-pager-view (6.4.0):
+  - react-native-pager-view (6.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1918,7 +1918,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-pager-view/common (= 6.4.0)
+    - react-native-pager-view/common (= 6.4.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1927,7 +1927,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-pager-view/common (6.4.0):
+  - react-native-pager-view/common (6.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3302,7 +3302,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 1c08607305558666fd16678b85ef135e455d5c96
   React-microtasksnativemodule: f13f03163b6a5ec66665dfe80a0df4468bb766a6
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
-  react-native-pager-view: 7985124bceda6e09dd9ca6811d5cebf5127e93cf
+  react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
   react-native-safe-area-context: 38fdd9b3c5561de7cabae64bd0cd2ce05d2768a1
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-slider: e1f4b4538f7de7417b626174874f4f58d4cf6c28

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
     "react-native-gesture-handler": "~2.20.0",
-    "react-native-pager-view": "6.4.0",
+    "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "~3.34.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1694,7 +1694,7 @@ PODS:
     - React-Core
   - react-native-netinfo (11.3.1):
     - React-Core
-  - react-native-pager-view (6.4.0):
+  - react-native-pager-view (6.4.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2881,7 +2881,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 87b8de96f937faefece8afd2cb3a518321b2ef99
   react-native-maps: cbf2f03bfeebfd7ec45966b066db13a075fd2af3
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
-  react-native-pager-view: 2aef9f11fb8f436a68e0c58f7658cad8736d1121
+  react-native-pager-view: c476f76d54f946df5147645e902d3d7173688187
   react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-skia: 68be40d53b1957f6c276cec19bcd50d293173868

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -70,7 +70,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.14.0",
-    "react-native-pager-view": "^6.4.0",
+    "react-native-pager-view": "^6.4.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -138,7 +138,7 @@
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-maps": "1.14.0",
-    "react-native-pager-view": "6.4.0",
+    "react-native-pager-view": "6.4.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -90,7 +90,7 @@
   "react-native-gesture-handler": "~2.20.0",
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.14.0",
-  "react-native-pager-view": "6.4.0",
+  "react-native-pager-view": "6.4.1",
   "react-native-reanimated": "~3.15.4",
   "react-native-screens": "3.31.1",
   "react-native-safe-area-context": "4.10.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13969,10 +13969,10 @@ react-native-maps@1.14.0:
   dependencies:
     "@types/geojson" "^7946.0.13"
 
-react-native-pager-view@6.4.0, react-native-pager-view@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.4.0.tgz#33b62b6036f6ec40c651c2a39dff7e3bc364ceac"
-  integrity sha512-6nuzjN0tXJXyOqRU2f9ZHfGuaFR7sptpAV1eIZIkm2GPnpvZ50mawQ2HTMvM6Ezic+WbuiUryy76yUWLFcvsBw==
+react-native-pager-view@6.4.1, react-native-pager-view@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.4.1.tgz#82d04107229c19967a503de53a231dd95fcccd10"
+  integrity sha512-HnDxXTRHnR6WJ/vnOitv0C32KG9MJjxLnxswuQlBJmQ7RxF2GWOHSPIRAdZ9fLxdLstV38z9Oz1C95+t+yXkcg==
 
 react-native-paper@^4.0.1:
   version "4.12.0"


### PR DESCRIPTION
# Why

Update `react-native-pager-view` for the SDK 52 release

# How

Changed the versions in package.jsons, ran pod install in the subdirectories

# Test Plan

Tested in BareExpo, TODO: still untested in Expo Go
