### PR TITLE
[docs] Update local EAS Build guide's title

### DIFF
--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -1,5 +1,6 @@
 ---
-title: Run builds locally or on your own infrastructure
+title: Run EAS Build locally with local flag
+sidebar_title: Run EAS Build locally
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @keith-kurak, the current title of the local EAS Build guide isn't clear. We both also observed when using docs search, this title is a bit misleading in those terms the page doesn't appear.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the guide's title to Run EAS Build locally with local flag. Also adds the sidebar title: Run EAS Build locally.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-07 at 03 06 49@2x](https://github.com/user-attachments/assets/96503262-ed1b-4893-9599-0b1a111b58c3)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
