### PR TITLE
[babel-preset-expo] Fix snapshots for worklets

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -261,10 +261,10 @@ console.log("Hey I'm running on the UI thread");
 
 exports[`metro supports reanimated worklets 1`] = `
 "var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
-function(){var _e=[new global.Error(),1,-27];var someWorklet_workletJs1=function someWorklet_workletJs1(greeting){
+function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet_workletJs1.__closure={};someWorklet_workletJs1.__workletHash=14307677064221;someWorklet_workletJs1.__initData=_worklet_14307677064221_init_data;someWorklet_workletJs1.__stackDetails=_e;return someWorklet_workletJs1;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`metro transpiles non-standard exports 1`] = `"Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _default=_interopRequireWildcard(require("./Animated"));exports.default=_default;function _getRequireWildcardCache(e){if("function"!=typeof WeakMap)return null;var r=new WeakMap(),t=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(e){return e?t:r;})(e);}function _interopRequireWildcard(e,r){if(!r&&e&&e.__esModule)return e;if(null===e||"object"!=typeof e&&"function"!=typeof e)return{default:e};var t=_getRequireWildcardCache(r);if(t&&t.has(e))return t.get(e);var n={__proto__:null},a=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var u in e)if("default"!==u&&Object.prototype.hasOwnProperty.call(e,u)){var i=a?Object.getOwnPropertyDescriptor(e,u):null;i&&(i.get||i.set)?Object.defineProperty(n,u,i):n[u]=e[u];}return n.default=e,t&&t.set(e,n),n;}"`;
@@ -290,10 +290,10 @@ console.log("Hey I'm running on the UI thread");
 
 exports[`metro+hermes supports reanimated worklets 1`] = `
 "var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
-function(){var _e=[new global.Error(),1,-27];var someWorklet_workletJs1=function(greeting){
+function(){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet_workletJs1.__closure={};someWorklet_workletJs1.__workletHash=14307677064221;someWorklet_workletJs1.__initData=_worklet_14307677064221_init_data;someWorklet_workletJs1.__stackDetails=_e;return someWorklet_workletJs1;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`metro+hermes transpiles non-standard exports 1`] = `"Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _default=_interopRequireWildcard(require("./Animated"));exports.default=_default;function _getRequireWildcardCache(e){if("function"!=typeof WeakMap)return null;var r=new WeakMap(),t=new WeakMap();return(_getRequireWildcardCache=function(e){return e?t:r;})(e);}function _interopRequireWildcard(e,r){if(!r&&e&&e.__esModule)return e;if(null===e||"object"!=typeof e&&"function"!=typeof e)return{default:e};var t=_getRequireWildcardCache(r);if(t&&t.has(e))return t.get(e);var n={__proto__:null},a=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var u in e)if("default"!==u&&Object.prototype.hasOwnProperty.call(e,u)){var i=a?Object.getOwnPropertyDescriptor(e,u):null;i&&(i.get||i.set)?Object.defineProperty(n,u,i):n[u]=e[u];}return n.default=e,t&&t.set(e,n),n;}"`;
@@ -319,10 +319,10 @@ console.log("Hey I'm running on the UI thread");
 
 exports[`webpack supports reanimated worklets 1`] = `
 "const _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};const someWorklet=
-function(){const _e=[new global.Error(),1,-27];const someWorklet_workletJs1=function(greeting){
+function(){const _e=[new global.Error(),1,-27];const someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet_workletJs1.__closure={};someWorklet_workletJs1.__workletHash=14307677064221;someWorklet_workletJs1.__initData=_worklet_14307677064221_init_data;someWorklet_workletJs1.__stackDetails=_e;return someWorklet_workletJs1;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `


### PR DESCRIPTION
# Why

Fix `et cp babel-preset-expo` failing on snapshots testing Reanimated worklets

# How

Updated snapshots

# Test Plan

CI check passes now (also locally)