### PR TITLE
[expo-screen-capture] Clarify and document how it works with the Android privacy changes.

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -19,10 +19,9 @@ This is especially important on Android since the [`android.media.projection`](h
 
 On Android, the screen capture callback works without additional permissions only for Android 14+. **You don't need to request or check permissions for blocking screen capture or using the callback on Android 14+.**
 
-If you want to use the screen capture callback on Android 13 or lower, you need to add the `READ_MEDIA_IMAGES` permission to your `AndroidManifest.xml` file.
-You can do that using the `android.permissions` key in your app config. [Learn more.](https://docs.expo.dev/guides/permissions/#android)
+If you want to use the screen capture callback on Android 13 or lower, you need to add the `READ_MEDIA_IMAGES` permission to your `AndroidManifest.xml` file. You can use the `android.permissions` key in your app config. See [Android permissions](/guides/permissions/#android) for more information.
 
-> **warning** The `READ_MEDIA_IMAGES` permission can be added only for apps with a need for broad access to photos. [Learn more.](https://support.google.com/googleplay/android-developer/answer/14115180)
+> **warning** The `READ_MEDIA_IMAGES` permission can be added only for apps needing broad access to photos. See [Details on Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -17,6 +17,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 This is especially important on Android since the [`android.media.projection`](https://developer.android.com/about/versions/android-5.0.html#ScreenCapture) API allows third-party apps to perform screen capture or screen sharing (even if the app is in the background).
 
+> **warning** On Android, the screen capture callback works without additional permissions only for Android 14+. **You don't need to request or check permissions for blocking screen capture or using the callback on Android 14+.**
+> If you want to use the screen capture callback on Android 13 or lower, you need to add the `READ_MEDIA_IMAGES` permission to your `AndroidManifest.xml` file.
+>
+> You can do that using the `android.permissions` key in your app config. [Learn more.](https://docs.expo.dev/guides/permissions/#android)
+> This permission can be added only apps with a need for broad access to photos. [Learn more.](https://support.google.com/googleplay/android-developer/answer/14115180)
+
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
 ## Installation
@@ -46,9 +52,9 @@ export default function ScreenCaptureExample() {
 
 </SnackInline>
 
-### Example: functions
+### Example: Blocking screen capture imperatively
 
-<SnackInline label="Screen Capture functions" dependencies={["expo-screen-capture", "expo-media-library"]}>
+<SnackInline label="Blocking screen capture" dependencies={["expo-screen-capture", "expo-media-library"]}>
 
 ```jsx
 import * as ScreenCapture from 'expo-screen-capture';
@@ -56,30 +62,6 @@ import { useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 
 export default function ScreenCaptureExample() {
-  const hasPermissions = async () => {
-    const { status } = await ScreenCapture.requestPermissionsAsync();
-    return status === 'granted';
-  };
-
-  useEffect(() => {
-    let subscription;
-
-    const addListenerAsync = async () => {
-      if (await hasPermissions()) {
-        subscription = ScreenCapture.addScreenshotListener(() => {
-          alert('Thanks for screenshotting my beautiful app 😊');
-        });
-      } else {
-        console.error('Permissions needed to subscribe to screenshot events are missing!');
-      }
-    };
-    addListenerAsync();
-
-    return () => {
-      subscription?.remove();
-    };
-  }, []);
-
   const activate = async () => {
     await ScreenCapture.preventScreenCaptureAsync();
   };
@@ -103,6 +85,45 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
+```
+
+</SnackInline>
+
+### Example: Callback for screen capture
+
+<SnackInline label="Callback for screen capture" dependencies={["expo-screen-capture", "expo-media-library"]}>
+
+```jsx
+import * as ScreenCapture from 'expo-screen-capture';
+import { useEffect } from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+
+export default function useScreenCaptureCallback() {
+  // Only use this if you add the READ_MEDIA_IMAGES permission to your AndroidManifest.xml
+  const hasPermissions = async () => {
+    const { status } = await ScreenCapture.requestPermissionsAsync();
+    return status === 'granted';
+  };
+
+  useEffect(() => {
+    let subscription;
+
+    const addListenerAsync = async () => {
+      if (await hasPermissions()) {
+        subscription = ScreenCapture.addScreenshotListener(() => {
+          alert('Thanks for screenshotting my beautiful app 😊');
+        });
+      } else {
+        console.error('Permissions needed to subscribe to screenshot events are missing!');
+      }
+    };
+    addListenerAsync();
+
+    return () => {
+      subscription?.remove();
+    };
+  }, []);
+}
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -17,11 +17,12 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 This is especially important on Android since the [`android.media.projection`](https://developer.android.com/about/versions/android-5.0.html#ScreenCapture) API allows third-party apps to perform screen capture or screen sharing (even if the app is in the background).
 
-> **warning** On Android, the screen capture callback works without additional permissions only for Android 14+. **You don't need to request or check permissions for blocking screen capture or using the callback on Android 14+.**
-> If you want to use the screen capture callback on Android 13 or lower, you need to add the `READ_MEDIA_IMAGES` permission to your `AndroidManifest.xml` file.
->
-> You can do that using the `android.permissions` key in your app config. [Learn more.](https://docs.expo.dev/guides/permissions/#android)
-> This permission can be added only apps with a need for broad access to photos. [Learn more.](https://support.google.com/googleplay/android-developer/answer/14115180)
+On Android, the screen capture callback works without additional permissions only for Android 14+. **You don't need to request or check permissions for blocking screen capture or using the callback on Android 14+.**
+
+If you want to use the screen capture callback on Android 13 or lower, you need to add the `READ_MEDIA_IMAGES` permission to your `AndroidManifest.xml` file.
+You can do that using the `android.permissions` key in your app config. [Learn more.](https://docs.expo.dev/guides/permissions/#android)
+
+> **warning** The `READ_MEDIA_IMAGES` permission can be added only for apps with a need for broad access to photos. [Learn more.](https://support.google.com/googleplay/android-developer/answer/14115180)
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Make permissions auto-grant on Android 14+. ([#31865](https://github.com/expo/expo/pull/31865) by [@aleqsio](https://github.com/aleqsio))
 - Bumped iOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🎉 New features

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+  <!-- <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/> -->
   <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" android:minSdkVersion="34" />
 </manifest>

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-  <!-- <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/> -->
   <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" android:minSdkVersion="34" />
 </manifest>

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -15,12 +15,11 @@ import expo.modules.kotlin.modules.ModuleDefinition
 const val eventName = "onScreenshot"
 
 val grantedPermissions = mapOf(
-      "canAskAgain" to true,
-      "granted" to true,
-      "expires" to "never",
-      "status" to "granted"
-    )
-
+  "canAskAgain" to true,
+  "granted" to true,
+  "expires" to "never",
+  "status" to "granted"
+)
 
 class ScreenCaptureModule : Module() {
   private val context: Context
@@ -53,7 +52,7 @@ class ScreenCaptureModule : Module() {
     }
 
     AsyncFunction("getPermissionsAsync") { promise: Promise ->
-      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         promise.resolve(grantedPermissions)
         return@AsyncFunction
       }
@@ -65,7 +64,7 @@ class ScreenCaptureModule : Module() {
     }
 
     AsyncFunction("requestPermissionsAsync") { promise: Promise ->
-      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         promise.resolve(grantedPermissions)
         return@AsyncFunction
       }

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -14,6 +14,14 @@ import expo.modules.kotlin.modules.ModuleDefinition
 
 const val eventName = "onScreenshot"
 
+val grantedPermissions = mapOf(
+      "canAskAgain" to true,
+      "granted" to true,
+      "expires" to "never",
+      "status" to "granted"
+    )
+
+
 class ScreenCaptureModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
@@ -45,6 +53,10 @@ class ScreenCaptureModule : Module() {
     }
 
     AsyncFunction("getPermissionsAsync") { promise: Promise ->
+      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        promise.resolve(grantedPermissions)
+        return@AsyncFunction
+      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         Permissions.getPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.READ_MEDIA_IMAGES)
       } else {
@@ -53,6 +65,10 @@ class ScreenCaptureModule : Module() {
     }
 
     AsyncFunction("requestPermissionsAsync") { promise: Promise ->
+      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        promise.resolve(grantedPermissions)
+        return@AsyncFunction
+      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.READ_MEDIA_IMAGES)
       } else {


### PR DESCRIPTION
# Why

The READ_MEDIA_IMAGES is now sensitive, so using it is limited to only apps which primary purpose is multimedia handling.

We want to get ready for that by limiting the permission only to modules that absolutely need it, and Screen Capture uses it only to support a screenshot taken callback on Android 13 and lower.

Let's remove the permission.

# How

1. Made the permissions methods auto grant on Android 14+ (as on Android 14+ we use a system callback https://developer.android.com/reference/android/app/Activity.ScreenCaptureCallback that requires no permissions).
2. Removed the `READ_MEDIA_IMAGES` from package's AndroidManifest.xml.
3. Documented current options in the docs, that are:
	1. Don't include or ask for the `READ_MEDIA_IMAGES`, which makes the callback work only on Android 14+
	2. Use `android.permissions` in app config to add the `READ_MEDIA_IMAGES` permissions manually, in which case the callback works as expected on Android 13 and lower

# Test Plan

Tested in Bare Expo

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
