### PR TITLE
[iOS][core] Move updating props to `finalizeUpdates`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -62,6 +62,7 @@
 - [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed views using the incorrect `AppContext` instance. ([#31897](https://github.com/expo/expo/pull/31897) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fixed crashes on the New Architecture when dispatching events during the props update.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -62,7 +62,7 @@
 - [iOS] Fixed `No space left on device` when saving persistent log. ([#31583](https://github.com/expo/expo/pull/31583) by [@RodolfoGS](https://github.com/RodolfoGS))
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed views using the incorrect `AppContext` instance. ([#31897](https://github.com/expo/expo/pull/31897) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fixed crashes on the New Architecture when dispatching events during the props update.
+- [iOS] Fixed crashes on the New Architecture when dispatching events during the props update. ([#31971](https://github.com/expo/expo/pull/31971) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -80,9 +80,7 @@ static NSString *normalizeEventName(NSString *eventName)
  */
 static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _componentFlavorsCache;
 
-@implementation ExpoFabricViewObjC {
-  ExpoViewEventEmitter::Shared _eventEmitter;
-}
+@implementation ExpoFabricViewObjC
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -118,36 +116,35 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
   };
 }
 
-- (void)updateProps:(const facebook::react::Props::Shared &)props oldProps:(const facebook::react::Props::Shared &)oldProps
+- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
-  const auto &newViewProps = *std::static_pointer_cast<ExpoViewProps const>(props);
-  NSMutableDictionary<NSString *, id> *propsMap = [[NSMutableDictionary alloc] init];
+  [super finalizeUpdates:updateMask];
 
-  for (const auto &item : newViewProps.propsMap) {
-    NSString *propName = [NSString stringWithUTF8String:item.first.c_str()];
+  if (updateMask & RNComponentViewUpdateMaskProps) {
+    const auto &newProps = static_cast<const ExpoViewProps &>(*_props);
+    NSMutableDictionary<NSString *, id> *propsMap = [[NSMutableDictionary alloc] init];
 
-    // Ignore props inherited from the base view and Yoga.
-    if ([self supportsPropWithName:propName]) {
-      propsMap[propName] = convertFollyDynamicToId(item.second);
+    for (const auto &item : newProps.propsMap) {
+      NSString *propName = [NSString stringWithUTF8String:item.first.c_str()];
+
+      // Ignore props inherited from the base view and Yoga.
+      if ([self supportsPropWithName:propName]) {
+        propsMap[propName] = convertFollyDynamicToId(item.second);
+      }
     }
+
+    [self updateProps:propsMap];
+    [self viewDidUpdateProps];
   }
-
-  [self updateProps:propsMap];
-  [super updateProps:props oldProps:oldProps];
-  [self viewDidUpdateProps];
-}
-
-- (void)updateEventEmitter:(const react::EventEmitter::Shared &)eventEmitter
-{
-  [super updateEventEmitter:eventEmitter];
-  _eventEmitter = std::static_pointer_cast<const ExpoViewEventEmitter>(eventEmitter);
 }
 
 #pragma mark - Events
 
 - (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
 {
-  _eventEmitter->dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {
+  const auto &eventEmitter = static_cast<const ExpoViewEventEmitter &>(*_eventEmitter);
+
+  eventEmitter.dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {
     return jsi::Value(runtime, expo::convertObjCObjectToJSIValue(runtime, payload));
   });
 }


### PR DESCRIPTION
# Why

Dispatching an event during the first props update (e.g. `onDisplay` in `expo-image` when shared ref is used as a source) is causing `EXC_BAD_ACCESS` crash on the New Architecture.

# How

I found out that we don't need to override the `updateEventEmitter` method to obtain the event emitter because we can already get it from `_eventEmitter` that is set by the base class. We should also update props in `finalizeUpdates` phase to make sure that the event emitter is correct when updating props.

# Test Plan

I tested a few components with events, including `expo-image` and `expo-video` – events seem to be dispatched correctly without crashes.