### PR TITLE
[core][iOS] Fixed views using the incorrect `AppContext` instance

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -60,7 +60,7 @@
 - [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
-- [iOS] Fixed views using the incorrect `AppContext` instance.
+- [iOS] Fixed views using the incorrect `AppContext` instance. ([#31897](https://github.com/expo/expo/pull/31897) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -60,6 +60,7 @@
 - [Android] Fixed R8 build error `Missing class expo.modules.kotlin.types.ExperimentalJSTypeConverter$URIConverter`. on macOS host. ([#31452](https://github.com/expo/expo/pull/31452) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
+- [iOS] Fixed views using the incorrect `AppContext` instance.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/build/NativeViewManagerAdapter.native.d.ts.map
+++ b/packages/expo-modules-core/build/NativeViewManagerAdapter.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"NativeViewManagerAdapter.native.d.ts","sourceRoot":"","sources":["../src/NativeViewManagerAdapter.native.tsx"],"names":[],"mappings":"AAIA,OAAO,KAAK,MAAM,OAAO,CAAC;AAuD1B;;GAEG;AACH,wBAAgB,wBAAwB,CAAC,CAAC,EAAE,QAAQ,EAAE,MAAM,GAAG,KAAK,CAAC,aAAa,CAAC,CAAC,CAAC,CAiDpF"}
+{"version":3,"file":"NativeViewManagerAdapter.native.d.ts","sourceRoot":"","sources":["../src/NativeViewManagerAdapter.native.tsx"],"names":[],"mappings":"AAIA,OAAO,KAAK,MAAM,OAAO,CAAC;AAuD1B;;GAEG;AACH,wBAAgB,wBAAwB,CAAC,CAAC,EAAE,QAAQ,EAAE,MAAM,GAAG,KAAK,CAAC,aAAa,CAAC,CAAC,CAAC,CAmDpF"}

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -84,6 +84,23 @@ public final class AppContext: NSObject {
       throw Exceptions.RuntimeLost()
     }
   }
+  
+  /**
+   The application identifier that is used to distinguish between different `RCTHost`.
+   It might be equal to `0`, meaning we couldn't obtain the Id for the current app.
+   It shouldn't be used on the Paper.
+   */
+  @objc
+  public var appIdentifier: Int {
+    #if RCT_NEW_ARCH_ENABLED
+    guard let moduleRegistry = reactBridge?.moduleRegistry else {
+      return 0
+    }
+    return abs(ObjectIdentifier(moduleRegistry).hashValue)
+    #else
+    return 0
+    #endif
+  }
 
   /**
    Code signing entitlements for code signing
@@ -406,6 +423,9 @@ public final class AppContext: NSObject {
     let runtime = try runtime
     let coreObject = runtime.createObject()
 
+    
+    coreObject.defineProperty("__expo_appIdentifier", value: appIdentifier == 0 ? "" : "\(appIdentifier)", options: [])
+    
     try coreModuleHolder.definition.decorate(object: coreObject, appContext: self)
 
     // Initialize `global.expo`.

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -423,7 +423,7 @@ public final class AppContext: NSObject {
     let runtime = try runtime
     let coreObject = runtime.createObject()
 
-    coreObject.defineProperty("__expo_appIdentifier__", value: appIdentifier, options: [])
+    coreObject.defineProperty("__expo_app_identifier__", value: appIdentifier, options: [])
 
     try coreModuleHolder.definition.decorate(object: coreObject, appContext: self)
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -87,18 +87,18 @@ public final class AppContext: NSObject {
 
   /**
    The application identifier that is used to distinguish between different `RCTHost`.
-   It might be equal to `0`, meaning we couldn't obtain the Id for the current app.
-   It shouldn't be used on the Paper.
+   It might be equal to `nil`, meaning we couldn't obtain the Id for the current app.
+   It shouldn't be used on the old architecture.
    */
   @objc
-  public var appIdentifier: Int {
+  public var appIdentifier: String? {
     #if RCT_NEW_ARCH_ENABLED
     guard let moduleRegistry = reactBridge?.moduleRegistry else {
-      return 0
+      return nil
     }
-    return abs(ObjectIdentifier(moduleRegistry).hashValue)
+    return "\(abs(ObjectIdentifier(moduleRegistry).hashValue))"
     #else
-    return 0
+    return nil
     #endif
   }
 
@@ -423,7 +423,7 @@ public final class AppContext: NSObject {
     let runtime = try runtime
     let coreObject = runtime.createObject()
 
-    coreObject.defineProperty("__expo_appIdentifier", value: appIdentifier == 0 ? "" : "\(appIdentifier)", options: [])
+    coreObject.defineProperty("__expo_appIdentifier__", value: appIdentifier, options: [])
 
     try coreModuleHolder.definition.decorate(object: coreObject, appContext: self)
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -84,7 +84,7 @@ public final class AppContext: NSObject {
       throw Exceptions.RuntimeLost()
     }
   }
-  
+
   /**
    The application identifier that is used to distinguish between different `RCTHost`.
    It might be equal to `0`, meaning we couldn't obtain the Id for the current app.
@@ -423,9 +423,8 @@ public final class AppContext: NSObject {
     let runtime = try runtime
     let coreObject = runtime.createObject()
 
-    
     coreObject.defineProperty("__expo_appIdentifier", value: appIdentifier == 0 ? "" : "\(appIdentifier)", options: [])
-    
+
     try coreModuleHolder.definition.decorate(object: coreObject, appContext: self)
 
     // Initialize `global.expo`.

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -21,13 +21,7 @@ internal final class CoreModule: Module {
     Function("getViewConfig") { (viewName: String) -> [String: Any]? in
       var validAttributes: [String: Any] = [:]
       var directEventTypes: [String: Any] = [:]
-      let parsedViewName: String
-      if let appIdentifier = appContext?.appIdentifier, viewName.hasSuffix("_\(appIdentifier)") {
-        parsedViewName = String(viewName.dropLast("_\(appIdentifier)".count))
-      } else {
-        parsedViewName = viewName
-      }
-      let moduleHolder = appContext?.moduleRegistry.get(moduleHolderForName: parsedViewName)
+      let moduleHolder = appContext?.moduleRegistry.get(moduleHolderForName: getHolderName(viewName))
 
       guard let viewDefinition = moduleHolder?.definition.view else {
         return nil
@@ -55,5 +49,13 @@ internal final class CoreModule: Module {
         RCTTriggerReloadCommandListeners(reason)
       }
     }
+  }
+
+  private func getHolderName(_ viewName: String) -> String {
+    if let appIdentifier = appContext?.appIdentifier, viewName.hasSuffix("_\(appIdentifier)") {
+      return String(viewName.dropLast("_\(appIdentifier)".count))
+    }
+
+    return viewName
   }
 }

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -21,7 +21,13 @@ internal final class CoreModule: Module {
     Function("getViewConfig") { (viewName: String) -> [String: Any]? in
       var validAttributes: [String: Any] = [:]
       var directEventTypes: [String: Any] = [:]
-      let moduleHolder = appContext?.moduleRegistry.get(moduleHolderForName: viewName)
+      let parsedViewName: String
+      if let appIdentifier = appContext?.appIdentifier, viewName.hasSuffix("_\(appIdentifier)") {
+        parsedViewName = String(viewName.dropLast("_\(appIdentifier)".count))
+      } else {
+        parsedViewName = viewName
+      }
+      let moduleHolder = appContext?.moduleRegistry.get(moduleHolderForName: parsedViewName)
 
       guard let viewDefinition = moduleHolder?.definition.view else {
         return nil

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -98,10 +98,15 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    Creates a subclass of `ViewModuleWrapper` in runtime. The new class overrides `moduleName` stub.
    */
   @objc
-  public static func createViewModuleWrapperClass(module: ViewModuleWrapper) -> ViewModuleWrapper.Type? {
+  public static func createViewModuleWrapperClass(module: ViewModuleWrapper, appId: Int) -> ViewModuleWrapper.Type? {
     // We're namespacing the view name so we know it uses our architecture.
-    let prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())"
-
+    let prefixedViewName: String
+    if (appId == 0) {
+      prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())"
+    } else {
+      prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())_\((appId))"
+    }
+    
     return prefixedViewName.withCString { viewNamePtr in
       // Create a new class that inherits from `ViewModuleWrapper`. The class name passed here, doesn't work for Swift classes,
       // so we also have to override `moduleName` class method.

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -98,13 +98,12 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    Creates a subclass of `ViewModuleWrapper` in runtime. The new class overrides `moduleName` stub.
    */
   @objc
-  public static func createViewModuleWrapperClass(module: ViewModuleWrapper, appId: Int) -> ViewModuleWrapper.Type? {
+  public static func createViewModuleWrapperClass(module: ViewModuleWrapper, appId: String?) -> ViewModuleWrapper.Type? {
     // We're namespacing the view name so we know it uses our architecture.
-    let prefixedViewName: String
-    if appId == 0 {
-      prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())"
+    let prefixedViewName = if let appId = appId {
+      "\(viewManagerAdapterPrefix)\(module.name())_\((appId))"
     } else {
-      prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())_\((appId))"
+      "\(viewManagerAdapterPrefix)\(module.name())"
     }
 
     return prefixedViewName.withCString { viewNamePtr in

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -101,12 +101,12 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
   public static func createViewModuleWrapperClass(module: ViewModuleWrapper, appId: Int) -> ViewModuleWrapper.Type? {
     // We're namespacing the view name so we know it uses our architecture.
     let prefixedViewName: String
-    if (appId == 0) {
+    if appId == 0 {
       prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())"
     } else {
       prefixedViewName = "\(viewManagerAdapterPrefix)\(module.name())_\((appId))"
     }
-    
+
     return prefixedViewName.withCString { viewNamePtr in
       // Create a new class that inherits from `ViewModuleWrapper`. The class name passed here, doesn't work for Swift classes,
       // so we also have to override `moduleName` class method.

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -9,7 +9,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
    The app context is injected into the class after the context is initialized.
    see the `makeClass` static function.
    */
-  public weak var appContext: AppContext? { ExpoFabricView.appContextFromClass() }
+  public weak var appContext: AppContext?
 
   /**
    The view definition that setup from `ExpoFabricView.create()`.
@@ -37,6 +37,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   }
 
   required public init(appContext: AppContext? = nil) {
+    self.appContext = appContext
     super.init(frame: .zero)
   }
 
@@ -137,8 +138,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
    but we can't do that as there might be more than one class with the same name (Expo Go) and allocating another one would return `nil`.
    */
   @objc
-  public static func makeViewClass(forAppContext appContext: AppContext, className: String) -> AnyClass? {
-    let moduleName = String(className.dropFirst(ViewModuleWrapper.viewManagerAdapterPrefix.count))
+  public static func makeViewClass(forAppContext appContext: AppContext, moduleName: String, className: String) -> AnyClass? {
     if let viewClass = viewClassesRegistry[className] {
       inject(appContext: appContext)
       injectInitializer(appContext: appContext, moduleName: moduleName, toViewClass: viewClass)

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -328,7 +328,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   [bridge registerAdditionalModuleClasses:moduleClasses];
 }
 
-- (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSInteger)appId
+- (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSString *)appId
 {
   // Hacky way to get a dictionary with `RCTComponentData` from UIManager.
   NSMutableDictionary<NSString *, RCTComponentData *> *componentDataByName = [[bridge uiManager] valueForKey:@"_componentDataByName"];

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -259,7 +259,9 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
 
   // Add dynamic wrappers for view modules written in Sweet API.
   for (ViewModuleWrapper *swiftViewModule in [_appContext getViewManagers]) {
-    Class wrappedViewModuleClass = [self registerComponentData:swiftViewModule inBridge:bridge];
+    Class wrappedViewModuleClass = [self registerComponentData:swiftViewModule
+                                                      inBridge:bridge
+                                                      forAppId:_appContext.appIdentifier];
     [additionalModuleClasses addObject:wrappedViewModuleClass];
     [visitedSweetModules addObject:swiftViewModule.name];
   }
@@ -326,12 +328,12 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   [bridge registerAdditionalModuleClasses:moduleClasses];
 }
 
-- (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge
+- (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSInteger)appId
 {
   // Hacky way to get a dictionary with `RCTComponentData` from UIManager.
   NSMutableDictionary<NSString *, RCTComponentData *> *componentDataByName = [[bridge uiManager] valueForKey:@"_componentDataByName"];
 
-  Class wrappedViewModuleClass = [ViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule];
+  Class wrappedViewModuleClass = [ViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule appId:appId];
   NSString *className = NSStringFromClass(wrappedViewModuleClass);
 
   if (componentDataByName[className]) {
@@ -345,7 +347,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   componentDataByName[className] = componentData;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-  Class viewClass = [ExpoFabricView makeViewClassForAppContext:_appContext className:className];
+  Class viewClass = [ExpoFabricView makeViewClassForAppContext:_appContext moduleName:viewModule.name className:className];
   [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
 #endif
 

--- a/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
+++ b/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
@@ -71,9 +71,11 @@ export function requireNativeViewManager<P>(viewName: string): React.ComponentTy
     );
   }
 
+  const appIdentifier = globalThis.expo?.['__expo_appIdentifier'] ?? '';
+  const viewNameSuffix = appIdentifier ? `_${appIdentifier}` : '';
   // Set up the React Native native component, which is an adapter to the universal module's view
   // manager
-  const reactNativeViewName = `ViewManagerAdapter_${viewName}`;
+  const reactNativeViewName = `ViewManagerAdapter_${viewName}${viewNameSuffix}`;
   const ReactNativeComponent = requireCachedNativeComponent(reactNativeViewName);
 
   class NativeComponent extends React.PureComponent<P> {

--- a/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
+++ b/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
@@ -71,7 +71,7 @@ export function requireNativeViewManager<P>(viewName: string): React.ComponentTy
     );
   }
 
-  const appIdentifier = globalThis.expo?.['__expo_appIdentifier__'] ?? '';
+  const appIdentifier = globalThis.expo?.['__expo_app_identifier__'] ?? '';
   const viewNameSuffix = appIdentifier ? `_${appIdentifier}` : '';
   // Set up the React Native native component, which is an adapter to the universal module's view
   // manager

--- a/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
+++ b/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
@@ -71,7 +71,7 @@ export function requireNativeViewManager<P>(viewName: string): React.ComponentTy
     );
   }
 
-  const appIdentifier = globalThis.expo?.['__expo_appIdentifier'] ?? '';
+  const appIdentifier = globalThis.expo?.['__expo_appIdentifier__'] ?? '';
   const viewNameSuffix = appIdentifier ? `_${appIdentifier}` : '';
   // Set up the React Native native component, which is an adapter to the universal module's view
   // manager


### PR DESCRIPTION
# Why

Fixes views using the incorrect `AppContext` instance.
If the app was using multiple react contexts at once—for instance, if you have the dev menu installed—our views weren't bind to the correct context. 

# How

We generated a new view wrapper for each `RCTHost` to bind it with the correct `AppContext`. That it a temporary solution and we couldn't figure out anything else. We would have to take some actions to change the behaviour in the RN itself. 

# Test Plan

| bare-expo     | iOS | Android |
| -------------: | :----: | :--------: |
| Paper         | ✅  | not tested      |
| Fabric        | ✅  | ✅      |

