### PR TITLE
[expo-updates][android] Change most Log.* errors to UpdatesLogger errors

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -105,7 +105,7 @@
 - [iOS] Disabled `ExpoView` recycling from the New Architecture. ([#31841](https://github.com/expo/expo/pull/31841) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`. ([#31921](https://github.com/expo/expo/pull/31921) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Throws a descriptive error when trying to use a released `SharedObject`. ([#31922](https://github.com/expo/expo/pull/31922) by [@lukmccall](https://github.com/lukmccall))
-- Include error cause message in logger ([#31929](https://github.com/expo/expo/pull/31929) by [@wschurman](https://github.com/wschurman))
+- Include error cause message in logger ([#31929](https://github.com/expo/expo/pull/31929), [#31953](https://github.com/expo/expo/pull/31953) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
@@ -64,7 +64,7 @@ class PersistentFileLog(
   /**
    * Filter existing entries and remove ones where filter(entry) == false
    */
-  fun purgeEntriesNotMatchingFilter(filter: (_: String) -> Boolean, completionHandler: (_: Error?) -> Unit) {
+  fun purgeEntriesNotMatchingFilter(filter: (_: String) -> Boolean, completionHandler: (_: Exception?) -> Unit) {
     queue.add {
       try {
         this.ensureFileExists()
@@ -73,7 +73,7 @@ class PersistentFileLog(
         this.writeFileLinesSync(reducedContents)
         completionHandler.invoke(null)
       } catch (e: Throwable) {
-        completionHandler.invoke(Error(e))
+        completionHandler.invoke(Exception(e))
       }
     }
   }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 - Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818, [#31854](https://github.com/expo/expo/pull/31854) by [@wschurman](https://github.com/wschurman))
 - Remove clearUpdateCacheExperimentalAsync ([#31871](https://github.com/expo/expo/pull/31871) by [@wschurman](https://github.com/wschurman))
-- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929), [#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
+- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929), [#31951](https://github.com/expo/expo/pull/31951), [#31953](https://github.com/expo/expo/pull/31953) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -11,6 +11,7 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.loader.Loader.LoaderCallback
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedUpdate
 import expo.modules.updates.manifest.Update
 import io.mockk.every
@@ -30,6 +31,7 @@ import java.security.NoSuchAlgorithmException
 class EmbeddedLoaderTest {
   private lateinit var db: UpdatesDatabase
   private lateinit var configuration: UpdatesConfiguration
+  private lateinit var logger: UpdatesLogger
   private lateinit var manifest: Update
   private lateinit var loader: EmbeddedLoader
   private lateinit var mockLoaderFiles: LoaderFiles
@@ -44,11 +46,13 @@ class EmbeddedLoaderTest {
     )
     configuration = UpdatesConfiguration(null, configMap)
     val context = InstrumentationRegistry.getInstrumentation().targetContext
+    logger = UpdatesLogger(context)
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
     mockLoaderFiles = mockk(relaxed = true)
     loader = EmbeddedLoader(
       context,
       configuration,
+      logger,
       db,
       File("testDirectory"),
       mockLoaderFiles

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -45,7 +45,7 @@ class FileDownloaderTest {
       "runtimeVersion" to "1.0"
     )
     val config = UpdatesConfiguration(null, configMap)
-    val actual = FileDownloader.createRequestForRemoteUpdate(null, config, context)
+    val actual = FileDownloader.createRequestForRemoteUpdate(null, config, logger, context)
     Assert.assertNull(actual.header("Cache-Control"))
   }
 
@@ -66,7 +66,7 @@ class FileDownloaderTest {
     }
 
     // manifest extraHeaders should have their values coerced to strings
-    val actual = FileDownloader.createRequestForRemoteUpdate(extraHeaders, config, context)
+    val actual = FileDownloader.createRequestForRemoteUpdate(extraHeaders, config, logger, context)
     Assert.assertEquals("test", actual.header("expo-string"))
     Assert.assertEquals("47.5", actual.header("expo-number"))
     Assert.assertEquals("true", actual.header("expo-boolean"))
@@ -90,7 +90,7 @@ class FileDownloaderTest {
     val extraHeaders = JSONObject()
     extraHeaders.put("expo-platform", "ios")
 
-    val actual = FileDownloader.createRequestForRemoteUpdate(extraHeaders, config, context)
+    val actual = FileDownloader.createRequestForRemoteUpdate(extraHeaders, config, logger, context)
     Assert.assertEquals("android", actual.header("expo-platform"))
     Assert.assertEquals("custom", actual.header("expo-updates-environment"))
   }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -13,6 +13,7 @@ import expo.modules.updates.codesigning.*
 import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.Loader.LoaderCallback
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.ExpoUpdatesUpdate
 import expo.modules.updates.manifest.Update
 import io.mockk.every
@@ -32,6 +33,7 @@ import java.util.*
 class RemoteLoaderTest {
   private lateinit var db: UpdatesDatabase
   private lateinit var configuration: UpdatesConfiguration
+  private lateinit var logger: UpdatesLogger
   private lateinit var manifest: Update
   private lateinit var loader: RemoteLoader
   private lateinit var mockLoaderFiles: LoaderFiles
@@ -47,12 +49,14 @@ class RemoteLoaderTest {
     )
     configuration = UpdatesConfiguration(null, configMap)
     val context = InstrumentationRegistry.getInstrumentation().targetContext
+    logger = UpdatesLogger(context)
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
     mockLoaderFiles = mockk(relaxed = true)
     mockFileDownloader = mockk()
     loader = RemoteLoader(
       context,
       configuration,
+      logger,
       db,
       mockFileDownloader,
       File("testDirectory"),

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -133,7 +133,7 @@ class UpdatesLoggingTest {
     Assert.assertEquals(0, thirdLogs.size)
 
     asyncTestUtil.asyncMethodRunning = true
-    var err: Error? = null
+    var err: Exception? = null
     reader.purgeLogEntries(
       secondTime
     ) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.app.Activity
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
@@ -13,6 +12,7 @@ import expo.modules.updates.events.IUpdatesEventManager
 import expo.modules.updates.events.QueueUpdatesEventManager
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.launcher.NoDatabaseLauncher
+import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.procedures.RecreateReactContextProcedure
 import expo.modules.updates.statemachine.UpdatesStateMachine
@@ -68,7 +68,7 @@ class DisabledUpdatesController(
         try {
           (this as java.lang.Object).wait()
         } catch (e: InterruptedException) {
-          Log.e(TAG, "Interrupted while waiting for launch asset file", e)
+          logger.error("Interrupted while waiting for launch asset file", e, UpdatesErrorCode.InitializationError)
         }
       }
       return launcher?.launchAssetFile
@@ -95,7 +95,7 @@ class DisabledUpdatesController(
     isStarted = true
     startupStartTimeMillis = System.currentTimeMillis()
 
-    launcher = NoDatabaseLauncher(context, fatalException)
+    launcher = NoDatabaseLauncher(context, logger, fatalException)
 
     startupEndTimeMillis = System.currentTimeMillis()
     notifyController()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
-import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
@@ -17,6 +16,7 @@ import expo.modules.updates.events.IUpdatesEventManager
 import expo.modules.updates.events.QueueUpdatesEventManager
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
@@ -58,7 +58,7 @@ class EnabledUpdatesController(
   private fun purgeUpdatesLogsOlderThanOneDay() {
     UpdatesLogReader(context).purgeLogEntries {
       if (it != null) {
-        Log.e(TAG, "UpdatesLogReader: error in purgeLogEntries", it)
+        logger.error("UpdatesLogReader: error in purgeLogEntries", it, UpdatesErrorCode.Unknown)
       }
     }
   }
@@ -110,7 +110,7 @@ class EnabledUpdatesController(
         try {
           (this as java.lang.Object).wait()
         } catch (e: InterruptedException) {
-          Log.e(TAG, "Interrupted while waiting for launch asset file", e)
+          logger.error("Interrupted while waiting for launch asset file", e, UpdatesErrorCode.InitializationError)
         }
       }
       return startupProcedure.launchAssetFile
@@ -211,7 +211,7 @@ class EnabledUpdatesController(
   }
 
   override fun fetchUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>) {
-    val procedure = FetchUpdateProcedure(context, updatesConfiguration, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate) {
+    val procedure = FetchUpdateProcedure(context, updatesConfiguration, logger, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate) {
       callback.onSuccess(it)
     }
     stateMachine.queueExecution(procedure)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
-import android.util.Log
 import android.net.Uri
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
@@ -22,6 +21,7 @@ import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.LauncherSelectionPolicySingleUpdate
 import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient
@@ -144,6 +144,7 @@ class UpdatesDevLauncherController(
     val loader = RemoteLoader(
       context,
       updatesConfiguration!!,
+      logger,
       databaseHolder.database,
       fileDownloader,
       updatesDirectory,
@@ -198,7 +199,7 @@ class UpdatesDevLauncherController(
       createUpdatesConfiguration(configuration)
       true
     } catch (e: Exception) {
-      Log.e(TAG, "Invalid updates configuration: ${e.localizedMessage}")
+      logger.error("Invalid updates configuration", e, UpdatesErrorCode.InitializationError)
       false
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -240,7 +240,7 @@ class UpdatesModule : Module() {
         }
     }
 
-    internal fun clearLogEntries(context: Context, completionHandler: (_: Error?) -> Unit) {
+    internal fun clearLogEntries(context: Context, completionHandler: (_: Exception?) -> Unit) {
       val reader = UpdatesLogReader(context)
       reader.purgeLogEntries(
         olderThan = Date(),

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -6,6 +6,8 @@ import android.util.Base64
 import android.util.Log
 import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
 import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.logging.UpdatesErrorCode
+import expo.modules.updates.logging.UpdatesLogger
 import org.apache.commons.io.FileUtils
 import org.json.JSONArray
 import org.json.JSONObject
@@ -154,6 +156,7 @@ object UpdatesUtils {
 
   fun shouldCheckForUpdateOnLaunch(
     updatesConfiguration: UpdatesConfiguration,
+    logger: UpdatesLogger,
     context: Context
   ): Boolean {
     return when (updatesConfiguration.checkOnLaunch) {
@@ -163,10 +166,8 @@ object UpdatesUtils {
       CheckAutomaticallyConfiguration.WIFI_ONLY -> {
         val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
         if (cm == null) {
-          Log.e(
-            TAG,
-            "Could not determine active network connection is metered; not checking for updates"
-          )
+          val cause = Exception("Null ConnectivityManager system service")
+          logger.error("Could not determine active network connection is metered; not checking for updates", cause, UpdatesErrorCode.Unknown)
           return false
         }
         !cm.isActiveNetworkMetered

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.errorrecovery
 
 import android.os.Handler
 import android.os.HandlerThread
-import android.util.Log
 import com.facebook.react.bridge.DefaultJSExceptionHandler
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarker.MarkerListener
@@ -111,7 +110,7 @@ class ErrorRecovery(
 
   private fun registerErrorHandlerImplBridge(devSupportManager: DevSupportManager) {
     if (devSupportManager !is ReleaseDevSupportManager) {
-      Log.d(TAG, "Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates error recovery will not behave properly.")
+      logger.debug("Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates error recovery will not behave properly.")
       return
     }
 
@@ -145,7 +144,7 @@ class ErrorRecovery(
   private fun unregisterErrorHandlerImplBridge() {
     weakDevSupportManager?.get()?.let { devSupportManager ->
       if (devSupportManager !is ReleaseDevSupportManager) {
-        Log.d(TAG, "Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates could not unregister its error handler")
+        logger.debug("Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates could not unregister its error handler")
         return
       }
       if (previousExceptionHandler == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -2,8 +2,8 @@ package expo.modules.updates.launcher
 
 import android.content.Context
 import android.os.AsyncTask
-import android.util.Log
 import expo.modules.updates.loader.EmbeddedLoader
+import expo.modules.updates.logging.UpdatesLogger
 import org.apache.commons.io.FileUtils
 import java.io.File
 
@@ -17,6 +17,7 @@ import java.io.File
  */
 class NoDatabaseLauncher @JvmOverloads constructor(
   private val context: Context,
+  private val logger: UpdatesLogger,
   fatalException: Exception? = null
 ) : Launcher {
   override val bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
@@ -31,7 +32,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
       val exceptionString = fatalException.toString()
       FileUtils.writeStringToFile(errorLogFile, exceptionString, "UTF-8", true)
     } catch (e: Exception) {
-      Log.e(TAG, "Failed to write fatal error to log", e)
+      logger.error("Failed to write fatal error to log", e)
     }
   }
 
@@ -40,7 +41,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
 
     private const val ERROR_LOG_FILENAME = "expo-error.log"
 
-    fun consumeErrorLog(context: Context): String? {
+    fun consumeErrorLog(context: Context, logger: UpdatesLogger): String? {
       return try {
         val errorLogFile = File(context.filesDir, ERROR_LOG_FILENAME)
         if (!errorLogFile.exists()) {
@@ -50,7 +51,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
         errorLogFile.delete()
         logContents
       } catch (e: Exception) {
-        Log.e(TAG, "Failed to read error log", e)
+        logger.error("Failed to read error log", e)
         null
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -7,6 +7,7 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.UpdatesUtils
+import expo.modules.updates.logging.UpdatesLogger
 import java.io.File
 import java.io.FileNotFoundException
 import java.lang.AssertionError
@@ -26,12 +27,14 @@ import java.util.*
 class EmbeddedLoader internal constructor(
   context: Context,
   private val configuration: UpdatesConfiguration,
+  logger: UpdatesLogger,
   database: UpdatesDatabase,
   updatesDirectory: File,
   private val loaderFiles: LoaderFiles
 ) : Loader(
   context,
   configuration,
+  logger,
   database,
   updatesDirectory,
   loaderFiles
@@ -40,9 +43,10 @@ class EmbeddedLoader internal constructor(
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     updatesDirectory: File
-  ) : this(context, configuration, database, updatesDirectory, LoaderFiles())
+  ) : this(context, configuration, logger, database, updatesDirectory, LoaderFiles())
 
   override fun loadRemoteUpdate(
     database: UpdatesDatabase,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -417,7 +417,7 @@ class FileDownloader(
   ) {
     try {
       downloadData(
-        createRequestForRemoteUpdate(extraHeaders, configuration, context),
+        createRequestForRemoteUpdate(extraHeaders, configuration, logger, context),
         object : Callback {
           override fun onFailure(call: Call, e: IOException) {
             val message = "Failed to download remote update"
@@ -616,6 +616,7 @@ class FileDownloader(
     internal fun createRequestForRemoteUpdate(
       extraHeaders: JSONObject?,
       configuration: UpdatesConfiguration,
+      logger: UpdatesLogger,
       context: Context
     ): Request {
       return Request.Builder()
@@ -635,7 +636,7 @@ class FileDownloader(
           }
         }
         .apply {
-          val previousFatalError = NoDatabaseLauncher.consumeErrorLog(context)
+          val previousFatalError = NoDatabaseLauncher.consumeErrorLog(context, logger)
           if (previousFatalError != null) {
             // some servers can have max length restrictions for headers,
             // so we restrict the length of the string to 1024 characters --

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -1,13 +1,14 @@
 package expo.modules.updates.loader
 
 import android.content.Context
-import android.util.Log
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
+import expo.modules.updates.logging.UpdatesErrorCode
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -23,20 +24,22 @@ import java.io.File
 class RemoteLoader internal constructor(
   context: Context,
   configuration: UpdatesConfiguration,
+  logger: UpdatesLogger,
   database: UpdatesDatabase,
   private val mFileDownloader: FileDownloader,
   updatesDirectory: File,
   private val launchedUpdate: UpdateEntity?,
   private val loaderFiles: LoaderFiles
-) : Loader(context, configuration, database, updatesDirectory, loaderFiles) {
+) : Loader(context, configuration, logger, database, updatesDirectory, loaderFiles) {
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     fileDownloader: FileDownloader,
     updatesDirectory: File,
     launchedUpdate: UpdateEntity?
-  ) : this(context, configuration, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
+  ) : this(context, configuration, logger, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
   override fun loadRemoteUpdate(
     database: UpdatesDatabase,
@@ -63,6 +66,7 @@ class RemoteLoader internal constructor(
     fun processSuccessLoaderResult(
       context: Context,
       configuration: UpdatesConfiguration,
+      logger: UpdatesLogger,
       database: UpdatesDatabase,
       selectionPolicy: SelectionPolicy,
       directory: File,
@@ -74,7 +78,7 @@ class RemoteLoader internal constructor(
       val updateDirective = loaderResult.updateDirective
 
       if (updateDirective != null && updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-        processRollBackToEmbeddedDirective(context, configuration, database, selectionPolicy, directory, launchedUpdate, updateDirective) { didRollBackToEmbedded ->
+        processRollBackToEmbeddedDirective(context, configuration, logger, database, selectionPolicy, directory, launchedUpdate, updateDirective) { didRollBackToEmbedded ->
           onComplete(null, didRollBackToEmbedded)
         }
       } else {
@@ -91,6 +95,7 @@ class RemoteLoader internal constructor(
     private fun processRollBackToEmbeddedDirective(
       context: Context,
       configuration: UpdatesConfiguration,
+      logger: UpdatesLogger,
       database: UpdatesDatabase,
       selectionPolicy: SelectionPolicy,
       directory: File,
@@ -114,12 +119,12 @@ class RemoteLoader internal constructor(
       embeddedUpdate.commitTime = updateDirective.commitTime
 
       // update the embedded update commit time in the database (requires loading and then updating)
-      EmbeddedLoader(context, configuration, database, directory).start(object : LoaderCallback {
+      EmbeddedLoader(context, configuration, logger, database, directory).start(object : LoaderCallback {
         /**
          * This should never happen since we check for the embedded update above
          */
         override fun onFailure(e: Exception) {
-          Log.e(TAG, "Embedded update erroneously null when applying roll back to embedded directive", e)
+          logger.error("Embedded update erroneously null when applying roll back to embedded directive", e, UpdatesErrorCode.UpdateFailedToLoad)
           onComplete(false)
         }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -3,7 +3,6 @@ package expo.modules.updates.logging
 import android.content.Context
 import expo.modules.core.logging.PersistentFileLog
 import expo.modules.updates.logging.UpdatesLogger.Companion.EXPO_UPDATES_LOGGING_TAG
-import java.lang.Error
 import java.lang.Long.max
 import java.util.*
 
@@ -19,7 +18,7 @@ class UpdatesLogReader(
    */
   fun purgeLogEntries(
     olderThan: Date = Date(Date().time - ONE_DAY_MILLISECONDS),
-    completionHandler: (_: Error?) -> Unit
+    completionHandler: (_: Exception?) -> Unit
   ) {
     val epochTimestamp = epochFromDateOrOneDayAgo(olderThan)
     persistentLog.purgeEntriesNotMatchingFilter(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifestUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifestUtils.kt
@@ -32,7 +32,7 @@ object EmbeddedManifestUtils {
         }
       } catch (e: Exception) {
         Log.e(TAG, "Could not read embedded manifest", e)
-        throw AssertionError("The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in android/app/build.gradle. " + e.message)
+        throw AssertionError("The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in android/app/build.gradle.", e)
       }
     }
     return sEmbeddedUpdate!!

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -12,6 +12,7 @@ import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import java.io.File
@@ -19,6 +20,7 @@ import java.io.File
 class FetchUpdateProcedure(
   private val context: Context,
   private val updatesConfiguration: UpdatesConfiguration,
+  private val logger: UpdatesLogger,
   private val databaseHolder: DatabaseHolder,
   private val updatesDirectory: File,
   private val fileDownloader: FileDownloader,
@@ -36,6 +38,7 @@ class FetchUpdateProcedure(
       RemoteLoader(
         context,
         updatesConfiguration,
+        logger,
         database,
         fileDownloader,
         updatesDirectory,
@@ -87,6 +90,7 @@ class FetchUpdateProcedure(
               RemoteLoader.processSuccessLoaderResult(
                 context,
                 updatesConfiguration,
+                logger,
                 database,
                 selectionPolicy,
                 updatesDirectory,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.AsyncTask
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.config.ReactFeatureFlags
@@ -16,6 +15,7 @@ import expo.modules.updates.db.Reaper
 import expo.modules.updates.launcher.DatabaseLauncher
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
@@ -73,7 +73,7 @@ class RelaunchProcedure(
             try {
               replaceLaunchAssetFileIfNeeded(reactApplication, newLaunchAssetFile)
             } catch (e: Exception) {
-              Log.e(TAG, "Could not reset launchAssetFile for the ReactApplication", e)
+              logger.error("Could not reset launchAssetFile for the ReactApplication", e, UpdatesErrorCode.Unknown)
             }
           }
           callback.onSuccess()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -88,7 +88,7 @@ class StartupProcedure(
     object : LoaderTask.LoaderTaskCallback {
       override fun onFailure(e: Exception) {
         logger.error("UpdatesController loaderTask onFailure", e, UpdatesErrorCode.None)
-        launcher = NoDatabaseLauncher(context, e)
+        launcher = NoDatabaseLauncher(context, logger, e)
         emergencyLaunchException = e
         notifyController()
       }
@@ -245,7 +245,7 @@ class StartupProcedure(
           return
         }
         remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
-        val remoteLoader = RemoteLoader(context, updatesConfiguration, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
+        val remoteLoader = RemoteLoader(context, updatesConfiguration, logger, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
         remoteLoader.start(object : Loader.LoaderCallback {
           override fun onFailure(e: Exception) {
             logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)


### PR DESCRIPTION
# Why

The goal here is to ensure that all errors in expo-updates are correctly logged to the logger (persistent file and OS sub-loggers).

# How

Grep for `Log.*`, update callsites where possible. A second iteration of this is probably needed soon.

# Test Plan

Build and run, integration tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
