### PR TITLE
[expo-media-library] Add info about Android sensitive permission changes to the docs.

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -19,6 +19,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
+> **warning** Android allows full access to the media library (which is the purpose of this package) only for applications needing broad access to photos. See [Details on Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
+
 ## Installation
 
 <APIInstallSection />
@@ -180,7 +182,16 @@ import * as MediaLibrary from 'expo-media-library';
 
 The following permissions are added automatically through this library's `AndroidManifest.xml`.
 
-<AndroidPermissions permissions={['READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE']} />
+<AndroidPermissions
+  permissions={[
+    'READ_EXTERNAL_STORAGE',
+    'WRITE_EXTERNAL_STORAGE',
+    'READ_MEDIA_IMAGES',
+    'READ_MEDIA_VIDEO',
+    'READ_MEDIA_AUDIO',
+    'READ_MEDIA_VISUAL_USER_SELECTED',
+  ]}
+/>
 
 ### iOS
 


### PR DESCRIPTION
# Why

Android is marking full media access as a sensitive permission.
https://linear.app/expo/issue/ENG-13698/remove-read-media-images-and-read-media-video-from-sdk-packages

For image-picker and screen-capture we're able to remove this permission and shift to new privacy-supporting APIs.

**For media-library, I don't see how this module could be used without the relevant permissions, so I'd suggest keeping them and warning about the additional requirements during app release.**

# What next
Should this still be a part of Expo Go? Will we be able to release Expo Go with the  `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions included? Should we disable this module from Expo Go?

I think we can try releasing it as is, but in case of any problems we should just drop it, but it could also delay us releasing Expo Go on Android, in which case we can also drop it now.

# Test Plan

No code changes here.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
