### PR TITLE
[expo-updates][cli] Disable console during runtime and fingeprint evaluation

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Rollback to system SQLite3 and fix incompatible issue when any third-party library uses iOS system SQLite3. ([#30826](https://github.com/expo/expo/pull/30826) by [@kudo](https://github.com/kudo))
 - Use expo-updates as source of truth for runtime version in dev client ([#31453](https://github.com/expo/expo/pull/31453) by [@wschurman](https://github.com/wschurman))
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
+- [cli] Disable console during runtime and fingeprint evaluation ([#31874](https://github.com/expo/expo/pull/31874) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/cli/build/configureCodeSigning.js
+++ b/packages/expo-updates/cli/build/configureCodeSigning.js
@@ -59,7 +59,7 @@ Configure expo-updates code signing for this project and verify setup
     const certificateInput = (0, args_1.requireArg)(args, '--certificate-input-directory');
     const keyInput = (0, args_1.requireArg)(args, '--key-input-directory');
     const keyid = args['--keyid'];
-    return await configureCodeSigningAsync((0, args_1.getProjectRoot)(args), {
+    await configureCodeSigningAsync((0, args_1.getProjectRoot)(args), {
         certificateInput,
         keyInput,
         keyid,

--- a/packages/expo-updates/cli/build/generateCodeSigning.js
+++ b/packages/expo-updates/cli/build/generateCodeSigning.js
@@ -63,7 +63,7 @@ Generate expo-updates private key, public key, and code signing certificate usin
     const certificateOutput = (0, args_1.requireArg)(args, '--certificate-output-directory');
     const certificateValidityDurationYears = (0, args_1.requireArg)(args, '--certificate-validity-duration-years');
     const certificateCommonName = (0, args_1.requireArg)(args, '--certificate-common-name');
-    return await generateCodeSigningAsync((0, args_1.getProjectRoot)(args), {
+    await generateCodeSigningAsync((0, args_1.getProjectRoot)(args), {
         certificateValidityDurationYears,
         keyOutput,
         certificateOutput,

--- a/packages/expo-updates/cli/build/generateFingerprint.js
+++ b/packages/expo-updates/cli/build/generateFingerprint.js
@@ -32,6 +32,7 @@ const chalk_1 = __importDefault(require("chalk"));
 const args_1 = require("./utils/args");
 const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
+const withConsoleDisabledAsync_1 = require("./utils/withConsoleDisabledAsync");
 const generateFingerprint = async (argv) => {
     const args = (0, args_1.assertArgs)({
         // Types
@@ -71,14 +72,18 @@ Generate fingerprint for use in expo-updates runtime version
     }
     const debug = args['--debug'];
     const projectRoot = (0, args_1.getProjectRoot)(args);
-    let result;
-    try {
-        const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
-        result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
-    }
-    catch (e) {
-        throw new errors_1.CommandError(e.message);
-    }
+    const result = await (0, withConsoleDisabledAsync_1.withConsoleDisabledAsync)(async () => {
+        try {
+            const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
+            return await createFingerprintAsync(projectRoot, platform, workflow, {
+                silent: true,
+                debug,
+            });
+        }
+        catch (e) {
+            throw new errors_1.CommandError(e.message);
+        }
+    });
     console.log(JSON.stringify(result));
 };
 exports.generateFingerprint = generateFingerprint;

--- a/packages/expo-updates/cli/build/resolveRuntimeVersion.js
+++ b/packages/expo-updates/cli/build/resolveRuntimeVersion.js
@@ -32,6 +32,7 @@ const chalk_1 = __importDefault(require("chalk"));
 const args_1 = require("./utils/args");
 const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
+const withConsoleDisabledAsync_1 = require("./utils/withConsoleDisabledAsync");
 const resolveRuntimeVersion = async (argv) => {
     const args = (0, args_1.assertArgs)({
         // Types
@@ -67,18 +68,19 @@ Resolve expo-updates runtime version
         throw new errors_1.CommandError(`Invalid workflow argument: ${workflow}. Must be either 'managed' or 'generic'`);
     }
     const debug = args['--debug'];
-    let runtimeVersionInfo;
-    try {
-        runtimeVersionInfo = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform, {
-            silent: true,
-            debug,
-        }, {
-            workflowOverride: workflow,
-        });
-    }
-    catch (e) {
-        throw new errors_1.CommandError(e.message);
-    }
+    const runtimeVersionInfo = await (0, withConsoleDisabledAsync_1.withConsoleDisabledAsync)(async () => {
+        try {
+            return await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform, {
+                silent: true,
+                debug,
+            }, {
+                workflowOverride: workflow,
+            });
+        }
+        catch (e) {
+            throw new errors_1.CommandError(e.message);
+        }
+    });
     console.log(JSON.stringify(runtimeVersionInfo));
 };
 exports.resolveRuntimeVersion = resolveRuntimeVersion;

--- a/packages/expo-updates/cli/build/utils/withConsoleDisabledAsync.d.ts
+++ b/packages/expo-updates/cli/build/utils/withConsoleDisabledAsync.d.ts
@@ -1,0 +1,1 @@
+export declare function withConsoleDisabledAsync<T>(block: () => Promise<T>): Promise<T>;

--- a/packages/expo-updates/cli/build/utils/withConsoleDisabledAsync.js
+++ b/packages/expo-updates/cli/build/utils/withConsoleDisabledAsync.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withConsoleDisabledAsync = void 0;
+async function withConsoleDisabledAsync(block) {
+    const loggingFunctions = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+    };
+    // Disable logging for this command since the only thing printed to stdout should be the JSON output.
+    console.log = function () { };
+    console.warn = function () { };
+    console.error = function () { };
+    try {
+        return await block();
+    }
+    finally {
+        // Re-enable logging functions for testing.
+        console.log = loggingFunctions.log;
+        console.warn = loggingFunctions.warn;
+        console.error = loggingFunctions.error;
+    }
+}
+exports.withConsoleDisabledAsync = withConsoleDisabledAsync;

--- a/packages/expo-updates/cli/src/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/src/configureCodeSigning.ts
@@ -43,7 +43,7 @@ Configure expo-updates code signing for this project and verify setup
   const keyInput = requireArg(args, '--key-input-directory');
   const keyid = args['--keyid'];
 
-  return await configureCodeSigningAsync(getProjectRoot(args), {
+  await configureCodeSigningAsync(getProjectRoot(args), {
     certificateInput,
     keyInput,
     keyid,

--- a/packages/expo-updates/cli/src/generateCodeSigning.ts
+++ b/packages/expo-updates/cli/src/generateCodeSigning.ts
@@ -50,7 +50,7 @@ Generate expo-updates private key, public key, and code signing certificate usin
   );
   const certificateCommonName = requireArg(args, '--certificate-common-name');
 
-  return await generateCodeSigningAsync(getProjectRoot(args), {
+  await generateCodeSigningAsync(getProjectRoot(args), {
     certificateValidityDurationYears,
     keyOutput,
     certificateOutput,

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -5,6 +5,7 @@ import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
 import { CommandError } from './utils/errors';
 import * as Log from './utils/log';
+import { withConsoleDisabledAsync } from './utils/withConsoleDisabledAsync';
 
 export const generateFingerprint: Command = async (argv) => {
   const args = assertArgs(
@@ -60,13 +61,17 @@ Generate fingerprint for use in expo-updates runtime version
 
   const projectRoot = getProjectRoot(args);
 
-  let result;
-  try {
-    const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
-    result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
-  } catch (e: any) {
-    throw new CommandError(e.message);
-  }
+  const result = await withConsoleDisabledAsync(async () => {
+    try {
+      const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
+      return await createFingerprintAsync(projectRoot, platform, workflow, {
+        silent: true,
+        debug,
+      });
+    } catch (e: any) {
+      throw new CommandError(e.message);
+    }
+  });
 
   console.log(JSON.stringify(result));
 };

--- a/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
+++ b/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
@@ -5,6 +5,7 @@ import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
 import { CommandError } from './utils/errors';
 import * as Log from './utils/log';
+import { withConsoleDisabledAsync } from './utils/withConsoleDisabledAsync';
 
 export const resolveRuntimeVersion: Command = async (argv) => {
   const args = assertArgs(
@@ -57,21 +58,23 @@ Resolve expo-updates runtime version
 
   const debug = args['--debug'];
 
-  let runtimeVersionInfo;
-  try {
-    runtimeVersionInfo = await resolveRuntimeVersionAsync(
-      getProjectRoot(args),
-      platform,
-      {
-        silent: true,
-        debug,
-      },
-      {
-        workflowOverride: workflow,
-      }
-    );
-  } catch (e: any) {
-    throw new CommandError(e.message);
-  }
+  const runtimeVersionInfo = await withConsoleDisabledAsync(async () => {
+    try {
+      return await resolveRuntimeVersionAsync(
+        getProjectRoot(args),
+        platform,
+        {
+          silent: true,
+          debug,
+        },
+        {
+          workflowOverride: workflow,
+        }
+      );
+    } catch (e: any) {
+      throw new CommandError(e.message);
+    }
+  });
+
   console.log(JSON.stringify(runtimeVersionInfo));
 };

--- a/packages/expo-updates/cli/src/utils/withConsoleDisabledAsync.ts
+++ b/packages/expo-updates/cli/src/utils/withConsoleDisabledAsync.ts
@@ -1,0 +1,20 @@
+export async function withConsoleDisabledAsync<T>(block: () => Promise<T>): Promise<T> {
+  const loggingFunctions = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  // Disable logging for this command since the only thing printed to stdout should be the JSON output.
+  console.log = function () {};
+  console.warn = function () {};
+  console.error = function () {};
+
+  try {
+    return await block();
+  } finally {
+    // Re-enable logging functions for testing.
+    console.log = loggingFunctions.log;
+    console.warn = loggingFunctions.warn;
+    console.error = loggingFunctions.error;
+  }
+}


### PR DESCRIPTION
# Why

When using app.config.js, sometimes there are console.logs.

This matters when running `npx expo config` since the output is often parsed as JSON, and any non-json output will make the parsing fail.

`npx expo config` has a `--json` flag to disable console: https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/config/configAsync.ts#L42

This PR does the same thing for `npx expo-updates runtimeversion:resolve` and `npx expo-updates fingerprint:generate`.

Fixes https://github.com/expo/eas-cli/issues/2515.
Closes ENG-13629.

# How

Add utility function and use it in the CLI.

# Test Plan

1. Create canary project: `yarn create expo-app test-eas-wahuhdada-lol --template blank@canary`, `npx expo install expo-updates` in the project
2. Change project to us `app.config.js` and add `console.log("THIS IS WAT");` to the top of the file.

Before:
```
$ npx expo-updates runtimeversion:resolve --platform ios
THIS IS WAT
{"runtimeVersion":null,"fingerprintSources":null,"workflow":"managed"}
```

After `yarn link expo-updates` with this PR checked out:
```
$ npx expo-updates runtimeversion:resolve --platform ios
{"runtimeVersion":null,"fingerprintSources":null,"workflow":"managed"}
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
