### PR TITLE
[expo-notifications][iOS] Plugin should not overwrite existing aps-entitlement

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [android] fix notifications actions not being presented ([#31795](https://github.com/expo/expo/pull/31795) by [@vonovak](https://github.com/vonovak))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30478](https://github.com/expo/expo/pull/30478) by [@byCedric](https://github.com/byCedric))
+- [iOS] do not overwrite existing aps entitlement. ([#31892](https://github.com/expo/expo/pull/31892) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/plugin/build/withNotificationsIOS.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsIOS.js
@@ -7,7 +7,9 @@ const path_1 = require("path");
 const ERROR_MSG_PREFIX = 'An error occurred while configuring iOS notifications. ';
 const withNotificationsIOS = (config, { mode = 'development', sounds = [] }) => {
     config = (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
-        config.modResults['aps-environment'] = mode;
+        if (!config.modResults['aps-environment']) {
+            config.modResults['aps-environment'] = mode;
+        }
         return config;
     });
     config = (0, exports.withNotificationSounds)(config, { sounds });

--- a/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
@@ -17,7 +17,9 @@ export const withNotificationsIOS: ConfigPlugin<NotificationsPluginProps> = (
   { mode = 'development', sounds = [] }
 ) => {
   config = withEntitlementsPlist(config, (config) => {
-    config.modResults['aps-environment'] = mode;
+    if (!config.modResults['aps-environment']) {
+      config.modResults['aps-environment'] = mode;
+    }
     return config;
   });
   config = withNotificationSounds(config, { sounds });


### PR DESCRIPTION
# Why

Customer reports that the expo-notifications plugin overwrites their setting for the aps-entitlement back to development, even though they have set it to production.

https://old.reddit.com/r/expo/comments/1fpwb3j/expo_prebuild_always_sets_apsenv_to_development/

# How

Adjust the plugin to check for an existing value for the entitlement before writing.

# Test Plan

Verified in our test app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
