### PR TITLE
[expo-go] Update vendored symlinks

### DIFF
--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskia.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskia.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskia.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskottie.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskottie.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskottie.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libsksg.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libsksg.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libsksg.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode_core.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode_core.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskunicode_core.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode_icu.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode_icu.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskunicode_icu.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskia.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskia.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskia.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskottie.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskottie.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskottie.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libsksg.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libsksg.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libsksg.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode_core.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode_core.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskunicode_core.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode_icu.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode_icu.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskunicode_icu.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskia.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskia.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskia.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskottie.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskottie.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskottie.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libsksg.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libsksg.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libsksg.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskunicode_core.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskunicode_core.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskunicode_core.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskunicode_icu.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskunicode_icu.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskunicode_icu.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskia.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskia.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskia.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskottie.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskottie.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskottie.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libsksg.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libsksg.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libsksg.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode_core.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode_core.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskunicode_core.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode_icu.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode_icu.a
@@ -1,0 +1,1 @@
+../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskunicode_icu.a

--- a/apps/expo-go/ios/vendored/common/libskia.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskia.xcframework
@@ -1,0 +1,1 @@
+../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskia.xcframework

--- a/apps/expo-go/ios/vendored/common/libskottie.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskottie.xcframework
@@ -1,0 +1,1 @@
+../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskottie.xcframework

--- a/apps/expo-go/ios/vendored/common/libsksg.xcframework
+++ b/apps/expo-go/ios/vendored/common/libsksg.xcframework
@@ -1,0 +1,1 @@
+../../../../../node_modules/@shopify/react-native-skia/libs/ios/libsksg.xcframework

--- a/apps/expo-go/ios/vendored/common/libskunicode.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskunicode.xcframework
@@ -1,1 +1,0 @@
-../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskunicode.xcframework

--- a/apps/expo-go/ios/vendored/common/libskunicode_core.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskunicode_core.xcframework
@@ -1,0 +1,1 @@
+../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskunicode_core.xcframework

--- a/apps/expo-go/ios/vendored/common/libskunicode_libgrapheme.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskunicode_libgrapheme.xcframework
@@ -1,0 +1,1 @@
+../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskunicode_libgrapheme.xcframework


### PR DESCRIPTION
# Why

I tried running `et publish-dev-home` on main and got this error:

```
$ et publish-dev-home

There was an error running publish-dev-home command: ENOENT: no such file or directory, stat '/Users/brent/code/expo/apps/expo-go/ios/vendored/common/libskunicode.xcframework'
```

This was symlinking to `../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskunicode.xcframework` - but `libskunicode.xcframework` no longer existed, and there were a bunch of other frameworks there. There was a similar issue on the Android side after cleaning up the iOS side.

# How

Re-create all symlinks related to shopify/react-native-skia in Expo Go's *vendored/common* directories for iOS and Android.

I don't know if this is actually needed / if we can delete the symlinks / if I should have added the new symlinks. Up to @Kudo to decide!

# Test Plan

```
et publish-dev-home
```

CI here should also verify that Expo Go builds.