### PR TITLE
[doctor] Enable new architecture directory check by default in SDK 52+

### DIFF
--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -139,7 +139,7 @@ export function getChecksInScopeForProject(exp: ExpoConfig, pkg: PackageJSONConf
     new StoreCompatibilityCheck(),
   ];
 
-  if (getReactNativeDirectoryCheckEnabled(pkg)) {
+  if (getReactNativeDirectoryCheckEnabled(exp, pkg)) {
     chalk.yellow(
       'Enabled experimental React Native Directory checks. Unset the EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK environment variable to disable this check.'
     );

--- a/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
@@ -4,6 +4,12 @@ import {
   getReactNativeDirectoryCheckListUnknownPackagesEnabled,
 } from '../doctorConfig';
 
+const exp = {
+  name: 'App',
+  slug: 'app',
+  sdkVersion: '51.0.0',
+};
+
 describe('getReactNativeDirectoryCheckExcludes', () => {
   it('returns an empty array if no config is present', () => {
     expect(getReactNativeDirectoryCheckExcludes({})).toEqual([]);
@@ -38,12 +44,12 @@ describe('getReactNativeDirectoryCheckExcludes', () => {
 
 describe('getReactNativeDirectoryCheckEnabled', () => {
   it('returns false if the config is empty', () => {
-    expect(getReactNativeDirectoryCheckEnabled({ expo: { doctor: {} } })).toBe(false);
+    expect(getReactNativeDirectoryCheckEnabled(exp, { expo: { doctor: {} } })).toBe(false);
   });
 
   it('returns true if the config is enabled', () => {
     expect(
-      getReactNativeDirectoryCheckEnabled({
+      getReactNativeDirectoryCheckEnabled(exp, {
         expo: { doctor: { reactNativeDirectoryCheck: { enabled: true } } },
       })
     ).toBe(true);
@@ -51,7 +57,7 @@ describe('getReactNativeDirectoryCheckEnabled', () => {
 
   it('reads from env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', () => {
     process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK = '1';
-    expect(getReactNativeDirectoryCheckEnabled({ expo: { doctor: {} } })).toBe(true);
+    expect(getReactNativeDirectoryCheckEnabled(exp, { expo: { doctor: {} } })).toBe(true);
     delete process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK;
   });
 
@@ -61,7 +67,7 @@ describe('getReactNativeDirectoryCheckEnabled', () => {
 
     process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK = '0';
     expect(
-      getReactNativeDirectoryCheckEnabled({
+      getReactNativeDirectoryCheckEnabled(exp, {
         expo: { doctor: { reactNativeDirectoryCheck: { enabled: true } } },
       })
     ).toBe(false);
@@ -72,6 +78,40 @@ describe('getReactNativeDirectoryCheckEnabled', () => {
     );
 
     console.warn = originalConsoleWarn;
+  });
+
+  it('defaults to disabled if sdk version is < 52.0.0', () => {
+    expect(
+      getReactNativeDirectoryCheckEnabled(
+        {
+          ...exp,
+          sdkVersion: '51.0.0',
+        },
+        { expo: { doctor: {} } }
+      )
+    ).toBe(false);
+  });
+
+  it('defaults to enabled if sdk version is >= 52.0.0', () => {
+    expect(
+      getReactNativeDirectoryCheckEnabled(
+        {
+          ...exp,
+          sdkVersion: '52.0.0',
+        },
+        { expo: { doctor: {} } }
+      )
+    ).toBe(true);
+
+    expect(
+      getReactNativeDirectoryCheckEnabled(
+        {
+          ...exp,
+          sdkVersion: 'UNVERSIONED',
+        },
+        { expo: { doctor: {} } }
+      )
+    ).toBe(true);
   });
 });
 

--- a/packages/expo-doctor/src/utils/doctorConfig.ts
+++ b/packages/expo-doctor/src/utils/doctorConfig.ts
@@ -1,4 +1,7 @@
+import { ExpoConfig, PackageJSONConfig } from '@expo/config';
+
 import { env } from './env';
+import { gteSdkVersion } from './versions';
 
 /**
  * Get the doctor config from the package.json.
@@ -39,7 +42,8 @@ export function getReactNativeDirectoryCheckExcludes(pkg: any) {
   });
 }
 
-export function getReactNativeDirectoryCheckEnabled(pkg: any) {
+export function getReactNativeDirectoryCheckEnabled(exp: ExpoConfig, pkg: PackageJSONConfig) {
+  const isEnabledByDefault = gteSdkVersion(exp, '52.0.0');
   const pkgJsonConfigSetting = getDoctorConfig(pkg).reactNativeDirectoryCheck?.enabled;
 
   if (env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK !== null) {
@@ -52,7 +56,7 @@ export function getReactNativeDirectoryCheckEnabled(pkg: any) {
     return env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK;
   }
 
-  return pkgJsonConfigSetting ?? false;
+  return pkgJsonConfigSetting ?? isEnabledByDefault;
 }
 
 export function getReactNativeDirectoryCheckListUnknownPackagesEnabled(pkg: any) {

--- a/packages/expo-doctor/src/utils/versions.ts
+++ b/packages/expo-doctor/src/utils/versions.ts
@@ -18,3 +18,24 @@ export function ltSdkVersion(expJson: Pick<ExpoConfig, 'sdkVersion'>, sdkVersion
     );
   }
 }
+
+export function gteSdkVersion(
+  expJson: Pick<ExpoConfig, 'sdkVersion'>,
+  sdkVersion: string
+): boolean {
+  if (!expJson.sdkVersion) {
+    return false;
+  }
+
+  if (expJson.sdkVersion === 'UNVERSIONED') {
+    return true;
+  }
+  try {
+    return semver.gte(expJson.sdkVersion, sdkVersion);
+  } catch {
+    throw new Error(
+      //'INVALID_VERSION',
+      `${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`
+    );
+  }
+}


### PR DESCRIPTION
# Why

We'd like people to run this check for SDK 52 projects, with the Great Migration underway.