### PR TITLE
[expo-updates] Refactor errors and logged info

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -105,6 +105,7 @@
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`. ([#31921](https://github.com/expo/expo/pull/31921) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Throws a descriptive error when trying to use a released `SharedObject`. ([#31922](https://github.com/expo/expo/pull/31922) by [@lukmccall](https://github.com/lukmccall))
+- Include error cause message in logger ([#31929](https://github.com/expo/expo/pull/31929) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/LoggerUtils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/LoggerUtils.kt
@@ -1,0 +1,5 @@
+package expo.modules.core.logging
+
+fun Throwable.localizedMessageWithCauseLocalizedMessage(): String {
+  return listOfNotNull(localizedMessage, cause?.localizedMessageWithCauseLocalizedMessage()).joinToString(": ")
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
@@ -12,7 +12,7 @@ internal class OSLogHandler(
     if (!isAndroid) {
       println("[${type.type}] $category\t$message")
       cause?.let {
-        println("${it.localizedMessage}\n${cause.stackTraceToString()}")
+        println("${it.localizedMessageWithCauseLocalizedMessage()}\n${cause.stackTraceToString()}")
       }
       return
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogHandler.kt
@@ -16,7 +16,7 @@ internal class PersistentFileLogHandler(
   override fun log(type: LogType, message: String, cause: Throwable?) {
     persistentFileLog.appendEntry(message)
     cause?.let {
-      persistentFileLog.appendEntry("${cause.localizedMessage}\n${cause.stackTraceToString()}")
+      persistentFileLog.appendEntry("${cause.localizedMessageWithCauseLocalizedMessage()}\n${cause.stackTraceToString()}")
     }
   }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 - Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818, [#31854](https://github.com/expo/expo/pull/31854) by [@wschurman](https://github.com/wschurman))
 - Remove clearUpdateCacheExperimentalAsync ([#31871](https://github.com/expo/expo/pull/31871) by [@wschurman](https://github.com/wschurman))
+- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -3,6 +3,7 @@ package expo.modules.updates.loader
 import android.net.Uri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.core.logging.localizedMessageWithCauseLocalizedMessage
 import expo.modules.updates.TestUtils.asJSONResponse
 import expo.modules.updates.TestUtils.asResponse
 import expo.modules.updates.UpdatesConfiguration
@@ -45,7 +46,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -90,7 +91,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -136,7 +137,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -181,7 +182,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = e
         }
 
@@ -191,7 +192,7 @@ class FileDownloaderManifestParsingTest {
       }
     )
 
-    Assert.assertEquals("Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the update being a rollback or other directive.", errorOccurred!!.message)
+    Assert.assertEquals("Invalid update response: Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the response being for a different protocol version.", errorOccurred!!.localizedMessageWithCauseLocalizedMessage())
     Assert.assertNull(resultUpdate)
   }
 
@@ -219,7 +220,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -262,7 +263,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -305,7 +306,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -348,7 +349,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -390,7 +391,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = e
         }
 
@@ -400,7 +401,7 @@ class FileDownloaderManifestParsingTest {
       }
     )
 
-    Assert.assertEquals("Missing body in remote update", errorOccurred!!.message)
+    Assert.assertEquals("Invalid update response: Empty body", errorOccurred!!.localizedMessageWithCauseLocalizedMessage())
     Assert.assertNull(resultUpdate)
   }
 
@@ -432,7 +433,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -499,7 +500,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -545,7 +546,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = e
         }
 
@@ -555,7 +556,7 @@ class FileDownloaderManifestParsingTest {
       }
     )
 
-    Assert.assertEquals("No expo-signature header specified", errorOccurred!!.message)
+    Assert.assertEquals("Code signing verification failed for manifest: No expo-signature header specified", errorOccurred!!.localizedMessageWithCauseLocalizedMessage())
     Assert.assertNull(resultUpdate)
   }
 
@@ -618,7 +619,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 
@@ -688,7 +689,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = e
         }
 
@@ -698,7 +699,7 @@ class FileDownloaderManifestParsingTest {
       }
     )
 
-    Assert.assertEquals("Invalid certificate for manifest project ID or scope key", errorOccurred!!.message)
+    Assert.assertEquals("Code signing verification failed for manifest: Code signing certificate project ID or scope key does not match project ID or scope key in response", errorOccurred!!.localizedMessageWithCauseLocalizedMessage())
     Assert.assertNull(resultUpdate)
   }
 
@@ -751,7 +752,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = e
         }
 
@@ -761,7 +762,7 @@ class FileDownloaderManifestParsingTest {
       }
     )
 
-    Assert.assertEquals("Invalid certificate for directive project ID or scope key", errorOccurred!!.message)
+    Assert.assertEquals("Code signing verification failed for directive: Code signing certificate project ID or scope key does not match project ID or scope key in response part", errorOccurred!!.localizedMessageWithCauseLocalizedMessage())
     Assert.assertNull(resultUpdateResponse)
   }
 
@@ -792,7 +793,7 @@ class FileDownloaderManifestParsingTest {
     FileDownloader(context, configuration).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
+        override fun onFailure(e: Exception) {
           errorOccurred = true
         }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.core.logging.localizedMessageWithCauseLocalizedMessage
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
@@ -247,7 +248,7 @@ class FileDownloaderTest {
       }
     )
 
-    Assert.assertTrue(error!!.message!!.contains("File download was successful but base64url-encoded SHA-256 did not match expected"))
+    Assert.assertTrue(error!!.localizedMessageWithCauseLocalizedMessage()!!.contains("File download was successful but base64url-encoded SHA-256 did not match expected"))
     Assert.assertFalse(didSucceed)
   }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -114,7 +114,8 @@ class UpdatesLoggingTest {
     logger.info("Message 1", UpdatesErrorCode.None)
     asyncTestUtil.waitForTimeout(500)
     val secondTime = Date()
-    logger.error("Message 2", UpdatesErrorCode.NoUpdatesAvailable)
+    val cause = Exception("test")
+    logger.error("Message 2", cause, UpdatesErrorCode.NoUpdatesAvailable)
     asyncTestUtil.waitForTimeout(500)
     val thirdTime = Date()
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -148,7 +148,7 @@ interface IUpdatesController {
     class NoUpdateAvailable(val reason: LoaderTask.RemoteCheckResultNotAvailableReason) : CheckForUpdateResult(Status.NO_UPDATE_AVAILABLE)
     class UpdateAvailable(val update: Update) : CheckForUpdateResult(Status.UPDATE_AVAILABLE)
     class RollBackToEmbedded(val commitTime: Date) : CheckForUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
-    class ErrorResult(val error: Exception, val message: String) : CheckForUpdateResult(Status.ERROR)
+    class ErrorResult(val error: Exception) : CheckForUpdateResult(Status.ERROR)
   }
   fun checkForUpdate(callback: ModuleCallback<CheckForUpdateResult>)
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -51,7 +51,8 @@ class UpdatesController {
         UpdatesUtils.getOrCreateUpdatesDirectory(context)
       } catch (e: Exception) {
         logger.error(
-          "The expo-updates system is disabled due to a storage access error: ${e.message}",
+          "The expo-updates system is disabled due to a storage access error",
+          e,
           UpdatesErrorCode.InitializationError
         )
         singletonInstance = DisabledUpdatesController(context, e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
-import android.util.Log
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
@@ -76,8 +75,7 @@ class UpdatesModule : Module() {
           override fun onSuccess(result: IUpdatesController.CheckForUpdateResult) {
             when (result) {
               is IUpdatesController.CheckForUpdateResult.ErrorResult -> {
-                promise.reject("ERR_UPDATES_CHECK", result.message, result.error)
-                Log.e(TAG, result.message, result.error)
+                promise.reject("ERR_UPDATES_CHECK", "Failed to check for update", result.error)
               }
               is IUpdatesController.CheckForUpdateResult.NoUpdateAvailable -> {
                 promise.resolve(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -67,7 +67,7 @@ class ErrorRecovery(
   }
 
   internal fun handleException(exception: Exception) {
-    logger.error("ErrorRecovery: exception encountered: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
+    logger.error("ErrorRecovery: exception encountered: ${exception.localizedMessage}", exception, UpdatesErrorCode.Unknown)
     handler.sendMessage(handler.obtainMessage(ErrorRecoveryHandler.MessageType.EXCEPTION_ENCOUNTERED, exception))
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecoveryHandler.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecoveryHandler.kt
@@ -107,7 +107,7 @@ internal class ErrorRecoveryHandler(
         tryRelaunchFromCache()
       }
       Task.CRASH -> {
-        logger.error("UpdatesErrorRecovery: could not recover from error, crashing", UpdatesErrorCode.Unknown)
+        logger.error("UpdatesErrorRecovery: could not recover from error, crashing", encounteredErrors[0], UpdatesErrorCode.Unknown)
         crash()
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/QueueUpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/QueueUpdatesEventManager.kt
@@ -31,7 +31,7 @@ class QueueUpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEven
 
     if (!shouldEmitJsEvents) {
       eventsToSendToJS.add(Pair(eventName, params))
-      logger.error(
+      logger.warn(
         "Could not emit $eventName ${eventType.type} event; no subscribers registered.",
         UpdatesErrorCode.JSRuntimeError
       )
@@ -41,7 +41,7 @@ class QueueUpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEven
     val eventEmitter = eventEmitter
     if (eventEmitter == null) {
       eventsToSendToJS.add(Pair(eventName, params))
-      logger.error(
+      logger.warn(
         "Could not emit $eventName ${eventType.type} event; no event emitter was found.",
         UpdatesErrorCode.JSRuntimeError
       )
@@ -54,7 +54,8 @@ class QueueUpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEven
     } catch (e: Exception) {
       eventsToSendToJS.add(Pair(eventName, params))
       logger.error(
-        "Could not emit $eventName $eventType event; ${e.message}",
+        "Could not emit $eventName $eventType event",
+        e,
         UpdatesErrorCode.JSRuntimeError
       )
     }
@@ -64,7 +65,8 @@ class QueueUpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEven
   private fun sendQueuedEventsToEventEmitter() {
     val eventEmitter = eventEmitter
     if (eventEmitter == null) {
-      logger.error("Could not emit events; no event emitter was found.", UpdatesErrorCode.JSRuntimeError)
+      val cause = Exception("Null emitter")
+      logger.error("Could not emit events; no event emitter was found.", cause, UpdatesErrorCode.JSRuntimeError)
       return
     }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -60,8 +60,7 @@ class EmbeddedLoader internal constructor(
         )
       )
     } else {
-      val message = "Embedded manifest is null"
-      callback.onFailure(message, Exception(message))
+      callback.onFailure(Exception("Embedded manifest is null"))
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -59,7 +59,7 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
   }
 
   interface RemoteUpdateDownloadCallback {
-    fun onFailure(message: String, e: Exception)
+    fun onFailure(e: Exception)
     fun onSuccess(updateResponse: UpdateResponse)
   }
 
@@ -78,16 +78,18 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
       request,
       object : Callback {
         override fun onFailure(call: Call, e: IOException) {
-          logger.error("Failed to download asset from ${request.url}", UpdatesErrorCode.AssetsFailedToLoad, e)
-          callback.onFailure(e)
+          val message = "Failed to download asset from URL ${request.url}"
+          logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
+          callback.onFailure(IOException(message, e))
         }
 
         @Throws(IOException::class)
         override fun onResponse(call: Call, response: Response) {
           if (!response.isSuccessful) {
-            val error = Exception("Network request failed: " + response.body!!.string())
-            logger.error("Failed to download file from ${request.url}", UpdatesErrorCode.AssetsFailedToLoad, error)
-            callback.onFailure(error)
+            val message = "Asset download request not successful"
+            val cause = IOException(response.body!!.string())
+            logger.error(message, cause, UpdatesErrorCode.AssetsFailedToLoad)
+            callback.onFailure(IOException(message, cause))
             return
           }
           try {
@@ -96,8 +98,9 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
               callback.onSuccess(destination, hash)
             }
           } catch (e: Exception) {
-            logger.error("Failed to write file from ${request.url} to destination $destination", UpdatesErrorCode.AssetsFailedToLoad, e)
-            callback.onFailure(e)
+            val message = "Failed to write asset file from ${request.url} to destination $destination"
+            logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
+            callback.onFailure(IOException(message, e))
           }
         }
       }
@@ -127,12 +130,10 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         return
       }
 
-      val message = "Missing body in remote update"
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(
-        message,
-        IOException(message)
-      )
+      val message = "Invalid update response"
+      val cause = IOException("Empty body")
+      logger.error(message, cause, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, cause))
       return
     }
 
@@ -153,8 +154,8 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         null,
         null,
         object : ParseManifestCallback {
-          override fun onFailure(message: String, e: Exception) {
-            callback.onFailure(message, e)
+          override fun onFailure(e: Exception) {
+            callback.onFailure(e)
           }
 
           override fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart) {
@@ -204,11 +205,8 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
       // okhttp multipart reader doesn't support empty multipart bodies, but our spec does
       if (responseBody.bytes().isNotEmpty()) {
         val message = "Error while reading multipart remote update response"
-        logger.error(message, UpdatesErrorCode.UpdateFailedToLoad, e)
-        callback.onFailure(
-          message,
-          e
-        )
+        logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+        callback.onFailure(IOException(message, e))
         return
       }
     }
@@ -216,20 +214,18 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
     val extensions = try {
       extensionsBody?.let { JSONObject(it) }
     } catch (e: Exception) {
-      val message = "Failed to parse multipart remote update extensions"
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(
-        message,
-        e
-      )
+      val message = "Failed to parse multipart remote update extensions part"
+      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, e))
       return
     }
 
     // in v0 compatibility mode require a manifest
     if (configuration.enableExpoUpdatesProtocolV0CompatibilityMode && manifestPartBodyAndHeaders == null) {
-      val message = "Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the update being a rollback or other directive."
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(message, IOException(message))
+      val message = "Invalid update response"
+      val cause = IOException("Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the response being for a different protocol version.")
+      logger.error(message, cause, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, cause))
       return
     }
 
@@ -286,10 +282,10 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         directiveResponseInfo,
         certificateChainString,
         object : ParseDirectiveCallback {
-          override fun onFailure(message: String, e: Exception) {
+          override fun onFailure(e: Exception) {
             if (!didError) {
               didError = true
-              callback.onFailure(message, e)
+              callback.onFailure(e)
             }
           }
 
@@ -307,10 +303,10 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         extensions,
         certificateChainString,
         object : ParseManifestCallback {
-          override fun onFailure(message: String, e: Exception) {
+          override fun onFailure(e: Exception) {
             if (!didError) {
               didError = true
-              callback.onFailure(message, e)
+              callback.onFailure(e)
             }
           }
           override fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart) {
@@ -328,7 +324,7 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
   }
 
   interface ParseDirectiveCallback {
-    fun onFailure(message: String, e: Exception)
+    fun onFailure(e: Exception)
     fun onSuccess(directiveUpdateResponsePart: UpdateResponsePart.DirectiveUpdateResponsePart)
   }
 
@@ -354,7 +350,7 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
             certificateChainFromManifestResponse
           )
           if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
-            throw IOException("Directive download was successful, but signature was incorrect")
+            throw IOException("Incorrect signature")
           }
 
           if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
@@ -363,29 +359,28 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
               if (expoProjectInformation.projectId != directiveForProjectInformation.signingInfo?.easProjectId ||
                 expoProjectInformation.scopeKey != directiveForProjectInformation.signingInfo.scopeKey
               ) {
-                throw CertificateException("Invalid certificate for directive project ID or scope key")
+                throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response part")
               }
             }
           }
         }
       } catch (e: Exception) {
-        callback.onFailure(e.message!!, e)
+        val message = "Code signing verification failed for directive"
+        logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
+        callback.onFailure(IOException(message, e))
         return
       }
 
       callback.onSuccess(UpdateResponsePart.DirectiveUpdateResponsePart(UpdateDirective.fromJSONString(body)))
     } catch (e: Exception) {
-      val message = "Failed to parse directive data: ${e.localizedMessage}"
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad, e)
-      callback.onFailure(
-        message,
-        e
-      )
+      val message = "Failed to construct directive from response"
+      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, e))
     }
   }
 
   interface ParseManifestCallback {
-    fun onFailure(message: String, e: Exception)
+    fun onFailure(e: Exception)
     fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart)
   }
 
@@ -408,12 +403,9 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         callback = callback
       )
     } catch (e: Exception) {
-      val message = "Failed to parse manifest data: ${e.localizedMessage}"
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad, e)
-      callback.onFailure(
-        message,
-        e
-      )
+      val message = "Failed to construct manifest from response"
+      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, e))
     }
   }
 
@@ -427,23 +419,18 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         createRequestForRemoteUpdate(extraHeaders, configuration, context),
         object : Callback {
           override fun onFailure(call: Call, e: IOException) {
-            val message = "Failed to download remote update from URL: ${configuration.updateUrl}: ${e.localizedMessage}"
-            logger.error(message, UpdatesErrorCode.UpdateFailedToLoad, e)
-            callback.onFailure(
-              message,
-              e
-            )
+            val message = "Failed to download remote update"
+            logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+            callback.onFailure(IOException(message, e))
           }
 
           @Throws(IOException::class)
           override fun onResponse(call: Call, response: Response) {
             if (!response.isSuccessful) {
-              val message = "Failed to download remote update from URL: ${configuration.updateUrl}"
-              logger.error(message, UpdatesErrorCode.UpdateFailedToLoad)
-              callback.onFailure(
-                message,
-                Exception(response.body!!.string())
-              )
+              val message = "Remote update request not successful"
+              val underlyingError = IOException(response.body!!.string())
+              logger.error(message, underlyingError, UpdatesErrorCode.UpdateFailedToLoad)
+              callback.onFailure(IOException(message, underlyingError))
               return
             }
 
@@ -452,12 +439,9 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
         }
       )
     } catch (e: Exception) {
-      val message = "Failed to download remote update from URL: ${configuration.updateUrl}: ${e.localizedMessage}"
-      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad, e)
-      callback.onFailure(
-        message,
-        e
-      )
+      val message = "Failed to download remote update"
+      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(IOException(message, e))
     }
   }
 
@@ -468,9 +452,10 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
     callback: AssetDownloadCallback
   ) {
     if (asset.url == null) {
-      val message = "Could not download asset " + asset.key + " with no URL"
-      logger.error(message, UpdatesErrorCode.AssetsFailedToLoad)
-      callback.onFailure(Exception(message), asset)
+      val message = "Failed to download asset ${asset.key}"
+      val error = Exception("Asset missing URL")
+      logger.error(message, error, UpdatesErrorCode.AssetsFailedToLoad)
+      callback.onFailure(IOException(message, error), asset)
       return
     }
     val filename = UpdatesUtils.createFilenameForAsset(asset)
@@ -498,8 +483,9 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
           }
         )
       } catch (e: Exception) {
-        logger.error("Failed to download asset ${asset.key}: ${e.localizedMessage}", UpdatesErrorCode.AssetsFailedToLoad, e)
-        callback.onFailure(e, asset)
+        val message = "Failed to download asset ${asset.key}"
+        logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
+        callback.onFailure(IOException(message, e), asset)
       }
     }
   }
@@ -526,10 +512,6 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
   }
 
   companion object {
-    // Standard line separator for HTTP.
-    private const val CRLF = "\r\n"
-
-    @Throws(Exception::class)
     private fun checkCodeSigningAndCreateManifest(
       bodyString: String,
       preManifest: JSONObject,
@@ -562,7 +544,7 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
             certificateChainFromManifestResponse
           )
           if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
-            throw IOException("Manifest download was successful, but signature was incorrect")
+            throw IOException("Incorrect signature")
           }
 
           if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
@@ -576,25 +558,24 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
               if (expoProjectInformation.projectId != manifestForProjectInformation.getEASProjectID() ||
                 expoProjectInformation.scopeKey != manifestForProjectInformation.getScopeKey()
               ) {
-                throw CertificateException("Invalid certificate for manifest project ID or scope key")
+                throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response")
               }
             }
 
-            logger.info("Update code signature verified successfully")
+            logger.info("Manifest code signing signature verified successfully")
             preManifest.put("isVerified", true)
           }
         }
       } catch (e: Exception) {
-        logger.error(e.message!!, UpdatesErrorCode.UpdateCodeSigningError)
-        callback.onFailure(e.message!!, e)
+        val message = "Code signing verification failed for manifest"
+        logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
+        callback.onFailure(IOException(message, e))
         return
       }
 
       val update = UpdateFactory.getUpdate(preManifest, responseHeaderData, extensions, configuration)
       if (!SelectionPolicies.matchesFilters(update.updateEntity!!, responseHeaderData.manifestFilters)) {
-        val message =
-          "Downloaded manifest is invalid; provides filters that do not match its content"
-        callback.onFailure(message, Exception(message))
+        callback.onFailure(Exception("Manifest filters that do not manifest content for downloaded manifest"))
       } else {
         callback.onSuccess(UpdateResponsePart.ManifestUpdateResponsePart(update))
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -13,6 +13,7 @@ import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.Update
 import java.io.File
+import java.io.IOException
 import java.util.*
 
 /**
@@ -101,8 +102,8 @@ abstract class Loader protected constructor(
       database,
       configuration,
       object : RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
-          finishWithError(message, e)
+        override fun onFailure(e: Exception) {
+          finishWithException(e)
         }
 
         override fun onSuccess(updateResponse: UpdateResponse) {
@@ -157,8 +158,8 @@ abstract class Loader protected constructor(
     reset()
   }
 
-  private fun finishWithError(message: String, e: Exception) {
-    Log.e(TAG, message, e)
+  private fun finishWithException(e: Exception) {
+    Log.e(TAG, e.message!!)
     if (callback == null) {
       Log.e(
         TAG,
@@ -317,12 +318,12 @@ abstract class Loader protected constructor(
           database.updateDao().markUpdateFinished(updateEntity!!)
         }
       } catch (e: Exception) {
-        finishWithError("Error while adding new update to database", e)
+        finishWithException(IOException("Error while adding new update to database", e))
         return
       }
 
       if (erroredAssetList.size > 0) {
-        finishWithError("Failed to load all assets", Exception("Failed to load all assets"))
+        finishWithException(Exception("Failed to load all assets"))
       } else {
         finishWithSuccess()
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.procedures
 
 import android.content.Context
 import android.os.AsyncTask
+import expo.modules.core.logging.localizedMessageWithCauseLocalizedMessage
 import expo.modules.updates.IUpdatesController
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
@@ -43,9 +44,9 @@ class CheckForUpdateProcedure(
         extraHeaders,
         context,
         object : FileDownloader.RemoteUpdateDownloadCallback {
-          override fun onFailure(message: String, e: Exception) {
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckError(message))
-            callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e, message))
+          override fun onFailure(e: Exception) {
+            procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))
+            callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e))
             procedureContext.onComplete()
           }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -85,7 +85,7 @@ class StartupProcedure(
     selectionPolicy,
     object : LoaderTask.LoaderTaskCallback {
       override fun onFailure(e: Exception) {
-        logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
+        logger.error("UpdatesController loaderTask onFailure", e, UpdatesErrorCode.None)
         launcher = NoDatabaseLauncher(context, e)
         emergencyLaunchException = e
         notifyController()
@@ -155,7 +155,7 @@ class StartupProcedure(
             if (exception == null) {
               throw AssertionError("Background update with error status must have a nonnull exception object")
             }
-            logger.error("UpdatesController onBackgroundUpdateFinished: Error: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
+            logger.error("UpdatesController onBackgroundUpdateFinished", exception, UpdatesErrorCode.Unknown)
             remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
 
             // Since errors can happen through a number of paths, we do these checks
@@ -192,7 +192,7 @@ class StartupProcedure(
           }
           LoaderTask.RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {
             remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-            logger.error("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
+            logger.info("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
             // TODO: handle rollbacks properly, but this works for now
             if (procedureContext.getCurrentState() == UpdatesStateValue.Downloading) {
               procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
@@ -246,7 +246,7 @@ class StartupProcedure(
         val remoteLoader = RemoteLoader(context, updatesConfiguration, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
         remoteLoader.start(object : Loader.LoaderCallback {
           override fun onFailure(e: Exception) {
-            logger.error("UpdatesController loadRemoteUpdate onFailure: ${e.localizedMessage}", UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
+            logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
             setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
             databaseHolder.releaseDatabase()
           }


### PR DESCRIPTION
# Why

The overarching goal of this stack of PRs is to expose more detailed information in errors, and to ensure all errors are logged consistently.

The idea behind this PR is simple: all `UpdatesLogger.error`/`UpdatesLogger.fatal` calls should have an exception (cause) in addition to a message. This matches our use within the library fairly well and ensures

The secondary goal of this is to print more info about the error in the logger, including the cause.

# How

1. Change signature of `UpdatesLogger.error`/`UpdatesLogger.fatal` to require error.
2. Create a new `Throwable. localizedMessageWithCauseLocalizedMessage` recursive message to get the localized message with all cause localized messages concatenated recursively. This should help with incomplete error info being logged on non-android platforms.

# Test Plan

Run all integration tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
