### PR TITLE
[expo-image-picker] Remove READ_MEDIA_IMAGES and READ_MEDIA_VIDEO

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions. ([#31902](https://github.com/expo/expo/pull/31902) by [@aleqsio](https://github.com/aleqsio))
 - Bumped iOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))
 - The default value for `quality` option has been changed from `0.2` to `1.0` for better performance and to match the most common expectation. ([#30896](https://github.com/expo/expo/pull/30896) by [@tsapeta](https://github.com/tsapeta))
 - `ImagePicker.MediaTypeOptions` have been deprecated. Use a single MediaType or an array of MediaTypes instead. ([#30957](https://github.com/expo/expo/pull/30957) by [@behenate](https://github.com/behenate))

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
   <!-- Required for picking images from camera roll -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
   <application>
     <service

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -250,10 +250,7 @@ class ImagePickerModule : Module() {
 
   private fun getMediaLibraryPermissions(writeOnly: Boolean): Array<String> =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      listOfNotNull(
-        READ_MEDIA_IMAGES,
-        READ_MEDIA_VIDEO
-      ).toTypedArray()
+      emptyArray<String>()
     } else {
       listOfNotNull(
         Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -1,8 +1,6 @@
 package expo.modules.imagepicker
 
 import android.Manifest
-import android.Manifest.permission.READ_MEDIA_IMAGES
-import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager


### PR DESCRIPTION
# Why

We want to remove `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions from SDK packages.

These permissions are now sensitive and require justification. See [here](https://support.google.com/googleplay/android-developer/answer/14115180) for more details.

https://linear.app/expo/issue/ENG-13698/remove-read-media-images-and-read-media-video-from-sdk-packages

# How

Did some testing on API>=34, API33 and API28.

I think we can safely remove these from `AndroidManifest.xml` without even adding them to the config plugin options, since having them does not change the behavior of image picker – it either uses the `READ_EXTERNAL_STORAGE` on API<33, or the OS limited access picker that returns only the selected photos for us.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
