### PR TITLE
[docs] Add videos for universal app tutorial

### DIFF
--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -9,8 +9,15 @@ import { FileTree } from '~/ui/components/FileTree';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn Expo Router's fundamentals to create stack navigation and a bottom tab bar with two tabs.
+
+<VideoBoxLink
+  videoId="8336fcFV_T4"
+  title="How to add navigation to your app with Expo Router Universal App tutorial #2"
+  description="Learn how to add navigation to your app using Expo Router."
+/>
 
 ## Expo Router basics
 

--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -13,11 +13,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn Expo Router's fundamentals to create stack navigation and a bottom tab bar with two tabs.
 
-<VideoBoxLink
-  videoId="8336fcFV_T4"
-  title="How to add navigation to your app with Expo Router Universal App tutorial #2"
-  description="Learn how to add navigation to your app using Expo Router."
-/>
+<VideoBoxLink videoId="8336fcFV_T4" title="Watch: Adding navigation in your universal Expo app" />
 
 ## Expo Router basics
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -9,6 +9,7 @@ import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll create the first screen of the StickerSmash app.
 
@@ -21,6 +22,12 @@ In this chapter, we'll create the first screen of the StickerSmash app.
 The screen above displays an image and two buttons. The app user can select an image using one of the two buttons. The first button allows the user to select an image from their device. The second button allows the user to continue with a default image provided by the app.
 
 Once the user selects an image, they can add a sticker to it. So, let's start creating this screen.
+
+<VideoBoxLink
+  videoId="8336fcFV_T4"
+  title="How to build a screen in an Expo app Universal App tutorial #3"
+  description="In this video you will create the first screen of the StickerSmash app."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -23,11 +23,7 @@ The screen above displays an image and two buttons. The app user can select an i
 
 Once the user selects an image, they can add a sticker to it. So, let's start creating this screen.
 
-<VideoBoxLink
-  videoId="8336fcFV_T4"
-  title="How to build a screen in an Expo app Universal App tutorial #3"
-  description="In this video you will create the first screen of the StickerSmash app."
-/>
+<VideoBoxLink videoId="3rcOP8xDwTQ" title="Watch: Building a screen in your universal Expo app" />
 
 <Step label="1">
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -8,8 +8,15 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll address some app details before deploying our app to an app store, such as theming the statusbar, add a splash screen, and customizing the app icon.
+
+<VideoBoxLink
+  videoId="OgGCYdElcZo"
+  title="How to configure status bar, splash screen & app icon Universal App #9"
+  description="In this video you will learn how to configure the status bar, set a splash screen and an app icon."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -14,8 +14,7 @@ In this chapter, we'll address some app details before deploying our app to an a
 
 <VideoBoxLink
   videoId="OgGCYdElcZo"
-  title="How to configure status bar, splash screen & app icon Universal App #9"
-  description="In this video you will learn how to configure the status bar, set a splash screen and an app icon."
+  title="Watch: Adding the finishing touches to your universal Expo app"
 />
 
 <Step label="1">

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -6,10 +6,17 @@ description: In this tutorial, learn how to create a modal from React Native to 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal) that presents content above the rest of your app. In general, modals are used to draw a user's attention toward critical information or guide them to take action. For example, in the [third chapter](/tutorial/build-a-screen/#step-7-enhance-the-reusable-button-component), after pressing the button, we used `alert()` to display some placeholder text. That's how a modal component displays an overlay.
 
 In this chapter, we'll create a modal that shows an emoji picker list.
+
+<VideoBoxLink
+  videoId="HRAMzrBwVeo"
+  title="How to create a modal in React Native Universal App tutorial #5"
+  description="This is chapter we explore how the modal component works and how it can be used to grab the user's attention."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -14,8 +14,7 @@ In this chapter, we'll create a modal that shows an emoji picker list.
 
 <VideoBoxLink
   videoId="HRAMzrBwVeo"
-  title="How to create a modal in React Native Universal App tutorial #5"
-  description="This is chapter we explore how the modal component works and how it can be used to grab the user's attention."
+  title="Watch: How to build a modal in your universal Expo app"
 />
 
 <Step label="1">

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -14,7 +14,7 @@ In this chapter, we'll create a modal that shows an emoji picker list.
 
 <VideoBoxLink
   videoId="HRAMzrBwVeo"
-  title="Watch: How to build a modal in your universal Expo app"
+  title="Watch: Creating a modal in your universal Expo app"
 />
 
 <Step label="1">

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -12,10 +12,7 @@ React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal
 
 In this chapter, we'll create a modal that shows an emoji picker list.
 
-<VideoBoxLink
-  videoId="HRAMzrBwVeo"
-  title="Watch: Creating a modal in your universal Expo app"
-/>
+<VideoBoxLink videoId="HRAMzrBwVeo" title="Watch: Creating a modal in your universal Expo app" />
 
 <Step label="1">
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -17,11 +17,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, let's learn how to create a new Expo project and how to get it running.
 
-<VideoBoxLink
-  videoId="m1-bc53EGh8"
-  title="How to create your first Expo app Universal App tutorial #1"
-  description="Learn how to create your first app in this universal app video tutorial."
-/>
+<VideoBoxLink videoId="m1-bc53EGh8" title="Watch: Creating your first universal Expo app" />
 
 ## Prerequisites
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -13,8 +13,15 @@ import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, let's learn how to create a new Expo project and how to get it running.
+
+<VideoBoxLink
+  videoId="m1-bc53EGh8"
+  title="How to create your first Expo app Universal App tutorial #1"
+  description="Learn how to create your first app in this universal app video tutorial."
+/>
 
 ## Prerequisites
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -15,11 +15,7 @@ Gestures are a great way to provide an intuitive user experience in an app. The 
 
 We'll also use the [Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/handling-gestures/) library to animate between gesture states.
 
-<VideoBoxLink
-  videoId="0q48LLvTGDU"
-  title="How to add gestures to an Expo App Universal App tutorial #6"
-  description="In this chapter we add different gestures using the Gesture Handler library."
-/>
+<VideoBoxLink videoId="0q48LLvTGDU" title="Watch: Adding gestures to your universal Expo app" />
 
 <Step label="1">
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -6,6 +6,7 @@ description: In this tutorial, learn how to implement gestures from React Native
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Gestures are a great way to provide an intuitive user experience in an app. The [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/) library provides built-in native components that can handle gestures. It recognizes pan, tap, rotation, and other gestures using the platform's native touch handling system. In this chapter, we'll to add two different gestures using this library:
 
@@ -13,6 +14,12 @@ Gestures are a great way to provide an intuitive user experience in an app. The 
 - Pan to move the emoji sticker around the screen so that the user can place the sticker anywhere on the image.
 
 We'll also use the [Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/handling-gestures/) library to animate between gesture states.
+
+<VideoBoxLink
+  videoId="0q48LLvTGDU"
+  title="How to add gestures to an Expo App Universal App tutorial #6"
+  description="In this chapter we add different gestures using the Gesture Handler library."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -18,8 +18,7 @@ We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library fro
 
 <VideoBoxLink
   videoId="iEQZU58naS8"
-  title="How to use an image picker Universal App tutorial #4"
-  description="This is chapter 4 in our Universal App tutorial series. Beto demonstrates how to install expo-image-picker."
+  title="Watch: Using an image picker in your universal Expo app"
 />
 
 <Step label="1">

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -8,12 +8,19 @@ import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 React Native provides built-in components as standard building blocks, such as `<View>`, `<Text>`, and `<Pressable>`. We are building a feature to select an image from the device's media gallery. This isn't possible with the core components and we'll need a library to add this feature in our app.
 
 We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library from Expo SDK.
 
 > `expo-image-picker` provides access to the system's UI to select images and videos from the phone's library.
+
+<VideoBoxLink
+  videoId="iEQZU58naS8"
+  title="How to use an image picker Universal App tutorial #4"
+  description="This is chapter 4 in our Universal App tutorial series. Beto demonstrates how to install expo-image-picker."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -17,8 +17,7 @@ In this chapter, we'll learn how to handle capturing screenshots for web browser
 
 <VideoBoxLink
   videoId="mEKQvF4irBM"
-  title="How to handle platform differences Universal App tutorial #8"
-  description="In this video you will learn how to handle platform differences to be able to have the same functionality across web, iOS, and Android platforms."
+  title="Watch: Handling platform differences in your universal Expo app"
 />
 
 <Step label="1">

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -9,10 +9,17 @@ import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Android, iOS, and the web have different capabilities. In our case, both Android and iOS can capture a screenshot with the `react-native-view-shot` library. However, web browsers cannot.
 
 In this chapter, we'll learn how to handle capturing screenshots for web browsers so our app has the same functionality on all platforms.
+
+<VideoBoxLink
+  videoId="mEKQvF4irBM"
+  title="How to handle platform differences Universal App tutorial #8"
+  description="In this video you will learn how to handle platform differences to be able to have the same functionality across web, iOS, and Android platforms."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -8,10 +8,17 @@ import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn how to take a screenshot using a third-party library and save it on the device's media library. We'll use [`react-native-view-shot`](https://github.com/gre/react-native-view-shot) to take a screenshot and [`expo-media-library`](/versions/latest/sdk/media-library/) to save an image on device's media library.
 
 > **info** So far, we have used third-party libraries, such as `react-native-gesture-handler`, `react-native-reanimated`. We can find hundreds of other third-party libraries on [React Native Directory](https://reactnative.directory/) depending on a use case.
+
+<VideoBoxLink
+  videoId="Jft3_Yfr-p4"
+  title="How to take and save screenshots Universal App tutorial #7"
+  description="In this video, you'll learn how to take and save screenshots."
+/>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -14,11 +14,7 @@ In this chapter, we'll learn how to take a screenshot using a third-party librar
 
 > **info** So far, we have used third-party libraries, such as `react-native-gesture-handler`, `react-native-reanimated`. We can find hundreds of other third-party libraries on [React Native Directory](https://reactnative.directory/) depending on a use case.
 
-<VideoBoxLink
-  videoId="Jft3_Yfr-p4"
-  title="How to take and save screenshots Universal App tutorial #7"
-  description="In this video, you'll learn how to take and save screenshots."
-/>
+<VideoBoxLink videoId="Jft3_Yfr-p4" title="Watch: Taking screenshots in your universal Expo app" />
 
 <Step label="1">
 


### PR DESCRIPTION
# Why

Fixes [DES-92](https://linear.app/expo/issue/DES-92/[video]-tutorial-video-series)

# How

Used `VideoBoxLink` to embed videos in each lesson

# Test Plan

Run locally and validate videos display correctly.

https://github.com/user-attachments/assets/906d3257-4840-4317-af38-f5d8b1c223c9

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
