### PR TITLE
[iOS][Contacts] Fix missing birthday when year component is set

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed an iOS issue where the contact's birthday isn't displayed when the year is set. ( by [@chrfalch](https://github.com/chrfalch))
+- Fixed an iOS issue where the contact's birthday isn't displayed when the year is set. ([#31948](https://github.com/expo/expo/pull/31948) by [@chrfalch](https://github.com/chrfalch))
 - Fixed an Android issue where creating a contact with a birthday was not saved. ([#30131](https://github.com/expo/expo/issues/30131) by [@Eric013](https://github.com/Eric013))
 - Fixed an issue on android where phone number and email labels were ignored on contact creation. ([#31309](https://github.com/expo/expo/pull/31309) by [@mlecoq](https://github.com/mlecoq))
 - Fixed an issue where the `requestPermissionsAsync` promise throws when denying access to contacts on iOS. ([#29529](https://github.com/expo/expo/pull/29529) by [@jp1987](https://github.com/jp1987))

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an iOS issue where the contact's birthday isn't displayed when the year is set. ( by [@chrfalch](https://github.com/chrfalch))
 - Fixed an Android issue where creating a contact with a birthday was not saved. ([#30131](https://github.com/expo/expo/issues/30131) by [@Eric013](https://github.com/Eric013))
 - Fixed an issue on android where phone number and email labels were ignored on contact creation. ([#31309](https://github.com/expo/expo/pull/31309) by [@mlecoq](https://github.com/mlecoq))
 - Fixed an issue where the `requestPermissionsAsync` promise throws when denying access to contacts on iOS. ([#29529](https://github.com/expo/expo/pull/29529) by [@jp1987](https://github.com/jp1987))

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -99,6 +99,9 @@ func decodeBirthday(_ input: ContactDate?, contact: CNContact) -> DateComponents
   }
   if let year = input.year {
     components.year = year
+    // To be able to display a birthday with year component the contact requires
+    // us to set the calendar as well.
+    components.calendar = Calendar.current
   }
   if let day = input.day {
     components.day = day


### PR DESCRIPTION
# Why

When setting the year component in a birthday the Contacts Controller requires a Calendar on iOS to display the birthday correctly:

This contact will not be displayed with the birthday field:

```ts
const contact = {
  contactType: 'person',
  birthday: {
    label: 'birthday',
    day: 1,
    month: 1,
    year: 2000,
  },
}
```

This will:

```ts
const contact = {
  contactType: 'person',
  birthday: {
    label: 'birthday',
    day: 1,
    month: 1
  },
}
```

# How

This commit adds setting the current calendar when the year is provided.

Closes #31895

# Test Plan

Run the following snack's (from the issue) code and verify that the example now works when providing a year for the birthday.

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
