### PR TITLE
[third-party] Update `react-native-reanimated` to `3.15.4`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2430,7 +2430,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2450,10 +2450,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
+    - RNReanimated/reanimated (= 3.15.4)
+    - RNReanimated/worklets (= 3.15.4)
     - Yoga
-  - RNReanimated/reanimated (3.15.0):
+  - RNReanimated/reanimated (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2474,7 +2474,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3321,7 +3321,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 00f430c6e77e6d9723954a5b5a820644d4b488a2
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: f769e1b9057085db07546aa3e259daa85c898dc7
-  RNReanimated: f72882a50158dd5b8b429b60b41331e4aec39151
+  RNReanimated: b3d406ee69af6972be20715d972b45d713aad400
   RNScreens: de6e57426ba0e6cbc3fb5b4f496e7f08cb2773c2
   RNSVG: 515aaaaef804aade0f285d7fc9514da8f7f0e11f
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -63,7 +63,7 @@
     "react-native": "0.75.2",
     "react-native-gesture-handler": "~2.18.1",
     "react-native-pager-view": "6.4.0",
-    "react-native-reanimated": "~3.15.0",
+    "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2075,7 +2075,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2095,10 +2095,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
+    - RNReanimated/reanimated (= 3.15.4)
+    - RNReanimated/worklets (= 3.15.4)
     - Yoga
-  - RNReanimated/reanimated (3.15.0):
+  - RNReanimated/reanimated (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2119,7 +2119,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.15.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2900,7 +2900,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: cd42eda5f315fc320f0b359413bd598957f7e601
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 939f21fabf5d45a725c0bf175eb819dd25cf2e70
-  RNReanimated: fcf3bcecd669832b71f2a4cad6e9ac881d34eced
+  RNReanimated: 97db82e83543c0b68233132ae87cfa033a89b7a8
   RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
   RNSVG: 4590aa95758149fa27c5c83e54a6a466349a1688
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -72,7 +72,7 @@
     "react-native-maps": "1.14.0",
     "react-native-pager-view": "^6.4.0",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.15.0",
+    "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "react-native-maps": "1.14.0",
     "react-native-pager-view": "6.4.0",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.15.0",
+    "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -91,7 +91,7 @@
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.14.0",
   "react-native-pager-view": "6.4.0",
-  "react-native-reanimated": "~3.15.0",
+  "react-native-reanimated": "~3.15.4",
   "react-native-screens": "3.31.1",
   "react-native-safe-area-context": "4.10.9",
   "react-native-svg": "15.7.1",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
     "react-native-gesture-handler": "~2.18.1",
-    "react-native-reanimated": "~3.15.0",
+    "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.10.9",
     "react-native-screens": "3.34.0",
     "react-native-web": "~0.19.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13983,10 +13983,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.15.0.tgz#8814af7c78bbdf4c92bbd583f2266febf962e66a"
-  integrity sha512-yGxOyYAAu/5CyjonM2SgsM5sviiiK8HiHL9jT1bKfRxMLnNX9cFP8/UXRkbMT7ZXIfOlCvNFR0AqnphpuXIPVA==
+react-native-reanimated@~3.15.4:
+  version "3.15.4"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.15.4.tgz#0d4aa65b53f9c845fe8c33aa8a3ad3d06a23f063"
+  integrity sha512-jcpHE+MnsvSbClhHgAFoken7SnaHrUJ5gVA8BUw8S1j6rkrw2VzRpht6cxn14NlqYx5ytjfG9IXJDOzq8tFvfw==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"


### PR DESCRIPTION
# Why

Updates `react-native-reanimated` to `3.15.4`.
Closes ENG-13691.

# Test Plan

| bare-expo     | iOS | Android |
| -------------: | :----: | :--------: |
| Paper         | ✅  | ✅      |
| Fabric        | ✅  | ✅      |