### PR TITLE
[iOS][core] Made `CMTime` from `CoreMedia` a convertible type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Added `nativeRefType` to `SharedRef`. ([#31776](https://github.com/expo/expo/pull/31776) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `kotlin.time.Duration` support. ([#31858](https://github.com/expo/expo/pull/31858) by [@lukmccall](https://github.com/lukmccall))
 - Return duration from logger timer block methods. ([#31805](https://github.com/expo/expo/pull/31805) by [@wschurman](https://github.com/wschurman))
-- [iOS] Made `CMTime` from `CoreMedia` a convertible type.
+- [iOS] Made `CMTime` from `CoreMedia` a convertible type. ([#31967](https://github.com/expo/expo/pull/31967) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added `nativeRefType` to `SharedRef`. ([#31776](https://github.com/expo/expo/pull/31776) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `kotlin.time.Duration` support. ([#31858](https://github.com/expo/expo/pull/31858) by [@lukmccall](https://github.com/lukmccall))
 - Return duration from logger timer block methods. ([#31805](https://github.com/expo/expo/pull/31805) by [@wschurman](https://github.com/wschurman))
+- [iOS] Made `CMTime` from `CoreMedia` a convertible type.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+CMTime.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+CMTime.swift
@@ -1,0 +1,18 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import CoreMedia
+
+extension CMTime: Convertible {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> CMTime {
+    if let seconds = value as? Double {
+      return CMTime(seconds: seconds, preferredTimescale: .max)
+    }
+    if let seconds = value as? any BinaryInteger {
+      return CMTime(seconds: Double(seconds), preferredTimescale: .max)
+    }
+    if let time = value as? CMTime {
+      return time
+    }
+    throw Conversions.ConvertingException<CMTime>(value)
+  }
+}


### PR DESCRIPTION
# Why

For #31807 where it's nice to have a conversion from numbers (seconds) to `CMTime` type

# How

Added conformance to `Convertible` protocol on the `CMTime` type

# Test Plan

Tested when working on #31807 