### PR TITLE
[core][Android] Add a flag to turn warnings into errors

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 
 group = 'host.exp.exponent'
@@ -50,6 +52,8 @@ USE_HERMES = USE_HERMES && isExpoModulesCoreTests
 // END HERMES
 
 def isNewArchitectureEnabled = findProperty("newArchEnabled") == "true"
+
+def shouldTurnWarningsIntoErrors = findProperty("EXPO_WERROR") == "true"
 
 android {
   if (rootProject.hasProperty("ndkPath")) {
@@ -189,5 +193,14 @@ dependencies {
     } else {
       compileOnly "org.webkit:android-jsc:+"
     }
+  }
+}
+
+if (shouldTurnWarningsIntoErrors) {
+  tasks.withType(JavaCompile) configureEach {
+    options.compilerArgs << "-Werror" << "-Xlint:all"
+  }
+  tasks.withType(KotlinCompile) configureEach {
+    compilerOptions.allWarningsAsErrors = true
   }
 }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -53,7 +53,7 @@ USE_HERMES = USE_HERMES && isExpoModulesCoreTests
 
 def isNewArchitectureEnabled = findProperty("newArchEnabled") == "true"
 
-def shouldTurnWarningsIntoErrors = findProperty("EXPO_WERROR") == "true"
+def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
 android {
   if (rootProject.hasProperty("ndkPath")) {


### PR DESCRIPTION
# Why

Adds a flag to turn all warnings into errors to `e-m-c`. 
We aim to enable this flag in our projects to eliminate all warnings. 
We can't do that yet because there are so many of them. I'll try to reduce the number over time. 