### PR TITLE
[core] add docs links to Record implementations

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### 💡 Others
 
-- add documentations links to `Record` and `Field` implementations ([#31997](https://github.com/expo/expo/pull/31997) by [@vonovak](https://github.com/vonovak))
+- Added documentation links to `Record` and `Field` implementations ([#31997](https://github.com/expo/expo/pull/31997) by [@vonovak](https://github.com/vonovak))
 - Remove web hydration `process.env` type. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))
 - Added an `async` extension for OkHttp requests. ([#30841](https://github.com/expo/expo/pull/30841) by [@aleqsio](https://github.com/aleqsio))
 - Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### 💡 Others
 
+- add documentations links to `Record` and `Field` implementations ([#31997](https://github.com/expo/expo/pull/31997) by [@vonovak](https://github.com/vonovak))
 - Remove web hydration `process.env` type. ([#31267](https://github.com/expo/expo/pull/31267) by [@EvanBacon](https://github.com/EvanBacon))
 - Added an `async` extension for OkHttp requests. ([#30841](https://github.com/expo/expo/pull/30841) by [@aleqsio](https://github.com/aleqsio))
 - Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Field.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Field.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.records
 
+// For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Field(val key: String = "")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
@@ -1,3 +1,4 @@
 package expo.modules.kotlin.records
 
+// For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
 interface Record

--- a/packages/expo-modules-core/ios/Core/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Field.swift
@@ -1,5 +1,6 @@
 /**
  Property wrapper for `Record`'s data members that takes part in the process of serialization to and deserialization from the dictionary.
+ For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
  */
 @propertyWrapper
 public final class Field<Type: AnyArgument>: AnyFieldInternal {

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -1,5 +1,6 @@
 /**
  A protocol that allows initializing the object with a dictionary.
+ For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
  */
 public protocol Record: Convertible {
   /**


### PR DESCRIPTION
# Why

As a developer, it'd be nice to have some help for when I cmd+click on our `Record` / `Field` annotations.

# How

Added comments with links to the Expo documentation page that lists supported argument types for modules. These comments were inserted in the following files:
- `Field.kt` and `Record.kt` for Android
- `Field.swift` and `Record.swift` for iOS

# Test Plan


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).