### PR TITLE
[expo-go][android] make notifications compatible with refactors

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedCategoryAwareNotificationBuilder.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedCategoryAwareNotificationBuilder.kt
@@ -3,14 +3,16 @@ package host.exp.exponent.notifications
 import android.content.Context
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.service.delegates.SharedPreferencesNotificationCategoriesStore
 import host.exp.exponent.notifications.model.ScopedNotificationRequest
 import versioned.host.exp.exponent.modules.api.notifications.ScopedNotificationsIdUtils
 
 class ScopedCategoryAwareNotificationBuilder(
   context: Context,
+  notification: Notification,
   store: SharedPreferencesNotificationCategoriesStore
-) : ScopedExpoNotificationBuilder(context, store) {
+) : ScopedExpoNotificationBuilder(context, notification, store) {
 
   override fun addActionsToBuilder(
     builder: NotificationCompat.Builder,

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedExpoNotificationBuilder.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedExpoNotificationBuilder.kt
@@ -3,11 +3,10 @@ package host.exp.exponent.notifications
 import android.content.Context
 import android.util.Log
 import expo.modules.notifications.notifications.channels.managers.NotificationsChannelManager
-import expo.modules.notifications.notifications.interfaces.NotificationBuilder
 import expo.modules.notifications.notifications.model.Notification
-import expo.modules.notifications.notifications.presentation.builders.CategoryAwareNotificationBuilder
 import expo.modules.notifications.service.delegates.SharedPreferencesNotificationCategoriesStore
 import expo.modules.manifests.core.Manifest
+import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.kernel.ExperienceKey
@@ -21,19 +20,17 @@ import javax.inject.Inject
 
 open class ScopedExpoNotificationBuilder(
   context: Context,
-  store: SharedPreferencesNotificationCategoriesStore?
-) : CategoryAwareNotificationBuilder(context, store!!) {
+  notification: Notification,
+  store: SharedPreferencesNotificationCategoriesStore
+) : ExpoNotificationBuilder(context, notification, store) {
   @Inject
   lateinit var exponentManifest: ExponentManifest
 
   var manifest: Manifest? = null
   var experienceKey: ExperienceKey? = null
 
-  override fun setNotification(notification: Notification?): NotificationBuilder {
-    super.setNotification(notification)
-
-    // We parse manifest here to have easy access to it from other methods.
-    val requester = getNotification().notificationRequest
+  init {
+    val requester = this.notification.notificationRequest
     if (requester is ScopedNotificationRequest) {
       val experienceScopeKey = requester.experienceScopeKeyString
       try {
@@ -45,12 +42,11 @@ open class ScopedExpoNotificationBuilder(
         e.printStackTrace()
       }
     }
-    return this
   }
 
-  override fun getNotificationsChannelManager(): NotificationsChannelManager {
+  override val notificationsChannelManager: NotificationsChannelManager get() {
     return if (experienceKey == null) {
-      super.getNotificationsChannelManager()
+      super.notificationsChannelManager
     } else {
       ScopedNotificationsChannelManager(
         context,

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
@@ -17,8 +17,7 @@ import java.util.*
 
 class ScopedExpoPresentationDelegate(context: Context) : ExpoPresentationDelegate(context) {
   override suspend fun createNotification(notification: Notification, notificationBehavior: NotificationBehavior?): android.app.Notification =
-    ScopedCategoryAwareNotificationBuilder(context, SharedPreferencesNotificationCategoriesStore(context)).also {
-      it.setNotification(notification)
+    ScopedCategoryAwareNotificationBuilder(context, notification, SharedPreferencesNotificationCategoriesStore(context)).also {
       it.setAllowedBehavior(notificationBehavior)
     }.build()
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/BaseNotificationBuilder.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/BaseNotificationBuilder.kt
@@ -78,7 +78,7 @@ abstract class BaseNotificationBuilder protected constructor(protected val conte
       return channelForRequestedId.id
     }
 
-  private val notificationsChannelManager: NotificationsChannelManager
+  open val notificationsChannelManager: NotificationsChannelManager
     get() = AndroidXNotificationsChannelManager(
       context,
       AndroidXNotificationsChannelGroupManager(context)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
@@ -34,7 +34,7 @@ open class ExpoNotificationBuilder(
   private val store: SharedPreferencesNotificationCategoriesStore
 ) : BaseNotificationBuilder(context, notification) {
 
-  protected fun addActionsToBuilder(
+  open fun addActionsToBuilder(
     builder: NotificationCompat.Builder,
     categoryIdentifier: String
   ) {


### PR DESCRIPTION
# Why

Expo Go is not compatible with previous refactors (down this PR stack) of the notifications package. This PR fixes that.

# How

reorganize the code to make it compile

# Test Plan

tested in expo go with NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
