### PR TITLE
[expo-updates][ios] Refactor errors and logging

### DIFF
--- a/apps/expo-go/ios/Client/HomeAppLoader.swift
+++ b/apps/expo-go/ios/Client/HomeAppLoader.swift
@@ -21,6 +21,7 @@ final class HomeAppLoader: AppLoader {
   required init(
     manifestAndAssetRequestHeaders: ManifestAndAssetRequestHeaders,
     config: UpdatesConfig,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     directory: URL,
     launchedUpdate: Update?,
@@ -29,7 +30,7 @@ final class HomeAppLoader: AppLoader {
     self.manifestAndAssetRequestHeaders = manifestAndAssetRequestHeaders
     self.downloader = FileDownloader(config: config)
     self.completionQueue = completionQueue
-    super.init(config: config, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
+    super.init(config: config, logger: logger, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
   }
 
   func loadHome(
@@ -82,13 +83,7 @@ final class HomeAppLoader: AppLoader {
       } else {
         guard let assetUrl = asset.url else {
           self.handleAssetDownload(
-            withError: NSError(
-              domain: HomeAppLoader.ErrorDomain,
-              code: 1006,
-              userInfo: [
-                NSLocalizedDescriptionKey: "Failed to download asset with no URL provided"
-              ]
-            ),
+            withError: UpdatesError.remoteAppLoaderAssetMissingUrl,
             asset: asset
           )
           return

--- a/apps/expo-go/ios/Client/HomeAppLoaderTask.swift
+++ b/apps/expo-go/ios/Client/HomeAppLoaderTask.swift
@@ -21,6 +21,7 @@ public final class HomeAppLoaderTask: NSObject {
 
   private let manifestAndAssetRequestHeaders: ManifestAndAssetRequestHeaders
   private let config: UpdatesConfig
+  private let logger = UpdatesLogger()
   private let database: UpdatesDatabase
   private let directory: URL
   private let selectionPolicy: SelectionPolicy
@@ -95,6 +96,7 @@ public final class HomeAppLoaderTask: NSObject {
     HomeAppLoader(
       manifestAndAssetRequestHeaders: self.manifestAndAssetRequestHeaders,
       config: config,
+      logger: logger,
       database: database,
       directory: directory,
       launchedUpdate: nil,
@@ -111,7 +113,7 @@ public final class HomeAppLoaderTask: NSObject {
   }
 
   private func launchUpdate(_ updateBeingLaunched: Update?, error: Error?) {
-    if let updateBeingLaunched = updateBeingLaunched {
+    if updateBeingLaunched != nil {
       let launcher = AppLauncherWithDatabase(
         config: self.config,
         database: self.database,

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Move location of assetPatternsToBeBundled config key ([#31584](https://github.com/expo/expo/pull/31584) by [@wschurman](https://github.com/wschurman))
 - Refactor JS event queueing and emitting ([#31818](https://github.com/expo/expo/pull/31818, [#31854](https://github.com/expo/expo/pull/31854) by [@wschurman](https://github.com/wschurman))
 - Remove clearUpdateCacheExperimentalAsync ([#31871](https://github.com/expo/expo/pull/31871) by [@wschurman](https://github.com/wschurman))
-- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929), [#31951](https://github.com/expo/expo/pull/31951), [#31953](https://github.com/expo/expo/pull/31953) by [@wschurman](https://github.com/wschurman))
+- Refactor errors, context injection, and error logs ([#31929](https://github.com/expo/expo/pull/31929), [#31951](https://github.com/expo/expo/pull/31951), [#31953](https://github.com/expo/expo/pull/31953), [#32009](https://github.com/expo/expo/pull/32009) by [@wschurman](https://github.com/wschurman))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -269,11 +269,12 @@ public class AppController: NSObject {
         try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: directory)
         _sharedInstance = EnabledAppController(config: config, database: updatesDatabase, updatesDirectory: directory)
       } catch {
+        let cause = UpdatesError.appControllerInitializationError(cause: error)
         logger.error(
-          message: "The expo-updates system is disabled due to an error during initialization: \(error.localizedDescription)",
+          cause: cause,
           code: .initializationError
         )
-        _sharedInstance = DisabledAppController(error: error)
+        _sharedInstance = DisabledAppController(error: cause)
         return
       }
     } else {

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public typealias AppLauncherCompletionBlock = (_ error: Error?, _ success: Bool) -> Void
+public typealias AppLauncherCompletionBlock = (_ error: UpdatesError?, _ success: Bool) -> Void
 
 /**
  * Protocol through which an update can be launched from disk. Classes that implement this protocol

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
@@ -1,7 +1,5 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable force_unwrapping
-
 import Foundation
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -27,8 +27,6 @@ public final class EmbeddedAppLoader: AppLoader {
   public static let EXUpdatesBareEmbeddedBundleFilename = "main"
   public static let EXUpdatesBareEmbeddedBundleFileType = "jsbundle"
 
-  private static let ErrorDomain = "EXUpdatesEmbeddedAppLoader"
-
   private static var embeddedManifestInternal: EmbeddedUpdate?
   public static func embeddedManifest(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> EmbeddedUpdate? {
     guard config.hasEmbeddedUpdate else {
@@ -106,13 +104,7 @@ public final class EmbeddedAppLoader: AppLoader {
     error errorBlock: @escaping AppLoaderErrorBlock
   ) {
     guard let embeddedManifest = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database) else {
-      errorBlock(NSError(
-        domain: EmbeddedAppLoader.ErrorDomain,
-        code: 1008,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
-        ]
-      ))
+      errorBlock(UpdatesError.embeddedAppLoaderEmbeddedManifestLoadFailed)
       return
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -1,6 +1,5 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable closure_body_length
 // swiftlint:disable function_parameter_count
 
 import Foundation
@@ -9,14 +8,13 @@ import Foundation
  * Subclass of AppLoader which handles downloading updates from a remote server.
  */
 public final class RemoteAppLoader: AppLoader {
-  private static let ErrorDomain = "EXUpdatesRemoteAppLoader"
-
   private let downloader: FileDownloader
   private var remoteUpdateResponse: UpdateResponse?
   private let completionQueue: DispatchQueue
 
   public required override init(
     config: UpdatesConfig,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     directory: URL,
     launchedUpdate: Update?,
@@ -24,7 +22,7 @@ public final class RemoteAppLoader: AppLoader {
   ) {
     self.downloader = FileDownloader(config: config)
     self.completionQueue = completionQueue
-    super.init(config: config, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
+    super.init(config: config, logger: logger, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
   }
 
   override public func loadUpdate(
@@ -52,8 +50,9 @@ public final class RemoteAppLoader: AppLoader {
             try strongSelf.database.setMetadata(withResponseHeaderData: responseHeaderData, scopeKey: strongSelf.config.scopeKey)
             successBlockArg(updateResponse)
           } catch {
-            NSLog("Error persisting header data to disk: %@", error.localizedDescription)
-            errorBlockArg(error)
+            let cause = UpdatesError.remoteAppLoaderHeaderDataError(cause: error)
+            strongSelf.logger.error(cause: cause, code: UpdatesErrorCode.unknown)
+            errorBlockArg(cause)
           }
         }
       } else {
@@ -66,6 +65,7 @@ public final class RemoteAppLoader: AppLoader {
       let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
         withDatabase: self.database,
         config: self.config,
+        logger: self.logger,
         launchedUpdate: self.launchedUpdate,
         embeddedUpdate: embeddedUpdate
       )
@@ -96,13 +96,7 @@ public final class RemoteAppLoader: AppLoader {
       } else {
         guard let assetUrl = asset.url else {
           self.handleAssetDownload(
-            withError: NSError(
-              domain: RemoteAppLoader.ErrorDomain,
-              code: 1006,
-              userInfo: [
-                NSLocalizedDescriptionKey: "Failed to download asset with no URL provided"
-              ]
-            ),
+            withError: UpdatesError.remoteAppLoaderAssetMissingUrl,
             asset: asset
           )
           return
@@ -128,20 +122,22 @@ public final class RemoteAppLoader: AppLoader {
 
   static func processSuccessLoaderResult(
     config: UpdatesConfig,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     selectionPolicy: SelectionPolicy,
     launchedUpdate: Update?,
     directory: URL,
     loaderTaskQueue: DispatchQueue,
     updateResponse: UpdateResponse?,
-    priorError: Error?,
-    onComplete: @escaping (_ updateToLaunch: Update?, _ error: Error?, _ didRollBackToEmbedded: Bool) -> Void
+    priorError: UpdatesError?,
+    onComplete: @escaping (_ updateToLaunch: Update?, _ error: UpdatesError?, _ didRollBackToEmbedded: Bool) -> Void
   ) {
     let updateBeingLaunched = updateResponse?.manifestUpdateResponsePart?.updateManifest
 
     if let rollBackDirective = updateResponse?.directiveUpdateResponsePart?.updateDirective as? RollBackToEmbeddedUpdateDirective {
       self.processRollBackToEmbeddedDirective(
         config: config,
+        logger: logger,
         database: database,
         selectionPolicy: selectionPolicy,
         launchedUpdate: launchedUpdate,
@@ -166,6 +162,7 @@ public final class RemoteAppLoader: AppLoader {
    */
   private static func processRollBackToEmbeddedDirective(
     config: UpdatesConfig,
+    logger: UpdatesLogger,
     database: UpdatesDatabase,
     selectionPolicy: SelectionPolicy,
     launchedUpdate: Update?,
@@ -173,8 +170,8 @@ public final class RemoteAppLoader: AppLoader {
     loaderTaskQueue: DispatchQueue,
     rollBackDirective: RollBackToEmbeddedUpdateDirective,
     manifestFilters: [String: Any]?,
-    priorError: Error?,
-    onComplete: @escaping (_ updateToLaunch: Update?, _ error: Error?, _ didRollBackToEmbedded: Bool) -> Void
+    priorError: UpdatesError?,
+    onComplete: @escaping (_ updateToLaunch: Update?, _ error: UpdatesError?, _ didRollBackToEmbedded: Bool) -> Void
   ) {
     if !config.hasEmbeddedUpdate {
       onComplete(nil, priorError, false)
@@ -201,6 +198,7 @@ public final class RemoteAppLoader: AppLoader {
 
     EmbeddedAppLoader(
       config: config,
+      logger: logger,
       database: database,
       directory: directory,
       launchedUpdate: nil,
@@ -220,7 +218,7 @@ public final class RemoteAppLoader: AppLoader {
           }
           onComplete(update, priorError, true)
         } catch {
-          onComplete(nil, error, false)
+          onComplete(nil, UpdatesError.remoteAppLoaderUnknownError(cause: error), false)
         }
       }, error: { embeddedLoaderError in
         onComplete(nil, embeddedLoaderError, false)

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/StructuredHeaders/StringDictionary.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/StructuredHeaders/StringDictionary.swift
@@ -2,10 +2,21 @@
 
 import Foundation
 
-public enum SerializerError: Error {
+public enum SerializerError: Error, Sendable, LocalizedError {
   case emptyKey
   case invalidCharacterInKey(key: String, character: Character)
   case invalidCharacterInString(string: String, character: Character)
+
+  public var errorDescription: String? {
+    switch self {
+    case .emptyKey:
+      return "Empty key found during expo-structured-headers serialization"
+    case let .invalidCharacterInKey(key, character):
+      return "Unable to serialize character in expo-structured-headers key (key: \(key), character: \(character))"
+    case let .invalidCharacterInString(string, character):
+      return "Unable to serialize character in expo-structured-headers string (string: \(string), character: \(character))"
+    }
+  }
 }
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateAsset.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateAsset.swift
@@ -54,6 +54,7 @@ public final class UpdateAsset: NSObject {
 
     guard let key = key else {
       // create a filename that's unlikely to collide with any other asset
+      // swiftlint:disable:next legacy_random
       return String(format: "asset-%d-%u%@", arguments: [Int(Date().timeIntervalSince1970), arc4random(), fileExtension])
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
@@ -2,9 +2,18 @@
 
 import React
 
-internal enum RemoteUpdateError: Error {
+internal enum RemoteUpdateError: Error, Sendable, LocalizedError {
   case directiveParsingError
-  case invalidDirectiveType
+  case invalidDirectiveType(messageType: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .directiveParsingError:
+      return "Directive JSON could not be parsed"
+    case let .invalidDirectiveType(messageType):
+      return "Unsupported directive type: \(messageType)"
+    }
+  }
 }
 
 internal final class SigningInfo {
@@ -50,7 +59,7 @@ public class UpdateDirective: NSObject {
       }
       return RollBackToEmbeddedUpdateDirective(commitTime: commitTime, signingInfo: signingInfo)
     default:
-      throw RemoteUpdateError.invalidDirectiveType
+      throw RemoteUpdateError.invalidDirectiveType(messageType: messageType)
     }
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/CertificateChain.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/CertificateChain.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import Foundation
+// swiftlint:disable force_unwrapping
+// swiftlint:disable identifier_name
 
 internal typealias Certificate = (SecCertificate, X509Certificate)
 
@@ -179,8 +180,7 @@ private extension SecTrust {
     var optionalTrust: SecTrust?
     let status = SecTrustCreateWithCertificates(certificates as AnyObject, policy, &optionalTrust)
     guard let trust = optionalTrust, status.isSuccess else {
-      NSLog("Could not create sec trust with certificates (OSStatus: %@)", status)
-      throw CodeSigningError.CertificateChainError
+      throw CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: status))
     }
     return trust
   }
@@ -188,22 +188,19 @@ private extension SecTrust {
   func setAnchorCertificates(_ anchorCertificates: [SecCertificate]) throws {
     let status = SecTrustSetAnchorCertificates(self, anchorCertificates as CFArray)
     guard status.isSuccess else {
-      NSLog("Could not set anchor certificates on sec trust (OSStatus: %@)", status)
-      throw CodeSigningError.CertificateChainError
+      throw CodeSigningError.CertificateChainError(reason: .couldNotSetAnchorOnSecTrust(osStatus: status))
     }
 
     let status2 = SecTrustSetAnchorCertificatesOnly(self, true)
     guard status2.isSuccess else {
-      NSLog("Could not set anchor certificates only setting on sec trust (OSStatus: %@)", status)
-      throw CodeSigningError.CertificateChainError
+      throw CodeSigningError.CertificateChainError(reason: .couldNotSetAnchorOnlySettingOnSecTrust(osStatus: status2))
     }
   }
 
   func disableNetwork() throws {
     let status = SecTrustSetNetworkFetchAllowed(self, false)
     guard status.isSuccess else {
-      NSLog("Could not disable network fetch on sec trust (OSStatus: %@)", status)
-      throw CodeSigningError.CertificateChainError
+      throw CodeSigningError.CertificateChainError(reason: .couldNotDisableNetworkFetchOnSecTrust(osStatus: status))
     }
   }
 
@@ -211,10 +208,10 @@ private extension SecTrust {
     var error: CFError?
     let success = SecTrustEvaluateWithError(self, &error)
     if !success {
-      if let error = error {
-        NSLog("Sec trust evaluation error: %@", error.localizedDescription)
-      }
-      throw CodeSigningError.CertificateChainError
+      throw CodeSigningError.CertificateChainError(reason: .secTrustEvaluationError(cause: error))
     }
   }
 }
+
+// swiftlint:enable force_unwrapping
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/CodeSigningError.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/CodeSigningError.swift
@@ -2,9 +2,30 @@
 
 // swiftlint:disable identifier_name
 
-import Foundation
+public enum CodeSigningError: Error, Sendable, LocalizedError {
+  public enum CertificateChainErrorReason: Sendable {
+    case couldNotCreateSecTrust(osStatus: OSStatus)
+    case couldNotSetAnchorOnSecTrust(osStatus: OSStatus)
+    case couldNotSetAnchorOnlySettingOnSecTrust(osStatus: OSStatus)
+    case couldNotDisableNetworkFetchOnSecTrust(osStatus: OSStatus)
+    case secTrustEvaluationError(cause: Error?)
 
-internal enum CodeSigningError: Error {
+    var localizedDescription: String {
+      switch self {
+      case let .couldNotCreateSecTrust(osStatus):
+        return "Could not create sec trust with certificates (OSStatus: \(osStatus))"
+      case let .couldNotSetAnchorOnSecTrust(osStatus):
+        return "Could not set anchor certificates on sec trust (OSStatus: \(osStatus))"
+      case let .couldNotSetAnchorOnlySettingOnSecTrust(osStatus):
+        return "Could not set anchor certificates only setting on sec trust (OSStatus: \(osStatus))"
+      case let .couldNotDisableNetworkFetchOnSecTrust(osStatus):
+        return "Could not disable network fetch on sec trust (OSStatus: \(osStatus))"
+      case let .secTrustEvaluationError(cause):
+        return "Sec trust evaluation error: \(cause?.localizedDescription ?? "Unknown evaluation error")"
+      }
+    }
+  }
+
   case CertificateEncodingError
   case CertificateDERDecodeError
   case CertificateValidityError
@@ -14,9 +35,9 @@ internal enum CodeSigningError: Error {
   case CertificateRootNotCA
   case CertificateProjectInformationChainError
   case KeyIdMismatchError
-  case SecurityFrameworkError
+  case SecurityFrameworkSecKeyVerificationError(cause: Error)
   case CertificateEmptyError
-  case CertificateChainError
+  case CertificateChainError(reason: CertificateChainErrorReason)
   case CertificateRootNotSelfSigned
   case SignatureHeaderMissing
   case SignatureHeaderStructuredFieldParseError
@@ -26,7 +47,7 @@ internal enum CodeSigningError: Error {
   case AlgorithmParseError
   case InvalidExpoProjectInformationExtensionValue
 
-  func message() -> String {
+  public var errorDescription: String? {
     switch self {
     case .CertificateEncodingError:
       return "Code signing certificate could not be encoded in a lossless manner using utf8 encoding"
@@ -46,12 +67,12 @@ internal enum CodeSigningError: Error {
       return "Expo project information must be a subset or equal of that of parent certificates"
     case .KeyIdMismatchError:
       return "Key with keyid from signature not found in client configuration"
-    case .SecurityFrameworkError:
-      return "Signature verification failed due to security framework error"
+    case let .SecurityFrameworkSecKeyVerificationError(cause):
+      return "Signature verification failed due to security framework sec key verification error: \(cause.localizedDescription)"
     case .CertificateEmptyError:
       return "No code signing certificates provided"
-    case .CertificateChainError:
-      return "Certificate chain error"
+    case let .CertificateChainError(reason):
+      return "Certificate chain error: \(reason.localizedDescription)"
     case .CertificateRootNotSelfSigned:
       return "Root certificate not self-signed"
     case .SignatureHeaderMissing:
@@ -71,3 +92,5 @@ internal enum CodeSigningError: Error {
     }
   }
 }
+
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
@@ -7,10 +7,21 @@ import sqlite3
 import SQLite3
 #endif
 
-internal enum UpdatesDatabaseMigrationError: Error {
+internal enum UpdatesDatabaseMigrationError: Error, Sendable, LocalizedError {
   case foreignKeysError
   case transactionError
   case migrationSQLError
+
+  var errorDescription: String? {
+    switch self {
+    case .foreignKeysError:
+      return "SQLite error temporarily disabling foreign keys"
+    case .transactionError:
+      return "SQLite error beginning or ending transaction"
+    case .migrationSQLError:
+      return "SQLite error running migration"
+    }
+  }
 }
 
 internal final class TransactionExecutor {

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
@@ -42,3 +42,5 @@ internal final class UpdatesDatabaseMigration4To5: UpdatesDatabaseMigration {
     }
   }
 }
+
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
@@ -50,3 +50,5 @@ internal final class UpdatesDatabaseMigration5To6: UpdatesDatabaseMigration {
     }
   }
 }
+
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
@@ -49,3 +49,5 @@ internal final class UpdatesDatabaseMigration6To7: UpdatesDatabaseMigration {
     }
   }
 }
+
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
@@ -53,3 +53,5 @@ internal final class UpdatesDatabaseMigration9To10: UpdatesDatabaseMigration {
     }
   }
 }
+
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -5,9 +5,8 @@
 // data compatibility.
 // swiftlint:disable legacy_objc_type
 // swiftlint:disable line_length
-// swiftlint:disable type_body_length
 // swiftlint:disable force_unwrapping
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 
 import Foundation
 #if canImport(sqlite3)
@@ -17,15 +16,30 @@ import SQLite3
 #endif
 import EXManifests
 
-internal enum UpdatesDatabaseError: Error {
-  case addExistingAssetMissingAssetKey
-  case addExistingAssetInsertError
-  case addExistingAssetAssetNotFoundError
-  case markMissingAssetsError
-  case deleteUpdatesError
-  case deleteUnusedAssetsError
-  case getUpdatesError
-  case setJsonDataError
+internal enum UpdatesDatabaseError: Error, Sendable, LocalizedError {
+  case addExistingAssetInsertOrReplaceIntoError(cause: Error)
+  case addExistingAssetUpdateLaunchAssetError(cause: Error)
+  case markMissingAssetsError(cause: Error)
+  case deleteUpdatesError(cause: Error)
+  case deleteUnusedAssetsError(cause: Error)
+  case setJsonDataError(cause: Error)
+
+  var errorDescription: String? {
+    switch self {
+    case let .addExistingAssetInsertOrReplaceIntoError(cause):
+      return "Database error while inserting asset: \(cause.localizedDescription)"
+    case let .addExistingAssetUpdateLaunchAssetError(cause):
+      return "Database error while updating launch asset on update: \(cause.localizedDescription)"
+    case let .markMissingAssetsError(cause):
+      return "Database error while marking missing assets: \(cause.localizedDescription)"
+    case let .deleteUpdatesError(cause):
+      return "Database error while deleting updates: \(cause.localizedDescription)"
+    case let .deleteUnusedAssetsError(cause):
+      return "Database error while deleting unused assets: \(cause.localizedDescription)"
+    case let .setJsonDataError(cause):
+      return "Database error while setting JSON data: \(cause.localizedDescription)"
+    }
+  }
 }
 
 enum UpdatesDatabaseHashType: Int {
@@ -190,7 +204,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try execute(sql: insertSql, withArgs: [updateId, assetId.intValue])
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.addExistingAssetInsertError
+        throw UpdatesDatabaseError.addExistingAssetInsertOrReplaceIntoError(cause: error)
       }
 
       if asset.isLaunchAsset {
@@ -199,7 +213,7 @@ public final class UpdatesDatabase: NSObject {
           _ = try execute(sql: updateSql, withArgs: [assetId.intValue, updateId])
         } catch {
           sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-          throw UpdatesDatabaseError.addExistingAssetInsertError
+          throw UpdatesDatabaseError.addExistingAssetUpdateLaunchAssetError(cause: error)
         }
       }
     }
@@ -307,7 +321,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try execute(sql: updateSql, withArgs: [UpdateStatus.StatusPending.rawValue, asset.assetId])
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.markMissingAssetsError
+        throw UpdatesDatabaseError.markMissingAssetsError(cause: error)
       }
     }
 
@@ -323,7 +337,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try execute(sql: updateSql, withArgs: [update.updateId])
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.deleteUpdatesError
+        throw UpdatesDatabaseError.deleteUpdatesError(cause: error)
       }
     }
 
@@ -343,7 +357,7 @@ public final class UpdatesDatabase: NSObject {
       _ = try execute(sql: update1Sql, withArgs: nil)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-      throw UpdatesDatabaseError.deleteUnusedAssetsError
+      throw UpdatesDatabaseError.deleteUnusedAssetsError(cause: error)
     }
 
     let update2Sql = "UPDATE assets SET marked_for_deletion = 0 WHERE id IN (SELECT asset_id FROM updates_assets INNER JOIN updates ON updates_assets.update_id = updates.id WHERE updates.keep = 1);"
@@ -351,7 +365,7 @@ public final class UpdatesDatabase: NSObject {
       _ = try execute(sql: update2Sql, withArgs: nil)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-      throw UpdatesDatabaseError.deleteUnusedAssetsError
+      throw UpdatesDatabaseError.deleteUnusedAssetsError(cause: error)
     }
 
     // check for duplicate rows representing a single file on disk
@@ -360,7 +374,7 @@ public final class UpdatesDatabase: NSObject {
       _ = try execute(sql: update3Sql, withArgs: nil)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-      throw UpdatesDatabaseError.deleteUnusedAssetsError
+      throw UpdatesDatabaseError.deleteUnusedAssetsError(cause: error)
     }
 
     var rows: [[String: Any?]]
@@ -369,7 +383,7 @@ public final class UpdatesDatabase: NSObject {
       rows = try execute(sql: selectSql, withArgs: nil)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-      throw UpdatesDatabaseError.deleteUnusedAssetsError
+      throw UpdatesDatabaseError.deleteUnusedAssetsError(cause: error)
     }
 
     let assets = rows.map { row in
@@ -381,7 +395,7 @@ public final class UpdatesDatabase: NSObject {
       _ = try execute(sql: deleteSql, withArgs: nil)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-      throw UpdatesDatabaseError.deleteUnusedAssetsError
+      throw UpdatesDatabaseError.deleteUnusedAssetsError(cause: error)
     }
 
     sqlite3_exec(db, "COMMIT;", nil, nil, nil)
@@ -495,7 +509,7 @@ public final class UpdatesDatabase: NSObject {
       if !isInTransaction {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
       }
-      throw UpdatesDatabaseError.setJsonDataError
+      throw UpdatesDatabaseError.setJsonDataError(cause: error)
     }
 
     let insertSql = """
@@ -507,7 +521,7 @@ public final class UpdatesDatabase: NSObject {
       if !isInTransaction {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
       }
-      throw UpdatesDatabaseError.setJsonDataError
+      throw UpdatesDatabaseError.setJsonDataError(cause: error)
     }
 
     if !isInTransaction {
@@ -577,7 +591,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try setJsonData(serverDefinedHeaders, withKey: UpdatesDatabase.ServerDefinedHeadersKey, scopeKey: scopeKey, isInTransaction: true)
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.setJsonDataError
+        throw UpdatesDatabaseError.setJsonDataError(cause: error)
       }
     }
 
@@ -586,7 +600,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try setJsonData(manifestFilters, withKey: UpdatesDatabase.ManifestFiltersKey, scopeKey: scopeKey, isInTransaction: true)
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.setJsonDataError
+        throw UpdatesDatabaseError.setJsonDataError(cause: error)
       }
     }
 
@@ -659,7 +673,7 @@ public final class UpdatesDatabase: NSObject {
     asset.metadata = metadata
 
     if let launchAssetId = launchAssetId?.intValue,
-       launchAssetId == assetId.intValue {
+      launchAssetId == assetId.intValue {
       asset.isLaunchAsset = true
     } else {
       asset.isLaunchAsset = false
@@ -668,3 +682,8 @@ public final class UpdatesDatabase: NSObject {
     return asset
   }
 }
+
+// swiftlint:enable legacy_objc_type
+// swiftlint:enable line_length
+// swiftlint:enable force_unwrapping
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -12,13 +12,30 @@ import sqlite3
 import SQLite3
 #endif
 
-enum UpdatesDatabaseInitializationError: Error {
-  case migrateAndRemoveOldDatabaseFailure
-  case moveExistingCorruptedDatabaseFailure
+enum UpdatesDatabaseInitializationError: Error, Sendable, LocalizedError {
+  case migrateAndRemoveOldDatabaseFailure(cause: Error)
+  case moveExistingCorruptedDatabaseFailure(cause: Error)
   case openAfterMovingCorruptedDatabaseFailure
   case openInitialDatabaseOtherFailure
   case openDatabaseFalure
   case databseSchemaInitializationFailure
+
+  var errorDescription: String? {
+    switch self {
+    case let .migrateAndRemoveOldDatabaseFailure(cause):
+      return "Failed to remove old database after failed migration: \(cause.localizedDescription)"
+    case let .moveExistingCorruptedDatabaseFailure(cause):
+      return "Failed to archive corrupted databse: \(cause.localizedDescription)"
+    case .openAfterMovingCorruptedDatabaseFailure:
+      return "Failed to open new database after corrupted database archive operation"
+    case .openInitialDatabaseOtherFailure:
+      return "Failed to open database: other failure"
+    case .openDatabaseFalure:
+      return "Failed to open database"
+    case .databseSchemaInitializationFailure:
+      return "Failed to initialize database schema"
+    }
+  }
 }
 
 /**
@@ -99,16 +116,17 @@ internal final class UpdatesDatabaseInitialization {
     shouldMigrate: Bool,
     migrations: [UpdatesDatabaseMigration]
   ) throws -> OpaquePointer {
+    let logger = UpdatesLogger()
     let dbUrl = directory.appendingPathComponent(filename)
     var shouldInitializeDatabaseSchema = !FileManager.default.fileExists(atPath: dbUrl.path)
 
-    let success = migrateDatabase(inDirectory: directory, migrations: migrations)
+    let success = migrateDatabase(inDirectory: directory, migrations: migrations, logger: logger)
     if !success {
       if FileManager.default.fileExists(atPath: dbUrl.path) {
         do {
           try FileManager.default.removeItem(atPath: dbUrl.path)
         } catch {
-          throw UpdatesDatabaseInitializationError.migrateAndRemoveOldDatabaseFailure
+          throw UpdatesDatabaseInitializationError.migrateAndRemoveOldDatabaseFailure(cause: error)
         }
       }
       shouldInitializeDatabaseSchema = true
@@ -124,7 +142,7 @@ internal final class UpdatesDatabaseInitialization {
     }
 
     if resultCode != SQLITE_OK {
-      NSLog("Error opening SQLite db: %@", [UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db).message])
+      logger.warn(message: "Error opening SQLite db: \(UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db).message)", code: .initializationError)
       sqlite3_close(db)
 
       if resultCode == SQLITE_CORRUPT || resultCode == SQLITE_NOTADB {
@@ -133,10 +151,10 @@ internal final class UpdatesDatabaseInitialization {
         do {
           try FileManager.default.moveItem(at: dbUrl, to: destinationUrl)
         } catch {
-          throw UpdatesDatabaseInitializationError.moveExistingCorruptedDatabaseFailure
+          throw UpdatesDatabaseInitializationError.moveExistingCorruptedDatabaseFailure(cause: error)
         }
 
-        NSLog("Moved corrupt SQLite db to %@", archivedDbFilename)
+        logger.info(message: "Moved corrupt SQLite db to %@ \(archivedDbFilename)")
         var dbInit2: OpaquePointer?
         guard sqlite3_open(dbUrl.path, &dbInit2) == SQLITE_OK else {
           throw UpdatesDatabaseInitializationError.openAfterMovingCorruptedDatabaseFailure
@@ -157,7 +175,7 @@ internal final class UpdatesDatabaseInitialization {
     do {
       _ = try UpdatesDatabaseUtils.execute(sql: "PRAGMA foreign_keys=ON;", withArgs: nil, onDatabase: db)
     } catch {
-      NSLog("Error turning on foreign key constraint: %@", [error.localizedDescription])
+      logger.warn(message: "Error turning on foreign key constraint: \(error.localizedDescription)")
     }
 
     if shouldInitializeDatabaseSchema {
@@ -169,7 +187,7 @@ internal final class UpdatesDatabaseInitialization {
     return db
   }
 
-  private static func migrateDatabase(inDirectory directory: URL, migrations: [UpdatesDatabaseMigration]) -> Bool {
+  private static func migrateDatabase(inDirectory directory: URL, migrations: [UpdatesDatabaseMigration], logger: UpdatesLogger) -> Bool {
     let latestURL = directory.appendingPathComponent(LatestFilename)
     if FileManager.default.fileExists(atPath: latestURL.path) {
       return true
@@ -194,13 +212,13 @@ internal final class UpdatesDatabaseInitialization {
     do {
       try FileManager.default.moveItem(atPath: existingURL.path, toPath: latestURL.path)
     } catch {
-      NSLog("Migration failed: failed to rename database file")
+      logger.warn(message: "Migration failed: failed to rename database file")
       return false
     }
 
     var db: OpaquePointer?
     if sqlite3_open(latestURL.path, &db) != SQLITE_OK {
-      NSLog("Error opening migrated SQLite db: %@", [UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db!).message])
+      logger.warn(message: "Error opening migrated SQLite db: \(UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db!).message)")
       sqlite3_close(db)
       return false
     }
@@ -209,7 +227,7 @@ internal final class UpdatesDatabaseInitialization {
     do {
       _ = try UpdatesDatabaseUtils.execute(sql: "PRAGMA foreign_keys=ON;", withArgs: nil, onDatabase: db!)
     } catch {
-      NSLog("Error turning on foreign key constraint: %@", [error.localizedDescription])
+      logger.warn(message: "Error turning on foreign key constraint: \(error.localizedDescription)")
     }
 
     for index in startingMigrationIndex..<migrations.count {
@@ -217,7 +235,7 @@ internal final class UpdatesDatabaseInitialization {
       do {
         try migration.runMigration(onDatabase: db!)
       } catch {
-        NSLog("Error migrating SQLite db: %@", [UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db!).message])
+        logger.warn(message: "Error migrating SQLite db: \(UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db!).message)")
         sqlite3_close(db)
         return false
       }
@@ -228,3 +246,6 @@ internal final class UpdatesDatabaseInitialization {
     return true
   }
 }
+
+// swiftlint:enable force_unwrapping
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
@@ -19,13 +19,15 @@ public final class UpdatesReaper: NSObject {
     selectionPolicy: SelectionPolicy,
     launchedUpdate: Update
   ) {
+    let logger = UpdatesLogger()
+
     database.databaseQueue.async {
       let beginDeleteFromDatabase = Date()
 
       do {
         try database.markUpdateFinished(launchedUpdate)
       } catch {
-        NSLog("Error reaping updates: %@", [error.localizedDescription])
+        logger.warn(message: "Error reaping updates: \(error.localizedDescription)")
         return
       }
 
@@ -33,7 +35,7 @@ public final class UpdatesReaper: NSObject {
       do {
         allUpdates = try database.allUpdates(withConfig: config)
       } catch {
-        NSLog("Error reaping updates: %@", [error.localizedDescription])
+        logger.warn(message: "Error reaping updates: \(error.localizedDescription)")
         return
       }
 
@@ -41,15 +43,15 @@ public final class UpdatesReaper: NSObject {
       do {
         manifestFilters = try database.manifestFilters(withScopeKey: config.scopeKey)
       } catch {
-        NSLog("Error selecting manifest filters while reaping updates: %@", [error.localizedDescription])
+        logger.warn(message: "Error selecting manifest filters while reaping updates: \(error.localizedDescription)")
         return
       }
 
-      var updatesToDelete = selectionPolicy.updatesToDelete(withLaunchedUpdate: launchedUpdate, updates: allUpdates, filters: manifestFilters)
+      let updatesToDelete = selectionPolicy.updatesToDelete(withLaunchedUpdate: launchedUpdate, updates: allUpdates, filters: manifestFilters)
       do {
         try database.deleteUpdates(updatesToDelete)
       } catch {
-        NSLog("Error reaping updates: %@", [error.localizedDescription])
+        logger.warn(message: "Error reaping updates: \(error.localizedDescription)")
         return
       }
 
@@ -57,11 +59,11 @@ public final class UpdatesReaper: NSObject {
       do {
         assetsForDeletion = try database.deleteUnusedAssets()
       } catch {
-        NSLog("Error reaping updates: %@", [error.localizedDescription])
+        logger.warn(message: "Error reaping updates: \(error.localizedDescription)")
         return
       }
 
-      NSLog("Deleted assets and updates from SQLite in %f ms", [beginDeleteFromDatabase.timeIntervalSinceNow * -1000])
+      logger.info(message: "Deleted assets and updates from SQLite in \(beginDeleteFromDatabase.timeIntervalSinceNow * -1000) ms")
 
       FileDownloader.assetFilesQueue.async {
         var deletedAssets = 0
@@ -75,14 +77,14 @@ public final class UpdatesReaper: NSObject {
               try FileManager.default.removeItem(at: localUrl)
               deletedAssets += 1
             } catch {
-              NSLog("Error deleting asset at %@: %@", [localUrl, error.localizedDescription])
+              logger.warn(message: "Error deleting asset at \(localUrl): \(error.localizedDescription)")
               erroredAssets.append(asset)
             }
           } else {
             deletedAssets += 1
           }
         }
-        NSLog("Deleted %lu assets from disk in %f ms", [deletedAssets, beginDeleteAssets.timeIntervalSinceNow * -1000])
+        logger.info(message: "Deleted \(deletedAssets) assets from disk in \(beginDeleteAssets.timeIntervalSinceNow * -1000) ms")
 
         // retry errored deletions
         let beginRetryDeletes = Date()
@@ -92,12 +94,15 @@ public final class UpdatesReaper: NSObject {
             do {
               try FileManager.default.removeItem(at: localUrl)
             } catch {
-              NSLog("Retried deleting asset at %@ and failed again: %@", [localUrl, error.localizedDescription])
+              logger.warn(message: "Retried deleting asset at \(localUrl) and failed again: \(error.localizedDescription)")
             }
           }
         }
-        NSLog("Retried deleting assets from disk in %f ms", [beginRetryDeletes.timeIntervalSinceNow * -1000])
+
+        logger.info(message: "Retried deleting assets from disk in \(beginRetryDeletes.timeIntervalSinceNow * -1000) ms")
       }
     }
   }
 }
+
+// swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -30,6 +30,8 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
 
   public let eventManager: UpdatesEventManager = NoOpUpdatesEventManager()
 
+  private let logger = UpdatesLogger()
+
   public weak var delegate: AppControllerDelegate?
   public weak var updatesExternalInterfaceDelegate: (any EXUpdatesInterface.UpdatesExternalInterfaceDelegate)?
 
@@ -132,6 +134,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
 
     let loader = RemoteAppLoader(
       config: updatesConfiguration,
+      logger: self.logger,
       database: self.database,
       directory: self.updatesDirectory!,
       launchedUpdate: nil,
@@ -175,10 +178,10 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
 
   public func isValidUpdatesConfiguration(_ configuration: [String: Any]) -> Bool {
     do {
-      try createUpdatesConfiguration(configuration)
+      _ = try createUpdatesConfiguration(configuration)
       return true
     } catch let error {
-      NSLog("Invalid updates configuration: %@", error.localizedDescription)
+      logger.warn(message: "Invalid updates configuration: \(error.localizedDescription)")
     }
     return false
   }

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -32,12 +32,12 @@ public class DisabledAppController: InternalAppControllerInterface {
   // disabled controller state machine can only be idle or restarting
   private let stateMachine: UpdatesStateMachine
 
-  private let initializationError: Error?
+  private let initializationError: UpdatesError?
   private var launcher: AppLauncher?
 
   public let updatesDirectory: URL? = nil // internal for E2E test
 
-  required init(error: Error?) {
+  required init(error: UpdatesError?) {
     self.initializationError = error
     self.eventManager = QueueUpdatesEventManager(logger: self.logger)
     self.stateMachine = UpdatesStateMachine(eventManager: self.eventManager, validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting])
@@ -63,7 +63,7 @@ public class DisabledAppController: InternalAppControllerInterface {
     }
 
     if let initializationError = self.initializationError {
-      ErrorRecovery.writeErrorOrExceptionToLog(initializationError)
+      ErrorRecovery.writeErrorOrExceptionToLog(initializationError, logger)
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -9,8 +9,6 @@ import ExpoModulesCore
  * Updates controller for applications that have updates enabled and properly-configured.
  */
 public class EnabledAppController: InternalAppControllerInterface, StartupProcedureDelegate {
-  private static let ErrorDomain = "EXUpdatesAppController"
-
   public weak var delegate: AppControllerDelegate?
 
   internal let config: UpdatesConfig
@@ -69,7 +67,7 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
 
     purgeUpdatesLogsOlderThanOneDay()
 
-    UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: database, config: config)
+    UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: database, config: config, logger: logger)
 
     startupProcedure = StartupProcedure(
       database: self.database,
@@ -108,7 +106,7 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
       view = viewController?.view
       viewController?.view = nil
     } else {
-      NSLog("Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.")
+      logger.warn(message: "Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.")
       view = UIView()
       view?.backgroundColor = .white
     }
@@ -192,7 +190,7 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
   // MARK: - Internal
 
   private func purgeUpdatesLogsOlderThanOneDay() {
-    UpdatesUtils.purgeUpdatesLogsOlderThanOneDay()
+    UpdatesUtils.purgeUpdatesLogsOlderThanOneDay(logger: logger)
   }
 
   // MARK: - JS API

--- a/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
+++ b/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
@@ -1,13 +1,6 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
 // swiftlint:disable legacy_objc_type
-
-// for some reason xcode #selector requires @objc in addition to @objcMembers
-// swiftlint:disable redundant_objc_attribute
-
-// this class was writted with implicit non-null constraints between method calls. not worth restructuring to appease linter
 // swiftlint:disable force_unwrapping
 
 import Foundation
@@ -133,12 +126,12 @@ public final class ErrorRecovery: NSObject {
 
   public func handle(error: NSError) {
     startPipeline(withEncounteredError: error)
-    ErrorRecovery.writeErrorOrExceptionToLog(error)
+    ErrorRecovery.writeErrorOrExceptionToLog(error, logger)
   }
 
   public func handle(exception: NSException) {
     startPipeline(withEncounteredError: exception)
-    ErrorRecovery.writeErrorOrExceptionToLog(exception)
+    ErrorRecovery.writeErrorOrExceptionToLog(exception, logger)
   }
 
   public func notify(newRemoteLoadStatus newStatus: RemoteLoadStatus) {
@@ -191,7 +184,7 @@ public final class ErrorRecovery: NSObject {
       logger.info(message: "ErrorRecovery: launching a cached update")
       tryRelaunchFromCache()
     case .crash:
-      logger.error(message: "ErrorRecovery: could not recover from error, crashing", code: .updateFailedToLoad)
+      logger.error(cause: UpdatesError.errorRecoveryCrashing, code: .updateFailedToLoad)
       crash()
     }
   }
@@ -357,7 +350,7 @@ public final class ErrorRecovery: NSObject {
 
   // MARK: - error persisting
 
-  public static func consumeErrorLog() -> String? {
+  public static func consumeErrorLog(logger: UpdatesLogger) -> String? {
     let errorLogFile = errorLogFile()
     guard let data = try? Data(contentsOf: errorLogFile) else {
       return nil
@@ -366,16 +359,18 @@ public final class ErrorRecovery: NSObject {
     do {
       try FileManager.default.removeItem(at: errorLogFile)
     } catch {
-      NSLog("Could not delete error log: %@", error.localizedDescription)
+      logger.warn(message: "Could not delete error log: \(error.localizedDescription)", code: UpdatesErrorCode.unknown)
     }
 
     return String(data: data, encoding: .utf8)
   }
 
-  public static func writeErrorOrExceptionToLog(_ errorOrException: Any, dispatchQueue: DispatchQueue = DispatchQueue.global()) {
+  public static func writeErrorOrExceptionToLog(_ errorOrException: Any, _ logger: UpdatesLogger, dispatchQueue: DispatchQueue = DispatchQueue.global()) {
     dispatchQueue.async {
       var serializedError: String
-      if let errorOrException = errorOrException as? NSError {
+      if let errorOrException = errorOrException as? UpdatesError {
+        serializedError = "Fatal error: \(ErrorRecovery.serialize(updatesError: errorOrException))"
+      } else if let errorOrException = errorOrException as? NSError {
         serializedError = "Fatal error: \(ErrorRecovery.serialize(error: errorOrException))"
       } else if let errorOrException = errorOrException as? NSException {
         serializedError = "Fatal exception: \(ErrorRecovery.serialize(exception: errorOrException))"
@@ -383,7 +378,7 @@ public final class ErrorRecovery: NSObject {
         return
       }
 
-      UpdatesLogger().error(message: "ErrorRecovery fatal exception: \(serializedError)", code: .jsRuntimeError)
+      logger.error(cause: UpdatesError.errorRecoveryFatalException(serializedError: serializedError), code: .jsRuntimeError)
       let data = serializedError.data(using: .utf8)!
       let errorLogFile = ErrorRecovery.errorLogFile()
       if FileManager.default.fileExists(atPath: errorLogFile.path) {
@@ -396,10 +391,18 @@ public final class ErrorRecovery: NSObject {
         do {
           try data.write(to: errorLogFile, options: .atomic)
         } catch {
-          NSLog("Could not write fatal error to log: %@", error.localizedDescription)
+          logger.error(cause: UpdatesError.errorRecoveryCouldNotWriteToLog(cause: error))
         }
       }
     }
+  }
+
+  private static func serialize(updatesError: UpdatesError) -> String {
+    return String(
+      format: "Time: %f\nDescription: %@\n\n",
+      Date().timeIntervalSince1970 * 1000,
+      updatesError.localizedDescription
+    )
   }
 
   private static func serialize(exception: NSException) -> String {
@@ -438,3 +441,6 @@ public final class ErrorRecovery: NSObject {
     return applicationDocumentsDirectory.appendingPathComponent(ErrorLogFile)
   }
 }
+
+// swiftlint:enable legacy_objc_type
+// swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -67,3 +67,5 @@ internal final class NotAvailableInDevClientException: Exception {
     "\(jsMethodName) is not supported in development builds."
   }
 }
+
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
@@ -1,5 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+// swiftlint:disable function_parameter_count
+
 import Foundation
 import os.log
 
@@ -8,8 +10,10 @@ import ExpoModulesCore
 /**
  Class that implements logging for expo-updates in its own os.log category
  */
-internal final class UpdatesLogger {
+public final class UpdatesLogger {
   static let EXPO_UPDATES_LOG_CATEGORY = "expo-updates"
+
+  public init() {}
 
   private let logger = Logger(logHandlers: [
     createOSLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),
@@ -103,37 +107,37 @@ internal final class UpdatesLogger {
   }
 
   func error(
-    message: String,
+    cause: UpdatesError,
     code: UpdatesErrorCode = .none,
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .error, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: cause.localizedDescription, code: code, level: .error, duration: nil, updateId: updateId, assetId: assetId)
     logger.error(entry)
   }
 
   func error(
-    message: String,
+    cause: UpdatesError,
     code: UpdatesErrorCode = .none
   ) {
-    error(message: message, code: code, updateId: nil, assetId: nil)
+    error(cause: cause, code: code, updateId: nil, assetId: nil)
   }
 
   func fatal(
-    message: String,
+    cause: UpdatesError,
     code: UpdatesErrorCode = .none,
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .fatal, duration: nil, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: cause.localizedDescription, code: code, level: .fatal, duration: nil, updateId: updateId, assetId: assetId)
     logger.fatal(entry)
   }
 
   func fatal(
-    message: String,
+    cause: UpdatesError,
     code: UpdatesErrorCode = .none
   ) {
-    fatal(message: message, code: code, updateId: nil, assetId: nil)
+    fatal(cause: cause, code: code, updateId: nil, assetId: nil)
   }
 
   func startTimer(label: String) -> LoggerTimer {
@@ -168,3 +172,5 @@ internal final class UpdatesLogger {
     return "\(logEntry.asString() ?? logEntry.message)"
   }
 }
+
+// swiftlint:enable function_parameter_count

--- a/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
@@ -47,6 +47,7 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
       let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
         withDatabase: self.database,
         config: self.config,
+        logger: self.logger,
         launchedUpdate: self.getLaunchedUpdate(),
         embeddedUpdate: embeddedUpdate
       )

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -40,6 +40,7 @@ final class FetchUpdateProcedure: StateMachineProcedure {
 
     self.remoteAppLoader = RemoteAppLoader(
       config: self.config,
+      logger: self.logger,
       database: self.database,
       directory: self.updatesDirectory,
       launchedUpdate: self.getLaunchedUpdate(),
@@ -95,6 +96,7 @@ final class FetchUpdateProcedure: StateMachineProcedure {
     } success: { updateResponse in
       RemoteAppLoader.processSuccessLoaderResult(
         config: self.config,
+        logger: self.logger,
         database: self.database,
         selectionPolicy: self.selectionPolicy,
         launchedUpdate: self.getLaunchedUpdate(),

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -70,22 +70,22 @@ final class RelaunchProcedure: StateMachineProcedure {
           self.requestStartErrorMonitoring()
           RCTReloadCommandSetBundleURL(self.launcherWithDatabase.launchAssetUrl)
           RCTTriggerReloadCommandListeners(self.triggerReloadCommandListenersReason)
-          
+
           // TODO(wschurman): this was moved to after the RCT calls to unify reload
           // code between JS API call and error recovery handler. double check that
           // this is okay
           self.successBlock()
-          
+
           if self.shouldRunReaper {
             self.runReaper()
           }
-          
+
           // Reset the state machine
           procedureContext.resetState()
           procedureContext.onComplete()
         } else {
           // swiftlint:disable:next force_unwrapping
-          NSLog("Failed to relaunch: %@", error!.localizedDescription)
+          self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: error!))
           self.errorBlock(UpdatesReloadException())
           procedureContext.onComplete()
         }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyDevelopmentClient.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyDevelopmentClient.swift
@@ -1,7 +1,5 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-import Foundation
-
 /**
  * A ReaperSelectionPolicy which keeps a predefined maximum number of updates across all scopes,
  * and, once that number is surpassed, selects the updates least recently accessed (and then least
@@ -45,6 +43,7 @@ public final class ReaperSelectionPolicyDevelopmentClient: NSObject, ReaperSelec
     var hasFoundLaunchedUpdate = false
 
     while updatesMutable.count > maxUpdatesToKeep {
+      // swiftlint:disable:next force_unwrapping
       let oldest = updatesMutable.first!
       updatesMutable.remove(at: 0)
 

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
@@ -1,6 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-import Foundation
+// swiftlint:disable identifier_name
 
 /**
  * A ReaperSelectionPolicy which chooses which updates to delete taking into account manifest filters
@@ -47,7 +47,7 @@ public final class ReaperSelectionPolicyFilterAware: NSObject, ReaperSelectionPo
 
         if SelectionPolicies.doesUpdate(update, matchFilters: filters) {
           if let nextNewestUpdateMatchingFiltersInner = nextNewestUpdateMatchingFilters,
-             update.commitTime.compare(nextNewestUpdateMatchingFiltersInner.commitTime) == .orderedDescending {
+            update.commitTime.compare(nextNewestUpdateMatchingFiltersInner.commitTime) == .orderedDescending {
             nextNewestUpdateMatchingFilters = update
           } else {
             nextNewestUpdateMatchingFilters = update
@@ -64,3 +64,5 @@ public final class ReaperSelectionPolicyFilterAware: NSObject, ReaperSelectionPo
     return updatesToDelete
   }
 }
+
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -35,6 +35,7 @@ public extension Optional {
   }
 }
 
+// swiftlint:disable identifier_name
 /**
  * Download status that indicates whether or under what conditions an
  * update is able to be launched.
@@ -71,11 +72,20 @@ public enum UpdateStatus: Int {
    */
   case StatusDevelopment = 6
 }
+// swiftlint:enable identifier_name
 
-@objc(EXUpdatesUpdateError)
-public enum UpdateError: Int, Error {
-  case invalidExpoProtocolVersion
+public enum UpdateError: Error, Sendable, LocalizedError {
+  case invalidExpoProtocolVersion(protocolVersion: Int)
   case legacyManifestInstantiationInvalid
+
+  public var errorDescription: String? {
+    switch self {
+    case let .invalidExpoProtocolVersion(protocolVersion):
+      return "Invalid Expo Updates protocol version: \(protocolVersion)"
+    case .legacyManifestInstantiationInvalid:
+      return "This version of expo-updates can no longer load legacy manifests"
+    }
+  }
 }
 
 @objc(EXUpdatesUpdate)
@@ -136,10 +146,10 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase
   ) throws -> Update {
-    let protocolVersion = responseHeaderData.protocolVersion
-    switch protocolVersion {
-    case nil:
+    guard let protocolVersion = responseHeaderData.protocolVersion else {
       throw UpdateError.legacyManifestInstantiationInvalid
+    }
+    switch protocolVersion {
     case 0, 1:
       return ExpoUpdatesUpdate.update(
         withExpoUpdatesManifest: ExpoUpdatesManifest(rawManifestJSON: withManifest),
@@ -148,7 +158,7 @@ public class Update: NSObject {
         database: database
       )
     default:
-      throw UpdateError.invalidExpoProtocolVersion
+      throw UpdateError.invalidExpoProtocolVersion(protocolVersion: protocolVersion)
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -25,11 +25,21 @@ public enum CheckAutomaticallyConfig: Int {
   }
 }
 
-@objc(EXUpdatesConfigError)
-public enum UpdatesConfigError: Int, Error {
+public enum UpdatesConfigError: Error, Sendable, LocalizedError {
   case ExpoUpdatesConfigPlistError
   case ExpoUpdatesConfigMissingURLError
   case ExpoUpdatesMissingRuntimeVersionError
+
+  public var errorDescription: String? {
+    switch self {
+    case .ExpoUpdatesConfigPlistError:
+      return "Expo.plist not found in bundle or invalid"
+    case .ExpoUpdatesConfigMissingURLError:
+      return "Config for expo-updates missing URL"
+    case .ExpoUpdatesMissingRuntimeVersionError:
+      return "Config for expo-updates missing runtime version"
+    }
+  }
 }
 
 public enum UpdatesConfigurationValidationResult {
@@ -200,7 +210,8 @@ public final class UpdatesConfig: NSObject {
       // swiftlint:disable:next legacy_objc_type
       if let it = it as? NSNumber {
         return it.intValue
-      } else if let it = it as? String {
+      }
+      if let it = it as? String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .none
         return formatter.number(from: it)?.intValue
@@ -308,3 +319,5 @@ public final class UpdatesConfig: NSObject {
     }
   }
 }
+
+// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
@@ -1,0 +1,138 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+
+public enum UpdatesError: Error, Sendable, LocalizedError {
+  case fileDownloaderAssetDownloadEmptyResponse(url: URL)
+  case fileDownloaderAssetMismatchedHash(url: URL, expectedBase64URLEncodedSHA256Hash: String, actualBase64URLEncodedSHA256Hash: String)
+  case fileDownloaderAssetFileWriteFailed(cause: Error, destinationPath: String)
+  case fileDownloaderResponseNotHTTPURLResponse
+  case fileDownloaderRemoteUpdateMissingBody
+  case fileDownloaderMissingMultipartBoundary
+  case fileDownloaderErrorReadingMultipartResponse
+  case fileDownloaderMultipartExtensionsPartParseFailed
+  case fileDownloaderDirectiveParseFailed(cause: Error)
+  case fileDownloaderManifestParseFailed(cause: Error?)
+  case fileDownloaderMultipartMissingManifestVersion0
+  case fileDownloaderCodeSigningError(cause: CodeSigningError)
+  case fileDownloaderCodeSigningUnknownError(cause: Error)
+  case fileDownloaderCodeSigningIncorrectSignature
+  case fileDownloaderCodeSigningCertificateScopeKeyOrProjectIdMismatch
+  case fileDownloaderManifestFilterManifestMismatch
+  case fileDownloaderHTTPResponseError(statusCode: Int, body: String)
+  case fileDownloaderServerDefinedHeaderFailure(cause: Error)
+  case fileDownloaderExtraParamFailure(cause: Error)
+  case fileDownloaderFailedUpdateIDsFailure(cause: Error)
+  case fileDownloaderUnknownError(cause: Error)
+  case remoteAppLoaderAssetMissingUrl
+  case remoteAppLoaderHeaderDataError(cause: Error)
+  case remoteAppLoaderUnknownError(cause: Error)
+  case appLoaderFailedToLoadAllAssets
+  case appLoaderUnknownError(cause: Error)
+  case appLoaderTaskFailedToLaunch(cause: Error?)
+  case appLoaderTaskUnexpectedErrorDuringLaunch
+  case appControllerInitializationError(cause: Error)
+  case errorRecoveryCrashing
+  case errorRecoveryFatalException(serializedError: String)
+  case errorRecoveryCouldNotWriteToLog(cause: Error)
+  case appLauncherWithDatabaseAssetMissingUrl
+  case appLauncherWithDatabaseAssetBundlePathNil
+  case appLauncherWithDatabaseAssetCopyFailed
+  case appLauncherWithDatabaseUnknownError(cause: Error)
+  case appLauncherNoLaunchableUpdates(cause: Error?)
+  case embeddedAppLoaderEmbeddedManifestLoadFailed
+  case startupProcedureDidFinishWithError(cause: Error)
+  case startupProcedureDidFinishBackgroundUpdateWithStatusWithError(cause: Error)
+  case relaunchProcedureFailedToRelaunch(cause: Error)
+
+  public var errorDescription: String? {
+    switch self {
+    case let .fileDownloaderAssetDownloadEmptyResponse(url):
+      return "Asset download response was empty for URL: \(url)"
+    case let .fileDownloaderAssetMismatchedHash(url, expectedBase64URLEncodedSHA256Hash, actualBase64URLEncodedSHA256Hash):
+      return "Asset download was successful but base64url-encoded SHA-256 did not match expected; URL: \(url.absoluteString); expected hash: \(expectedBase64URLEncodedSHA256Hash); actual hash: \(actualBase64URLEncodedSHA256Hash)"
+    case let .fileDownloaderAssetFileWriteFailed(cause, destinationPath):
+      return "Could not write downloaded asset file to path \(destinationPath): \(cause.localizedDescription)"
+    case .fileDownloaderResponseNotHTTPURLResponse:
+      return "Response not HTTPURLResponse"
+    case .fileDownloaderRemoteUpdateMissingBody:
+      return "Missing body in remote update"
+    case .fileDownloaderMissingMultipartBoundary:
+      return "Missing boundary in multipart manifest content-type"
+    case .fileDownloaderErrorReadingMultipartResponse:
+      return "Could not read multipart remote update response"
+    case .fileDownloaderMultipartExtensionsPartParseFailed:
+      return "Failed to parse multipart remote update extensions"
+    case let .fileDownloaderDirectiveParseFailed(cause):
+      return "Failed to parse directive: \(cause.localizedDescription)"
+    case let .fileDownloaderManifestParseFailed(cause):
+      return "Failed to parse manifest JSON: \(cause?.localizedDescription ?? "Unknown error")"
+    case .fileDownloaderMultipartMissingManifestVersion0:
+      return "Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the response being for a different protocol version."
+    case let .fileDownloaderCodeSigningError(cause):
+      return "Code signature validation failed: \(cause.localizedDescription)"
+    case let .fileDownloaderCodeSigningUnknownError(cause):
+      return "Code signature validation failed: \(cause.localizedDescription)"
+    case .fileDownloaderCodeSigningIncorrectSignature:
+      return "Code signing incorrect signature"
+    case .fileDownloaderCodeSigningCertificateScopeKeyOrProjectIdMismatch:
+      return "Code signing certificate project ID or scope key does not match project ID or scope key in response part"
+    case .fileDownloaderManifestFilterManifestMismatch:
+      return "Manifest filters do not match manifest content for downloaded manifest"
+    case let .fileDownloaderHTTPResponseError(statusCode, body):
+      return "HTTP response error \(statusCode): \(body)"
+    case let .fileDownloaderServerDefinedHeaderFailure(cause):
+      return "Error selecting serverDefinedHeaders from database: \(cause.localizedDescription)"
+    case let .fileDownloaderExtraParamFailure(cause):
+      return "Error adding extra params to headers: \(cause.localizedDescription)"
+    case let .fileDownloaderFailedUpdateIDsFailure(cause):
+      return "Error selecting failedUpdateIDs from database: \(cause.localizedDescription)"
+    case let .fileDownloaderUnknownError(cause):
+      return "Unknown error: \(cause.localizedDescription)"
+    case .remoteAppLoaderAssetMissingUrl:
+      return "Failed to download asset with no URL provided"
+    case let .remoteAppLoaderHeaderDataError(cause):
+      return "Error persisting header data to disk: \(cause.localizedDescription)"
+    case .appLoaderFailedToLoadAllAssets:
+      return "Failed to load all assets"
+    case let .remoteAppLoaderUnknownError(cause):
+      return "Unknown error: \(cause.localizedDescription)"
+    case let .appLoaderUnknownError(cause):
+      return "Unknown error: \(cause.localizedDescription)"
+    case let .appLoaderTaskFailedToLaunch(cause):
+      return "Failed to launch embedded or launchable update: \(cause?.localizedDescription ?? "")"
+    case .appLoaderTaskUnexpectedErrorDuringLaunch:
+      return "AppLoaderTask encountered an unexpected error and could not launch an update."
+    case let .appControllerInitializationError(cause):
+      return "The expo-updates system is disabled due to an error during initialization: \(cause.localizedDescription)"
+    case .errorRecoveryCrashing:
+      return "ErrorRecovery: could not recover from error, crashing"
+    case let .errorRecoveryFatalException(serializedError):
+      return "ErrorRecovery fatal exception: \(serializedError)"
+    case let .errorRecoveryCouldNotWriteToLog(cause):
+      return "Could not write fatal error to log: \(cause.localizedDescription)"
+    case .appLauncherWithDatabaseAssetMissingUrl:
+      return "Failed to download asset with no URL provided"
+    case .appLauncherWithDatabaseAssetBundlePathNil:
+      return "Asset bundlePath was unexpectedly nil"
+    case .appLauncherWithDatabaseAssetCopyFailed:
+      return "Asset copy failed"
+    case let .appLauncherWithDatabaseUnknownError(cause):
+      return "Unknown error: \(cause.localizedDescription)"
+    case let .appLauncherNoLaunchableUpdates(cause):
+      return "No launchable updates found in database: \(cause?.localizedDescription ?? "Unknown error")"
+    case .embeddedAppLoaderEmbeddedManifestLoadFailed:
+      return "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
+    case let .startupProcedureDidFinishWithError(cause):
+      return "AppController appLoaderTask didFinishWithError: \(cause.localizedDescription)"
+    case let .startupProcedureDidFinishBackgroundUpdateWithStatusWithError(cause):
+      return "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=Error: \(cause.localizedDescription)"
+    case let .relaunchProcedureFailedToRelaunch(cause):
+      return "Failed to relaunch: \(cause.localizedDescription)"
+    }
+  }
+}
+
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/UpdatesJsEvents.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesJsEvents.swift
@@ -1,7 +1,3 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-// swiftlint:disable identifier_name
-
 internal let EXUpdatesStateChangeEventName = "Expo.nativeUpdatesStateChangeEvent"
-
-// swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -1,7 +1,5 @@
 // Copyright 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable closure_body_length
-
 import ExpoModulesCore
 
 /**
@@ -144,5 +142,3 @@ public final class UpdatesModule: Module {
     }
   }
 }
-
-// swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -125,10 +125,10 @@ public final class UpdatesUtils: NSObject {
   /**
    Purges entries in the expo-updates log file that are older than 1 day
    */
-  internal static func purgeUpdatesLogsOlderThanOneDay() {
+  internal static func purgeUpdatesLogsOlderThanOneDay(logger: UpdatesLogger) {
     UpdatesLogReader().purgeLogEntries { error in
       if let error = error {
-        NSLog("UpdatesUtils: error in purgeOldUpdatesLogs: %@", error.localizedDescription)
+        logger.warn(message: "UpdatesUtils: error in purgeOldUpdatesLogs: \(error.localizedDescription)")
       }
     }
   }

--- a/packages/expo-updates/ios/Tests/CertificateChainSpec.swift
+++ b/packages/expo-updates/ios/Tests/CertificateChainSpec.swift
@@ -55,10 +55,9 @@ class CertificateChainSpec : ExpoSpec {
       // missing intermediate
       let leafCert = getTestCertificate(TestCertificate.chainLeaf)
       let rootCert = getTestCertificate(TestCertificate.chainRoot)
-
       expect {
         try CertificateChain(certificateStrings: [leafCert, rootCert]).codeSigningCertificate()
-      }.to(throwError(CodeSigningError.CertificateChainError))
+      }.to(throwError(CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: 1))))
     }
 
     it("throws when any signature is invalid") {
@@ -68,7 +67,7 @@ class CertificateChainSpec : ExpoSpec {
 
       expect {
         try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()
-      }.to(throwError(CodeSigningError.CertificateChainError))
+      }.to(throwError(CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: 1))))
     }
 
     it("throws when root is not self signed") {
@@ -87,7 +86,7 @@ class CertificateChainSpec : ExpoSpec {
 
       expect {
         try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()
-      }.to(throwError(CodeSigningError.CertificateChainError))
+      }.to(throwError(CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: 1))))
     }
 
     it("throws when intermediate CA not CA") {
@@ -97,7 +96,7 @@ class CertificateChainSpec : ExpoSpec {
 
       expect {
         try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()
-      }.to(throwError(CodeSigningError.CertificateChainError))
+      }.to(throwError(CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: 1))))
     }
 
     it("throws when CA path len violated") {
@@ -107,7 +106,7 @@ class CertificateChainSpec : ExpoSpec {
 
       expect {
         try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()
-      }.to(throwError(CodeSigningError.CertificateChainError))
+      }.to(throwError(CodeSigningError.CertificateChainError(reason: .couldNotCreateSecTrust(osStatus: 1))))
     }
 
     it("throws when expo project information violation") {

--- a/packages/expo-updates/ios/Tests/CodeSigningConfigurationSpec.swift
+++ b/packages/expo-updates/ios/Tests/CodeSigningConfigurationSpec.swift
@@ -89,6 +89,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
     describe("validateSignature") {
       it("works for valid case") {
         let cert = getTestCertificate(TestCertificate.test)
+        let logger = UpdatesLogger()
         let configuration = try CodeSigningConfiguration(
           embeddedCertificateString: cert,
           metadata: [:],
@@ -96,6 +97,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: false
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: CertificateFixtures.testExpoUpdatesManifestBodySignature,
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: nil
@@ -106,6 +108,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
 
       it("returns false when signature is invalid") {
         let cert = getTestCertificate(TestCertificate.test)
+        let logger = UpdatesLogger()
         let configuration = try CodeSigningConfiguration(
           embeddedCertificateString: cert,
           metadata: [:],
@@ -113,6 +116,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: false
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: "sig=\"aGVsbG8=\"",
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: nil
@@ -122,6 +126,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
       }
 
       it("throws when key does not match") {
+        let logger = UpdatesLogger()
         let cert = getTestCertificate(TestCertificate.test)
         let configuration = try CodeSigningConfiguration(
           embeddedCertificateString: cert,
@@ -131,6 +136,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
         )
         expect {
           try configuration.validateSignature(
+            logger: logger,
             signature: "sig=\"aGVsbG8=\", keyid=\"other\"",
             signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
             manifestResponseCertificateChain: nil
@@ -139,6 +145,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
       }
 
       it("does not use chain in manifest response if flag is false") {
+        let logger = UpdatesLogger()
         let testCert = getTestCertificate(TestCertificate.test)
         let leafCert = getTestCertificate(TestCertificate.chainLeaf)
         let intermediateCert = getTestCertificate(TestCertificate.chainIntermediate)
@@ -149,6 +156,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: false
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: CertificateFixtures.testExpoUpdatesManifestBodySignature,
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: leafCert + intermediateCert
@@ -158,6 +166,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
       }
 
       it("does use chain in manifest response if flag is true") {
+        let logger = UpdatesLogger()
         let leafCert = getTestCertificate(TestCertificate.chainLeaf)
         let intermediateCert = getTestCertificate(TestCertificate.chainIntermediate)
         let rootCert = getTestCertificate(TestCertificate.chainRoot)
@@ -168,6 +177,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: false
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: CertificateFixtures.testExpoUpdatesManifestBodyValidChainLeafSignature,
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: leafCert + intermediateCert
@@ -180,6 +190,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
       }
 
       it("AllowsUnsignedManifestIfAllowUnsignedFlagIsTrue") {
+        let logger = UpdatesLogger()
         let testCert = getTestCertificate(TestCertificate.test)
         let configuration = try CodeSigningConfiguration(
           embeddedCertificateString: testCert,
@@ -188,6 +199,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: true
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: nil,
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: nil
@@ -197,6 +209,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
       }
 
       it("ChecksSignedManifestIfAllowUnsignedFlagIsTrueButSignatureIsProvided") {
+        let logger = UpdatesLogger()
         let testCert = getTestCertificate(TestCertificate.test)
         let configuration = try CodeSigningConfiguration(
           embeddedCertificateString: testCert,
@@ -205,6 +218,7 @@ class CodeSigningConfigurationSpec : ExpoSpec {
           allowUnsignedManifests: true
         )
         let signatureValidationResult = try configuration.validateSignature(
+          logger: logger,
           signature: "sig=\"aGVsbG8=\"",
           signedData: CertificateFixtures.testExpoUpdatesManifestBody.data(using: .utf8)!,
           manifestResponseCertificateChain: nil

--- a/packages/expo-updates/ios/Tests/ErrorRecoverySpec.swift
+++ b/packages/expo-updates/ios/Tests/ErrorRecoverySpec.swift
@@ -546,35 +546,37 @@ class ErrorRecoverySpec : ExpoSpec {
     
     describe("error log") {
       it("consume") {
+        let logger = UpdatesLogger()
         let (testQueue, _) = setUp()
         // start with a clean slate
-        _ = ErrorRecovery.consumeErrorLog()
-        
+        _ = ErrorRecovery.consumeErrorLog(logger: logger)
+
         let error = NSError(domain: "TestDomain", code: 47, userInfo: [NSLocalizedDescriptionKey: "TestLocalizedDescription"])
-        ErrorRecovery.writeErrorOrExceptionToLog(error, dispatchQueue: testQueue)
+        ErrorRecovery.writeErrorOrExceptionToLog(error, logger, dispatchQueue: testQueue)
         testQueue.flush()
         DispatchQueue.global().flush()
 
-        let errorLog = ErrorRecovery.consumeErrorLog()
+        let errorLog = ErrorRecovery.consumeErrorLog(logger: logger)
         expect(errorLog?.contains("TestDomain")) == true
         expect(errorLog?.contains("47")) == true
         expect(errorLog?.contains("TestLocalizedDescription")) == true
       }
       
       it("consume multiple errors") {
+        let logger = UpdatesLogger()
         let (testQueue, _) = setUp()
         // start with a clean slate
-        _ = ErrorRecovery.consumeErrorLog()
-        
+        _ = ErrorRecovery.consumeErrorLog(logger: logger)
+
         let error = NSError(domain: "TestDomain", code: 47, userInfo: [NSLocalizedDescriptionKey: "TestLocalizedDescription"])
-        ErrorRecovery.writeErrorOrExceptionToLog(error, dispatchQueue: testQueue)
+        ErrorRecovery.writeErrorOrExceptionToLog(error, logger, dispatchQueue: testQueue)
 
         let exception = NSException(name: NSExceptionName(rawValue: "TestName"), reason: "TestReason")
-        ErrorRecovery.writeErrorOrExceptionToLog(exception, dispatchQueue: testQueue)
+        ErrorRecovery.writeErrorOrExceptionToLog(exception, logger, dispatchQueue: testQueue)
         testQueue.flush()
         DispatchQueue.global().flush()
 
-        let errorLog = ErrorRecovery.consumeErrorLog()
+        let errorLog = ErrorRecovery.consumeErrorLog(logger: logger)
         expect(errorLog?.contains("TestDomain")) == true
         expect(errorLog?.contains("47")) == true
         expect(errorLog?.contains("TestLocalizedDescription")) == true

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -164,7 +164,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           errorOccurred = error
         }
         
-        expect(errorOccurred?.localizedDescription) == "Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the update being a rollback or other directive."
+        expect(errorOccurred?.localizedDescription) == "Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the response being for a different protocol version."
         expect(resultUpdateResponse).to(beNil())
       }
       
@@ -449,7 +449,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           errorOccurred = error
         }
         
-        expect(errorOccurred?.localizedDescription) == "No expo-signature header specified"
+        expect(errorOccurred?.localizedDescription) == "Code signature validation failed: No expo-signature header specified"
         expect(resultUpdateResponse).to(beNil())
       }
       
@@ -545,7 +545,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           errorOccurred = error
         }
         
-        expect(errorOccurred?.localizedDescription) == "Invalid certificate for manifest project ID or scope key"
+        expect(errorOccurred?.localizedDescription) == "Code signing certificate project ID or scope key does not match project ID or scope key in response part"
         expect(resultUpdateResponse).to(beNil())
       }
       
@@ -591,7 +591,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           errorOccurred = error
         }
         
-        expect(errorOccurred?.localizedDescription) == "Invalid certificate for directive project ID or scope key"
+        expect(errorOccurred?.localizedDescription) == "Code signing certificate project ID or scope key does not match project ID or scope key in response part"
         expect(resultUpdateResponse).to(beNil())
       }
       

--- a/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
@@ -10,7 +10,8 @@ class FileDownloaderSpec : ExpoSpec {
   override class func spec() {
     var testDatabaseDir: URL!
     var db: UpdatesDatabase!
-    
+    var logger: UpdatesLogger!
+
     beforeEach {
       let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
       testDatabaseDir = applicationSupportDir!.appendingPathComponent("UpdatesDatabaseTests")
@@ -25,6 +26,8 @@ class FileDownloaderSpec : ExpoSpec {
       db.databaseQueue.sync {
         try! db.openDatabase(inDirectory: testDatabaseDir)
       }
+
+      logger = UpdatesLogger()
     }
     
     afterEach {
@@ -154,6 +157,7 @@ class FileDownloaderSpec : ExpoSpec {
           let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
             withDatabase: db,
             config: config,
+            logger: logger,
             launchedUpdate: launchedUpdate,
             embeddedUpdate: embeddedUpdate
           )
@@ -161,7 +165,7 @@ class FileDownloaderSpec : ExpoSpec {
           expect(extraHeaders["Expo-Embedded-Update-ID"] as? String) == embeddedUpdateUUIDString
           expect(extraHeaders["Expo-Extra-Params"] as? String).to(contain("what=\"123\""))
           expect(extraHeaders["Expo-Extra-Params"] as? String).to(contain("hello=\"world\""))
-          expect(extraHeaders["Expo-Recent-Failed-Update-IDs"] as? String).to(contain("\"\(launchedUpdateUUIDString.uppercased())\", \"\(embeddedUpdateUUIDString.uppercased())\""))
+          expect(extraHeaders["Expo-Recent-Failed-Update-IDs"] as? String).to(contain("\"\(launchedUpdateUUIDString)\", \"\(embeddedUpdateUUIDString)\""))
         }
       }
       
@@ -175,6 +179,7 @@ class FileDownloaderSpec : ExpoSpec {
           let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
             withDatabase: db,
             config: config,
+            logger: logger,
             launchedUpdate: nil,
             embeddedUpdate: nil
           )

--- a/packages/expo-updates/ios/Tests/UpdateSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdateSpec.swift
@@ -87,7 +87,7 @@ class UpdateSpec : ExpoSpec {
           extensions: [:],
           config: config,
           database: database
-        )).to(throwError(UpdateError.invalidExpoProtocolVersion))
+        )).to(throwError(UpdateError.invalidExpoProtocolVersion(protocolVersion: 2)))
       }
       
       it("works for embedded bare manifest") {

--- a/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
@@ -12,6 +12,7 @@ class UpdatesBuildDataSpec : ExpoSpec {
 
     var testDatabaseDir: URL!
     var db: UpdatesDatabase!
+    var logger: UpdatesLogger!
     var manifest: ExpoUpdatesManifest!
     var configChannelTestDictionary: [String: Any]!
     var configChannelTest: UpdatesConfig!
@@ -32,7 +33,9 @@ class UpdatesBuildDataSpec : ExpoSpec {
       db.databaseQueue.sync {
         try! db.openDatabase(inDirectory: testDatabaseDir)
       }
-      
+
+      logger = UpdatesLogger()
+
       manifest = ExpoUpdatesManifest(rawManifestJSON: [
         "runtimeVersion": "1",
         "id": "0eef8214-4833-4089-9dff-b4138a14f196",
@@ -83,7 +86,7 @@ class UpdatesBuildDataSpec : ExpoSpec {
         }
         
         db.databaseQueue.async {
-          UpdatesBuildData.clearAllUpdatesAndSetStaticBuildData(database: db, config: configChannelTest, scopeKey: scopeKey)
+          UpdatesBuildData.clearAllUpdatesAndSetStaticBuildData(database: db, config: configChannelTest, logger: logger, scopeKey: scopeKey)
         }
         
         db.databaseQueue.sync {
@@ -99,8 +102,8 @@ class UpdatesBuildDataSpec : ExpoSpec {
           expect(try! db.allUpdates(withConfig: configChannelTest).count) == 1
         }
         
-        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTest)
-        
+        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTest, logger: logger)
+
         db.databaseQueue.sync {
           expect(try! db.staticBuildData(withScopeKey: scopeKey)).toNot(beNil())
           expect(try! db.allUpdates(withConfig: configChannelTest).count) == 1
@@ -113,8 +116,8 @@ class UpdatesBuildDataSpec : ExpoSpec {
           try! db.setStaticBuildData(UpdatesBuildData.getBuildDataFromConfig(configChannelTest), withScopeKey: configChannelTest.scopeKey)
         }
         
-        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTest)
-        
+        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTest, logger: logger)
+
         db.databaseQueue.sync {
           let staticBuildData = try! db.staticBuildData(withScopeKey: scopeKey)
           expect(
@@ -130,7 +133,7 @@ class UpdatesBuildDataSpec : ExpoSpec {
           try! db.setStaticBuildData(UpdatesBuildData.getBuildDataFromConfig(configChannelTest), withScopeKey: configChannelTest.scopeKey)
         }
         
-        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTestTwo)
+        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configChannelTestTwo, logger: logger)
         
         db.databaseQueue.sync {
           let staticBuildData = try! db.staticBuildData(withScopeKey: scopeKey)

--- a/packages/expo-updates/ios/Tests/UpdatesLoggerSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLoggerSpec.swift
@@ -15,7 +15,7 @@ class UpdatesLoggerSpec : ExpoSpec {
       let epoch = Date()
 
       // Write a log message
-      logger.error(message: "Test message", code: .noUpdatesAvailable)
+      logger.error(cause: UpdatesError.appLoaderFailedToLoadAllAssets, code: .noUpdatesAvailable)
 
       // Write another log message
       logger.warn(message: "Warning message", code: .assetsFailedToLoad, updateId: "myUpdateId", assetId: "myAssetId")


### PR DESCRIPTION
# Why

This is roughly the iOS equivalent of https://app.graphite.dev/github/pr/expo/expo/31929/expo-updates-Refactor-errors-and-logged-info, https://app.graphite.dev/github/pr/expo/expo/31951/expo-updates-android-Refactor-where-context-is-injected-into-controllers, and https://app.graphite.dev/github/pr/expo/expo/31953/expo-updates-android-Change-most-Log-errors-to-UpdatesLogger-errors.

iOS errors are structured slightly differently than android (`Log.e` takes a message and a cause whereas iOS is just a message), and therefore the structure here is a bit different than android.

The overarching goal of this PR is to make error logging consistent (logs all errors to all logger destinations) and to make error messages contain all info (recursively contain the sub-error's `localizedDescriptions`).

# How

This is done by taking a hint from the Alamofire and how they handle errors.

Similar to their [`AFError`](https://github.com/Alamofire/Alamofire/blob/master/Source/Core/AFError.swift), we introduce `UpdatesError`, which is a LocalizedError and should print nice error messages when `localizedDescription` is called.

Then, we convert all errors in our library to `UpdatesError`. And finally, we update the logger to take an `UpdatesError`.

Then, we grep for `NSLog` and replace with error instances and logger calls.

# Test Plan

This was building successfully before the rebase on main (which looks to be broken as well?).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
