### PR TITLE
Update react-native-safe-area-context to 4.11.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1948,7 +1948,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.10.9):
+  - react-native-safe-area-context (4.11.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1961,8 +1961,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 4.10.9)
-    - react-native-safe-area-context/fabric (= 4.10.9)
+    - react-native-safe-area-context/common (= 4.11.0)
+    - react-native-safe-area-context/fabric (= 4.11.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1971,7 +1971,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (4.10.9):
+  - react-native-safe-area-context/common (4.11.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1992,7 +1992,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (4.10.9):
+  - react-native-safe-area-context/fabric (4.11.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3303,7 +3303,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: f13f03163b6a5ec66665dfe80a0df4468bb766a6
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
-  react-native-safe-area-context: 38fdd9b3c5561de7cabae64bd0cd2ce05d2768a1
+  react-native-safe-area-context: f1fda705dfe14355f41933debb5932887e234cc5
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-slider: e1f4b4538f7de7417b626174874f4f58d4cf6c28
   react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688
@@ -3349,7 +3349,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   UMAppLoader: c34fd315863887c7961e059efd9475e056bdd72d
-  Yoga: 2a45d7e59592db061217551fd3bbe2dd993817ae
+  Yoga: a1d7895431387402a674fd0d1c04ec85e87909b8
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 453324bb0c65cf3972121640836c8744febbf4c7

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "react-native-gesture-handler": "~2.20.0",
     "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.15.4",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",
     "react-native-view-shot": "3.8.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1715,7 +1715,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.10.9):
+  - react-native-safe-area-context (4.11.0):
     - React-Core
   - react-native-segmented-control (2.5.4):
     - React-Core
@@ -2835,7 +2835,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: 4f939d00605a084dbd4fe27529e9900f59b34036
+  hermes-engine: f18c6a3958352b6f725d0940dd4546d5ef2b66e7
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -2882,7 +2882,7 @@ SPEC CHECKSUMS:
   react-native-maps: cbf2f03bfeebfd7ec45966b066db13a075fd2af3
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: c476f76d54f946df5147645e902d3d7173688187
-  react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
+  react-native-safe-area-context: 851c62c48dce80ccaa5637b6aa5991a1bc36eca9
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-skia: 8cbbeae25285ade497b646696103832e67ffd64b
   react-native-slider: 97ce0bd921f40de79cead9754546d5e4e7ba44f8
@@ -2937,7 +2937,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: c24f990b03a68a7f6fe704b15dd487e7bb6b603e
   StripeUICore: f2d514e900c37436dc5427fdf2c29d68ab1c2935
   UMAppLoader: c34fd315863887c7961e059efd9475e056bdd72d
-  Yoga: 2a45d7e59592db061217551fd3bbe2dd993817ae
+  Yoga: a1d7895431387402a674fd0d1c04ec85e87909b8
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: daf14d519f64da4392fd9bde1dacc3221d66e652

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -73,7 +73,7 @@
     "react-native-pager-view": "^6.4.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.15.4",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",
     "react-redux": "^7.2.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -141,7 +141,7 @@
     "react-native-pager-view": "6.4.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.15.4",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "~3.34.0",
     "react-native-svg": "15.7.1",
     "react-native-view-shot": "3.8.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -23,7 +23,7 @@
     "expo-sqlite": "~14.0.3",
     "react": "18.3.1",
     "react-native": "0.75.2",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "3.34.0",
     "react-native-webview": "13.8.6"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -11,7 +11,7 @@
     "expo-router": "^3.5.15",
     "expo-splash-screen": "~0.27.0",
     "expo-status-bar": "^1.12.1",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "~3.34.0"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "react-native-pager-view": "6.4.1",
   "react-native-reanimated": "~3.15.4",
   "react-native-screens": "3.31.1",
-  "react-native-safe-area-context": "4.10.9",
+  "react-native-safe-area-context": "4.11.0",
   "react-native-svg": "15.7.1",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.8.6",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -35,7 +35,7 @@
     "react-native": "0.75.2",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-reanimated": "~3.15.4",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "3.34.0",
     "react-native-web": "~0.19.10"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -29,7 +29,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.75.2",
     "react-native-reanimated": "~3.15.0",
-    "react-native-safe-area-context": "4.10.9",
+    "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "3.34.0",
     "react-native-web": "~0.19.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14000,10 +14000,10 @@ react-native-reanimated@~3.15.4:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.10.9:
-  version "4.10.9"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.10.9.tgz#6ab82dc866ab499b101b033cb0f5b40125a4d410"
-  integrity sha512-wz/JXV1kARWyP5q93PFNKQP03StVBimOK7rRYEJjM+blZdXbM6H7EP3XhQUb6OK620+0M1AzpcGgyTHvgSJNAw==
+react-native-safe-area-context@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.11.0.tgz#d45271363672dc1923ddb0ce5a6ad588e210c85d"
+  integrity sha512-Bg7bozxEB+ZS+H3tVYs5yY1cvxNXgR6nRQwpSMkYR9IN5CbxohLnSprrOPG/ostTCd4F6iCk0c51pExEhifSKQ==
 
 react-native-screens@3.34.0, react-native-screens@~3.34.0:
   version "3.34.0"


### PR DESCRIPTION
# Why

Updates `react-native-safe-area-context` to 4.11.0
Closes ENG-13692

# How

Bumped versions in dependencies and reinstalled pods

# Test Plan

Confirmed it works in Expo Go on iOS. I couldn't test it on Android because it's crashing on missing Firebase credentials 😅