### PR TITLE
[iOS][core] Disable view recycling in ExpoView

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -97,7 +97,7 @@
 - Removed deprecated code for react-native 0.74.0. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] View recycling from the New Architecture is now off by default.
+- [iOS] View recycling from the New Architecture is now off by default. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Removed deprecated code for react-native 0.74.0. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] View recycling from the New Architecture is now off by default.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -97,7 +97,7 @@
 - Removed deprecated code for react-native 0.74.0. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] View recycling from the New Architecture is now off by default. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -118,6 +118,17 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
 
   // MARK: - Statics
 
+  /**
+   Called by React Native to check if the view supports recycling.
+   */
+  @objc
+  public static func shouldBeRecycled() -> Bool {
+    // Turn off recycling for Expo views by default.
+    // We don't think there is any benefit of recycling – it may lead to more bugs than gains.
+    // Module authors can override this function if they want to change the behavior.
+    return false
+  }
+
   internal static var viewClassesRegistry = [String: AnyClass]()
 
   /**

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -123,9 +123,8 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
    */
   @objc
   public static func shouldBeRecycled() -> Bool {
-    // Turn off recycling for Expo views by default.
-    // We don't think there is any benefit of recycling – it may lead to more bugs than gains.
-    // Module authors can override this function if they want to change the behavior.
+    // Turn off recycling for Expo views. We don't think there is any benefit of recycling – it may lead to more bugs than gains.
+    // TODO: Make it possible to override this behavior for particular views
     return false
   }
 


### PR DESCRIPTION
# Why

We don't think there is any benefit of having view recycling enabled by default. It may lead to more bugs than gains, especially if module authors don't handle recycling well.

# How

Implemented a static function `shouldBeRecycled` that is called by React Native to check if the view class supports recycling.

# Test Plan

I confirmed that this function is being called by React Native for each of our view classes and that the views are not added to the recycle pool.