### PR TITLE
fix(babel-preset-expo): pin babel-plugin-react-compiler to fixed version avoiding `postinstall` issue

### DIFF
--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-typescript": "^7.23.0",
     "@babel/preset-react": "^7.22.15",
     "@react-native/babel-preset": "0.74.87",
-    "babel-plugin-react-compiler": "^0.0.0-experimental-592953e-20240517",
+    "babel-plugin-react-compiler": "0.0.0-experimental-592953e-20240517",
     "babel-plugin-react-native-web": "~0.19.10",
     "react-refresh": "^0.14.2"
   },


### PR DESCRIPTION
# Why

Fixes #31912

# How

Pin `babel-plugin-react-compiler` to exact version, avoiding the current `postinstall` issues. https://github.com/facebook/react/issues/31150

# Test Plan

See new release

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
