### PR TITLE
[core][Android] Add support for `kotlin.time.Duration`

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -583,6 +583,7 @@ Similarly, some common Android types from packages like `java.io`, `java.net`, o
 | `android.graphics.Color`                                                      | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
 | `kotlin.Pair<A, B>`                                                           | Array with two values, where the first one is of type _A_ and the second is of type _B_                                                                                           |
 | `kotlin.ByteArray`                                                            | `Uint8Array` <StatusTag note="SDK 50+" />                                                                                                                                         |
+| `kotlin.time.Duration`                                                        | `number` represents a duration in seconds <StatusTag note="SDK 52+" />                                                                                                            |
 
 </APIBox>
 <APIBox header="Records">

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))
 - [Android] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31784](https://github.com/expo/expo/pull/31784) by [@lukmccall](https://github.com/lukmccall))
 - Added `nativeRefType` to `SharedRef`. ([#31776](https://github.com/expo/expo/pull/31776) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added `kotlin.time.Duration` support.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Added Apple shared app groups support. ([#31519](https://github.com/expo/expo/pull/31519) by [@kudo](https://github.com/kudo))
 - [Android] Added a way to provide shared objects memory pressure to improve garbage collection of native objects retaining some heavy data. ([#31784](https://github.com/expo/expo/pull/31784) by [@lukmccall](https://github.com/lukmccall))
 - Added `nativeRefType` to `SharedRef`. ([#31776](https://github.com/expo/expo/pull/31776) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Added `kotlin.time.Duration` support.
+- [Android] Added `kotlin.time.Duration` support. ([#31858](https://github.com/expo/expo/pull/31858) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/DurationTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/DurationTypeConversionTest.kt
@@ -1,0 +1,28 @@
+package expo.modules.kotlin.jni.types
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import kotlin.time.Duration
+
+class DurationTypeConversionTest {
+  @Test
+  fun should_convert_from_double() = conversionTest<Duration, Long>(
+    jsValue = "10.0",
+    nativeAssertion = { duration: Duration ->
+      Truth.assertThat(duration.inWholeSeconds).isEqualTo(10)
+    },
+    map = { duration: Duration ->
+      duration.inWholeMicroseconds
+    },
+    jsAssertion = JSAssertion.IntEqual(10_000_000)
+  )
+
+  @Test
+  fun should_convert_to_double() = conversionTest<Duration>(
+    jsValue = "10.0",
+    nativeAssertion = { duration: Duration ->
+      Truth.assertThat(duration.inWholeSeconds).isEqualTo(10)
+    },
+    jsAssertion = JSAssertion.DoubleEqual(10.0)
+  )
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
@@ -40,7 +40,7 @@ class EitherTypeConversionTest {
   )
 
   @Test
-  fun either_with_overlapping_types_should_be_convertible() = conversionTest(
+  fun either_with_overlapping_types_should_be_convertible() = conversionTest<Either<URL, String>, URL>(
     jsValue = "https://expo.dev/".addSingleQuotes(),
     nativeAssertion = { either: Either<URL, String> ->
       Truth.assertThat(either.`is`(URL::class)).isTrue()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ListTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ListTypeConversionTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class ListTypeConversionTest {
   @Test
-  fun should_cast_single_argument_to_list() = conversionTest(
+  fun should_cast_single_argument_to_list() = conversionTest<List<Int>, Int>(
     jsValue = "21",
     nativeAssertion = { value: List<Int> ->
       Truth.assertThat(value).hasSize(1)
@@ -16,7 +16,7 @@ class ListTypeConversionTest {
   )
 
   @Test
-  fun should_cast_complex_single_argument_to_list() = conversionTest(
+  fun should_cast_complex_single_argument_to_list() = conversionTest<List<List<Int>>, Int>(
     jsValue = "[21]",
     nativeAssertion = { value: List<List<Int>> ->
       Truth.assertThat(value).hasSize(1)

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/TypeConversionHelper.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/TypeConversionHelper.kt
@@ -28,6 +28,9 @@ fun interface JSAssertion {
 
   class IntEqual(expectedValue: Int) :
     Equal<Int>(expectedValue, JavaScriptValue::getInt)
+
+  class DoubleEqual(expectedValue: Double) :
+    Equal<Double>(expectedValue, JavaScriptValue::getDouble)
 }
 
 internal class TestCase<T, R>(
@@ -86,6 +89,19 @@ internal inline fun <reified T, reified R> conversionTest(
     TestCase(jsValue, nativeAssertion, map, jsAssertion)
   )
 }
+
+@JvmName("conversionTestT")
+internal inline fun <reified T> conversionTest(
+  jsValue: String,
+  noinline nativeAssertion: (T) -> Unit = {},
+  noinline map: (T) -> T = { it },
+  jsAssertion: JSAssertion
+) = conversionTest<T, T>(
+  jsValue,
+  nativeAssertion,
+  map,
+  jsAssertion
+)
 
 @JvmName("conversionTestT")
 internal inline fun <reified T> conversionTest(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
@@ -1,0 +1,26 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+class DurationTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Duration>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Duration {
+    if (value.type != ReadableType.Number) {
+      throw IllegalArgumentException("Expected a number, but received ${value.type}")
+    }
+    return value.asDouble().toDuration(DurationUnit.SECONDS)
+  }
+
+  override fun convertFromAny(value: Any): Duration {
+    return (value as Double).toDuration(DurationUnit.SECONDS)
+  }
+
+  override fun getCppRequiredTypes() = ExpectedType(CppType.DOUBLE)
+
+  override fun isTrivial(): Boolean = false
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -11,6 +11,8 @@ import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
 import java.io.File
 import java.net.URI
 import java.net.URL
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 object JSTypeConverter {
   interface ContainerProvider {
@@ -48,6 +50,7 @@ object JSTypeConverter {
       is File -> value.toJSValue()
       is Pair<*, *> -> value.toJSValue(containerProvider)
       is Long -> value.toDouble()
+      is Duration -> value.toDouble(DurationUnit.SECONDS)
       is RawTypedArrayHolder -> value.rawArray
       is Collection<*> -> value.toJSValue(containerProvider)
       else -> value
@@ -78,6 +81,7 @@ object JSTypeConverter {
       is File -> value.toJSValue()
       is Pair<*, *> -> value.toJSValue(containerProvider)
       is Long -> value.toDouble()
+      is Duration -> value.toDouble(DurationUnit.SECONDS)
       is RawTypedArrayHolder -> value.rawArray
       is Collection<*> -> if (useExperimentalConverter) {
         value.toJSValueExperimental()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
@@ -3,6 +3,8 @@ package expo.modules.kotlin.types
 import android.os.Bundle
 import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
 import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 object ReturnTypeProvider {
   val types = mutableMapOf<KClass<*>, ReturnType>()
@@ -139,6 +141,13 @@ interface ExperimentalJSTypeConverter<T> {
     }
   }
 
+  class DurationConverter : ExperimentalJSTypeConverter<Duration> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Duration?>(value)
+      return value?.toDouble(DurationUnit.SECONDS)
+    }
+  }
+
   class RawTypedArrayHolderConverter : ExperimentalJSTypeConverter<expo.modules.kotlin.typedarray.RawTypedArrayHolder> {
     override fun convertToJS(value: Any?): Any? {
       enforceType<expo.modules.kotlin.typedarray.RawTypedArrayHolder?>(value)
@@ -178,6 +187,7 @@ class ReturnType(
       java.io.File::class -> ExperimentalJSTypeConverter.FileConverter()
       Pair::class -> ExperimentalJSTypeConverter.PairConverter()
       Long::class -> ExperimentalJSTypeConverter.LongConverter()
+      Duration::class -> ExperimentalJSTypeConverter.DurationConverter()
       Any::class -> ExperimentalJSTypeConverter.AnyConverter()
       else -> null
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -46,6 +46,7 @@ import java.time.LocalDate
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
+import kotlin.time.Duration
 
 interface TypeConverterProvider {
   fun obtainTypeConverter(type: KType): TypeConverter<*>
@@ -280,6 +281,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       URI::class to JavaURITypeConverter(isOptional),
 
       File::class to FileTypeConverter(isOptional),
+
+      Duration::class to DurationTypeConverter(isOptional),
 
       Any::class to AnyTypeConverter(isOptional),
 


### PR DESCRIPTION
# Why

Adds support for `kotlin.time.Duration` in both direction: from native to js and from js to native.

# How

Added a new duration converter.

# Test Plan

- unit tests ✅ 