### PR TITLE
[expo-updates][android] Refactor where context is injected into controllers

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed broken unit test on iOS 17 where `URL()` without scheme returns nil. ([#30178](https://github.com/expo/expo/pull/30178) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
+- Refactor expo-updates context injection ([#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -40,12 +40,12 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
     }
 
     val validConfiguration = updatesInterface?.let {
-      val runtimeVersion = it.getRuntimeVersion(context)
+      val runtimeVersion = it.runtimeVersion
       if (runtimeVersion == null) {
         null
       } else {
         val configurationCandidate = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
-        if (it.isValidUpdatesConfiguration(configurationCandidate, context)) {
+        if (it.isValidUpdatesConfiguration(configurationCandidate)) {
           configurationCandidate
         } else {
           null

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -59,8 +59,8 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   private fun getUpdatesConfig(): WritableMap {
     val map = Arguments.createMap()
 
-    val runtimeVersion = controller.updatesInterface?.getRuntimeVersion(reactApplicationContext)
-    val projectUri = controller.updatesInterface?.getUpdateUrl(reactApplicationContext)
+    val runtimeVersion = controller.updatesInterface?.runtimeVersion
+    val projectUri = controller.updatesInterface?.updateUrl
     val appId = projectUri?.lastPathSegment ?: ""
 
     val isModernManifestProtocol = projectUri?.host.equals("u.expo.dev") || projectUri?.host.equals("staging-u.expo.dev")
@@ -223,10 +223,10 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
     val packageInfo = packageManager.getPackageInfo(packageName, 0)
     val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
     val appName = packageManager.getApplicationLabel(applicationInfo).toString()
-    val runtimeVersion = controller.updatesInterface?.getRuntimeVersion(reactApplicationContext)
+    val runtimeVersion = controller.updatesInterface?.runtimeVersion
     val appIcon = getApplicationIconUri()
 
-    val updatesUrl = controller.updatesInterface?.getUpdateUrl(reactApplicationContext)
+    val updatesUrl = controller.updatesInterface?.updateUrl
     val appId = if (updatesUrl !== null) {
       updatesUrl.lastPathSegment ?: ""
     } else {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -19,7 +19,6 @@ suspend fun UpdatesInterface.loadUpdate(
   suspendCoroutine { cont ->
     this.fetchUpdateWithConfiguration(
       configuration,
-      context,
       object : UpdatesInterface.UpdateCallback {
         override fun onSuccess(update: UpdatesInterface.Update?) {
           // if the update is null, we previously aborted the fetch, so we've already resumed

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -48,12 +48,12 @@ internal class DevLauncherUpdatesHelperTest {
     val updatesInterface = mockk<UpdatesInterface>()
     val slot = slot<UpdatesInterface.UpdateCallback>()
     every {
-      updatesInterface.isValidUpdatesConfiguration(any(), any())
+      updatesInterface.isValidUpdatesConfiguration(any())
     } answers {
       true
     }
     every {
-      updatesInterface.fetchUpdateWithConfiguration(any(), any(), capture(slot))
+      updatesInterface.fetchUpdateWithConfiguration(any(), capture(slot))
     } answers {
       val callback = slot.captured
       val onManifestLoadedCallbackValue = callback.onManifestLoaded(mockManifest)

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -96,7 +96,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(developmentManifestJSONString) {
       Truth.assertThat(it).isFalse()
     }.let { updatesInterface ->
-      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns true
+      every { updatesInterface.isValidUpdatesConfiguration(any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -113,7 +113,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(publishedManifestJSONString) {
       Truth.assertThat(it).isTrue()
     }.let { updatesInterface ->
-      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns true
+      every { updatesInterface.isValidUpdatesConfiguration(any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -130,7 +130,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(developmentManifestJSONString) {
       Truth.assertThat(it).isTrue()
     }.let { updatesInterface ->
-      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns false
+      every { updatesInterface.isValidUpdatesConfiguration(any()) } returns false
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Refactor context injection ([#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
+
 ## 0.16.2 — 2024-05-09
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -1,6 +1,5 @@
 package expo.modules.updatesinterface
 
-import android.content.Context
 import android.net.Uri
 import org.json.JSONObject
 import java.lang.ref.WeakReference
@@ -31,9 +30,9 @@ interface UpdatesInterface {
   var updatesInterfaceCallbacks: WeakReference<UpdatesInterfaceCallbacks>?
 
   fun reset()
-  fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback)
-  fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean
+  fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, callback: UpdateCallback)
+  fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>): Boolean
 
-  fun getRuntimeVersion(context: Context): String?
-  fun getUpdateUrl(context: Context): Uri?
+  val runtimeVersion: String?
+  val updateUrl: Uri?
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 - Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818, [#31854](https://github.com/expo/expo/pull/31854) by [@wschurman](https://github.com/wschurman))
 - Remove clearUpdateCacheExperimentalAsync ([#31871](https://github.com/expo/expo/pull/31871) by [@wschurman](https://github.com/wschurman))
-- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929) by [@wschurman](https://github.com/wschurman))
+- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929), [#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -4,6 +4,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.events.IUpdatesEventManager
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import expo.modules.updates.statemachine.UpdatesStateEventType
@@ -38,6 +39,7 @@ class UpdatesStateMachineInstrumentationTest {
   }
 
   private val androidContext = InstrumentationRegistry.getInstrumentation().context
+  private val logger = UpdatesLogger(androidContext)
 
   // Test classes
   class TestStateChangeEventManager : IUpdatesEventManager {
@@ -57,14 +59,14 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_defaultState() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
   }
 
   @Test
   fun test_handleCheckAndCheckCompleteAvailable() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -87,7 +89,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleCheckCompleteUnavailable() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -107,7 +109,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleDownloadAndDownloadComplete() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Download())
 
@@ -132,7 +134,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleRollback() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
     val commitTime = Date()
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -151,7 +153,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_checkError() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -172,7 +174,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_invalidTransitions() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
     machine.processEventTest(UpdatesStateEvent.Check())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
 
@@ -192,7 +194,7 @@ class UpdatesStateMachineInstrumentationTest {
   fun test_invalidStateValues() {
     val testStateChangeEventManager = TestStateChangeEventManager()
     // can only be idle
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventManager, setOf(UpdatesStateValue.Idle))
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, setOf(UpdatesStateValue.Idle))
 
     // Test invalid value and ensure that state does not change
     Assert.assertThrows(AssertionError::class.java) {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
@@ -15,12 +15,13 @@ import org.junit.runner.RunWith
 class ErrorRecoveryTest {
   private var mockDelegate: ErrorRecoveryDelegate = mockk()
   private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-  private var errorRecovery: ErrorRecovery = ErrorRecovery(context)
+  private val updatesLogger = UpdatesLogger(context)
+  private var errorRecovery: ErrorRecovery = ErrorRecovery(updatesLogger)
 
   @Before
   fun setup() {
     mockDelegate = mockk(relaxed = true)
-    errorRecovery = ErrorRecovery(context)
+    errorRecovery = ErrorRecovery(updatesLogger)
     errorRecovery.initialize(mockDelegate)
     errorRecovery.handler = spyk(ErrorRecoveryHandler(errorRecovery.handlerThread.looper, mockDelegate, UpdatesLogger(context)))
     // make handler run synchronously

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -11,6 +11,7 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.Launcher.LauncherCallback
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import io.mockk.every
 import io.mockk.mockk
@@ -54,6 +55,7 @@ class DatabaseLauncherTest {
     db.assetDao().insertAssets(listOf(testAsset), testUpdate)
 
     val launcher = DatabaseLauncher(
+      context,
       UpdatesConfiguration(
         null,
         mapOf(
@@ -67,17 +69,18 @@ class DatabaseLauncherTest {
         mockk(),
         mockk(),
         mockk()
-      )
+      ),
+      UpdatesLogger(context)
     )
     val spyLauncher = spyk(launcher)
-    every { spyLauncher.getLaunchableUpdate(any(), any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
+    every { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
 
     val mockedFile = File(context.cacheDir, "test")
-    every { spyLauncher.ensureAssetExists(any(), any(), any()) } returns mockedFile
+    every { spyLauncher.ensureAssetExists(any(), any()) } returns mockedFile
 
     val mockedCallback = mockk<LauncherCallback>(relaxed = true)
 
-    spyLauncher.launch(db, context, mockedCallback)
+    spyLauncher.launch(db, mockedCallback)
 
     verify { mockedCallback.onSuccess() }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -11,6 +11,7 @@ import expo.modules.updates.codesigning.CODE_SIGNING_METADATA_KEY_ID_KEY
 import expo.modules.updates.codesigning.CertificateFixtures
 import expo.modules.updates.codesigning.TestCertificateType
 import expo.modules.updates.codesigning.getTestCertificate
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.Update
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MediaType.Companion.toMediaType
@@ -43,7 +44,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -88,7 +89,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -134,7 +135,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -179,7 +180,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred: Exception? = null
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -217,7 +218,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -260,7 +261,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -303,7 +304,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -346,7 +347,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -388,7 +389,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred: Exception? = null
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -430,7 +431,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -497,7 +498,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -543,7 +544,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred: Exception? = null
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -616,7 +617,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -686,7 +687,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred: Exception? = null
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -749,7 +750,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred: Exception? = null
     var resultUpdateResponse: UpdateResponse? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
@@ -790,7 +791,7 @@ class FileDownloaderManifestParsingTest {
     var errorOccurred = false
     var resultUpdate: Update? = null
 
-    FileDownloader(context, configuration).parseRemoteUpdateResponse(
+    FileDownloader(context, configuration, UpdatesLogger(context)).parseRemoteUpdateResponse(
       response,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -9,6 +9,7 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.ManifestMetadata
 import io.mockk.every
 import io.mockk.mockk
@@ -29,10 +30,12 @@ import java.util.*
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FileDownloaderTest {
   private lateinit var context: Context
+  private lateinit var logger: UpdatesLogger
 
   @Before
   fun setup() {
     context = InstrumentationRegistry.getInstrumentation().targetContext
+    logger = UpdatesLogger(context)
   }
 
   @Test
@@ -233,10 +236,9 @@ class FileDownloaderTest {
     var error: Exception? = null
     var didSucceed = false
 
-    FileDownloader(context, config, client).downloadAsset(
+    FileDownloader(context, config, logger, client).downloadAsset(
       assetEntity,
       File(context.cacheDir, "test"),
-      context,
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {
           error = e
@@ -248,7 +250,7 @@ class FileDownloaderTest {
       }
     )
 
-    Assert.assertTrue(error!!.localizedMessageWithCauseLocalizedMessage()!!.contains("File download was successful but base64url-encoded SHA-256 did not match expected"))
+    Assert.assertTrue(error!!.localizedMessageWithCauseLocalizedMessage().contains("File download was successful but base64url-encoded SHA-256 did not match expected"))
     Assert.assertFalse(didSucceed)
   }
 
@@ -283,10 +285,9 @@ class FileDownloaderTest {
     var error: Exception? = null
     var didSucceed = false
 
-    FileDownloader(context, config, client).downloadAsset(
+    FileDownloader(context, config, logger, client).downloadAsset(
       assetEntity,
       File(context.cacheDir, "test"),
-      context,
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {
           error = e

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -63,8 +63,8 @@ class RemoteLoaderTest {
     val manifestString = CertificateFixtures.testExpoUpdatesManifestBody
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
+    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,
@@ -74,9 +74,9 @@ class RemoteLoaderTest {
       )
     }
 
-    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
+    every { mockFileDownloader.downloadAsset(any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(3)
+      val callback = arg<AssetDownloadCallback>(2)
       callback.onSuccess(asset, true)
     }
 
@@ -90,7 +90,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -101,9 +101,9 @@ class RemoteLoaderTest {
 
   @Test
   fun testRemoteLoader_FailureToDownloadAssets() {
-    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
+    every { mockFileDownloader.downloadAsset(any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(3)
+      val callback = arg<AssetDownloadCallback>(2)
       callback.onFailure(IOException("mock failed to download asset"), asset)
     }
 
@@ -111,7 +111,7 @@ class RemoteLoaderTest {
 
     verify(exactly = 0) { mockCallback.onSuccess(any()) }
     verify { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -136,7 +136,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // only 1 asset (bundle) should be downloaded since the other asset already exists
-    verify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -163,7 +163,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // both assets should be downloaded regardless of what the database says
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -193,7 +193,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -217,7 +217,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // missing assets should still be downloaded
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -241,7 +241,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -256,8 +256,8 @@ class RemoteLoaderTest {
       "{\"metadata\":{},\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"},\"extra\":{\"expoGo\":{\"developer\":{\"tool\":\"expo-cli\",\"projectRoot\":\"/Users/eric/expo/updates-unit-test-template\"},\"packagerOpts\":{\"scheme\":null,\"hostType\":\"lan\",\"lanType\":\"ip\",\"dev\":true,\"minify\":false,\"urlRandomness\":null,\"https\":false}}}}"
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
+    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,
@@ -271,7 +271,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -281,8 +281,8 @@ class RemoteLoaderTest {
   @Test
   fun testRemoteLoader_RollBackDirective() {
     val updateDirective = UpdateDirective.RollBackToEmbeddedUpdateDirective(commitTime = Date(), signingInfo = null)
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
+    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,
@@ -296,7 +296,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(Loader.LoaderResult(null, updateDirective)) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(0, updates.size)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -42,7 +42,7 @@ class DisabledUpdatesController(
   override val eventManager: IUpdatesEventManager = QueueUpdatesEventManager(logger)
 
   // disabled controller state machine can only be idle or restarting
-  private val stateMachine = UpdatesStateMachine(context, eventManager, setOf(UpdatesStateValue.Idle, UpdatesStateValue.Restarting))
+  private val stateMachine = UpdatesStateMachine(logger, eventManager, setOf(UpdatesStateValue.Idle, UpdatesStateValue.Restarting))
 
   private var isStarted = false
   private var startupStartTimeMillis: Long? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -48,11 +48,11 @@ class EnabledUpdatesController(
   private val logger = UpdatesLogger(context)
   override val eventManager: IUpdatesEventManager = QueueUpdatesEventManager(logger)
 
-  private val fileDownloader = FileDownloader(context, updatesConfiguration)
+  private val fileDownloader = FileDownloader(context, updatesConfiguration, logger)
   private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
     updatesConfiguration.getRuntimeVersion()
   )
-  private val stateMachine = UpdatesStateMachine(context, eventManager, UpdatesStateValue.entries.toSet())
+  private val stateMachine = UpdatesStateMachine(logger, eventManager, UpdatesStateValue.entries.toSet())
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
 
   private fun purgeUpdatesLogsOlderThanOneDay() {
@@ -153,6 +153,7 @@ class EnabledUpdatesController(
       context,
       weakActivity,
       updatesConfiguration,
+      logger,
       databaseHolder,
       updatesDirectory,
       fileDownloader,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -22,6 +22,7 @@ import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.LauncherSelectionPolicySingleUpdate
 import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -54,6 +55,8 @@ class UpdatesDevLauncherController(
   override var updatesInterfaceCallbacks: WeakReference<UpdatesInterfaceCallbacks>? = null
 
   private var launcher: Launcher? = null
+
+  private val logger = UpdatesLogger(context)
 
   private var previousUpdatesConfiguration: UpdatesConfiguration? = null
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
@@ -108,13 +111,11 @@ class UpdatesDevLauncherController(
     launcher = null
   }
 
-  override fun getRuntimeVersion(context: Context): String? {
-    return updatesConfiguration?.getRuntimeVersion()
-  }
+  override val runtimeVersion: String?
+    get() = updatesConfiguration?.getRuntimeVersion()
 
-  override fun getUpdateUrl(context: Context): Uri? {
-    return updatesConfiguration?.updateUrl
-  }
+  override val updateUrl: Uri?
+    get() = updatesConfiguration?.updateUrl
 
   /**
    * Fetch an update using a dynamically generated configuration object (including a potentially
@@ -122,12 +123,11 @@ class UpdatesDevLauncherController(
    */
   override fun fetchUpdateWithConfiguration(
     configuration: HashMap<String, Any>,
-    context: Context,
     callback: UpdatesInterface.UpdateCallback
   ) {
     val newUpdatesConfiguration: UpdatesConfiguration
     try {
-      newUpdatesConfiguration = createUpdatesConfiguration(configuration, context)
+      newUpdatesConfiguration = createUpdatesConfiguration(configuration)
     } catch (e: Exception) {
       callback.onFailure(e)
       return
@@ -140,7 +140,7 @@ class UpdatesDevLauncherController(
 
     setDevelopmentSelectionPolicy()
 
-    val fileDownloader = FileDownloader(context, updatesConfiguration!!)
+    val fileDownloader = FileDownloader(context, updatesConfiguration!!, logger)
     val loader = RemoteLoader(
       context,
       updatesConfiguration!!,
@@ -164,7 +164,7 @@ class UpdatesDevLauncherController(
           callback.onSuccess(null)
           return
         }
-        launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, fileDownloader, context, callback)
+        launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, fileDownloader, callback)
       }
 
       override fun onAssetLoaded(
@@ -193,9 +193,9 @@ class UpdatesDevLauncherController(
     })
   }
 
-  override fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean {
+  override fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>): Boolean {
     return try {
-      createUpdatesConfiguration(configuration, context)
+      createUpdatesConfiguration(configuration)
       true
     } catch (e: Exception) {
       Log.e(TAG, "Invalid updates configuration: ${e.localizedMessage}")
@@ -204,7 +204,7 @@ class UpdatesDevLauncherController(
   }
 
   @Throws(Exception::class)
-  private fun createUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): UpdatesConfiguration {
+  private fun createUpdatesConfiguration(configuration: HashMap<String, Any>): UpdatesConfiguration {
     if (updatesDirectory == null) {
       throw updatesDirectoryException!!
     }
@@ -240,7 +240,6 @@ class UpdatesDevLauncherController(
     update: UpdateEntity,
     configuration: UpdatesConfiguration,
     fileDownloader: FileDownloader,
-    context: Context,
     callback: UpdatesInterface.UpdateCallback
   ) {
     // ensure that we launch the update we want, even if it isn't the latest one
@@ -258,14 +257,15 @@ class UpdatesDevLauncherController(
     )
 
     val launcher = DatabaseLauncher(
+      context,
       configuration,
       updatesDirectory!!,
       fileDownloader,
-      selectionPolicy
+      selectionPolicy,
+      logger
     )
     launcher.launch(
       databaseHolder.database,
-      context,
       object : Launcher.LauncherCallback {
         override fun onFailure(e: Exception) {
           databaseHolder.releaseDatabase()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
@@ -58,9 +58,9 @@ abstract class UpdatesDatabase : RoomDatabase() {
     private const val DB_NAME = "updates.db"
 
     @JvmStatic @Synchronized
-    fun getInstance(context: Context?): UpdatesDatabase {
+    fun getInstance(context: Context): UpdatesDatabase {
       if (instance == null) {
-        instance = Room.databaseBuilder(context!!, UpdatesDatabase::class.java, DB_NAME)
+        instance = Room.databaseBuilder(context, UpdatesDatabase::class.java, DB_NAME)
           .addMigrations(MIGRATION_4_5)
           .addMigrations(MIGRATION_5_6)
           .addMigrations(MIGRATION_6_7)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -1,6 +1,5 @@
 package expo.modules.updates.errorrecovery
 
-import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
@@ -29,11 +28,10 @@ import java.lang.ref.WeakReference
  * and so there is no more need to trigger the error recovery pipeline.
  */
 class ErrorRecovery(
-  private val context: Context
+  private val logger: UpdatesLogger
 ) {
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
   internal lateinit var handler: Handler
-  internal val logger = UpdatesLogger(context)
 
   private var weakDevSupportManager: WeakReference<DevSupportManager>? = null
   private var previousExceptionHandler: DefaultJSExceptionHandler? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -16,7 +16,7 @@ import java.io.File
  * on [UpdatesModule] should be `true` whenever this class is used.
  */
 class NoDatabaseLauncher @JvmOverloads constructor(
-  context: Context,
+  private val context: Context,
   fatalException: Exception? = null
 ) : Launcher {
   override val bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
@@ -25,7 +25,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
   override val localAssetFiles = null
   override val isUsingEmbeddedAssets = true
 
-  private fun writeErrorToLog(context: Context, fatalException: Exception) {
+  private fun writeErrorToLog(fatalException: Exception) {
     try {
       val errorLogFile = File(context.filesDir, ERROR_LOG_FILENAME)
       val exceptionString = fatalException.toString()
@@ -58,7 +58,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
 
   init {
     if (fatalException != null) {
-      AsyncTask.execute { writeErrorToLog(context, fatalException) }
+      AsyncTask.execute { writeErrorToLog(fatalException) }
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -24,7 +24,7 @@ import java.util.*
  * re-downloaded if included in future updates.
  */
 class EmbeddedLoader internal constructor(
-  private val context: Context,
+  context: Context,
   private val configuration: UpdatesConfiguration,
   database: UpdatesDatabase,
   updatesDirectory: File,
@@ -45,7 +45,6 @@ class EmbeddedLoader internal constructor(
   ) : this(context, configuration, database, updatesDirectory, LoaderFiles())
 
   override fun loadRemoteUpdate(
-    context: Context,
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration,
     callback: RemoteUpdateDownloadCallback
@@ -65,7 +64,6 @@ class EmbeddedLoader internal constructor(
   }
 
   override fun loadAsset(
-    context: Context,
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -33,7 +33,11 @@ import java.util.concurrent.TimeUnit
  * Utility class that holds all the logic for downloading data and files, such as update manifests
  * and assets, using an instance of [OkHttpClient].
  */
-class FileDownloader(context: Context, private val configuration: UpdatesConfiguration) {
+class FileDownloader(
+  private val context: Context,
+  private val configuration: UpdatesConfiguration,
+  private val logger: UpdatesLogger
+) {
   // If the configured launch wait milliseconds is greater than the okhttp default (10_000)
   // we should use that as the timeout. For example, let's say launchWaitMs is 20 seconds,
   // the HTTP timeout should be at least 20 seconds.
@@ -47,11 +51,9 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
   /**
    * Constructor for tests
    */
-  constructor(context: Context, configuration: UpdatesConfiguration, client: OkHttpClient) : this(context, configuration) {
+  constructor(context: Context, configuration: UpdatesConfiguration, logger: UpdatesLogger, client: OkHttpClient) : this(context, configuration, logger) {
     this.client = client
   }
-
-  private val logger = UpdatesLogger(context)
 
   interface FileDownloadCallback {
     fun onFailure(e: Exception)
@@ -411,7 +413,6 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
 
   fun downloadRemoteUpdate(
     extraHeaders: JSONObject?,
-    context: Context,
     callback: RemoteUpdateDownloadCallback
   ) {
     try {
@@ -448,7 +449,6 @@ class FileDownloader(context: Context, private val configuration: UpdatesConfigu
   fun downloadAsset(
     asset: AssetEntity,
     destinationDirectory: File?,
-    context: Context,
     callback: AssetDownloadCallback
   ) {
     if (asset.url == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -24,7 +24,7 @@ import java.util.*
  * application package. These correspond to the two loader subclasses.
  */
 abstract class Loader protected constructor(
-  private val context: Context,
+  protected val context: Context,
   private val configuration: UpdatesConfiguration,
   private val database: UpdatesDatabase,
   private val updatesDirectory: File,
@@ -75,14 +75,12 @@ abstract class Loader protected constructor(
   }
 
   protected abstract fun loadRemoteUpdate(
-    context: Context,
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration,
     callback: RemoteUpdateDownloadCallback
   )
 
   protected abstract fun loadAsset(
-    context: Context,
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
@@ -98,7 +96,6 @@ abstract class Loader protected constructor(
     this.callback = callback
 
     loadRemoteUpdate(
-      context,
       database,
       configuration,
       object : RemoteUpdateDownloadCallback {
@@ -249,7 +246,6 @@ abstract class Loader protected constructor(
       }
 
       loadAsset(
-        context,
         assetEntity,
         updatesDirectory,
         configuration,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -39,24 +39,22 @@ class RemoteLoader internal constructor(
   ) : this(context, configuration, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
   override fun loadRemoteUpdate(
-    context: Context,
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration,
     callback: RemoteUpdateDownloadCallback
   ) {
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(database, configuration, launchedUpdate, embeddedUpdate)
-    mFileDownloader.downloadRemoteUpdate(extraHeaders, context, callback)
+    mFileDownloader.downloadRemoteUpdate(extraHeaders, callback)
   }
 
   override fun loadAsset(
-    context: Context,
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     callback: AssetDownloadCallback
   ) {
-    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, context, callback)
+    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, callback)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -42,7 +42,6 @@ class CheckForUpdateProcedure(
       databaseHolder.releaseDatabase()
       fileDownloader.downloadRemoteUpdate(
         extraHeaders,
-        context,
         object : FileDownloader.RemoteUpdateDownloadCallback {
           override fun onFailure(e: Exception) {
             procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -16,6 +16,7 @@ import expo.modules.updates.db.Reaper
 import expo.modules.updates.launcher.DatabaseLauncher
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import java.io.File
@@ -25,6 +26,7 @@ class RelaunchProcedure(
   private val context: Context,
   private val weakActivity: WeakReference<Activity>?,
   private val updatesConfiguration: UpdatesConfiguration,
+  private val logger: UpdatesLogger,
   private val databaseHolder: DatabaseHolder,
   private val updatesDirectory: File,
   private val fileDownloader: FileDownloader,
@@ -47,14 +49,15 @@ class RelaunchProcedure(
     val oldLaunchAssetFile = getCurrentLauncher().launchAssetFile
 
     val newLauncher = DatabaseLauncher(
+      context,
       updatesConfiguration,
       updatesDirectory,
       fileDownloader,
-      selectionPolicy
+      selectionPolicy,
+      logger
     )
     newLauncher.launch(
       databaseHolder.database,
-      context,
       object : Launcher.LauncherCallback {
         override fun onFailure(e: Exception) {
           callback.onFailure(e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -64,7 +64,7 @@ class StartupProcedure(
 
   var emergencyLaunchException: Exception? = null
     private set
-  private val errorRecovery = ErrorRecovery(context)
+  private val errorRecovery = ErrorRecovery(logger)
   private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
 
   // TODO: move away from DatabaseHolder pattern to Handler thread
@@ -78,11 +78,13 @@ class StartupProcedure(
   }
 
   private val loaderTask = LoaderTask(
+    context,
     updatesConfiguration,
     databaseHolder,
     updatesDirectory,
     fileDownloader,
     selectionPolicy,
+    logger,
     object : LoaderTask.LoaderTaskCallback {
       override fun onFailure(e: Exception) {
         logger.error("UpdatesController loaderTask onFailure", e, UpdatesErrorCode.None)
@@ -208,7 +210,7 @@ class StartupProcedure(
     this.procedureContext = procedureContext
     initializeDatabaseHandler()
     initializeErrorRecovery()
-    loaderTask.start(context)
+    loaderTask.start()
   }
 
   @Synchronized

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -1,6 +1,5 @@
 package expo.modules.updates.statemachine
 
-import android.content.Context
 import expo.modules.updates.events.IUpdatesEventManager
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.procedures.StateMachineProcedure
@@ -12,12 +11,10 @@ import java.util.Date
  * in a production app, instantiated as a property of UpdatesController.
  */
 class UpdatesStateMachine(
-  androidContext: Context,
+  private val logger: UpdatesLogger,
   private val eventManager: IUpdatesEventManager,
   private val validUpdatesStateValues: Set<UpdatesStateValue>
 ) {
-  private val logger = UpdatesLogger(androidContext)
-
   private val serialExecutorQueue = StateMachineSerialExecutorQueue(
     logger,
     object : StateMachineProcedure.StateMachineProcedureContext {


### PR DESCRIPTION
# Why

This is part 2 of #31929.

The goal of this one is to ensure logger and context are correctly supplied to controllers and are always non-null in order to better guarantee that all errors are logged consistently.

# How

Refactor where Context is supplied to the classes. Note that this really only could have an effect on dev client (`UpdatesInterface`) which previously specified `Context` as an arg to each method. I don't _think_ this is necessary since the context used here _should_ be the same as the context used to instantiate the `UpdatesDevLauncherController`.

Also refactor so that the controllers each are the owners of the logger and that the logger is explicitly injected. While this isn't strictly necessary, it helps to identify which classes only needed context in order to instantiate their own logger instance.

The secondary benefit of injecting logger is that we can theoretically mockk and test it in the future.

# Test Plan

Run all integration tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
