### PR TITLE
refactor(cli): integrate new metro types for `metro@0.80.12`

### DIFF
--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -406,7 +406,9 @@ export async function createMetroServerAndBundleRequestAsync(
     sourceMapUrl = path.basename(sourceMapUrl);
   }
 
-  const bundleRequest = {
+  // TODO(cedric): check if we can use the proper `bundleType=bundle` and `entryPoint=mainModuleName` properties
+  // @ts-expect-error: see above
+  const bundleRequest: BundleOptions = {
     ...Server.DEFAULT_BUNDLE_OPTIONS,
     ...getMetroDirectBundleOptionsForExpoConfig(projectRoot, exp, {
       splitChunks: false,

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -1,5 +1,6 @@
 import { resolveEntryPoint } from '@expo/config/paths';
 import arg from 'arg';
+import type { OutputOptions } from 'metro/src/shared/types';
 import os from 'os';
 import path from 'path';
 
@@ -21,7 +22,7 @@ export interface Options {
   platform: string;
   dev: boolean;
   bundleOutput: string;
-  bundleEncoding?: string;
+  bundleEncoding?: OutputOptions['bundleEncoding'];
   maxWorkers?: number;
   sourcemapOutput?: string;
   sourcemapSourcesRoot?: string;
@@ -35,6 +36,12 @@ function assertIsBoolean(val: any): asserts val is boolean {
   if (typeof val !== 'boolean') {
     throw new CommandError(`Expected boolean, got ${typeof val}`);
   }
+}
+
+function getBundleEncoding(encoding: string | undefined): OutputOptions['bundleEncoding'] {
+  return encoding === 'utf8' || encoding === 'utf16le' || encoding === 'ascii'
+    ? encoding
+    : undefined;
 }
 
 export function resolveOptions(
@@ -60,7 +67,7 @@ export function resolveOptions(
     // TODO: Support `--dev false`
     //   dev: false,
     bundleOutput,
-    bundleEncoding: args['--bundle-encoding'] ?? 'utf8',
+    bundleEncoding: getBundleEncoding(args['--bundle-encoding']) ?? 'utf8',
     maxWorkers: args['--max-workers'],
     sourcemapOutput: args['--sourcemap-output'],
     sourcemapSourcesRoot: args['--sourcemap-sources-root'],

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -1,6 +1,7 @@
 import { resolveEntryPoint } from '@expo/config/paths';
 import arg from 'arg';
 import type { OutputOptions } from 'metro/src/shared/types';
+import canonicalize from 'metro-core/src/canonicalize';
 import os from 'os';
 import path from 'path';
 
@@ -8,8 +9,6 @@ import { isAndroidUsingHermes, isIosUsingHermes } from './guessHermes';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
 import { resolveCustomBooleanArgsAsync } from '../../utils/resolveArgs';
-
-const canonicalize = require('metro-core/src/canonicalize');
 
 export interface Options {
   assetsDest?: string;

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1477,7 +1477,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
           serverRoot: config.server.unstable_serverRoot ?? config.projectRoot,
           shouldAddToIgnoreList,
 
-          // passed to our serializer to enable non-serial return values.
+          // @ts-expect-error: passed to our serializer to enable non-serial return values.
           serializerOptions,
         }
       );

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -20,6 +20,7 @@ import type MetroHmrServer from 'metro/src/HmrServer';
 import type { Client as MetroHmrClient } from 'metro/src/HmrServer';
 import { GraphRevision } from 'metro/src/IncrementalBundler';
 import bundleToString from 'metro/src/lib/bundleToString';
+import getGraphId from 'metro/src/lib/getGraphId';
 import { TransformProfile } from 'metro-babel-transformer';
 import type { CustomResolverOptions } from 'metro-resolver/src/types';
 import path from 'path';
@@ -90,17 +91,6 @@ type SSRLoadModuleFunc = <T extends Record<string, any>>(
 ) => Promise<T>;
 
 const debug = require('debug')('expo:start:server:metro') as typeof console.log;
-
-const getGraphId = require('metro/src/lib/getGraphId') as (
-  entryFile: string,
-  options: any,
-  etc: {
-    shallow: boolean;
-    lazy: boolean;
-    unstable_allowRequireContext: boolean;
-    resolverOptions: unknown;
-  }
-) => string;
 
 /** Default port to use for apps running in Expo Go. */
 const EXPO_GO_METRO_PORT = 8081;

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -511,6 +511,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         'default',
       customTransformOptions: expoBundleOptions.customTransformOptions ?? Object.create(null),
       platform: expoBundleOptions.platform ?? 'web',
+      // @ts-expect-error: `runtimeBytecodeVersion` does not exist in `expoBundleOptions` or `TransformInputOptions`
       runtimeBytecodeVersion: expoBundleOptions.runtimeBytecodeVersion,
     };
 
@@ -1390,16 +1391,15 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         entryFile: resolvedEntryFilePath,
         minify: transformOptions.minify,
         platform: transformOptions.platform,
-        // @ts-expect-error: typed incorrectly upstream
         customResolverOptions: resolverOptions.customResolverOptions,
-        customTransformOptions: transformOptions.customTransformOptions,
+        customTransformOptions: transformOptions.customTransformOptions ?? {},
       },
       isPrefetch: false,
       type: 'bundle_build_started',
     });
 
     try {
-      let delta: DeltaResult<void>;
+      let delta: DeltaResult;
       let revision: GraphRevision;
 
       // TODO: Some bug in Metro/RSC causes this to break when changing imports in server components.
@@ -1415,7 +1415,6 @@ export class MetroBundlerDevServer extends BundlerDevServer {
           {
             onProgress,
             shallow: graphOptions.shallow,
-            // @ts-expect-error: typed incorrectly
             lazy: graphOptions.lazy,
           }
         );
@@ -1434,7 +1433,6 @@ export class MetroBundlerDevServer extends BundlerDevServer {
               {
                 onProgress,
                 shallow: graphOptions.shallow,
-                // @ts-expect-error: typed incorrectly
                 lazy: graphOptions.lazy,
               }
             ));
@@ -1489,7 +1487,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
           serverRoot: config.server.unstable_serverRoot ?? config.projectRoot,
           shouldAddToIgnoreList,
 
-          // @ts-expect-error: passed to our serializer to enable non-serial return values.
+          // passed to our serializer to enable non-serial return values.
           serializerOptions,
         }
       );

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
@@ -75,11 +75,7 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
   }
 
   /** Gives subclasses an easy interface for filtering out logs. Return `true` to skip. */
-  shouldFilterClientLog(event: {
-    type: 'client_log';
-    level: 'trace' | 'info' | 'warn' | 'log' | 'group' | 'groupCollapsed' | 'groupEnd' | 'debug';
-    data: unknown[];
-  }): boolean {
+  shouldFilterClientLog(event: TerminalReportableEvent): boolean {
     return false;
   }
 

--- a/packages/@expo/cli/src/start/server/metro/getCssModulesFromBundler.ts
+++ b/packages/@expo/cli/src/start/server/metro/getCssModulesFromBundler.ts
@@ -50,7 +50,7 @@ export async function getCssModulesFromBundler(
     [entryFile],
     transformOptions,
     resolverOptions,
-    { onProgress, shallow: false }
+    { onProgress, shallow: false, lazy: false }
   );
 
   return getCssModules(dependencies, {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -38,12 +38,10 @@ class LogRespectingTerminal extends Terminal {
     super(stream);
 
     const sendLog = (...args: any[]) => {
-      // @ts-expect-error
       this._logLines.push(
         // format args like console.log
         util.format(...args)
       );
-      // @ts-expect-error
       this._scheduleUpdate();
 
       // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
@@ -222,7 +220,6 @@ export async function instantiateMetroAsync(
     metroBundler,
     metroConfig,
     {
-      // @ts-expect-error: Inconsistent `websocketEndpoints` type in metro
       websocketEndpoints: {
         ...websocketEndpoints,
         ...createDevToolsPluginWebsocketEndpoint(),

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -142,7 +142,6 @@ export const runServer = async (
       );
 
       Object.assign(websocketEndpoints, {
-        // @ts-expect-error: incorrect types
         '/hot': createWebsocketServer({
           websocketServer: hmrServer,
         }),

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -49,7 +49,7 @@ function withWebPolyfills(
     ? config.serializer.getPolyfills.bind(config.serializer)
     : () => [];
 
-  const getPolyfills = (ctx: { platform: string | null }): readonly string[] => {
+  const getPolyfills = (ctx: { platform?: string | null }): readonly string[] => {
     const virtualEnvVarId = `\0polyfill:environment-variables`;
 
     getMetroBundlerWithVirtualModules(getMetroBundler()).setVirtualModule(
@@ -185,9 +185,11 @@ export function withExtendedResolver(
   const resolver = isFastResolverEnabled
     ? createFastResolver({
         preserveSymlinks: true,
-        blockList: Array.isArray(config.resolver?.blockList)
-          ? config.resolver?.blockList
-          : [config.resolver?.blockList],
+        blockList: !config.resolver?.blockList
+          ? []
+          : Array.isArray(config.resolver?.blockList)
+            ? config.resolver?.blockList
+            : [config.resolver?.blockList],
       })
     : defaultResolver;
 

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -703,6 +703,11 @@ declare module 'metro/src/DeltaBundler/Transformer' {
   export default Transformer;
 }
 
+// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
+declare module 'metro/src/DeltaBundler/types' {
+  export * from 'metro/src/DeltaBundler/types.flow';
+}
+
 // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/types.flow.js
 declare module 'metro/src/DeltaBundler/types.flow' {
   import type * as _babel_types from '@babel/types';
@@ -2615,7 +2620,7 @@ declare module 'metro/src/Server' {
       shallow: false;
       sourceMapUrl: null;
       sourceUrl: null;
-      sourcePaths: SourcePathsMode;
+      sourcePaths: SourcePathsMode.Absolute;
     } & typeof Server.DEFAULT_GRAPH_OPTIONS;
     _getServerRootDir(): string;
     _getEntryPointAbsolutePath(entryFile: string): string;
@@ -2836,6 +2841,11 @@ declare module 'metro/src/shared/output/writeFile' {
   ) => Promise<any>;
   const writeFile: WriteFn;
   export default writeFile;
+}
+
+// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
+declare module 'metro/src/shared/types' {
+  export * from 'metro/src/shared/types.flow';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/types.flow.js

--- a/packages/@expo/metro-runtime/src/HMRClient.ts
+++ b/packages/@expo/metro-runtime/src/HMRClient.ts
@@ -8,13 +8,13 @@
  * Based on this but with web support:
  * https://github.com/facebook/react-native/blob/086714b02b0fb838dee5a66c5bcefe73b53cf3df/Libraries/Utilities/HMRClient.js
  */
+import MetroHMRClient from 'metro-runtime/src/modules/HMRClient';
 import prettyFormat, { plugins } from 'pretty-format';
 
 import LoadingView from './LoadingView';
 import LogBox from './error-overlay/LogBox';
 import getDevServer from './getDevServer';
 
-const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const pendingEntryPoints: string[] = [];
 
 // @ts-expect-error: Account for multiple versions of pretty-format inside of a monorepo.


### PR DESCRIPTION
# Why

This PR is part of #31986, split up to survive the RN upgrade PRs. There will be more stacked PRs, to integrate the types properly in `@expo/cli`, `@expo/metro-config`, and `@expo/metro-runtime`. Also for RN 0.76, we need to update the Metro types to `0.81.x`.

## Full PR stack

- https://github.com/expo/expo/pull/32007
- 👉 https://github.com/expo/expo/pull/32010
- https://github.com/expo/expo/pull/32012
- https://github.com/expo/expo/pull/32013
- https://github.com/expo/expo/pull/32051

# How

- _**Previous PR**: https://github.com/expo/expo/pull/32007_
- Manually added `metro/src/shared/types` and `metro/src/DeltaBundler/types` as an alias to their `types.flow` original
- Removed 8 `@ts-expect-error` where types are correct
- Added 2 `@ts-expect-error` where types are incorrect
- _**Next PR**: https://github.com/expo/expo/pull/32012_

# Test Plan

See CI (type checks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
