### PR TITLE
[docs] Backport runtime version docs changes to 51

### DIFF
--- a/docs/pages/versions/v51.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/updates.mdx
@@ -17,7 +17,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 `expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates.
 
-## Installation and configuration
+## Installation
 
 The `expo-updates` library can be automatically configured using [EAS Update](/eas-update/introduction/), which is a hosted service that manages and serves updates to your app. To get started with EAS Update, follow the instructions in the [Get started](/eas-update/getting-started/) guide.
 
@@ -32,7 +32,7 @@ If you're installing this library in a [bare React Native app](/bare/overview/) 
 If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
 
 - [`updates.url`](/versions/latest/config/app/#updates): a URL of a remote service implementing the [Expo Updates protocol](/technical-specs/expo-updates-1/)
-- [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](/eas-update/runtime-versions/)
+- [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](#runtime-version)
 
 The remote service must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/). [EAS Update](/eas-update/introduction) is one such service, but it is also possible to use this library with a custom server.
 
@@ -45,11 +45,152 @@ The remote service must implement the [Expo Updates protocol](/technical-specs/e
 
 </Collapsible>
 
-### Additional configuration options
+## Configuration
 
-These are build-time configuration options that control the behavior of the library. For most apps, these configuration values can be set in the [app config](/workflow/configuration/) under the [`updates` property](/versions/latest/config/app/#updates).
+There are build-time configuration options that control the behavior of the library. For most apps, these configuration values are set in the [app config](/workflow/configuration/) under the [`updates` property](/versions/latest/config/app/#updates).
 
-You can also configure the library in your app's native project files if your project does not use Continuous Native Generation. It is also possible to override the configuration from native code.
+| [App Config property](/versions/latest/config/app/#updates) | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
+| ----------------------------------------------------------- | -------- | ----------- | --------------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| `updates.enabled`                                           | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
+| `updates.url`                                               | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
+| `updates.requestHeaders`                                    | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
+| `runtimeVersion`                                            | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
+| `updates.checkAutomatically`                                | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
+| `updates.fallbackToCacheTimeout`                            | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
+| `updates.useEmbeddedUpdate`                                 | `true`   | <NoIcon />  | `EXUpdatesHasEmbeddedUpdate`      | `expo.modules.updates.HAS_EMBEDDED_UPDATE`                       | `hasEmbeddedUpdate`      |
+| `updates.codeSigningCertificate`                            | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
+| `updates.codeSigningMetadata`                               | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+
+The two core required configuration options are:
+
+- [`updates.url`](/versions/latest/config/app/#updates): the URL at which the library fetches remote updates
+- [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](#runtime-version)
+
+These are configured automatically when following the EAS Update [Get started](/eas-update/getting-started/) guide.
+
+#### Runtime version
+
+Each time you build a binary for your app it includes the native code and configuration present at the time of the build as well as native configuration, and this unique combination is represented by a string called a runtime version. A remote update targets one runtime version, indicating that only binaries with a matching runtime version can load the remote update.
+
+<Collapsible summary="Manual configuration">
+
+The runtime version can be managed manually by setting the string value in the config field.
+
+```json
+{
+  "expo": {
+    "runtimeVersion": "<runtime_version_string>"
+  }
+}
+```
+
+</Collapsible>
+
+<Collapsible summary = "Automatic configuration using runtime version policies">
+
+Runtime version policies derive the runtime version from another piece of information already present in your project. They can be set in the [`runtimeVersion`](/versions/latest/config/app/#runtimeversion) config field as follows:
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "<policy_name>"
+    }
+  }
+}
+```
+
+Available policy types:
+
+<Collapsible summary="appVersion">
+
+The `"appVersion"` policy is provided for projects with that wish to define their runtime compatibility based on the app version.
+
+For example, in a project that has the following in its app config:
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "version": "1.0.0",
+    "ios": {
+      "buildNumber": "1"
+    },
+    "android": {
+      "versionCode": 1
+    }
+  }
+}
+```
+
+The `"appVersion"` policy will set the runtime version to the project's current `"version"` property. In this case, the runtime version for the Android and iOS builds and any updates would be `"1.0.0"`.
+
+This policy is great for projects that contain custom native code and that update the `"version"` field after every public release. To submit an app, the app stores require an updated native version number for each submitted build, which makes this policy convenient if you want to be sure that every version installed on user devices has a different runtime version.
+
+When using this policy, you need to manually update `"version"` field in the app config every time there is a public release, but for Play Store's Internal Test Track and the App Store's TestFlight uploads, you can rely on `"autoIncrement"` option in **eas.json** to [manage versions for you](/build-reference/app-versions/#remote-version-source).
+
+</Collapsible>
+
+<Collapsible summary="nativeVersion">
+
+The `"nativeVersion"` policy is provided for projects that wish to define their runtime compatibility based on the project's current `"version"` and `"versionCode"` (Android) or `"buildNumber"` (iOS) properties.
+
+For example, in a project that has the following in its app config:
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "nativeVersion"
+    },
+    "version": "1.0.0",
+    "ios": {
+      "buildNumber": "1"
+    },
+    "android": {
+      "versionCode": 1
+    }
+  }
+}
+```
+
+The runtime version for the Android and iOS builds and any updates would be the combination of `"[version]([buildNumber|versionCode])"`, which in this case would be `"1.0.0(1)"`.
+
+This policy is great for projects containing custom native code that update the native version numbers (`"buildNumber"` for iOS and `"versionCode"` for Android) for each build. To submit an app, the app stores require an updated native version number for each submitted build, which makes this policy convenient if you want to be sure that every app uploaded to the Play Store's Internal Test Track and the App Store's TestFlight distribution tools has a different `runtimeVersion`.
+
+It's important to know that this policy requires management of the native version numbers manually between each build.
+
+Also, if you select a different native version between Android and iOS, you'll end up with builds and updates with separate runtime versions.
+
+</Collapsible>
+
+<Collapsible summary="fingerprint">
+
+> **warning** The `fingerprint` runtime policy is still in beta for SDK >= 51 and not yet considered stable. Use may result in unexpected behavior.
+
+The `"fingerprint"` runtime version policy automatically calculates the runtime version for you, including through changes like SDK upgrades or adding custom native code.
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    }
+  }
+}
+```
+
+This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
+
+</Collapsible>
+
+</Collapsible>
+
+#### Native configuration and overriding
+
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 
@@ -70,18 +211,6 @@ If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you wil
 </Collapsible>
 
 </Collapsible>
-
-| [App Config property](/versions/latest/config/app/#updates) | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
-| ----------------------------------------------------------- | -------- | ----------- | --------------------------------- | ---------------------------------------------------------------- | ------------------------ |
-| `updates.enabled`                                           | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
-| `updates.url`                                               | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
-| `updates.requestHeaders`                                    | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
-| `runtimeVersion`                                            | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
-| `updates.checkAutomatically`                                | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
-| `updates.fallbackToCacheTimeout`                            | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
-| `updates.useEmbeddedUpdate`                                 | `true`   | <NoIcon />  | `EXUpdatesHasEmbeddedUpdate`      | `expo.modules.updates.HAS_EMBEDDED_UPDATE`                       | `hasEmbeddedUpdate`      |
-| `updates.codeSigningCertificate`                            | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
-| `updates.codeSigningMetadata`                               | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
 
 ## Usage
 
@@ -129,11 +258,11 @@ You can configure your app to check for updates manually by doing the following 
 
 Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
-**To test the content of an update in a development build**, run [`eas update`](/eas-update/publish/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
+**To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 
 **To test updates in a release build**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test). The full [Updates API](#api) is available in a release build.
 
-**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/publish/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
+**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
 
 ## API
 
@@ -145,11 +274,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                              | Description                                                                                                                                                                                                                                                    |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                          |
-| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                               |
-| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                  |
-| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                    |
-| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                             |
+| Code                              | Description                                                                                                                                                                                                                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                              |
+| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare React Native apps, double-check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                                   |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                      |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                        |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                                 |


### PR DESCRIPTION
# Why

This PR backports https://app.graphite.dev/github/pr/expo/expo/31554/rfc-docs-Consolidate-technical-details-of-runtime-version-documentation-into-expo-updates-SDK-doc to SDK 51 to fix broken links that point to latest (which is not unversioned).

Closes ENG-13774.

# How

[![copypasta](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/WjlTemxb6oA4PgZFmj08/ad1d6316-1e6b-41d1-baa1-4e01688fae82/copypasta.png)](https://app.graphite.dev//settings/meme-library?org=expo) 

... then remove a few things that were added to be released in SDK 52.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
