### PR TITLE
[video] Fix code availability for tvOS

### DIFF
--- a/packages/expo-video/ios/Thumbnails/VideoThumbnailGenerator.swift
+++ b/packages/expo-video/ios/Thumbnails/VideoThumbnailGenerator.swift
@@ -24,7 +24,7 @@ internal func generateThumbnails(asset: AVAsset, times: [CMTime]) async throws -
  Generates an array of thumbnails using the given image generator. It uses two different ways to generate the images, based on the platform version.
  */
 private func generateThumbnails(generator: AVAssetImageGenerator, times: [CMTime]) async throws -> [VideoThumbnail] {
-  if #available(iOS 16, *) {
+  if #available(iOS 16, *), #available(tvOS 16, *) {
     return try await generator
       .images(for: times)
       .reduce(into: [VideoThumbnail]()) { thumbnails, result in

--- a/packages/expo-video/ios/Thumbnails/VideoThumbnailGenerator.swift
+++ b/packages/expo-video/ios/Thumbnails/VideoThumbnailGenerator.swift
@@ -24,7 +24,7 @@ internal func generateThumbnails(asset: AVAsset, times: [CMTime]) async throws -
  Generates an array of thumbnails using the given image generator. It uses two different ways to generate the images, based on the platform version.
  */
 private func generateThumbnails(generator: AVAssetImageGenerator, times: [CMTime]) async throws -> [VideoThumbnail] {
-  if #available(iOS 16, *), #available(tvOS 16, *) {
+  if #available(iOS 16, tvOS 16, *) {
     return try await generator
       .images(for: times)
       .reduce(into: [VideoThumbnail]()) { thumbnails, result in


### PR DESCRIPTION
# Why

tvOS compile job is failing after landing #31807 
https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/34951423-8675-4068-89f4-bca192b6d630

# How

Added `#available(tvOS 16, *)` condition

# Test Plan

CI job passes now: https://github.com/expo/expo/actions/runs/11299912434/job/31431833423