### PR TITLE
[go] bump skia to 1.4.2

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1719,7 +1719,7 @@ PODS:
     - React-Core
   - react-native-segmented-control (2.5.4):
     - React-Core
-  - react-native-skia (1.3.11):
+  - react-native-skia (1.4.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2884,7 +2884,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 2aef9f11fb8f436a68e0c58f7658cad8736d1121
   react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
-  react-native-skia: 68be40d53b1957f6c276cec19bcd50d293173868
+  react-native-skia: 8cbbeae25285ade497b646696103832e67ffd64b
   react-native-slider: 97ce0bd921f40de79cead9754546d5e4e7ba44f8
   react-native-webview: 05bae3a03a1e4f59568dfc05286c0ebf8954106c
   React-nativeconfig: 57781b79e11d5af7573e6f77cbf1143b71802a6d

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -34,7 +34,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@shopify/flash-list": "1.7.1",
-    "@shopify/react-native-skia": "1.3.11",
+    "@shopify/react-native-skia": "1.4.2",
     "@stripe/stripe-react-native": "0.38.6",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -49,7 +49,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@shopify/flash-list": "1.7.1",
-    "@shopify/react-native-skia": "1.3.11",
+    "@shopify/react-native-skia": "1.4.2",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~51.0.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.6.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "1.3.11",
+  "@shopify/react-native-skia": "1.4.2",
   "@shopify/flash-list": "1.7.1",
   "@sentry/react-native": "~5.33.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3564,10 +3564,10 @@
     recyclerlistview "4.2.1"
     tslib "2.6.3"
 
-"@shopify/react-native-skia@1.3.11":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.3.11.tgz#fc4793b6a71604007cfa178ed780fbf3a6a1991f"
-  integrity sha512-fIkxh77TVbIFAIFuJbB9wjNCvehOeARWsCOTSo5HdkjZ3/f4QPGR4RWN5zOMvi8aD83oRfJ6AVcnozFYYZREaA==
+"@shopify/react-native-skia@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.4.2.tgz#80faed6569edb93a3fe6191760efcf2748257433"
+  integrity sha512-Qg1H/MglY5BJiL4g2+8Tz97fZZp8XM48lb1xjGHqKmo54KwCmhc3GREnL/MYqcTcuJnIUNVYQmAJUw5xT3Chsg==
   dependencies:
     canvaskit-wasm "0.39.1"
     react-reconciler "0.27.0"


### PR DESCRIPTION
# Why

bump `@shopify/react-native-skia@1.4.2`
close ENG-13686

# How

bump the version in package.json

# Test Plan

NCL for android/ios expo-go

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
