### PR TITLE
remove default babel config

### DIFF
--- a/templates/expo-template-bare-minimum/babel.config.js
+++ b/templates/expo-template-bare-minimum/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo']
-  };
-};

--- a/templates/expo-template-blank-typescript/babel.config.js
+++ b/templates/expo-template-blank-typescript/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/templates/expo-template-blank/babel.config.js
+++ b/templates/expo-template-blank/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/templates/expo-template-default/babel.config.js
+++ b/templates/expo-template-default/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/templates/expo-template-tabs/babel.config.js
+++ b/templates/expo-template-tabs/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo']
-  };
-};


### PR DESCRIPTION
# Why

We haven't needed a babel.config.js file with defaults for a while now. Because Metro doesn't consider the contents of the babel.config.js in the transform cache, it can lead to unexpected errors if the user customizes the file without a reasonable understanding in how the bundler works.

The primary uses of the `babel.config.js` in the past have been to add TS paths support, environment variables, and reanimated. All of these features are built-in to Expo CLI by default now.

Users can still expose the babel config by running `npx expo customize babel.config.js`.
