### PR TITLE
[docs] Remove step6 to notify Google of sitemap changes in docs deployment

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -22,7 +22,7 @@ fi
 #   5. Add custom redirects
 #   6. Notify Google of sitemap changes for SEO
 
-echo "::group::[1/6] Sync Next.js static assets in \`_next/**\` folder"
+echo "::group::[1/5] Sync Next.js static assets in \`_next/**\` folder"
 aws s3 sync \
   --no-progress \
   --exclude "*" \
@@ -32,7 +32,7 @@ aws s3 sync \
   "s3://${bucket}"
 echo "::endgroup::"
 
-echo "::group::[2/6] Sync assets in \`static/**\` folder"
+echo "::group::[2/5] Sync assets in \`static/**\` folder"
 aws s3 sync \
   --no-progress \
   --exclude "*" \
@@ -44,7 +44,7 @@ echo "::endgroup::"
 
 # Due to a bug with `aws s3 sync` we need to copy everything first instead of syncing
 # see: https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849
-echo "::group::[3/6] Overwrite HTML dependents, not located in \`_next/**\` or \`static/**\` folder"
+echo "::group::[3/5] Overwrite HTML dependents, not located in \`_next/**\` or \`static/**\` folder"
 aws s3 cp \
   --no-progress \
   --recursive \
@@ -54,7 +54,7 @@ aws s3 cp \
   "s3://${bucket}"
 echo "::endgroup::"
 
-echo "::group::[4/6] Sync assets and clean up outdated files from previous deployments"
+echo "::group::[4/5] Sync assets and clean up outdated files from previous deployments"
 aws s3 sync \
   --no-progress \
   --delete \
@@ -286,7 +286,7 @@ redirects[guides/troubleshooting-proxies]=troubleshooting/proxies
 redirects[guides/linking]=linking/overview
 redirects[guides/deep-linking]=/linking/into-your-app
 
-echo "::group::[5/6] Add custom redirects"
+echo "::group::[5/5] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do
   aws s3 cp \
@@ -310,10 +310,3 @@ do
   fi
 done
 echo "::endgroup::"
-
-
-# if [ "$bucket" = "docs.expo.dev" ]; then
-#   echo "::group::[6/6] Notify Google of sitemap changes"
-#   curl -m 15 "https://www.google.com/ping\?sitemap\=https%3A%2F%2F${bucket}%2Fsitemap.xml"
-#   echo "\n::endgroup::"
-# fi

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -312,8 +312,8 @@ done
 echo "::endgroup::"
 
 
-if [ "$bucket" = "docs.expo.dev" ]; then
-  echo "::group::[6/6] Notify Google of sitemap changes"
-  curl -m 15 "https://www.google.com/ping\?sitemap\=https%3A%2F%2F${bucket}%2Fsitemap.xml"
-  echo "\n::endgroup::"
-fi
+# if [ "$bucket" = "docs.expo.dev" ]; then
+#   echo "::group::[6/6] Notify Google of sitemap changes"
+#   curl -m 15 "https://www.google.com/ping\?sitemap\=https%3A%2F%2F${bucket}%2Fsitemap.xml"
+#   echo "\n::endgroup::"
+# fi


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Docs deployments are currently failing because of the following error:

![CleanShot 2024-10-11 at 23 47 11@2x](https://github.com/user-attachments/assets/9c8c4e02-1f1c-46d2-9e7f-9a28a0216fc3)

The issue is related to the sitemap pings being deprecated, which is described in this blog post: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping.

I've created a follow-up task to investigate further and apply the changes mentioned in the above blog post to our sitemap.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove step 6 to notify Google of sitemap changes in docs deployment.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
