### PR TITLE
[babel-preset] allows type exports in dom components

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Make `babel-plugin-react-compiler` an optional peer dependency. ([#30960](https://github.com/expo/expo/pull/30960) by [@EvanBacon](https://github.com/EvanBacon))
 - Changed the react client reference collection property to be a string. ([#29646](https://github.com/expo/expo/pull/29646) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed DOM components bundling issues for Android emulators and release builds. ([#30974](https://github.com/expo/expo/pull/30974) by [@kudo](https://github.com/kudo))
+- Allows type exports in DOM components. ([#31855](https://github.com/expo/expo/pull/31855) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.d.ts
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.d.ts
@@ -1,5 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI } from '@babel/core';
-export declare function expoUseDomDirectivePlugin(api: ConfigAPI): babel.PluginObj;
+import { ConfigAPI, types } from '@babel/core';
+export declare function expoUseDomDirectivePlugin(api: ConfigAPI & {
+    types: typeof types;
+}): babel.PluginObj;

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.js
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.js
@@ -13,6 +13,7 @@ const path_1 = require("path");
 const url_1 = __importDefault(require("url"));
 const common_1 = require("./common");
 function expoUseDomDirectivePlugin(api) {
+    const { types: t } = api;
     // TODO: Is exporting
     const isProduction = api.caller(common_1.getIsProd);
     const platform = api.caller((caller) => caller?.platform);
@@ -41,6 +42,14 @@ function expoUseDomDirectivePlugin(api) {
                 // Collect all of the exports
                 path.traverse({
                     ExportNamedDeclaration(path) {
+                        const declaration = path.node.declaration;
+                        if (t.isTypeAlias(declaration) ||
+                            t.isInterfaceDeclaration(declaration) ||
+                            t.isTSTypeAliasDeclaration(declaration) ||
+                            t.isTSInterfaceDeclaration(declaration)) {
+                            // Allows type exports
+                            return;
+                        }
                         throw path.buildCodeFrameError('Modules with the "use dom" directive only support a single default export.');
                     },
                     ExportDefaultDeclaration() {

--- a/packages/babel-preset-expo/src/__tests__/use-dom-directive-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/use-dom-directive-plugin.test.ts
@@ -177,6 +177,24 @@ it(`keeps React import from tsx`, () => {
   expect(res.code).toMatch(/_react\.default/);
   expect(res.code).not.toMatch(/React\.createElement/);
 });
+it('allows type exports', () => {
+  const sourceCode = `
+    'use dom';
+
+    export type CustomType = string;
+
+    export interface CustomInterface {
+      key: string;
+    };
+
+    export default function App() {
+      return <div />;
+    }
+`;
+
+  const res = transformClient({ sourceCode });
+  expect(res.code).toMatch('expo/dom/internal');
+});
 
 describe('errors', () => {
   it(`throws when there are non-default exports`, () => {


### PR DESCRIPTION
# Why

we have type exports in https://github.com/expo/expo/blob/8771e62556479d2c5cadc51d9d111e390a0922a0/apps/router-e2e/__e2e__/dom-components/components/07-forward-ref.tsx#L6. that would break from the `Modules with the "use dom" directive only support a single default export.` error.

# How

- this cause be me missing the change during rebase from #31108
- this pr allows type exports in the **use-dom-directive-plugin**

# Test Plan

add unit test and run router-e2e test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
