### PR TITLE
[docs] Enable text selection in SidebarTitle

### DIFF
--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -7,7 +7,7 @@ type SidebarTitleProps = {
 } & PropsWithChildren;
 
 export const SidebarTitle = ({ children, Icon }: SidebarTitleProps) => (
-  <div className="flex gap-2 items-center relative ml-3 -mr-4 pb-1 select-text">
+  <div className="flex gap-2 items-center relative ml-3 -mr-4 pb-1">
     {Icon && <Icon className="icon-sm" />}
     <LABEL weight="medium" crawlable={false}>
       {children}

--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -7,7 +7,7 @@ type SidebarTitleProps = {
 } & PropsWithChildren;
 
 export const SidebarTitle = ({ children, Icon }: SidebarTitleProps) => (
-  <div className="flex gap-2 items-center relative ml-3 -mr-4 pb-1 select-none">
+  <div className="flex gap-2 items-center relative ml-3 -mr-4 pb-1 select-text">
     {Icon && <Icon className="icon-sm" />}
     <LABEL weight="medium" crawlable={false}>
       {children}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1728600901524329)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove classname  `select-none` from `SidebarTitle`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


https://github.com/user-attachments/assets/847f2678-7db9-443d-943a-518439dc5c27

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
