### PR TITLE
[core][Android] Throws a descriptive error when using a released `SharedObject`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -101,7 +101,7 @@
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Throws a descriptive error when trying to use a released `SharedObject`.
+- [Android] Throws a descriptive error when trying to use a released `SharedObject`. ([#31922](https://github.com/expo/expo/pull/31922) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -101,6 +101,7 @@
 - [Android] Improve error messages when converting the `Either` type. ([#31787](https://github.com/expo/expo/pull/31787) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Improved converting function results. ([#31827](https://github.com/expo/expo/pull/31827) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Throws a descriptive error when trying to use a released `SharedObject`.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -98,7 +98,7 @@ class SharedObjectTest {
       .runtimeContextHolder
       .get()
       ?.sharedObjectRegistry
-      ?.toNativeObject(jsObject)
+      ?.toNativeObjectOrNull(jsObject)
 
     // Send an event from the native object to JS
     nativeObject?.emit("test event", 1, 2, 3)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -182,10 +182,14 @@ internal class ArgumentCastException(
   }
 }
 
-internal class InvalidSharedObjectException(
+internal class InvalidSharedObjectIdException : CodedException(
+  message = "Cannot convert provided JavaScriptObject to the SharedObject, because it doesn't contain valid id"
+)
+
+internal class InvalidSharedObjectTypeException(
   sharedType: KType
 ) : CodedException(
-  message = "Cannot convert provided JavaScriptObject to the '$sharedType', because it doesn't contain valid id"
+  message = "Cannot convert provided JavaScriptObject to the '$sharedType', because the native type doesn't match"
 )
 
 internal class IncorrectRefTypeException(
@@ -255,4 +259,8 @@ internal class UnsupportedClass(
 
 internal class PromiseAlreadySettledException(functionName: String) : CodedException(
   message = "Promise passed to '$functionName' was already settled. It will lead to a crash in the production environment!"
+)
+
+internal class UsingReleasedSharedObjectException : CodedException(
+  message = "Cannot use shared object that was already released"
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -137,7 +137,7 @@ class JSIContext : Destructible, AutoCloseable {
   @DoNotStrip
   fun getSharedObject(id: Int): JavaScriptObject? {
     val runtimeContext = runtimeContextHolder.get() ?: return null
-    return SharedObjectId(id).toJavaScriptObject(runtimeContext)
+    return SharedObjectId(id).toJavaScriptObjectNull(runtimeContext)
   }
 
   @Suppress("unused")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -34,7 +34,7 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
 
   private fun getJavaScriptObject(): JavaScriptWeakObject? {
     return SharedObjectId(sharedObjectId.value)
-      .toWeakJavaScriptObject(
+      .toWeakJavaScriptObjectNull(
         runtimeContext ?: return null
       )
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -1,43 +1,31 @@
 package expo.modules.kotlin.sharedobjects
 
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.exception.InvalidSharedObjectIdException
+import expo.modules.kotlin.exception.UsingReleasedSharedObjectException
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptWeakObject
 import expo.modules.kotlin.weak
 
 @JvmInline
 value class SharedObjectId(val value: Int) {
-  @Deprecated("Use toNativeObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toNativeObject(runtimeContext: RuntimeContext)"))
-  fun toNativeObject(appContext: AppContext): SharedObject? {
-    return appContext.hostingRuntimeContext.sharedObjectRegistry.toNativeObject(this)
-  }
-
-  @Deprecated("Use toJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toJavaScriptObject(runtimeContext: RuntimeContext)"))
-  fun toJavaScriptObject(appContext: AppContext): JavaScriptObject? {
-    val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.hostingRuntimeContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
-  }
-
-  @Deprecated("Use toWeakJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toWeakJavaScriptObject(runtimeContext: RuntimeContext)"))
-  fun toWeakJavaScriptObject(appContext: AppContext): JavaScriptWeakObject? {
-    val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.hostingRuntimeContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
-  }
-
-  fun toNativeObject(runtimeContext: RuntimeContext): SharedObject? {
+  fun toNativeObject(runtimeContext: RuntimeContext): SharedObject {
     return runtimeContext.sharedObjectRegistry.toNativeObject(this)
   }
 
-  fun toJavaScriptObject(runtimeContext: RuntimeContext): JavaScriptObject? {
-    val nativeObject = toNativeObject(runtimeContext) ?: return null
-    return runtimeContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
+  fun toNativeObjectOrNull(runtimeContext: RuntimeContext): SharedObject? {
+    return runtimeContext.sharedObjectRegistry.toNativeObjectOrNull(this)
   }
 
-  fun toWeakJavaScriptObject(runtimeContext: RuntimeContext): JavaScriptWeakObject? {
-    val nativeObject = toNativeObject(runtimeContext) ?: return null
-    return runtimeContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
+  fun toJavaScriptObjectNull(runtimeContext: RuntimeContext): JavaScriptObject? {
+    val nativeObject = toNativeObjectOrNull(runtimeContext) ?: return null
+    return runtimeContext.sharedObjectRegistry.toJavaScriptObjectOrNull(nativeObject)
+  }
+
+  fun toWeakJavaScriptObjectNull(runtimeContext: RuntimeContext): JavaScriptWeakObject? {
+    val nativeObject = toNativeObjectOrNull(runtimeContext) ?: return null
+    return runtimeContext.sharedObjectRegistry.toWeakJavaScriptObjectOrNull(nativeObject)
   }
 }
 
@@ -105,13 +93,18 @@ class SharedObjectRegistry(runtimeContext: RuntimeContext) {
     }
   }
 
-  internal fun toNativeObject(id: SharedObjectId): SharedObject? {
+  internal fun toNativeObject(id: SharedObjectId): SharedObject {
+    val native = pairs[id.ensureWasNotRelease()]?.first
+    return native ?: throw InvalidSharedObjectIdException()
+  }
+
+  internal fun toNativeObjectOrNull(id: SharedObjectId): SharedObject? {
     return synchronized(this) {
       pairs[id]?.first
     }
   }
 
-  internal fun toNativeObject(js: JavaScriptObject): SharedObject? {
+  internal fun toNativeObjectOrNull(js: JavaScriptObject): SharedObject? {
     if (!js.hasProperty(sharedObjectIdPropertyName)) {
       return null
     }
@@ -120,15 +113,21 @@ class SharedObjectRegistry(runtimeContext: RuntimeContext) {
     return pairs[id]?.first
   }
 
-  internal fun toJavaScriptObject(native: SharedObject): JavaScriptObject? {
+  internal fun toJavaScriptObjectOrNull(native: SharedObject): JavaScriptObject? {
     return synchronized(this) {
       pairs[native.sharedObjectId]?.second?.lock()
     }
   }
 
-  internal fun toWeakJavaScriptObject(nativeObject: SharedObject): JavaScriptWeakObject? {
+  internal fun toWeakJavaScriptObjectOrNull(nativeObject: SharedObject): JavaScriptWeakObject? {
     return synchronized(this) {
       pairs[nativeObject.sharedObjectId]?.second
+    }
+  }
+
+  private fun SharedObjectId.ensureWasNotRelease() = apply {
+    if (!pairs.contains(this) && value != 0 && value < currentId.value) {
+      throw UsingReleasedSharedObjectException()
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -3,7 +3,7 @@ package expo.modules.kotlin.sharedobjects
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.IncorrectRefTypeException
-import expo.modules.kotlin.exception.InvalidSharedObjectException
+import expo.modules.kotlin.exception.InvalidSharedObjectTypeException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.toStrongReference
@@ -27,9 +27,7 @@ class SharedObjectTypeConverter<T : SharedObject>(
     )
 
     val appContext = context.toStrongReference()
-    val result = id.toNativeObject(appContext)
-      ?: throw InvalidSharedObjectException(type)
-
+    val result = id.toNativeObject(appContext.hostingRuntimeContext)
     return result as T
   }
 
@@ -69,7 +67,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
   override fun convertNonOptional(value: Any, context: AppContext?): T {
     val sharedObject = sharedObjectTypeConverter.convert(value, context)
     if (sharedObject !is SharedRef<*>) {
-      throw InvalidSharedObjectException(type)
+      throw InvalidSharedObjectTypeException(type)
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
# Why

Throws a descriptive error when the user tries to use a released `SharedObject`.

# How

Changed how the `SharedObjectTypeConverter` works. Now it detects if the provided id was used before, but it's no longer valid. 

# Test Plan

- bare-expo ✅ 