### PR TITLE
[doctor] Show more info on network errors, allow overriding of network errors

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Show more info on network errors, allow overriding of network errors ([#31926](https://github.com/expo/expo/pull/31926) by [@keith-kurak](https://github.com/keith-kurak))
+
 - Add support for `.easignore` files when performing project validations. ([#31334](https://github.com/expo/expo/pull/31334) by [@betomoedano](https://github.com/betomoedano))
 
 ### 🐛 Bug fixes

--- a/packages/expo-doctor/src/__tests__/doctor.test.ts
+++ b/packages/expo-doctor/src/__tests__/doctor.test.ts
@@ -200,6 +200,23 @@ describe(printCheckResultSummaryOnComplete, () => {
     expect(jest.mocked(Log.error).mock.calls[0][0]).toContain('Unexpected error while running');
     expect(jest.mocked(Log.exception).mock.calls[0][0].message).toContain('Some error');
   });
+
+  it(`Prints the error cause if check throws a network error`, () => {
+    jest.mocked(Log.error).mockReset();
+    jest.mocked(Log.exception).mockReset();
+    const error = new Error('ENOTFOUND');
+    // @ts-ignore
+    error.cause = { code: 'ENOTFOUND' };
+    // @ts-ignore
+    error.cause.toString = () => 'ENOTFOUND';
+    printCheckResultSummaryOnComplete({
+      result: { isSuccessful: false, issues: [], advice: '' },
+      check: new MockFailedCheck(),
+      duration: 0,
+      error,
+    });
+    expect(jest.mocked(Log.error).mock.calls[1][0]).toContain('ENOTFOUND');
+  });
 });
 
 describe(printFailedCheckIssueAndAdvice, () => {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -67,9 +67,9 @@ export async function printCheckResultSummaryOnComplete(job: DoctorCheckRunnerJo
       Log.error(
         'This check requires a connection to the Expo API. Please check your network connection.'
       );
-      if (env.EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES) {
+      if (env.EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS) {
         Log.warn(
-          'EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES is enabled. Ignoring network error for this check.'
+          'EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS is enabled. Ignoring network error for this check.'
         );
       }
     }
@@ -208,11 +208,11 @@ export async function actionAsync(projectRoot: string) {
       failedJobs.forEach((job) => printFailedCheckIssueAndAdvice(job));
     }
     // check if all checks failed due to a network error if the flag to override network errors is enabled
-    if (env.EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES) {
+    if (env.EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS) {
       const failedJobsDueToNetworkError = failedJobs.filter((job) => isNetworkError(job.error));
       if (failedJobsDueToNetworkError.length === failedJobs.length) {
         Log.warn(
-          'One or more checks failed due to network errors, but EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES is enabled, so these errors will not fail Doctor. Run Doctor to retry these checks once the network is available.'
+          'One or more checks failed due to network errors, but EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS is enabled, so these errors will not fail Doctor. Run Doctor to retry these checks once the network is available.'
         );
         return;
       }

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -20,13 +20,13 @@ import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck'
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
 import { getReactNativeDirectoryCheckEnabled } from './utils/doctorConfig';
 import { env } from './utils/env';
+import { isNetworkError } from './utils/errors';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
 import { logNewSection } from './utils/ora';
 import { endTimer, formatMilliseconds, startTimer } from './utils/timer';
 import { ltSdkVersion } from './utils/versions';
 import { warnUponCmdExe } from './warnings/windows';
-import { isNetworkError } from './utils/errors';
 
 interface DoctorCheckRunnerJob {
   check: DoctorCheck;

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -212,7 +212,7 @@ export async function actionAsync(projectRoot: string) {
       const failedJobsDueToNetworkError = failedJobs.filter((job) => isNetworkError(job.error));
       if (failedJobsDueToNetworkError.length === failedJobs.length) {
         Log.warn(
-          'One or more checks failed due to network errors, but EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES is enabled. Run Doctor to retry these checks once the network is available.'
+          'One or more checks failed due to network errors, but EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES is enabled, so these errors will not fail Doctor. Run Doctor to retry these checks once the network is available.'
         );
         return;
       }

--- a/packages/expo-doctor/src/utils/__tests__/errors.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,20 @@
+import { isNetworkError } from '../errors';
+
+describe(isNetworkError, () => {
+  it('returns true for ENOTFOUND', () => {
+    const error = new Error('ENOTFOUND');
+    // @ts-ignore
+    error.cause = { code: 'ENOTFOUND' };
+    expect(isNetworkError(error)).toBe(true);
+  });
+
+  it('returns true for generic network error message', () => {
+    const error = new Error('fetch failed');
+    expect(isNetworkError(error)).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    const error = new Error('Something went wrong');
+    expect(isNetworkError(error)).toBe(false);
+  });
+});

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -31,8 +31,8 @@ class Env {
   }
 
   /** If a test makes an online check and failures due to a network error, don't count it as failing the overall doctor check */
-  get EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES() {
-    return boolish('EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES', false);
+  get EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS() {
+    return boolish('EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS', false);
   }
 }
 

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -29,6 +29,11 @@ class Env {
 
     return boolish('EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', false);
   }
+
+  /** If a test makes an online check and failures due to a network error, don't count it as failing the overall doctor check */
+  get EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES() {
+    return boolish('EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES', false);
+  }
 }
 
 export const env = new Env();

--- a/packages/expo-doctor/src/utils/errors.ts
+++ b/packages/expo-doctor/src/utils/errors.ts
@@ -1,0 +1,17 @@
+export function isNetworkError(error: any): boolean {
+  if (error instanceof Error) {
+    // 1. look for explicit ENOTFOUND
+    if (
+      error.cause &&
+      typeof error.cause === 'object' &&
+      'code' in error.cause &&
+      typeof error.cause.code === 'string' &&
+      error.cause.code === 'ENOTFOUND'
+    ) {
+      return true;
+    }
+    // 2. look for generic network error message
+    return error.message.includes('fetch failed');
+  }
+  return false;
+}


### PR DESCRIPTION
# Why
Some of the doctor checks depend on the versions/ schema endpoints. They can fail for... reasons.
The errors don't actually have that much info attached to them, but we can show a little more (note that it will show a full trace with `EXPO_DEBUG=1`, even before this change).

Also, some people run Doctor in CI, and they don't really want their CI to fail because it couldn't check the network at this time, so suggesting a flag to allow this.

# How
- Add more network error info and put it under test
- Added `EXPO_DOCTOR_OVERRIDE_NETWORK_ERROR_FAILURES` flag to turn these errors into warnings and not fail doctor if only network errors occur (separate commit in case we don't want that).

# Test Plan

<img width="850" alt="image" src="https://github.com/user-attachments/assets/ef9adc53-6030-4069-a909-01e095f0ca1c">
<img width="996" alt="image" src="https://github.com/user-attachments/assets/2c4c9d81-9285-47bd-9da3-bdf759d3c6b1">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
