### PR TITLE
[go] remove unused skia files

### DIFF
--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskparagraph.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskparagraph.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskparagraph.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskshaper.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskshaper.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskshaper.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/arm64-v8a/libsvg.a
+++ b/apps/expo-go/android/vendored/common/libs/arm64-v8a/libsvg.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/arm64-v8a/libsvg.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskparagraph.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskparagraph.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskparagraph.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskshaper.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskshaper.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskshaper.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libsvg.a
+++ b/apps/expo-go/android/vendored/common/libs/armeabi-v7a/libsvg.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/armeabi-v7a/libsvg.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskparagraph.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskparagraph.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskparagraph.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskshaper.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskshaper.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskshaper.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/x86/libsvg.a
+++ b/apps/expo-go/android/vendored/common/libs/x86/libsvg.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86/libsvg.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskparagraph.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskparagraph.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskparagraph.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskshaper.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskshaper.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskshaper.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libskunicode.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libskunicode.a

--- a/apps/expo-go/android/vendored/common/libs/x86_64/libsvg.a
+++ b/apps/expo-go/android/vendored/common/libs/x86_64/libsvg.a
@@ -1,1 +1,0 @@
-../../../../../../../node_modules/@shopify/react-native-skia/libs/android/x86_64/libsvg.a

--- a/apps/expo-go/ios/vendored/common/libskparagraph.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskparagraph.xcframework
@@ -1,1 +1,0 @@
-../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskparagraph.xcframework

--- a/apps/expo-go/ios/vendored/common/libskshaper.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskshaper.xcframework
@@ -1,1 +1,0 @@
-../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskshaper.xcframework

--- a/apps/expo-go/ios/vendored/common/libskunicode.xcframework
+++ b/apps/expo-go/ios/vendored/common/libskunicode.xcframework
@@ -1,1 +1,0 @@
-../../../../../node_modules/@shopify/react-native-skia/libs/ios/libskunicode.xcframework

--- a/apps/expo-go/ios/vendored/common/libsvg.xcframework
+++ b/apps/expo-go/ios/vendored/common/libsvg.xcframework
@@ -1,1 +1,0 @@
-../../../../../node_modules/@shopify/react-native-skia/libs/ios/libsvg.xcframework


### PR DESCRIPTION
# Why

supersede #31909

# How

we don't need these skia symlinks and can just remove them

# Test Plan

android/ios expo go + skia NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
