### PR TITLE
[notifications][android] fix notification with ChannelAwareTrigger not being presented

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -90,6 +90,28 @@ export default class NotificationScreen extends React.Component<
           title="Present a notification immediately"
         />
         <ListButton
+          onPress={async () => {
+            await this._obtainUserFacingNotifPermissionsAsync();
+            await Notifications.setNotificationChannelAsync('high-importance', {
+              name: 'important notification',
+              importance: Notifications.AndroidImportance.MAX,
+              bypassDnd: true,
+            });
+            await Notifications.scheduleNotificationAsync({
+              content: {
+                categoryIdentifier: 'welcome',
+                title: 'Here is a notification!',
+                body: 'This one has buttons!',
+                autoDismiss: true,
+              },
+              trigger: {
+                channelId: 'high-importance',
+              },
+            });
+          }}
+          title="Present a notification with action buttons"
+        />
+        <ListButton
           onPress={this._scheduleLocalNotificationAsync}
           title="Schedule notification for 10 seconds from now"
         />
@@ -194,7 +216,18 @@ export default class NotificationScreen extends React.Component<
     // Calling alert(message) immediately fails to show the alert on Android
     // if after backgrounding the app and then clicking on a notification
     // to foreground the app
-    setTimeout(() => Alert.alert('You clicked on the notification 🥇'), 1000);
+    setTimeout(
+      () =>
+        Alert.alert(
+          'You clicked on the notification 🥇',
+          JSON.stringify({
+            actionIdentifier: notificationResponse.actionIdentifier,
+            userText: notificationResponse.userText,
+          })
+        ),
+      1000
+    );
+    Notifications.dismissNotificationAsync(notificationResponse.notification.request.identifier);
   };
 
   private getPermissionsAsync = async () => {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] fix notifications with `ChannelAwareTrigger` not being presented ([#31999](https://github.com/expo/expo/pull/31999) by [@vonovak](https://github.com/vonovak))
 - export `PermissionStatus` as value, not as type ([#31968](https://github.com/expo/expo/pull/31968) by [@vonovak](https://github.com/vonovak))
 - throw improved error on invalid subscription in removeNotificationSubscription ([#31842](https://github.com/expo/expo/pull/31842) by [@vonovak](https://github.com/vonovak))
 - [android] fix notifications actions not being presented ([#31795](https://github.com/expo/expo/pull/31795) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
@@ -9,6 +9,7 @@ import androidx.core.app.AlarmManagerCompat
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationRequest
+import expo.modules.notifications.notifications.triggers.ChannelAwareTrigger
 import expo.modules.notifications.service.NotificationsService
 import expo.modules.notifications.service.interfaces.SchedulingDelegate
 import java.io.IOException
@@ -50,6 +51,10 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
     }
 
     if (request.trigger !is SchedulableNotificationTrigger) {
+      if (request.trigger is ChannelAwareTrigger) {
+        NotificationsService.receive(context, Notification(request))
+        return
+      }
       throw IllegalArgumentException("Notification request \"${request.identifier}\" does not have a schedulable trigger (it's ${request.trigger}). Refusing to schedule.")
     }
 


### PR DESCRIPTION
# Why

When presenting a notification that specifies `channelId` in the trigger (as seen in the example code added), calling `scheduleNotificationAsync` would reject.

# How

Handled the case of `request.trigger is ChannelAwareTrigger` specifically.

It's not a nice fix, and I believe `channel` shouldn't be part of a trigger at all (`ChannelAwareTrigger` wouldn't exists) but this is the least invasive fix

# Test Plan

tested with the added example code in Expo Go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
