### PR TITLE
[expo-updates][ios] Refactor JS event queueing and emitting

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -30,7 +30,7 @@
 - [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
-- Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818) by [@wschurman](https://github.com/wschurman))
+- Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818, [#31854](https://github.com/expo/expo/pull/31854) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -127,15 +127,9 @@ public protocol AppControllerInterface {
 }
 
 public protocol InternalAppControllerInterface: AppControllerInterface {
-  /**
-   The AppContext from expo-modules-core.
-   This is optional, but required for expo-updates module events to work.
-   */
-  var appContext: AppContext? { get set }
-
   var updatesDirectory: URL? { get }
 
-  var shouldEmitJsEvents: Bool { get set }
+  var eventManager: UpdatesEventManager { get }
 
   func getConstantsForModule() -> UpdatesModuleConstants
   func requestRelaunch(
@@ -345,15 +339,15 @@ public class AppController: NSObject {
    For `UpdatesModule` to set the `shouldEmitJsEvents` property
    */
   internal static var shouldEmitJsEvents: Bool {
-    get { _sharedInstance?.shouldEmitJsEvents ?? false }
-    set { _sharedInstance?.shouldEmitJsEvents = newValue }
+    get { _sharedInstance?.eventManager.shouldEmitJsEvents ?? false }
+    set { _sharedInstance?.eventManager.shouldEmitJsEvents = newValue }
   }
 
   /**
    Binds the `AppContext` instance from `UpdatesModule`.
    */
   internal static func bindAppContext(_ appContext: AppContext?) {
-    _sharedInstance?.appContext = appContext
+    _sharedInstance?.eventManager.appContext = appContext
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -19,8 +19,16 @@ import ExpoModulesCore
 @objc(EXUpdatesDevLauncherController)
 @objcMembers
 public final class DevLauncherAppController: NSObject, InternalAppControllerInterface, UpdatesExternalInterface {
-  public weak var appContext: AppContext?
-  public var shouldEmitJsEvents = false
+  public var appContext: AppContext? {
+    get {
+      return eventManager.appContext
+    }
+    set {
+      eventManager.appContext = newValue
+    }
+  }
+
+  public let eventManager: UpdatesEventManager = NoOpUpdatesEventManager()
 
   public weak var delegate: AppControllerDelegate?
   public weak var updatesExternalInterfaceDelegate: (any EXUpdatesInterface.UpdatesExternalInterfaceDelegate)?

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -23,14 +23,14 @@ public class DisabledAppController: InternalAppControllerInterface {
     })
   }
 
-  public var shouldEmitJsEvents = false
-
-  public weak var appContext: AppContext?
-
   public weak var delegate: AppControllerDelegate?
 
+  private let logger = UpdatesLogger()
+
+  public let eventManager: UpdatesEventManager
+
   // disabled controller state machine can only be idle or restarting
-  private let stateMachine = UpdatesStateMachine(validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting])
+  private let stateMachine: UpdatesStateMachine
 
   private let initializationError: Error?
   private var launcher: AppLauncher?
@@ -39,6 +39,8 @@ public class DisabledAppController: InternalAppControllerInterface {
 
   required init(error: Error?) {
     self.initializationError = error
+    self.eventManager = QueueUpdatesEventManager(logger: self.logger)
+    self.stateMachine = UpdatesStateMachine(eventManager: self.eventManager, validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting])
   }
 
   public func start() {

--- a/packages/expo-updates/ios/EXUpdates/Events/NoOpUpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/NoOpUpdatesEventManager.swift
@@ -1,0 +1,10 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+internal class NoOpUpdatesEventManager: UpdatesEventManager {
+  internal weak var appContext: AppContext?
+  internal var shouldEmitJsEvents: Bool = false
+
+  internal func sendUpdateStateChangeEventToAppContext(_ eventType: UpdatesStateEventType, context: UpdatesStateContext) {}
+}

--- a/packages/expo-updates/ios/EXUpdates/Events/QueueUpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/QueueUpdatesEventManager.swift
@@ -1,0 +1,64 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+internal class QueueUpdatesEventManager: UpdatesEventManager {
+  private let logger: UpdatesLogger
+
+  required init(logger: UpdatesLogger) {
+    self.logger = logger
+  }
+
+  internal weak var appContext: AppContext?
+  internal var shouldEmitJsEvents = false {
+    didSet {
+      if shouldEmitJsEvents == true {
+        sendQueuedEventsToAppContext()
+      }
+    }
+  }
+
+  private var eventsToSendToJS: [[String: Any?]] = []
+
+  internal func sendUpdateStateChangeEventToAppContext(_ eventType: UpdatesStateEventType, context: UpdatesStateContext) {
+    logger.info(message: "sendUpdateStateChangeEventToAppContext(): type = \(eventType)")
+    sendEventToAppContext(EXUpdatesStateChangeEventName, "\(eventType)", body: [
+      "context": context.json
+    ])
+  }
+
+  private func sendEventToAppContext(_ eventName: String, _ eventType: String, body: [String: Any?]) {
+    var mutableBody = body
+    mutableBody["type"] = eventType
+
+    guard let appContext = appContext,
+      let eventEmitter = appContext.eventEmitter,
+      shouldEmitJsEvents == true else {
+      eventsToSendToJS.append([
+        "eventName": eventName,
+        "mutableBody": mutableBody
+      ])
+      logger.warn(message: "EXUpdates: Could not emit event: name = \(eventName), type = \(eventType). Event will be emitted when the appContext is available", code: .jsRuntimeError)
+      return
+    }
+    logger.debug(message: "sendEventToAppContext: \(eventName), \(mutableBody)")
+    eventEmitter.sendEvent(withName: eventName, body: mutableBody)
+  }
+
+  private func sendQueuedEventsToAppContext() {
+    guard let appContext = appContext,
+      let eventEmitter = appContext.eventEmitter,
+      shouldEmitJsEvents == true else {
+      return
+    }
+    eventsToSendToJS.forEach { event in
+      guard let eventName = event["eventName"] as? String,
+        let mutableBody = event["mutableBody"] as? [String: Any?] else {
+        return
+      }
+      logger.debug(message: "sendEventToAppContext: \(eventName), \(mutableBody)")
+      eventEmitter.sendEvent(withName: eventName, body: mutableBody)
+    }
+    eventsToSendToJS = []
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Events/UpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/UpdatesEventManager.swift
@@ -1,0 +1,14 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+public protocol UpdatesEventManager: AnyObject {
+  /**
+   The AppContext from expo-modules-core.
+   This is optional, but required for expo-updates module events to work.
+   */
+  var appContext: AppContext? { get set }
+  var shouldEmitJsEvents: Bool { get set }
+
+  func sendUpdateStateChangeEventToAppContext(_ eventType: UpdatesStateEventType, context: UpdatesStateContext)
+}

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -8,12 +8,18 @@ import ExpoModulesTestCore
 
 import EXManifests
 
-class TestStateChangeDelegate: UpdatesStateChangeDelegate {
-  var lastEventType: EXUpdates.UpdatesStateEventType?
-  var lastEventBody: [String: Any?]?
-  func sendUpdateStateChangeEventToAppContext(_ eventType: EXUpdates.UpdatesStateEventType, body: [String: Any?]) {
+class TestStateChangeEventManager: UpdatesEventManager {
+  required init() {}
+
+  var appContext: ExpoModulesCore.AppContext? = nil
+  var shouldEmitJsEvents: Bool = false
+
+  var lastEventType: UpdatesStateEventType? = nil
+  var lastContext: UpdatesStateContext? = nil
+
+  func sendUpdateStateChangeEventToAppContext(_ eventType: EXUpdates.UpdatesStateEventType, context: EXUpdates.UpdatesStateContext) {
     lastEventType = eventType
-    lastEventBody = body
+    lastContext = context
   }
 }
 
@@ -21,20 +27,18 @@ class UpdatesStateMachineSpec: ExpoSpec {
   override class func spec() {
     describe("default state") {
       it("instantiates") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         expect(machine.getStateForTesting()) == .idle
       }
 
       it("should handle check and checkCompleteAvailable") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(UpdatesStateEventCheck())
         expect(machine.getStateForTesting()) == .checking
-        expect(testStateChangeDelegate.lastEventType) == .check
+        expect(testStateChangeEventManager.lastEventType) == .check
 
         machine.processEventForTesting(UpdatesStateEventCheckCompleteWithUpdate(manifest: [
           "updateId": "0000-xxxx"
@@ -45,15 +49,14 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.context.latestManifest?["updateId"] as? String ?? "") == "0000-xxxx"
         expect(machine.context.isUpdateAvailable) == true
         expect(machine.context.isUpdatePending) == false
-        expect(testStateChangeDelegate.lastEventType) == .checkCompleteAvailable
-        let values = testStateChangeDelegate.lastEventBody?["context"] as? [String: Any] ?? [:]
-        expect(values["isUpdateAvailable"] as? Bool ?? false) == true
+        expect(testStateChangeEventManager.lastEventType) == .checkCompleteAvailable
+        let values = testStateChangeEventManager.lastContext
+        expect(values?.isUpdateAvailable) == true
       }
 
       it("should handle check and checkCompleteUnavailable") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(UpdatesStateEventCheck())
         expect(machine.getStateForTesting()) == .checking
@@ -68,9 +71,8 @@ class UpdatesStateMachineSpec: ExpoSpec {
       }
 
       it("should handle download and downloadComplete") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(UpdatesStateEventDownload())
         expect(machine.getStateForTesting()) == .downloading
@@ -89,9 +91,8 @@ class UpdatesStateMachineSpec: ExpoSpec {
       }
 
       it("should handle rollback") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         let commitTime = Date()
         machine.processEventForTesting(UpdatesStateEventCheck())
         expect(machine.getStateForTesting()) == .checking
@@ -107,15 +108,14 @@ class UpdatesStateMachineSpec: ExpoSpec {
       }
 
       it("invalid transitions are handled as expected") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(UpdatesStateEventCheck())
         expect(machine.getStateForTesting()) == .checking
         // Reset the test delegate
-        testStateChangeDelegate.lastEventBody = nil
-        testStateChangeDelegate.lastEventType = nil
+        testStateChangeEventManager.lastContext = nil
+        testStateChangeEventManager.lastEventType = nil
 
         // In .checking state, download events should be ignored,
         // state should not change, context should not change,
@@ -123,8 +123,8 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
 
         expect(machine.getStateForTesting()) == .checking
-        expect(testStateChangeDelegate.lastEventType).to(beNil())
-        expect(testStateChangeDelegate.lastEventBody).to(beNil())
+        expect(testStateChangeEventManager.lastEventType).to(beNil())
+        expect(testStateChangeEventManager.lastContext).to(beNil())
 
         expect(
           machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
@@ -152,14 +152,13 @@ class UpdatesStateMachineSpec: ExpoSpec {
       }
 
       it("invalid state values are handled as expected") {
-        let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine(validUpdatesStateValues: [UpdatesStateValue.idle])
-        machine.changeEventDelegate = testStateChangeDelegate
+        let testStateChangeEventManager = TestStateChangeEventManager()
+        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: [UpdatesStateValue.idle])
 
         expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
         expect(machine.getStateForTesting()) == .idle
-        expect(testStateChangeDelegate.lastEventType).to(beNil())
-        expect(testStateChangeDelegate.lastEventBody).to(beNil())
+        expect(testStateChangeEventManager.lastEventType).to(beNil())
+        expect(testStateChangeEventManager.lastContext).to(beNil())
       }
     }
   }


### PR DESCRIPTION
iOS equivalent of https://app.graphite.dev/github/pr/expo/expo/31818/expo-updates-android-Refactor-JS-event-queueing-and-emitting

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
