### PR TITLE
[ios][calendar] Initialize EKEventStore as a singleton

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Standardize `getEventsAsync` to return events sorted by start date ([#28353](https://github.com/expo/expo/pull/28353) by [@demfabris](https://github.com/demfabris))
 - Add missing `react-native` peer dependencies for isolated modules. ([#30461](https://github.com/expo/expo/pull/30461) by [@byCedric](https://github.com/byCedric))
+- Initialize EKEventStore as a singleton ([#31847](https://github.com/expo/expo/pull/31847) by [@JacquesLeupin](https://github.com/JacquesLeupin))
+
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -5,7 +5,10 @@ import EventKitUI
 
 public class CalendarModule: Module {
   private var permittedEntities: EKEntityMask = .event
-  private var eventStore = EKEventStore()
+  private static let sharedEventStore = EKEventStore()
+  private var eventStore: EKEventStore {
+    return CalendarModule.sharedEventStore
+  }
   private var calendarDialogDelegate: CalendarDialogDelegate?
 
   // swiftlint:disable:next cyclomatic_complexity


### PR DESCRIPTION
# Why

- as titled, this initializes EKEventStore as a singleton, to avoid issues described in [this thread](https://forums.developer.apple.com/forums/thread/737536)
- this fix solves errors I observed locally wherein `Calendar.getCalendarPermissionsAsync()` would return the incorrect permissions status when creating non-production (local development) builds

# How

- fixed locally, because I was encountering issues when developing

# Test Plan

- I've tested this locally, but there don't appear to be tests for the iOS native code in the `expo-calendar` package 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
