### PR TITLE
[docs] Improve markdown's `hr` tag

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -25,6 +25,8 @@ Once the user selects an image, they can add a sticker to it. So, let's start cr
 
 <VideoBoxLink videoId="3rcOP8xDwTQ" title="Watch: Building a screen in your universal Expo app" />
 
+---
+
 <Step label="1">
 
 ## Break down the screen

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -17,6 +17,8 @@ In this chapter, we'll address some app details before deploying our app to an a
   title="Watch: Adding the finishing touches to your universal Expo app"
 />
 
+---
+
 <Step label="1">
 
 ## Configure the status bar

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -14,6 +14,8 @@ In this chapter, we'll create a modal that shows an emoji picker list.
 
 <VideoBoxLink videoId="HRAMzrBwVeo" title="Watch: Creating a modal in your universal Expo app" />
 
+---
+
 <Step label="1">
 
 ## Declare a state variable to show buttons

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -19,6 +19,8 @@ In this chapter, let's learn how to create a new Expo project and how to get it 
 
 <VideoBoxLink videoId="m1-bc53EGh8" title="Watch: Creating your first universal Expo app" />
 
+---
+
 ## Prerequisites
 
 We'll need the following to get started:

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -17,6 +17,8 @@ We'll also use the [Reanimated](https://docs.swmansion.com/react-native-reanimat
 
 <VideoBoxLink videoId="0q48LLvTGDU" title="Watch: Adding gestures to your universal Expo app" />
 
+---
+
 <Step label="1">
 
 ## Add GestureHandlerRootView

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -21,6 +21,8 @@ We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library fro
   title="Watch: Using an image picker in your universal Expo app"
 />
 
+---
+
 <Step label="1">
 
 ## Install expo-image-picker

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -20,6 +20,8 @@ In this chapter, we'll learn how to handle capturing screenshots for web browser
   title="Watch: Handling platform differences in your universal Expo app"
 />
 
+---
+
 <Step label="1">
 
 ## Install and import dom-to-image

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -16,6 +16,8 @@ In this chapter, we'll learn how to take a screenshot using a third-party librar
 
 <VideoBoxLink videoId="Jft3_Yfr-p4" title="Watch: Taking screenshots in your universal Expo app" />
 
+---
+
 <Step label="1">
 
 ## Install libraries

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -58,7 +58,10 @@ const markdownStyles: Record<string, Config | null> = {
   hr: {
     Component: 'hr',
     css: typography.utility.hr,
-    style: { margin: `2ch 0` },
+    style: {
+      margin: `2ch 0`,
+      marginTop: `3rem`,
+    },
   },
   blockquote: {
     Component: Callout,

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -60,7 +60,7 @@ const markdownStyles: Record<string, Config | null> = {
     css: typography.utility.hr,
     style: {
       margin: `2ch 0`,
-      marginTop: `3rem`,
+      marginTop: '3rem',
     },
   },
   blockquote: {

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -21,6 +21,7 @@ export function VideoBoxLink({ title, description, videoId, className }: VideoBo
         'flex overflow-hidden items-stretch relative border border-default rounded-lg bg-default transition shadow-xs',
         'hocus:shadow-sm',
         'max-sm-gutters:flex-col',
+        '[&+hr]:!mt-6',
         className
       )}
       isStyled>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the spacing for using `<hr />` tag is uneven.

Also, based on feedback from [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1728600700583939)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update `<hr />` styles used in Markdown
- Reduce margin top value of `<hr />` when used adjacent to `VideBoxLink`.

This PR 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-12 at 01 07 11@2x](https://github.com/user-attachments/assets/99efea9f-4718-4ed5-bbe6-c4aaab144c8d)

![CleanShot 2024-10-12 at 01 07 27@2x](https://github.com/user-attachments/assets/8ea8123d-0a69-4d94-8942-e9be8b0b2037)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
