### PR TITLE
[notifications][android] rename subTitle -> subText internally

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -101,7 +101,7 @@ public class NotificationSerializer {
   public static Bundle toBundle(INotificationContent content) {
     Bundle serializedContent = new Bundle();
     serializedContent.putString("title", content.getTitle());
-    serializedContent.putString("subtitle", content.getSubtitle());
+    serializedContent.putString("subtitle", content.getSubText());
     serializedContent.putString("body", content.getText());
     if (content.getColor() != null) {
       serializedContent.putString("color", String.format("#%08X", content.getColor().intValue()));

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/debug/DebugLogging.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/debug/DebugLogging.kt
@@ -70,7 +70,7 @@ object DebugLogging {
       """
       $caller:
         notification.notificationRequest.content.title: ${notification.notificationRequest.content.title}
-        notification.notificationRequest.content.subtitle: ${notification.notificationRequest.content.subtitle}
+        notification.notificationRequest.content.subtitle: ${notification.notificationRequest.content.subText}
         notification.notificationRequest.content.text: ${notification.notificationRequest.content.text}
         notification.notificationRequest.content.sound: ${notification.notificationRequest.content.soundName}
         notification.notificationRequest.content.channelID: ${notification.notificationRequest.trigger.notificationChannel}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/INotificationContent.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/INotificationContent.kt
@@ -17,7 +17,7 @@ import org.json.JSONObject
 interface INotificationContent : Parcelable {
   val title: String?
   val text: String?
-  val subtitle: String?
+  val subText: String?
   val badgeCount: Number?
   val shouldPlayDefaultSound: Boolean
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
@@ -75,7 +75,7 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
   }
 
   @Nullable
-  public String getSubtitle() {
+  public String getSubText() {
     return mSubtitle;
   }
 
@@ -129,7 +129,7 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
     return mBody;
   }
 
-  @Nullable
+  @NonNull
   public NotificationPriority getPriority() {
     return mPriority;
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/RemoteNotificationContent.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/RemoteNotificationContent.kt
@@ -75,7 +75,7 @@ class RemoteNotificationContent(private val remoteMessage: RemoteMessage) : INot
   override val isSticky: Boolean
     get() = remoteMessage.data["sticky"]?.toBoolean() ?: false
 
-  override val subtitle: String?
+  override val subText: String?
     get() = remoteMessage.data["subtitle"]
 
   override val badgeCount: Number?

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
@@ -35,7 +35,7 @@ open class ExpoNotificationBuilder(context: Context?) : ChannelAwareNotification
 
     builder.setContentTitle(content.title)
     builder.setContentText(content.text)
-    builder.setSubText(content.subtitle)
+    builder.setSubText(content.subText)
     // Sets the text/contentText as the bigText to allow the notification to be expanded and the
     // entire text to be viewed.
     builder.setStyle(NotificationCompat.BigTextStyle().bigText(content.text))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -595,17 +595,17 @@ open class NotificationsService : BroadcastReceiver() {
     val pendingIntent = goAsync()
     thread {
       try {
-        handleIntent(context, intent)
+        intent?.run { handleIntent(context, intent) }
       } finally {
         pendingIntent.finish()
       }
     }
   }
 
-  open fun handleIntent(context: Context, intent: Intent?) {
-    if (intent != null && SETUP_ACTIONS.contains(intent.action)) {
+  open fun handleIntent(context: Context, intent: Intent) {
+    if (SETUP_ACTIONS.contains(intent.action)) {
       onSetupScheduledNotifications(context, intent)
-    } else if (intent?.action === NOTIFICATION_EVENT_ACTION) {
+    } else if (intent.action === NOTIFICATION_EVENT_ACTION) {
       val receiver: ResultReceiver? = intent.extras?.get(RECEIVER_KEY) as? ResultReceiver
       try {
         var resultData: Bundle? = null
@@ -665,7 +665,7 @@ open class NotificationsService : BroadcastReceiver() {
         receiver?.send(ERROR_CODE, Bundle().also { it.putSerializable(EXCEPTION_KEY, e) })
       }
     } else {
-      throw IllegalArgumentException("Received intent of unrecognized action: ${intent?.action}. Ignoring.")
+      throw IllegalArgumentException("Received intent of unrecognized action: ${intent.action}. Ignoring.")
     }
   }
 

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationContentSerializationTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationContentSerializationTest.kt
@@ -98,7 +98,7 @@ class NotificationContentSerializationTest {
   private fun assertNotificationContentEquals(expected: NotificationContent, actual: NotificationContent) {
     assertEquals(expected.title, actual.title)
     assertEquals(expected.text, actual.text)
-    assertEquals(expected.subtitle, actual.subtitle)
+    assertEquals(expected.subText, actual.subText)
     assertEquals(expected.badgeCount, actual.badgeCount)
     assertEquals(expected.shouldPlayDefaultSound, actual.shouldPlayDefaultSound)
     assertEquals(expected.soundName, actual.soundName)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
