### PR TITLE
[iOS][image] Fix isAnimated property always returning true

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30469](https://github.com/expo/expo/pull/30469) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
 - [Web] Fix type incompatibility between style prop and `@types/react-native-web` ([#31150](https://github.com/expo/expo/pull/31150) by [@adamhari](https://github.com/adamhari))
+- [iOS] Fixed `isAnimated` property always returning `true`.
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30469](https://github.com/expo/expo/pull/30469) by [@byCedric](https://github.com/byCedric))
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
 - [Web] Fix type incompatibility between style prop and `@types/react-native-web` ([#31150](https://github.com/expo/expo/pull/31150) by [@adamhari](https://github.com/adamhari))
-- [iOS] Fixed `isAnimated` property always returning `true`.
+- [iOS] Fixed `isAnimated` property always returning `true`. ([#31834](https://github.com/expo/expo/pull/31834) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/Image.swift
+++ b/packages/expo-image/ios/Image.swift
@@ -3,6 +3,10 @@
 import ExpoModulesCore
 
 internal final class Image: SharedRef<UIImage> {
+  var isAnimated: Bool {
+    return !(ref.images?.isEmpty ?? true)
+  }
+
   override func getAdditionalMemoryPressure() -> Int {
     guard let cgImage = ref.cgImage else {
       return 0

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -198,7 +198,7 @@ public final class ImageModule: Module {
       Property("width", \.ref.size.width)
       Property("height", \.ref.size.height)
       Property("scale", \.ref.scale)
-      Property("isAnimated", \.ref.sd_isAnimated)
+      Property("isAnimated", \.isAnimated)
       Property("mediaType") { image in
         return imageFormatToMediaType(image.ref.sd_imageFormat)
       }


### PR DESCRIPTION
# Why

`isAnimated` was always returning `true` since we started using `SDAnimatedImage` class for all images.

# How

Instead of using the default implementation from `SDAnimatedImage`, we'll check if the `UIImage` has any additional frames.

# Test Plan

In NCL confirmed that non-animated images return `false` and GIFs return `true`