### PR TITLE
update @react-native-picker/picker to 2.8.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2365,7 +2365,7 @@ PODS:
     - Yoga
   - RNCMaskedView (0.3.1):
     - React-Core
-  - RNCPicker (2.7.5):
+  - RNCPicker (2.8.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3336,7 +3336,7 @@ SPEC CHECKSUMS:
   ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
   RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
-  RNCPicker: 7973f617de8809ab9e7577b93ce23d3449fb1ec7
+  RNCPicker: 6ad936eee086dbe2aeb658994021770b46897d62
   RNDateTimePicker: 6008d74df8122d6af6d9d08096bff19a8c6ba647
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -44,7 +44,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",
-    "@react-native-picker/picker": "2.7.5",
+    "@react-native-picker/picker": "2.8.1",
     "@react-native-segmented-control/segmented-control": "2.5.4",
     "@shopify/flash-list": "1.7.1",
     "expo": "~51.0.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2048,7 +2048,7 @@ PODS:
     - React-Core
   - RNCMaskedView (0.3.1):
     - React-Core
-  - RNCPicker (2.7.5):
+  - RNCPicker (2.8.1):
     - React-Core
   - RNDateTimePicker (8.2.0):
     - React-Core
@@ -2915,7 +2915,7 @@ SPEC CHECKSUMS:
   ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
-  RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
+  RNCPicker: 0b6860a6b208d4046227d2f626ad0722f99a969c
   RNDateTimePicker: 40ffda97d071a98a10fdca4fa97e3977102ccd14
   RNFlashList: 115dd44377580761bff386a0caebf165424cf16f
   RNGestureHandler: 6dfe7692a191ee224748964127114edf057a1475

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -26,7 +26,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "^0.3.1",
-    "@react-native-picker/picker": "2.7.5",
+    "@react-native-picker/picker": "2.8.1",
     "@react-native-segmented-control/segmented-control": "2.5.4",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/elements": "~1.3.6",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -40,7 +40,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",
-    "@react-native-picker/picker": "2.7.5",
+    "@react-native-picker/picker": "2.8.1",
     "@react-native-segmented-control/segmented-control": "2.5.4",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/drawer": "6.5.0",

--- a/apps/native-component-list/src/screens/PickerScreen.tsx
+++ b/apps/native-component-list/src/screens/PickerScreen.tsx
@@ -125,8 +125,8 @@ function FocusPicker(props: Partial<React.ComponentProps<typeof Picker>>) {
     </>
   );
 }
-function GenericPickerIOS(props: any) {
-  const [value, setValue] = React.useState<any>('java');
+function GenericPickerIOS(props: PickerProps) {
+  const [value, setValue] = React.useState<string | number>('java');
 
   return (
     <>

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -7,7 +7,7 @@
   "@react-native-community/netinfo": "11.4.1",
   "@react-native-community/slider": "4.5.2",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.7.5",
+  "@react-native-picker/picker": "2.8.1",
   "@react-native-segmented-control/segmented-control": "2.5.4",
   "@stripe/stripe-react-native": "0.38.6",
   "expo-analytics-amplitude": "~11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3163,10 +3163,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.3.1.tgz#5bd76f17004a6ccbcec03856893777ee91f23d29"
   integrity sha512-uVm8U6nwFIlUd1iDIB5cS+lDadApKR+l8k4k84d9hn+GN4lzAIJhUZ9syYX7c022MxNgAlbxoFLt0pqKoyaAGg==
 
-"@react-native-picker/picker@2.7.5":
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.7.5.tgz#e43fcd65f260fa4f23e974ccb9fb7c1f7a9ff94a"
-  integrity sha512-vhMaOLkXSUb+YKVbukMJToU4g+89VMhBG2U9+cLYF8X8HtFRidrHjohGqT8/OyesDuKIXeLIP+UFYI9Q9CRA9Q==
+"@react-native-picker/picker@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.8.1.tgz#0dcfba3ee9e981a384fe2105ca21477ce2d63dc8"
+  integrity sha512-iFhsKQzRh/z3GlmvJWSjJJ4333FdLE/PhXxlGlYllE7sFf+UTzziVY+ajatuJ+R5zDw2AxfJV4v/3tAzUJb0/A==
 
 "@react-native-segmented-control/segmented-control@2.5.4":
   version "2.5.4"


### PR DESCRIPTION
# Why

closes https://linear.app/expo/issue/ENG-13682

# How

Bumped versions in dependencies and reinstalled pods


# Test Plan

tested in bare expo, and expo go


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
