### PR TITLE
[core][Android] Rename `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -101,7 +101,7 @@
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`.
+- [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`. ([#31921](https://github.com/expo/expo/pull/31921) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -101,7 +101,7 @@
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Renamed `SharedObject.deallocate` to `SharedObject.wasReleased`.
+- [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -101,6 +101,7 @@
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Renamed `SharedObject.deallocate` to `SharedObject.wasReleased`.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -61,9 +61,15 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
   open fun onStopListeningToEvent(eventName: String) = Unit
 
   /**
+   * Called when the shared object was released.
+   */
+  open fun wasReleased() = deallocate()
+
+  /**
    * Called when the shared object being deallocated.
    */
-  open fun deallocate() {}
+  @Deprecated("Use didRelease() instead.", ReplaceWith("didRelease()"))
+  open fun deallocate() = Unit
 
   /**
    * Override this function to inform the JavaScript runtime that there is additional

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -63,12 +63,12 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
   /**
    * Called when the shared object was released.
    */
-  open fun wasReleased() = deallocate()
+  open fun sharedObjectDidRelease() = deallocate()
 
   /**
    * Called when the shared object being deallocated.
    */
-  @Deprecated("Use didRelease() instead.", ReplaceWith("didRelease()"))
+  @Deprecated("Use sharedObjectDidRelease() instead.", ReplaceWith("sharedObjectDidRelease()"))
   open fun deallocate() = Unit
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -101,7 +101,7 @@ class SharedObjectRegistry(runtimeContext: RuntimeContext) {
       pairs.remove(id)
     }?.let { (native, _) ->
       native.sharedObjectId = SharedObjectId(0)
-      native.deallocate()
+      native.wasReleased()
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -101,7 +101,7 @@ class SharedObjectRegistry(runtimeContext: RuntimeContext) {
       pairs.remove(id)
     }?.let { (native, _) ->
       native.sharedObjectId = SharedObjectId(0)
-      native.wasReleased()
+      native.sharedObjectDidRelease()
     }
   }
 


### PR DESCRIPTION
# Why

Renames `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`
I think it's a more suitable name for this function. 
