### PR TITLE
[doctor] fix conditional on iOS non-CNG check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- fix conditional on iOS non-CNG check ([#31920](https://github.com/expo/expo/pull/31920) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.10.1 — 2024-08-28

--- a/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
+++ b/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
@@ -55,8 +55,10 @@ export class AppConfigFieldsNotSyncedToNativeProjectsCheck implements DoctorChec
     if (
       unsyncedFields.length &&
       // git check-ignore needs a specific file to check gitignore, we choose Podfile or build.gradle
-      ((await existsAndIsNotIgnoredAsync(path.join(projectRoot, 'ios', 'Podfile')),
-      isBuildingOnEAS) ||
+      ((await existsAndIsNotIgnoredAsync(
+        path.join(projectRoot, 'ios', 'Podfile'),
+        isBuildingOnEAS
+      )) ||
         (await existsAndIsNotIgnoredAsync(
           path.join(projectRoot, 'android', 'build.gradle'),
           isBuildingOnEAS

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -16,6 +16,11 @@ class Env {
     return boolish('EXPO_STAGING', false);
   }
 
+  /** Allow disabling InstalledDependencyVersionCheck */
+  get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
+    return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
+  }
+
   /** Opt in to ReactNativeDirectoryCheck */
   get EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK() {
     if (typeof process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK === 'undefined') {
@@ -24,11 +29,6 @@ class Env {
 
     return boolish('EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', false);
   }
-
-    /** Allow disabling InstalledDependencyVersionCheck */
-    get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
-      return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
-    }
 }
 
 export const env = new Env();

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -16,11 +16,6 @@ class Env {
     return boolish('EXPO_STAGING', false);
   }
 
-  /** Allow disabling InstalledDependencyVersionCheck */
-  get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
-    return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
-  }
-
   /** Opt in to ReactNativeDirectoryCheck */
   get EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK() {
     if (typeof process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK === 'undefined') {

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -29,6 +29,11 @@ class Env {
 
     return boolish('EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', false);
   }
+
+    /** Allow disabling InstalledDependencyVersionCheck */
+    get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
+      return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
+    }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why
This stray paren was forcing the iOS non-CNG check to true if EAS Build use was detected. Noticed when my very-CNG project was failing this check ;-)

# How
Fixed the paren

# Test Plan
Tried the test on my non-CNG project. It passed again.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
