### PR TITLE
[notifications][android] createNotificationChannel could return incorrect channel information

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] `createNotificationChannel` could return incorrect channel information ([#32000](https://github.com/expo/expo/pull/32000) by [@vonovak](https://github.com/vonovak))
 - [android] fix notifications with `ChannelAwareTrigger` not being presented ([#31999](https://github.com/expo/expo/pull/31999) by [@vonovak](https://github.com/vonovak))
 - export `PermissionStatus` as value, not as type ([#31968](https://github.com/expo/expo/pull/31968) by [@vonovak](https://github.com/vonovak))
 - throw improved error on invalid subscription in removeNotificationSubscription ([#31842](https://github.com/expo/expo/pull/31842) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/managers/AndroidXNotificationsChannelManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/managers/AndroidXNotificationsChannelManager.java
@@ -80,7 +80,10 @@ public class AndroidXNotificationsChannelManager implements NotificationsChannel
     NotificationChannel channel = new NotificationChannel(channelId, name, importance);
     configureChannelWithOptions(channel, channelOptions);
     mNotificationManager.createNotificationChannel(channel);
-    return channel;
+    // We return the channel given by mNotificationManager, not the one we created.
+    // see "Note that the created channel may differ from this value." ("this value" = the one we provided)
+    // https://developer.android.com/reference/android/app/NotificationManager#createNotificationChannel(android.app.NotificationChannel)
+    return mNotificationManager.getNotificationChannel(channelId);
   }
 
   // Processing options


### PR DESCRIPTION
# Why

This change addresses a potential discrepancy between the created notification channel and the one returned by the Android system. It ensures that the method returns the actual channel created by the NotificationManager, which may differ from the one provided.

# How

The `createNotificationChannel` method has been updated to return the channel obtained from `mNotificationManager.getNotificationChannel(channelId)` instead of the locally created channel. This change aligns with the Android documentation, which notes that the created channel may differ from the provided value.

# Test Plan

tested locally with an android device where this culprit was observed - gotta love Android!

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).