### PR TITLE
[docs] Fix TypeScript error in camera.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -90,7 +90,7 @@ import { useState } from 'react';
 import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [facing, setFacing] = useState<CameraType>('back');
+  const [facing, setFacing] = useState<CameraType>(CameraType.back);
   const [permission, requestPermission] = useCameraPermissions();
 
   if (!permission) {

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -109,7 +109,7 @@ export default function App() {
   }
 
   function toggleCameraFacing() {
-    setFacing(current => (current === 'back' ? 'front' : 'back'));
+    setFacing(current => (current === CameraType.back ? CameraType.front : CameraType.back));
   }
 
   return (


### PR DESCRIPTION
# Why

It is cleaner to use the Enum instead of a hardcoded string "back" or "front" in the example implementation.

# How

Replacement of the string with the Enum value.

# Test Plan

As this is refactoring, tests alterations are not necessary. 

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
