### PR TITLE
[expo] Upgrade @react-native-community/datetimepicker to `8.2.0`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2386,7 +2386,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNDateTimePicker (8.0.0):
+  - RNDateTimePicker (8.2.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3337,7 +3337,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 7973f617de8809ab9e7577b93ce23d3449fb1ec7
-  RNDateTimePicker: 00f430c6e77e6d9723954a5b5a820644d4b488a2
+  RNDateTimePicker: 6008d74df8122d6af6d9d08096bff19a8c6ba647
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
   RNReanimated: b3d406ee69af6972be20715d972b45d713aad400

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -40,7 +40,7 @@
     "@expo/dom-webview": "0.0.1",
     "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "8.0.0",
+    "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2050,7 +2050,7 @@ PODS:
     - React-Core
   - RNCPicker (2.7.5):
     - React-Core
-  - RNDateTimePicker (8.0.0):
+  - RNDateTimePicker (8.2.0):
     - React-Core
   - RNFlashList (1.7.1):
     - DoubleConversion
@@ -2916,7 +2916,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
-  RNDateTimePicker: cd42eda5f315fc320f0b359413bd598957f7e601
+  RNDateTimePicker: 40ffda97d071a98a10fdca4fa97e3977102ccd14
   RNFlashList: 115dd44377580761bff386a0caebf165424cf16f
   RNGestureHandler: 6dfe7692a191ee224748964127114edf057a1475
   RNReanimated: 97db82e83543c0b68233132ae87cfa033a89b7a8

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -22,7 +22,7 @@
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "^8.0.0",
+    "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "^0.3.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -36,7 +36,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "8.0.0",
+    "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/metro-runtime": "~3.2.1",
   "@expo/vector-icons": "^14.0.2",
   "@react-native-async-storage/async-storage": "1.23.1",
-  "@react-native-community/datetimepicker": "8.0.1",
+  "@react-native-community/datetimepicker": "8.2.0",
   "@react-native-masked-view/masked-view": "0.3.1",
   "@react-native-community/netinfo": "11.4.1",
   "@react-native-community/slider": "4.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,10 +3141,10 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@react-native-community/datetimepicker@8.0.0", "@react-native-community/datetimepicker@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-8.0.0.tgz#2d0ee2c122495f556d42563a69ffaa8b63e66db9"
-  integrity sha512-hFiGlG5ovhspLYIZlvRs7sMg2NtKjHaG2CJQbECQH1M31760cR7BjYujS/MCM2d44ihhn4ZKLspAyXVN+Gh08g==
+"@react-native-community/datetimepicker@8.2.0", "@react-native-community/datetimepicker@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-8.2.0.tgz#f62ac4fc12bd527fbbe93934e6c1cfbb7ba570f3"
+  integrity sha512-qrUPhiBvKGuG9Y+vOqsc56RPFcHa1SU2qbAMT0hfGkoFIj3FodE0VuPVrEa8fgy7kcD5NQmkZIKgHOBLV0+hWg==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Why

Closes ENG-13680

# How

Upgrades  @react-native-community/datetimepicker to `8.2.0`


# Test Plan

- expo go  
- bare-expo 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
