### PR TITLE
[core][Android] Cleanup the `NativeModulesProxy`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/FabricComponentsRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/FabricComponentsRegistry.kt
@@ -10,14 +10,12 @@ import expo.modules.core.interfaces.DoNotStrip
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class FabricComponentsRegistry(viewManagerList: List<ViewManager<*, *>>) {
-  private val componentNames: List<String>
+  private val componentNames: List<String> = viewManagerList.map { it.name }
 
   @DoNotStrip
-  private val mHybridData: HybridData
+  private val mHybridData = initHybrid()
 
   init {
-    componentNames = viewManagerList.map { it.name }
-    mHybridData = initHybrid()
     registerComponentsRegistry(componentNames.toTypedArray())
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -1,7 +1,5 @@
 package expo.modules.adapters.react;
 
-import android.util.SparseArray;
-
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -10,7 +8,6 @@ import com.facebook.react.bridge.ReadableArray;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,23 +31,15 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   private final static String MODULES_CONSTANTS_KEY = "modulesConstants";
   private final static String EXPORTED_METHODS_KEY = "exportedMethods";
 
-  private final static String METHOD_INFO_KEY = "key";
-  private final static String METHOD_INFO_NAME = "name";
-
-  private final static String UNEXPECTED_ERROR = "E_UNEXPECTED_ERROR";
   private final static String UNDEFINED_METHOD_ERROR = "E_UNDEFINED_METHOD";
 
   private ModuleRegistry mModuleRegistry;
-  private Map<String, Map<String, Integer>> mExportedMethodsKeys;
-  private Map<String, SparseArray<String>> mExportedMethodsReverseKeys;
   private KotlinInteropModuleRegistry mKotlinInteropModuleRegistry;
   private Map<String, Object> cachedConstants;
 
   public NativeModulesProxy(ReactApplicationContext context, ModuleRegistry moduleRegistry) {
     super(context);
     mModuleRegistry = moduleRegistry;
-    mExportedMethodsKeys = new HashMap<>();
-    mExportedMethodsReverseKeys = new HashMap<>();
 
     mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
       Objects.requireNonNull(ExpoModulesHelper.Companion.getModulesProvider()),
@@ -62,8 +51,6 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   public NativeModulesProxy(ReactApplicationContext context, ModuleRegistry moduleRegistry, ModulesProvider modulesProvider) {
     super(context);
     mModuleRegistry = moduleRegistry;
-    mExportedMethodsKeys = new HashMap<>();
-    mExportedMethodsReverseKeys = new HashMap<>();
 
     mKotlinInteropModuleRegistry = new KotlinInteropModuleRegistry(
       Objects.requireNonNull(modulesProvider),
@@ -116,10 +103,6 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
    * is a method's constant key.
    */
   @ReactMethod
-  public void callMethod(String moduleName, int methodKey, ReadableArray arguments, final Promise promise) {
-    callMethod(moduleName, mExportedMethodsReverseKeys.get(moduleName).get(methodKey), arguments, promise);
-  }
-
   public void callMethod(String moduleName, String methodName, ReadableArray arguments, final Promise promise) {
     if (mKotlinInteropModuleRegistry.hasModule(moduleName)) {
       mKotlinInteropModuleRegistry.callMethod(moduleName, methodName, arguments, new KPromiseWrapper(promise));
@@ -130,40 +113,6 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
       UNDEFINED_METHOD_ERROR,
       "Method " + methodName + " of Java module " + moduleName + " is undefined."
     );
-  }
-
-  /**
-   * Assigns keys to exported method infos and updates {@link #mExportedMethodsKeys} and {@link #mExportedMethodsReverseKeys}.
-   * Mutates maps in provided list.
-   */
-  private void assignExportedMethodsKeys(String moduleName, List<Map<String, Object>> exportedMethodsInfos) {
-    if (mExportedMethodsKeys.get(moduleName) == null) {
-      mExportedMethodsKeys.put(moduleName, new HashMap<String, Integer>());
-    }
-
-    if (mExportedMethodsReverseKeys.get(moduleName) == null) {
-      mExportedMethodsReverseKeys.put(moduleName, new SparseArray<String>());
-    }
-
-    for (int i = 0; i < exportedMethodsInfos.size(); i++) {
-      Map<String, Object> methodInfo = exportedMethodsInfos.get(i);
-
-      if (methodInfo.get(METHOD_INFO_NAME) == null || !(methodInfo.get(METHOD_INFO_NAME) instanceof String)) {
-        throw new RuntimeException("No method name in MethodInfo - " + methodInfo.toString());
-      }
-
-      String methodName = (String) methodInfo.get(METHOD_INFO_NAME);
-      Integer maybePreviousIndex = mExportedMethodsKeys.get(moduleName).get(methodName);
-      if (maybePreviousIndex == null) {
-        int key = mExportedMethodsKeys.get(moduleName).values().size();
-        methodInfo.put(METHOD_INFO_KEY, key);
-        mExportedMethodsKeys.get(moduleName).put(methodName, key);
-        mExportedMethodsReverseKeys.get(moduleName).put(key, methodName);
-      } else {
-        int key = maybePreviousIndex;
-        methodInfo.put(METHOD_INFO_KEY, key);
-      }
-    }
   }
 
   @Override

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -12,18 +12,17 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
-import expo.modules.interfaces.permissions.Permissions
-import expo.modules.interfaces.permissions.PermissionsResponse
-import expo.modules.interfaces.permissions.PermissionsResponseListener
-import expo.modules.interfaces.permissions.PermissionsStatus
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.Promise
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.core.interfaces.InternalModule
 import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.UIManager
+import expo.modules.interfaces.permissions.Permissions
+import expo.modules.interfaces.permissions.PermissionsResponse
+import expo.modules.interfaces.permissions.PermissionsResponseListener
+import expo.modules.interfaces.permissions.PermissionsStatus
 import java.util.*
-import kotlin.collections.HashMap
 
 private const val PERMISSIONS_REQUEST: Int = 13
 private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/KotlinUtilities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/KotlinUtilities.kt
@@ -20,4 +20,4 @@ inline fun <T> T?.ifNull(block: () -> T): T = this ?: block()
  *   val y = (a.b as? Number)?.someMethod() // same, but needs parenthesis
  * ```
  */
-inline fun <reified T> Any?.takeIfInstanceOf(): T? = if (this is T) this else null
+inline fun <reified T> Any?.takeIfInstanceOf(): T? = this as? T


### PR DESCRIPTION
# Why

Removes some unused methods from `NativeModulesProxy` and other classes from `e-m-c`.