### PR TITLE
[docs] fix ungrammatical expression in installing-expo-modules.mdx

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -163,7 +163,7 @@ To exclude any of these modules, refer to the following guide on [excluding modu
 
 ### Excluding specific modules from autolinking
 
-If you need to exclude Expo modules that you are not using but they got installed by other dependencies, you can use the `expo.autolinking` field in **package.json**:
+If you need to exclude Expo modules you are not using, which were installed by other dependencies, you can use the `expo.autolinking` field in **package.json**:
 
 ```json package.json
 {


### PR DESCRIPTION
# Why

This sentence is understandable, but slightly ungrammatical and odd to a native-speaking ear.

Please correct/do with this proposed change what you will 🙏

# How

Reworded the sentence, slightly:

## Before 🐛

If you need to exclude Expo modules ~**that**~ you are not using **but they got** installed by other dependencies, you can use...

## After 🦋

If you need to exclude Expo modules you are not using, **which were** installed by other dependencies, you can use...


Please correct/do with this proposed change what you will 🙏