### PR TITLE
[notifications][android] simplify DateTrigger

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 💡 Others
 
+- [android] simplify DateTrigger ([#32002](https://github.com/expo/expo/pull/32002) by [@vonovak](https://github.com/vonovak))
 - [android] refactor ExpoNotificationBuilder ([#31838](https://github.com/expo/expo/pull/31838) by [@vonovak](https://github.com/vonovak))
 - Warn about limited support in Expo Go ([#31573](https://github.com/expo/expo/pull/31573) by [@vonovak](https://github.com/vonovak))
 - Keep using the legacy event emitter as the module is not fully migrated to Expo Modules API. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-notifications/android/src/androidTest/kotlin/expo/modules/notifications/NotificationTriggerTest.kt
+++ b/packages/expo-notifications/android/src/androidTest/kotlin/expo/modules/notifications/NotificationTriggerTest.kt
@@ -1,4 +1,3 @@
-@file:Suppress("DEPRECATION")
 
 package expo.modules.notifications
 
@@ -18,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Calendar
 
-@Suppress("DEPRECATION")
 @SmallTest
 class NotificationTriggerTest {
   private var calendarNow: Calendar = Calendar.getInstance()
@@ -96,10 +94,10 @@ class NotificationTriggerTest {
     val parcel = Parcel.obtain()
     dateTrigger.writeToParcel(parcel, 0)
     parcel.setDataPosition(0)
-    val dateTriggerFromParcel = DateTrigger(parcel)
+    val dateTriggerFromParcel = parcelableCreator<DateTrigger>().createFromParcel(parcel)
     assertEquals(dateTrigger.channelId, dateTriggerFromParcel.channelId)
-    assertEquals(dateTrigger.triggerDate, dateTriggerFromParcel.triggerDate)
-    assertEquals(calendar5MinutesFromNow.time.time, dateTriggerFromParcel.triggerDate.time)
+    assertEquals(dateTrigger.timestamp, dateTriggerFromParcel.timestamp)
+    assertEquals(calendar5MinutesFromNow.time.time, dateTriggerFromParcel.timestamp)
   }
 
   @Test

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -202,7 +202,7 @@ public class NotificationSerializer {
     } else if (trigger instanceof DateTrigger) {
       bundle.putString("type", "date");
       bundle.putBoolean("repeats", false);
-      bundle.putLong("value", ((DateTrigger) trigger).getTriggerDate().getTime());
+      bundle.putLong("value", ((DateTrigger) trigger).getTimestamp());
     } else if (trigger instanceof DailyTrigger) {
       bundle.putString("type", "daily");
       bundle.putInt("hour", ((DailyTrigger) trigger).getHour());

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
@@ -1,10 +1,8 @@
 package expo.modules.notifications.notifications.triggers
 
-import android.os.Parcel
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
 import kotlinx.parcelize.IgnoredOnParcel
-import kotlinx.parcelize.Parceler
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 import java.util.Calendar
@@ -46,29 +44,16 @@ class DailyTrigger(override val channelId: String?, val hour: Int, val minute: I
  */
 @Parcelize
 class DateTrigger(override val channelId: String?, val timestamp: Long) : ChannelAwareTrigger(channelId), SchedulableNotificationTrigger {
-  val triggerDate = Date(timestamp)
-
-  constructor(parcel: Parcel) : this(parcel.readString(), parcel.readLong())
 
   override fun nextTriggerDate(): Date? {
     val now = Date()
+    val triggerDate = Date(timestamp)
 
     if (triggerDate.before(now)) {
       return null
     }
 
     return triggerDate
-  }
-
-  companion object : Parceler<DateTrigger> {
-    override fun DateTrigger.write(parcel: Parcel, flags: Int) {
-      parcel.writeString(channelId)
-      parcel.writeLong(triggerDate.time)
-    }
-
-    override fun create(parcel: Parcel): DateTrigger {
-      return DateTrigger(parcel)
-    }
   }
 }
 


### PR DESCRIPTION
# Why

A follow up to recent PR this is a minor simplification of the Parcelable impl

# How

remove code, refactor places that depended on `triggerDate` property (NotificationSerializer.java)

# Test Plan

tests pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
