### PR TITLE
[third-party] Update `react-native-gesture-handler` to `2.20.0`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2409,7 +2409,7 @@ PODS:
     - Yoga
   - RNFlashList (1.6.4):
     - React-Core
-  - RNGestureHandler (2.18.1):
+  - RNGestureHandler (2.20.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3320,7 +3320,7 @@ SPEC CHECKSUMS:
   RNCPicker: 7973f617de8809ab9e7577b93ce23d3449fb1ec7
   RNDateTimePicker: 00f430c6e77e6d9723954a5b5a820644d4b488a2
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
-  RNGestureHandler: f769e1b9057085db07546aa3e259daa85c898dc7
+  RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
   RNReanimated: f72882a50158dd5b8b429b60b41331e4aec39151
   RNScreens: de6e57426ba0e6cbc3fb5b4f496e7f08cb2773c2
   RNSVG: 515aaaaef804aade0f285d7fc9514da8f7f0e11f

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -61,7 +61,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
-    "react-native-gesture-handler": "~2.18.1",
+    "react-native-gesture-handler": "~2.20.0",
     "react-native-pager-view": "6.4.0",
     "react-native-reanimated": "~3.15.0",
     "react-native-safe-area-context": "4.10.9",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2054,7 +2054,7 @@ PODS:
     - React-Core
   - RNFlashList (1.6.4):
     - React-Core
-  - RNGestureHandler (2.18.1):
+  - RNGestureHandler (2.20.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2899,7 +2899,7 @@ SPEC CHECKSUMS:
   RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
   RNDateTimePicker: cd42eda5f315fc320f0b359413bd598957f7e601
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
-  RNGestureHandler: 939f21fabf5d45a725c0bf175eb819dd25cf2e70
+  RNGestureHandler: 6dfe7692a191ee224748964127114edf057a1475
   RNReanimated: fcf3bcecd669832b71f2a4cad6e9ac881d34eced
   RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
   RNSVG: 4590aa95758149fa27c5c83e54a6a466349a1688

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -66,7 +66,7 @@
     "react": "18.2.0",
     "react-native": "0.75.2",
     "react-native-fade-in-image": "^1.6.1",
-    "react-native-gesture-handler": "~2.18.1",
+    "react-native-gesture-handler": "~2.20.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.14.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -136,7 +136,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
     "react-native-dropdown-picker": "^5.3.0",
-    "react-native-gesture-handler": "~2.18.1",
+    "react-native-gesture-handler": "~2.20.0",
     "react-native-maps": "1.14.0",
     "react-native-pager-view": "6.4.0",
     "react-native-paper": "^4.0.1",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.19",
     "react": "18.3.1",
     "react-native": "0.75.2",
-    "react-native-gesture-handler": "~2.18.1",
+    "react-native-gesture-handler": "~2.20.0",
     "sinon": "^7.1.1"
   },
   "browserslist": [

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -87,7 +87,7 @@
   "react-dom": "18.3.1",
   "react-native": "0.75.2",
   "react-native-web": "~0.19.10",
-  "react-native-gesture-handler": "~2.18.1",
+  "react-native-gesture-handler": "~2.20.0",
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.14.0",
   "react-native-pager-view": "6.4.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
-    "react-native-gesture-handler": "~2.18.1",
+    "react-native-gesture-handler": "~2.20.0",
     "react-native-reanimated": "~3.15.0",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "3.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13921,10 +13921,10 @@ react-native-fade-in-image@^1.6.1:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.18.1.tgz#ec9206f34cd2f34a66c0430b2c416d31ee6dff17"
-  integrity sha512-WF2fxQ5kTaxHghlkBM4YxO86SyGWVwrSNgJ1E8z/ZtL2xD5B3bg5agvuVFfOzvceC114yq71s6E9vKPz94ZxRw==
+react-native-gesture-handler@~2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.20.0.tgz#2d9ec4e9bd22619ebe36269dda3ecb1173928276"
+  integrity sha512-rFKqgHRfxQ7uSAivk8vxCiW4SB3G0U7jnv7kZD4Y90K5kp6YrU8Q3tWhxe3Rx55BIvSd3mBe9ZWbWVJ0FsSHPA==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
# Why

Bumps `react-native-gesture-handler` to `2.20.0`.
Closes ENG-13688.

# Test Plan

| bare-expo     | iOS | Android |
| -------------: | :----: | :--------: |
| Paper         | ✅  | ✅      |
| Fabric        | ✅  | ✅      |