### PR TITLE
[docs] Use new video component to update all YouTube video embeds

### DIFF
--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -3,10 +3,16 @@ title: App version management
 description: Learn about different version types and how to manage them remotely or locally.
 ---
 
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Android and iOS each expose two values to identify the version of an app: the version visible in stores (user-facing version) and the version visible only to developers (developer-facing build version). This guide explains how you can manage those versions remotely or locally.
+
+<VideoBoxLink
+  videoId="Gk7RHDWsLsQ"
+  title="Automatic App Version Management"
+  description="In this Expo feature focus video you'll learn about automatic app version management in Expo EAS Build."
+/>
 
 ## App versions
 
@@ -71,10 +77,6 @@ EAS servers can store and manage your app's developer-facing build version (`and
 The remote version is initialized with the value from the local project. For example, if you have `android.versionCode` set to `1` in app config, when you create a new build using the remote version source, it will auto increment to `2`. However, if you do not have build versions set in your app config, the remote version will initialize with `1` when the first build is created.
 
 When the `remote` version property is enabled inside **eas.json**, the build version values stored in app config are ignored and not updated when the version is incremented remotely. The remote version source values are set on the native project when running a build, which is considered the source of truth for these values. You can safely remove these values from your app config.
-
-### Video walkthrough
-
-<ContentSpotlight url="https://www.youtube.com/embed/Gk7RHDWsLsQ" />
 
 ### Syncing already defined versions to remote
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -7,6 +7,7 @@ sidebar_title: Runtime issues
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Whether you're developing your app locally, sending it out to select beta testers, or launching your app live to the app stores, you'll always find yourself debugging issues. It's useful to split errors into two categories:
 
@@ -114,7 +115,11 @@ It can be a frustrating scenario when a production app crashes. There is very li
 
 Start by reproducing the crash using your production app and then **find an associated crash report**. For Android, you can use `adb logcat` and for iOS you can use the Console app in Xcode.
 
-<ContentSpotlight url="https://www.youtube.com/watch?v=LvCci4Bwmpc" />
+<VideoBoxLink
+  videoId="LvCci4Bwmpc"
+  title="How to use Logcat & macOS Console to debug"
+  description="In this tutorial, you'll learn how to use native device logging features like ADB Logcat and macOS Console to find bugs in your code and quickly fix them."
+/>
 
 #### Crash reports using adb logcat
 

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -8,8 +8,15 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 A splash screen and an app icon are fundamental elements of a mobile app. They play an important role in the user experience and branding of the app. This guide provides steps on how to create and add them to your app.
+
+<VideoBoxLink
+  videoId="QSNkU7v0MPc"
+  title="Create an App Icon and Splash Screen"
+  description="See a detailed walkthrough on how to create an app icon and splash screen for an Expo project."
+/>
 
 ## Splash screen
 
@@ -22,10 +29,6 @@ The default splash screen in an Expo project is a blank white screen. It can be 
 ### Create a splash screen
 
 To create a splash image, you can use this [Figma template](https://www.figma.com/community/file/1155362909441341285). It provides a bare minimum design for an icon and splash images for Android and iOS.
-
-For an in-detail walkthrough, see the video below:
-
-<ContentSpotlight url="https://youtu.be/QSNkU7v0MPc" />
 
 <Collapsible summary="Dealing with various screen sizes for Android and iOS">
 
@@ -185,10 +188,6 @@ An app's icon is what your app users see on their device's home screen and app s
 ### Create an app icon
 
 To create an app icon, you can use this [Figma template](https://www.figma.com/community/file/1155362909441341285). It provides a bare minimum design for an icon and splash images for Android and iOS.
-
-For an in-detail walkthrough, see the video below:
-
-<ContentSpotlight url="https://youtu.be/QSNkU7v0MPc" />
 
 </Step>
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -6,8 +6,17 @@ description: Learn how to use basic debugging techniques to fix an update issue.
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 This guide shows how to verify our configuration so that we can find the source of problems like an app not showing a published update. It's important to tell the current state of our app at any given time, so EAS Update was built with this in mind. Once we know which updates are running on which builds, we can make changes so that our apps are in the state we expect.
+
+<VideoBoxLink
+  videoId="m9PLTr3t3S4"
+  title="How to debug EAS Update"
+  description="In this Expo debugging tutorial, you'll learn how to debug a situation where your build isn't getting an update."
+/>
+
+<br />
 
 > If we are not using EAS Build, our Deployments page will be empty. Follow the guide on [debugging configuration without EAS Build](/eas-update/debug-advanced/#configuration-without-eas-build) instead.
 
@@ -154,10 +163,6 @@ To create and publish an update, we can run the following command:
 <Terminal cmd={['$ eas update']} />
 
 After publishing, the output will display the branch and the runtime version. This information can help us verify that we're creating an update with the configuration we expect.
-
-## Video walkthrough
-
-<ContentSpotlight url="https://www.youtube.com/embed/m9PLTr3t3S4" />
 
 ## General strategies
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -7,17 +7,19 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Keyboard handling is crucial for creating an excellent user experience in your Expo app. React Native provides [`Keyboard`](https://reactnative.dev/docs/keyboard) and [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview), which are commonly used to handle keyboard events. For more complex or custom keyboard interactions, you can consider using [`react-native-keyboard-controller`](https://kirillzyusko.github.io/react-native-keyboard-controller), which is a library that offers advanced keyboard handling capabilities.
 
 This guide covers common keyboard interactions and how to manage them effectively.
 
-## Keyboard handling video tutorial
-
-<ContentSpotlight url="https://www.youtube.com/embed/Y51mDfAhd4E" />
+<VideoBoxLink
+  videoId="Y51mDfAhd4E"
+  title="Keyboard Handling tutorial for React Native apps"
+  description="In this keyboard handling tutorial for React Native apps, you'll learn how to solve the problem of the keyboard covering your input when you try to type on your app."
+/>
 
 ## Keyboard handling basics
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -4,14 +4,16 @@ sidebar_title: Create a native module
 description: A tutorial on creating a native module that persists settings with Expo Modules API.
 ---
 
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
+In this tutorial, we are going to build a module that stores the user's preferred app theme: either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 
-All the steps for creating a native module are listed below. If you're a visual learner, check out the video tutorial:
-
-<ContentSpotlight url="https://www.youtube.com/embed/CdaQSlyGik8" />
+<VideoBoxLink
+  videoId="CdaQSlyGik8"
+  title="How to create a native module with the Expo modules API"
+  description="Learn how to create a native module with the Expo Modules API to extend your apps capabilities by accessing native Android and iOS APIs."
+/>
 
 ## 1. Initialize a new module
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wrap third-party native libraries
-description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules.
+description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules API.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -9,19 +9,20 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-Expo modules make it possible to easily use native, external libraries built for Android and iOS in React Native projects.
-This tutorial focuses on utilizing the Expo Modules API to create radial charts using two similar libraries accessible on both native platforms.
+Expo modules make it possible to easily use native, external libraries built for Android and iOS in React Native projects. This tutorial focuses on utilizing the Expo Modules API to create radial charts using two similar libraries accessible on both native platforms.
 
 - [MPAndroidChart by PhilJay](https://github.com/PhilJay/MPAndroidChart)
 - [Charts by Daniel Cohen Gindi](https://github.com/danielgindi/Charts)
 
-The iOS library is inspired by the Android library, so they both have a very similar API and functionality.
-This makes them a good example for this tutorial.
+The iOS library is inspired by the Android library, so they both have a very similar API and functionality. This makes them a good example for this tutorial.
 
-## How to wrap native libraries video tutorial
-
-<ContentSpotlight url="https://www.youtube.com/embed/M8eNfH1o0eE" />
+<VideoBoxLink
+  videoId="M8eNfH1o0eE"
+  title="How to wrap native libraries"
+  description="In this video you will learn how to wrap native libraries using Expo Modules API."
+/>
 
 <Step label="1">
 

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -9,12 +9,10 @@ const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
 
 const PLAYER_WIDTH = '100%' as const;
 const PLAYER_HEIGHT = '100%' as const;
-const YOUTUBE_DOMAINS = ['youtube.com', 'youtu.be'] as const;
 
 type ContentSpotlightProps = {
   alt?: string;
   src?: string;
-  url?: string;
   file?: string;
   caption?: string;
   controls?: any;
@@ -26,7 +24,6 @@ type ContentSpotlightProps = {
 export function ContentSpotlight({
   alt,
   src,
-  url,
   file,
   caption,
   controls,
@@ -34,11 +31,8 @@ export function ContentSpotlight({
   className,
   containerClassName,
 }: ContentSpotlightProps) {
-  const isYouTubeDomain = (url?: string) => {
-    return url ? YOUTUBE_DOMAINS.some(domain => url.includes(domain)) : false;
-  };
-  const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
-  const isVideo = !!(url || file);
+  const [forceShowControls, setForceShowControls] = useState<boolean>();
+  const isVideo = !!file;
 
   return (
     <figure
@@ -66,7 +60,7 @@ export function ContentSpotlight({
           {({ isVisible }: { isVisible: boolean }) => (
             <div className="relative aspect-video bg-palette-black rounded-lg overflow-hidden">
               <ReactPlayer
-                url={isVisible ? url || `/static/videos/${file}` : undefined}
+                url={`/static/videos/${file}`}
                 className="react-player"
                 width={PLAYER_WIDTH}
                 height={PLAYER_HEIGHT}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-13758

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Replace all instances of `<ContentSpotlight URL />` with `VideoBoxLink`.
- Remove `url` prop from `ContetSpotlight` to disallow video embeds from YouTube.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
