### PR TITLE
[cli] throw error for dom components when no webview installed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Added public assets support for DOM components. ([#30975](https://github.com/expo/expo/pull/30975) by [@kudo](https://github.com/kudo))
 - Drop usage of `@react-native-community/cli-server-api` in favor of our own Metro dev middleware. ([#31570](https://github.com/expo/expo/pull/31570) by [@byCedric](https://github.com/byCedric))
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
+- Throwing an error for DOM components if no webview installed. ([#31974](https://github.com/expo/expo/pull/31974) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
@@ -15,6 +15,17 @@ const warnUnstable = memoize(() =>
   Log.warn('Using experimental DOM Components API. Production exports may not work as expected.')
 );
 
+const checkWebViewInstalled = memoize((projectRoot: string) => {
+  const webViewInstalled =
+    resolveFrom.silent(projectRoot, 'react-native-webview') ||
+    resolveFrom.silent(projectRoot, '@expo/dom-webview');
+  if (!webViewInstalled) {
+    throw new Error(
+      `To use DOM Components, you must install the 'react-native-webview' package. Run 'npx expo install react-native-webview' to install it.`
+    );
+  }
+});
+
 type CreateDomComponentsMiddlewareOptions = {
   /** The absolute metro or server root, used to calculate the relative dom entry path */
   metroRoot: string;
@@ -26,7 +37,9 @@ export function createDomComponentsMiddleware(
   { metroRoot, projectRoot }: CreateDomComponentsMiddlewareOptions,
   instanceMetroOptions: PickPartial<ExpoMetroOptions, 'mainModuleName' | 'platform' | 'bytecode'>
 ) {
-  return async (req: ServerRequest, res: ServerResponse, next: (err?: Error) => void) => {
+  const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
+
+  return (req: ServerRequest, res: ServerResponse, next: (err?: Error) => void) => {
     if (!req.url) return next();
 
     const url = coerceUrl(req.url);
@@ -45,11 +58,11 @@ export function createDomComponentsMiddleware(
       return res.end();
     }
 
+    checkWebViewInstalled(projectRoot);
     warnUnstable();
 
     // Generate a unique entry file for the webview.
     const generatedEntry = file.startsWith('file://') ? fileURLToFilePath(file) : file;
-    const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
     const relativeImport = './' + path.relative(path.dirname(virtualEntry), generatedEntry);
     // Create the script URL
     const requestUrlBase = `http://${req.headers.host}`;

--- a/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
@@ -37,8 +37,6 @@ export function createDomComponentsMiddleware(
   { metroRoot, projectRoot }: CreateDomComponentsMiddlewareOptions,
   instanceMetroOptions: PickPartial<ExpoMetroOptions, 'mainModuleName' | 'platform' | 'bytecode'>
 ) {
-  const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
-
   return (req: ServerRequest, res: ServerResponse, next: (err?: Error) => void) => {
     if (!req.url) return next();
 
@@ -63,6 +61,7 @@ export function createDomComponentsMiddleware(
 
     // Generate a unique entry file for the webview.
     const generatedEntry = file.startsWith('file://') ? fileURLToFilePath(file) : file;
+    const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
     const relativeImport = './' + path.relative(path.dirname(virtualEntry), generatedEntry);
     // Create the script URL
     const requestUrlBase = `http://${req.headers.host}`;

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/DomComponentsMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/DomComponentsMiddleware-test.ts
@@ -1,0 +1,85 @@
+import { getMetroServerRoot } from '@expo/config/paths';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { createDomComponentsMiddleware } from '../DomComponentsMiddleware';
+import type { ServerNext, ServerRequest, ServerResponse } from '../server.types';
+
+jest.mock('resolve-from');
+
+const asRequest = (req: Partial<ServerRequest>) => req as ServerRequest;
+
+function createMockResponse() {
+  return {
+    getHeader: jest.fn(),
+    setHeader: jest.fn(),
+    on: jest.fn(),
+    once: jest.fn(),
+    emit: jest.fn(),
+    end: jest.fn(),
+    statusCode: 200,
+  } as unknown as ServerResponse;
+}
+
+describe('Check webview package installation', () => {
+  const projectRoot = '/project';
+  const metroRoot = getMetroServerRoot(projectRoot);
+
+  const mockResolveFrom = resolveFrom as jest.MockedFunction<typeof resolveFrom>;
+  mockResolveFrom.mockImplementation((fromDirectory: string, moduleId: string) => {
+    if (moduleId === 'expo/dom/entry.js') {
+      return path.join(fromDirectory, 'node_modules/expo/dom/entry.js');
+    }
+    throw new Error(`Cannot resolve module '${moduleId}' from '${fromDirectory}'`);
+  });
+  const mockResolveSilent = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  let req: ServerRequest;
+  let res: ServerResponse;
+  let next: jest.Mock<ServerNext>;
+  let middleware: ReturnType<typeof createDomComponentsMiddleware>;
+
+  beforeEach(() => {
+    req = asRequest({
+      url: 'http://localhost:8081/_expo/@dom/hello.tsx?file=file://path/to/file.js',
+      headers: { host: 'localhost:8081' },
+    });
+    res = createMockResponse();
+    next = jest.fn();
+    middleware = createDomComponentsMiddleware(
+      { metroRoot, projectRoot },
+      {
+        mode: 'development',
+        routerRoot: projectRoot,
+        reactCompiler: false,
+        isExporting: false,
+      }
+    );
+  });
+
+  afterEach(() => {
+    mockResolveSilent.mockReset();
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should show an error message if the webview package is not installed', () => {
+    mockResolveSilent.mockReturnValue(undefined);
+    expect(() => middleware(req, res, next)).toThrow(
+      /To use DOM Components, you must install the 'react-native-webview' package. Run 'npx expo install react-native-webview' to install it./
+    );
+  });
+
+  it('should not show error messages if react-native-webview is installed', () => {
+    mockResolveSilent.mockReturnValue('/project/node_modules/react-native-webview');
+    expect(() => middleware(req, res, next)).not.toThrow();
+  });
+
+  it('should not show error messages if @expo/dom-webview is installed', () => {
+    mockResolveSilent.mockReturnValue('/project/node_modules/@expo/dom-webview');
+    expect(() => middleware(req, res, next)).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Why

close ENG-13529

# How

throw an error when no `react-native-webview` or `@expo/dom-webview` installed. this is done in the middleware so it's a debug only. when bundling (exporting) in release build, we don't do this check

![Screenshot 2024-10-10 at 11 22 18 PM](https://github.com/user-attachments/assets/580862eb-36c1-4283-9fdc-e20f8557b427)

# Test Plan

add unit test `DomComponentsMiddleware-test.ts`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
