### PR TITLE
[NCL] make ListButton easier to press

### DIFF
--- a/apps/native-component-list/src/components/ListButton.tsx
+++ b/apps/native-component-list/src/components/ListButton.tsx
@@ -18,11 +18,11 @@ const ListButton = ({ disabled, onPress, style, title }: Props) => {
   const buttonStyles = [styles.button, disabled && styles.disabledButton];
   const labelStyles = [styles.label, disabled && styles.disabledLabel];
   return (
-    <View style={[buttonStyles]}>
-      <TouchableHighlight style={style} disabled={disabled} onPress={onPress} underlayColor="#ddd">
+    <TouchableHighlight style={style} disabled={disabled} onPress={onPress} underlayColor="#ddd">
+      <View style={buttonStyles}>
         <Text style={labelStyles}>{title}</Text>
-      </TouchableHighlight>
-    </View>
+      </View>
+    </TouchableHighlight>
   );
 };
 


### PR DESCRIPTION
# Why

ListButton is kinda hard to press because only the text inside is pressable

# How

change the layout a bit

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
