### PR TITLE
[docs] Fix differences between `projectId` push notification examples

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -192,10 +192,9 @@ Using the previous example, when you are registering for push notifications, you
 
 `projectId` is automatically set when you create a development build. However, **we recommend setting it manually in your project's code**. To do so, you can use [`expo-constants`](/versions/latest/sdk/constants/) to get the `projectId` value from the app config.
 
-```js
-token = await Notifications.getExpoPushTokenAsync({
-  projectId: Constants.expoConfig.extra.eas.projectId,
-});
+```ts
+const projectId = Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
+const pushTokenString = (await Notifications.getExpoPushTokenAsync({ projectId })).data;
 ```
 
 One advantage of attributing the Expo push token to your project's ID is that it doesn't change when a project is transferred between different accounts or the existing account gets renamed.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #25313

Fix the differences to reference `projectId` in the example code in the Push notifications guide and the `expo-notifications` API reference.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the example code block under `projectId` section.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
