### PR TITLE
[iOS][camera]Migrate to swift concurrency

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -446,7 +446,7 @@ export default class CameraScreen extends React.Component<object, State> {
           mode={this.state.mode}
           mute={this.state.mute}
           zoom={this.state.zoom}
-          videoQuality="2160p"
+          videoQuality="1080p"
           onMountError={this.handleMountError}
           barcodeScannerSettings={{
             barcodeTypes: ['qr', 'pdf417'],

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] Migrated cameraview AAR to autolinking and removed related config-plugin about adding the maven repository. ([#30707](https://github.com/expo/expo/pull/30707) by [@kudo](https://github.com/kudo))
 - Remove the dependency on the legacy types from the newer package on web. ([#30952](https://github.com/expo/expo/pull/30952) by [@alanjhughes](https://github.com/alanjhughes))
 - Remove `preferredVideoStabilizationMode` until is is fully supported. ([#31514](https://github.com/expo/expo/pull/31514) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Migrate to swift concurrency.
 
 ### ⚠️ Notices
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Android] Migrated cameraview AAR to autolinking and removed related config-plugin about adding the maven repository. ([#30707](https://github.com/expo/expo/pull/30707) by [@kudo](https://github.com/kudo))
 - Remove the dependency on the legacy types from the newer package on web. ([#30952](https://github.com/expo/expo/pull/30952) by [@alanjhughes](https://github.com/alanjhughes))
 - Remove `preferredVideoStabilizationMode` until is is fully supported. ([#31514](https://github.com/expo/expo/pull/31514) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Migrate to swift concurrency.
+- [iOS] Migrate to swift concurrency. ([#31900](https://github.com/expo/expo/pull/31900) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Android] Migrated cameraview AAR to autolinking and removed related config-plugin about adding the maven repository. ([#30707](https://github.com/expo/expo/pull/30707) by [@kudo](https://github.com/kudo))
 - Remove the dependency on the legacy types from the newer package on web. ([#30952](https://github.com/expo/expo/pull/30952) by [@alanjhughes](https://github.com/alanjhughes))
 - Remove `preferredVideoStabilizationMode` until is is fully supported. ([#31514](https://github.com/expo/expo/pull/31514) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Migrate to swift concurrency. ([#31900](https://github.com/expo/expo/pull/31900) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Migrate to Swift concurrency. ([#31900](https://github.com/expo/expo/pull/31900) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### ⚠️ Notices
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -159,7 +159,9 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
 
       OnViewDidUpdateProps { view in
-        view.initCamera()
+        Task {
+          await view.initCamera()
+        }
       }
 
       AsyncFunction("resumePreview") { view in
@@ -182,15 +184,17 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         #else // not simulator
         view.takePicture(options: options, promise: promise)
         #endif
-      }.runOnQueue(.main)
+      }
 
       AsyncFunction("record") { (view, options: CameraRecordingOptions, promise: Promise) in
         #if targetEnvironment(simulator)
         throw Exceptions.SimulatorNotSupported()
         #else
-        view.record(options: options, promise: promise)
+        Task {
+          await view.record(options: options, promise: promise)
+        }
         #endif
-      }.runOnQueue(.main)
+      }
 
       AsyncFunction("stopRecording") { view in
         #if targetEnvironment(simulator)
@@ -198,7 +202,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         #else
         view.stopRecording()
         #endif
-      }.runOnQueue(.main)
+      }
     }
 
     AsyncFunction("launchScanner") { (options: VisionScannerOptions?) in

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -182,7 +182,9 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         #if targetEnvironment(simulator) // simulator
         try takePictureForSimulator(self.appContext, view, options, promise)
         #else // not simulator
-        view.takePicture(options: options, promise: promise)
+        Task {
+         await view.takePicture(options: options, promise: promise)
+        }
         #endif
       }
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -183,7 +183,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         try takePictureForSimulator(self.appContext, view, options, promise)
         #else // not simulator
         Task {
-         await view.takePicture(options: options, promise: promise)
+          await view.takePicture(options: options, promise: promise)
         }
         #endif
       }

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -1,54 +1,54 @@
 import ExpoModulesCore
 
-internal class CameraUnmountedException: Exception {
+internal final class CameraUnmountedException: Exception {
   override var reason: String {
     "Camera unmounted during taking photo process"
   }
 }
 
-internal class CameraNotReadyException: Exception {
+internal final class CameraNotReadyException: Exception {
   override var reason: String {
     "Camera unmounted during taking photo process"
   }
 }
 
-internal class CameraOutputNotReadyException: Exception {
+internal final class CameraOutputNotReadyException: Exception {
   override var reason: String {
     "Camera is not ready yet. Wait for 'onCameraReady' callback"
   }
 }
 
-internal class CameraImageCaptureException: Exception {
+internal final class CameraImageCaptureException: Exception {
   override var reason: String {
     "Image could not be captured"
   }
 }
 
-internal class CameraSavingImageException: Exception {
+internal final class CameraSavingImageException: Exception {
   override var reason: String {
     "Could not save the image"
   }
 }
 
-internal class CameraRecordingException: GenericException<String?> {
+internal final class CameraRecordingException: GenericException<String?> {
   override var reason: String {
     "Video Codec '\(String(describing: param))' is not supported on this device"
   }
 }
 
-internal class CameraRecordingFailedException: Exception {
+internal final class CameraRecordingFailedException: Exception {
   override var reason: String {
     "An error occurred while recording a video"
   }
 }
 
-internal class CameraMetadataDecodingException: Exception {
+internal final class CameraMetadataDecodingException: Exception {
   override var reason: String {
     "Could not decode image metadata"
   }
 }
 
-internal class CameraInvalidPhotoData: Exception {
+internal final class CameraInvalidPhotoData: Exception {
   override var reason: String {
     "An error occured while generating photo data"
   }

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -225,3 +225,10 @@ struct ExpoCameraUtils {
     return mutableMetadata
   }
 }
+
+extension Task where Success == Never, Failure == Never {
+  static func sleep(seconds: Double) async throws {
+    let duration = UInt64(seconds * 1_000_000_000)
+    try await Task.sleep(nanoseconds: duration)
+  }
+}

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -225,10 +225,3 @@ struct ExpoCameraUtils {
     return mutableMetadata
   }
 }
-
-extension Task where Success == Never, Failure == Never {
-  static func sleep(seconds: Double) async throws {
-    let duration = UInt64(seconds * 1_000_000_000)
-    try await Task.sleep(nanoseconds: duration)
-  }
-}

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -367,7 +367,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     }
 
     if !photoSettings.availablePreviewPhotoPixelFormatTypes.isEmpty,
-       let previewFormat = photoSettings.__availablePreviewPhotoPixelFormatTypes.first {
+    let previewFormat = photoSettings.__availablePreviewPhotoPixelFormatTypes.first {
       photoSettings.previewPhotoFormat = [kCVPixelBufferPixelFormatTypeKey as String: previewFormat]
     }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -84,7 +84,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   var mode = CameraMode.picture {
     didSet {
       Task {
-       await setCameraMode()
+        await setCameraMode()
       }
     }
   }
@@ -92,7 +92,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   var isMuted = false {
     didSet {
       Task {
-       await updateSessionAudioIsMuted()
+        await updateSessionAudioIsMuted()
       }
     }
   }
@@ -300,14 +300,12 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   private func addErrorNotification() {
     Task {
       for await error in NotificationCenter.default.notifications(named: .AVCaptureSessionRuntimeError, object: self.session)
-        .compactMap({ $0.userInfo?[AVCaptureSessionErrorKey] as? AVError }) {
-        if error.code == .mediaServicesWereReset {
-          if !session.isRunning {
-            session.startRunning()
-          }
-          await updateSessionAudioIsMuted()
-          onCameraReady()
+        .compactMap({ $0.userInfo?[AVCaptureSessionErrorKey] as? AVError }) where error.code == .mediaServicesWereReset {
+        if !session.isRunning {
+          session.startRunning()
         }
+        await updateSessionAudioIsMuted()
+        onCameraReady()
       }
     }
   }


### PR DESCRIPTION
# Why
Migrates the camera module to use swift concurrency. This provides easier management of the captureSession and a smoother experience when using the camera. 

Since the start of this module, there have always been odd bugs related to managing the capture session. Things like dead frames when switching to video or `startRunning` being called during a configuration change leading to a crash. I have tried to address these as they came up but it has always been difficult to debug and track down where exactly the issue occurred. Also, it is easy to regress these fixes with future changes. 

# How

Migrate our usage of `DispatchQueue` to Swifts async `Task` wherever possible. It is not possible to completely eliminate it but just for configuration changes alone this has made the code significantly easier to reason about and in my testing the camera seems to perform better. No UI hitches, no dead frames etc.

# Test Plan
bare-expo
