### PR TITLE
refactor(cli): bump types to `metro@0.81.0`

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -374,7 +374,6 @@ export function withExtendedResolver(
     // Mock out production react imports in development.
     (context: ResolutionContext, moduleName: string, platform: string | null) => {
       // This resolution is dev-only to prevent bundling the production React packages in development.
-      // @ts-expect-error: dev is not on type.
       if (!context.dev) return null;
 
       if (

--- a/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro-babel-transformer' {
   export { default } from 'metro-babel-transformer/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-babel-transformer/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-babel-transformer/src/index.js
 declare module 'metro-babel-transformer/src/index' {
   import type * as _babel_types from '@babel/types';
   import type { BabelFileMetadata, TransformOptions } from '@babel/core';

--- a/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-cache-key' {
   export { default } from 'metro-cache-key/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-cache-key/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-cache-key/src/index.js
 declare module 'metro-cache-key/src/index' {
   function getCacheKey(files: string[]): string;
   export default getCacheKey;

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -4,6 +4,11 @@ declare module 'metro-config' {
   export { default } from 'metro-config/src/index';
 }
 
+// NOTE(cedric): this is a manual change, to avoid having to import `../configTypes.flow`
+declare module 'metro-config/src/configTypes' {
+  export * from 'metro-config/src/configTypes.flow';
+}
+
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/configTypes.flow.js
 declare module 'metro-config/src/configTypes.flow' {
   import type { IntermediateStackFrame } from 'metro/src/Server/symbolicate';

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro-config' {
   export { default } from 'metro-config/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/configTypes.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/configTypes.flow.js
 declare module 'metro-config/src/configTypes.flow' {
   import type { IntermediateStackFrame } from 'metro/src/Server/symbolicate';
   import type { HandleFunction, Server } from 'connect';
@@ -23,26 +23,28 @@ declare module 'metro-config/src/configTypes.flow' {
   } from 'metro/src/DeltaBundler/types.flow';
   import type { Reporter } from 'metro/src/lib/reporting';
   import type MetroServer from 'metro/src/Server';
-  export type ExtraTransformOptions = {
-    readonly preloadedModules?:
-      | {
+  export type ExtraTransformOptions = Readonly<{
+    preloadedModules?:
+      | Readonly<{
           [path: string]: true;
-        }
+        }>
       | false;
-    readonly ramGroups?: string[];
-    readonly transform?: {
-      readonly experimentalImportSupport?: boolean;
-      readonly inlineRequires?:
-        | {
-            readonly blockList: {
+    ramGroups?: readonly string[];
+    transform?: Readonly<{
+      experimentalImportSupport?: boolean;
+      inlineRequires?:
+        | Readonly<{
+            blockList: Readonly<{
               [$$Key$$: string]: true;
-            };
-          }
+            }>;
+          }>
         | boolean;
-      readonly nonInlinedRequires?: readonly string[];
-      readonly unstable_disableES6Transforms?: boolean;
-    };
-  };
+      nonInlinedRequires?: readonly string[];
+      unstable_disableES6Transforms?: boolean;
+      unstable_memoizeInlineRequires?: boolean;
+      unstable_nonMemoizedInlineRequires?: readonly string[];
+    }>;
+  }>;
   export type GetTransformOptionsOpts = {
     dev: boolean;
     hot: boolean;
@@ -108,7 +110,6 @@ declare module 'metro-config/src/configTypes.flow' {
     dependencyExtractor?: null | string;
     emptyModulePath: string;
     enableGlobalPackages: boolean;
-    unstable_enableSymlinks: boolean;
     extraNodeModules: {
       [name: string]: string;
     };
@@ -216,36 +217,38 @@ declare module 'metro-config/src/configTypes.flow' {
   };
   type WatcherConfigT = {
     additionalExts: readonly string[];
-    healthCheck: {
+    healthCheck: Readonly<{
       enabled: boolean;
       interval: number;
       timeout: number;
       filePrefix: string;
-    };
+    }>;
     unstable_workerThreads: boolean;
-    watchman: {
+    watchman: Readonly<{
       deferStates: readonly string[];
-    };
+    }>;
   };
-  export type InputConfigT = Partial<
-    {} & MetalConfigT &
-      Readonly<{
-        cacheStores?:
-          | readonly CacheStore<TransformResult>[]
-          | (($$PARAM_0$$: MetroCache) => readonly CacheStore<TransformResult>[]);
-        resolver: Readonly<Partial<ResolverConfigT>>;
-        server: Readonly<Partial<ServerConfigT>>;
-        serializer: Readonly<Partial<SerializerConfigT>>;
-        symbolicator: Readonly<Partial<SymbolicatorConfigT>>;
-        transformer: Readonly<Partial<TransformerConfigT>>;
-        watcher: Readonly<
-          Partial<
-            {
-              healthCheck?: Readonly<Partial<WatcherConfigT['healthCheck']>>;
-            } & WatcherConfigT
-          >
-        >;
-      }>
+  export type InputConfigT = Readonly<
+    Partial<
+      {} & MetalConfigT &
+        Readonly<{
+          cacheStores?:
+            | readonly CacheStore<TransformResult>[]
+            | (($$PARAM_0$$: MetroCache) => readonly CacheStore<TransformResult>[]);
+          resolver: Readonly<Partial<ResolverConfigT>>;
+          server: Readonly<Partial<ServerConfigT>>;
+          serializer: Readonly<Partial<SerializerConfigT>>;
+          symbolicator: Readonly<Partial<SymbolicatorConfigT>>;
+          transformer: Readonly<Partial<TransformerConfigT>>;
+          watcher: Readonly<
+            Partial<
+              {
+                healthCheck?: Readonly<Partial<WatcherConfigT['healthCheck']>>;
+              } & WatcherConfigT
+            >
+          >;
+        }>
+    >
   >;
   export type MetroConfig = InputConfigT;
   export type IntermediateConfigT = {} & MetalConfigT & {
@@ -286,7 +289,7 @@ declare module 'metro-config/src/configTypes.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/defaults/defaults.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/defaults/defaults.js
 declare module 'metro-config/src/defaults/defaults' {
   import type { RootPerfLogger } from 'metro-config/src/configTypes.flow';
   export const assetExts: any;
@@ -300,9 +303,9 @@ declare module 'metro-config/src/defaults/defaults' {
   export const noopPerfLoggerFactory: () => RootPerfLogger;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/defaults/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/defaults/index.js
 declare module 'metro-config/src/defaults/index' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/defaults/index.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/defaults/index.js
 
   // NOTE(cedric): This file can't be typed properly due to complex CJS structures
 
@@ -313,15 +316,15 @@ declare module 'metro-config/src/defaults/index' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/defaults/validConfig.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/defaults/validConfig.js
 declare module 'metro-config/src/defaults/validConfig' {
   const $$EXPORT_DEFAULT_DECLARATION$$: () => any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/index.js
 declare module 'metro-config/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export type * from 'metro-config/src/configTypes.flow';
@@ -329,7 +332,7 @@ declare module 'metro-config/src/index' {
   export { loadConfig, mergeConfig, resolveConfig } from 'metro-config/src/loadConfig';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-config/src/loadConfig.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-config/src/loadConfig.js
 declare module 'metro-config/src/loadConfig' {
   import type { ConfigT, InputConfigT, YargArguments } from 'metro-config/src/configTypes.flow';
   type CosmiConfigResult = {

--- a/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
@@ -3,19 +3,19 @@ declare module 'metro-core' {
   export * from 'metro-core/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/canonicalize.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/canonicalize.js
 declare module 'metro-core/src/canonicalize' {
   function canonicalize(key: string, value: any): any;
   export default canonicalize;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/errors.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/errors.js
 declare module 'metro-core/src/errors' {
   export { default as AmbiguousModuleResolutionError } from 'metro-core/src/errors/AmbiguousModuleResolutionError';
   export { default as PackageResolutionError } from 'metro-core/src/errors/PackageResolutionError';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/errors/AmbiguousModuleResolutionError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/errors/AmbiguousModuleResolutionError.js
 declare module 'metro-core/src/errors/AmbiguousModuleResolutionError' {
   import type { DuplicateHasteCandidatesError } from 'metro-file-map';
   class AmbiguousModuleResolutionError extends Error {
@@ -26,7 +26,7 @@ declare module 'metro-core/src/errors/AmbiguousModuleResolutionError' {
   export default AmbiguousModuleResolutionError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/errors/PackageResolutionError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/errors/PackageResolutionError.js
 declare module 'metro-core/src/errors/PackageResolutionError' {
   import type { InvalidPackageError } from 'metro-resolver';
   class PackageResolutionError extends Error {
@@ -42,7 +42,7 @@ declare module 'metro-core/src/errors/PackageResolutionError' {
   export default PackageResolutionError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/index.js
 declare module 'metro-core/src/index' {
   export { default as AmbiguousModuleResolutionError } from 'metro-core/src/errors/AmbiguousModuleResolutionError';
   export { default as Logger } from 'metro-core/src/Logger';
@@ -50,7 +50,7 @@ declare module 'metro-core/src/index' {
   export { default as Terminal } from 'metro-core/src/Terminal';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/Logger.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/Logger.js
 declare module 'metro-core/src/Logger' {
   import type { BundleOptions } from 'metro/src/shared/types.flow';
   export type ActionLogEntryData = {
@@ -91,7 +91,7 @@ declare module 'metro-core/src/Logger' {
   export function log(logEntry: LogEntry): LogEntry;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-core/src/Terminal.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-core/src/Terminal.js
 declare module 'metro-core/src/Terminal' {
   import type * as _nodeStream from 'node:stream';
   import type * as _nodeNet from 'node:net';

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -1134,6 +1134,7 @@ declare module 'metro-file-map/src/watchers/FSEventsWatcher' {
     readonly dot: boolean;
     readonly doIgnore: (path: string) => boolean;
     readonly fsEventsWatchStopper: () => Promise<void>;
+    readonly watcherInitialReaddirPromise: Promise<void>;
     _tracked: Set<string>;
     static isSupported(): boolean;
     static _normalizeProxy(
@@ -1144,7 +1145,7 @@ declare module 'metro-file-map/src/watchers/FSEventsWatcher' {
       dirCallback: (normalizedPath: string, stats: Stats) => void,
       fileCallback: (normalizedPath: string, stats: Stats) => void,
       symlinkCallback: (normalizedPath: string, stats: Stats) => void,
-      endCallback: Function,
+      endCallback: () => void,
       errorCallback: Function,
       ignored?: Matcher
     ): void;

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro-file-map' {
   export { default } from 'metro-file-map/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/cache/DiskCacheManager.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/cache/DiskCacheManager.js
 declare module 'metro-file-map/src/cache/DiskCacheManager' {
   import type {
     BuildParameters,
@@ -31,7 +31,7 @@ declare module 'metro-file-map/src/cache/DiskCacheManager' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/constants.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/constants.js
 declare module 'metro-file-map/src/constants' {
   const constants: {
     DEPENDENCY_DELIM: '\0';
@@ -52,13 +52,13 @@ declare module 'metro-file-map/src/constants' {
   export default constants;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
 declare module 'metro-file-map/src/crawlers/node/hasNativeFindSupport' {
   function hasNativeFindSupport(): Promise<boolean>;
   export default hasNativeFindSupport;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/crawlers/node/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/crawlers/node/index.js
 declare module 'metro-file-map/src/crawlers/node/index' {
   import type { CanonicalPath, CrawlerOptions, FileData } from 'metro-file-map/src/flow-types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (options: CrawlerOptions) => Promise<{
@@ -68,7 +68,7 @@ declare module 'metro-file-map/src/crawlers/node/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/crawlers/watchman/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/crawlers/watchman/index.js
 declare module 'metro-file-map/src/crawlers/watchman/index' {
   import type {
     CanonicalPath,
@@ -84,7 +84,7 @@ declare module 'metro-file-map/src/crawlers/watchman/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/crawlers/watchman/planQuery.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/crawlers/watchman/planQuery.js
 declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
   import type { WatchmanQuery, WatchmanQuerySince } from 'fb-watchman';
   export function planQuery(
@@ -101,7 +101,7 @@ declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/flow-types.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/flow-types.js
 declare module 'metro-file-map/src/flow-types' {
   import type { PerfLogger, PerfLoggerFactory, RootPerfLogger } from 'metro-config';
   import type { AbortSignal } from 'node-abort-controller';
@@ -372,13 +372,13 @@ declare module 'metro-file-map/src/flow-types' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/getMockName.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/getMockName.js
 declare module 'metro-file-map/src/getMockName' {
   const getMockName: (filePath: string) => string;
   export default getMockName;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/index.js
 declare module 'metro-file-map/src/index' {
   import type {
     BuildParameters,
@@ -647,7 +647,7 @@ declare module 'metro-file-map/src/index' {
   export default FileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
 declare module 'metro-file-map/src/lib/checkWatchmanCapabilities' {
   function checkWatchmanCapabilities(requiredCapabilities: readonly string[]): Promise<{
     version: string;
@@ -655,12 +655,12 @@ declare module 'metro-file-map/src/lib/checkWatchmanCapabilities' {
   export default checkWatchmanCapabilities;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/dependencyExtractor.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/dependencyExtractor.js
 declare module 'metro-file-map/src/lib/dependencyExtractor' {
   export function extract(code: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/DuplicateError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/DuplicateError.js
 declare module 'metro-file-map/src/lib/DuplicateError' {
   export class DuplicateError extends Error {
     mockPath1: string;
@@ -669,7 +669,7 @@ declare module 'metro-file-map/src/lib/DuplicateError' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/DuplicateHasteCandidatesError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/DuplicateHasteCandidatesError.js
 declare module 'metro-file-map/src/lib/DuplicateHasteCandidatesError' {
   import type { DuplicatesSet } from 'metro-file-map/src/flow-types';
   export class DuplicateHasteCandidatesError extends Error {
@@ -686,13 +686,13 @@ declare module 'metro-file-map/src/lib/DuplicateHasteCandidatesError' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/fast_path.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/fast_path.js
 declare module 'metro-file-map/src/lib/fast_path' {
   export function relative(rootDir: string, filename: string): string;
   export function resolve(rootDir: string, normalPath: string): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/getPlatformExtension.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/getPlatformExtension.js
 declare module 'metro-file-map/src/lib/getPlatformExtension' {
   function getPlatformExtension(
     file: string,
@@ -701,7 +701,7 @@ declare module 'metro-file-map/src/lib/getPlatformExtension' {
   export default getPlatformExtension;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/MockMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/MockMap.js
 declare module 'metro-file-map/src/lib/MockMap' {
   import type { MockMap as IMockMap, Path, RawMockMap } from 'metro-file-map/src/flow-types';
   class MockMap implements IMockMap {
@@ -711,7 +711,7 @@ declare module 'metro-file-map/src/lib/MockMap' {
   export default MockMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/MutableHasteMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/MutableHasteMap.js
 declare module 'metro-file-map/src/lib/MutableHasteMap' {
   import type {
     Console,
@@ -767,19 +767,19 @@ declare module 'metro-file-map/src/lib/MutableHasteMap' {
   export default MutableHasteMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
 declare module 'metro-file-map/src/lib/normalizePathSeparatorsToPosix' {
   let normalizePathSeparatorsToPosix: (string: string) => string;
   export default normalizePathSeparatorsToPosix;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
 declare module 'metro-file-map/src/lib/normalizePathSeparatorsToSystem' {
   let normalizePathSeparatorsToSystem: (string: string) => string;
   export default normalizePathSeparatorsToSystem;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/RootPathUtils.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/RootPathUtils.js
 declare module 'metro-file-map/src/lib/RootPathUtils' {
   export class RootPathUtils {
     constructor(rootDir: string);
@@ -800,7 +800,7 @@ declare module 'metro-file-map/src/lib/RootPathUtils' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
 declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
   import type { BuildParameters } from 'metro-file-map/src/flow-types';
   function rootRelativeCacheKeys(buildParameters: BuildParameters): {
@@ -810,7 +810,7 @@ declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
   export default rootRelativeCacheKeys;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/lib/TreeFS.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/lib/TreeFS.js
 declare module 'metro-file-map/src/lib/TreeFS' {
   import type {
     FileData,
@@ -962,7 +962,7 @@ declare module 'metro-file-map/src/lib/TreeFS' {
   export default TreeFS;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/Watcher.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/Watcher.js
 declare module 'metro-file-map/src/Watcher' {
   import type {
     ChangeEventMetadata,
@@ -1044,7 +1044,7 @@ declare module 'metro-file-map/src/Watcher' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/watchers/common.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/watchers/common.js
 declare module 'metro-file-map/src/watchers/common' {
   import type { ChangeEventMetadata } from 'metro-file-map/src/flow-types';
   import type { Stats } from 'fs';
@@ -1105,7 +1105,7 @@ declare module 'metro-file-map/src/watchers/common' {
   export function typeFromStat(stat: Stats): null | undefined | ChangeEventMetadata['type'];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/watchers/FSEventsWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/watchers/FSEventsWatcher.js
 declare module 'metro-file-map/src/watchers/FSEventsWatcher' {
   import type { ChangeEventMetadata } from 'metro-file-map/src/flow-types';
   import type { Stats } from 'fs';
@@ -1164,13 +1164,13 @@ declare module 'metro-file-map/src/watchers/FSEventsWatcher' {
   export default FSEventsWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/watchers/NodeWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/watchers/NodeWatcher.js
 declare module 'metro-file-map/src/watchers/NodeWatcher' {
   const $$EXPORT_DEFAULT_DECLARATION$$: any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/watchers/RecrawlWarning.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/watchers/RecrawlWarning.js
 declare module 'metro-file-map/src/watchers/RecrawlWarning' {
   class RecrawlWarning {
     static RECRAWL_WARNINGS: RecrawlWarning[];
@@ -1184,7 +1184,7 @@ declare module 'metro-file-map/src/watchers/RecrawlWarning' {
   export default RecrawlWarning;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/watchers/WatchmanWatcher.js
 declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
   import type { ChangeEventMetadata } from 'metro-file-map/src/flow-types';
   import type { WatcherOptions } from 'metro-file-map/src/watchers/common';
@@ -1224,12 +1224,12 @@ declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
   export default WatchmanWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/worker.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/worker.js
 declare module 'metro-file-map/src/worker' {
   export function worker(data: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-file-map/src/workerExclusionList.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-file-map/src/workerExclusionList.js
 declare module 'metro-file-map/src/workerExclusionList' {
   const extensions: any;
   export default extensions;

--- a/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
@@ -1,0 +1,430 @@
+// #region metro-resolver
+declare module 'metro-resolver' {
+  export * from 'metro-resolver/src/index';
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/createDefaultContext.js
+declare module 'metro-resolver/src/createDefaultContext' {
+  import type { ResolutionContext } from 'metro-resolver/src/types';
+  import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
+  type PartialContext = Readonly<
+    {
+      redirectModulePath?: ResolutionContext['redirectModulePath'];
+    } & ResolutionContext
+  >;
+  /**
+   * Helper used by the `metro` package to create the `ResolutionContext` object.
+   * As context values can be overridden by callers, this occurs externally to
+   * `resolve.js`.
+   */
+  function createDefaultContext(
+    context: PartialContext,
+    dependency: TransformResultDependency
+  ): ResolutionContext;
+  export default createDefaultContext;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/FailedToResolveNameError.js
+declare module 'metro-resolver/src/errors/FailedToResolveNameError' {
+  class FailedToResolveNameError extends Error {
+    dirPaths: readonly string[];
+    extraPaths: readonly string[];
+    constructor(dirPaths: readonly string[], extraPaths: readonly string[]);
+  }
+  export default FailedToResolveNameError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/FailedToResolvePathError.js
+declare module 'metro-resolver/src/errors/FailedToResolvePathError' {
+  import type { FileAndDirCandidates } from 'metro-resolver/src/types';
+  class FailedToResolvePathError extends Error {
+    candidates: FileAndDirCandidates;
+    constructor(candidates: FileAndDirCandidates);
+  }
+  export default FailedToResolvePathError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/FailedToResolveUnsupportedError.js
+declare module 'metro-resolver/src/errors/FailedToResolveUnsupportedError' {
+  class FailedToResolveUnsupportedError extends Error {
+    constructor(message: string);
+  }
+  export default FailedToResolveUnsupportedError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/formatFileCandidates.js
+declare module 'metro-resolver/src/errors/formatFileCandidates' {
+  import type { FileCandidates } from 'metro-resolver/src/types';
+  function formatFileCandidates(candidates: FileCandidates): string;
+  export default formatFileCandidates;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/InvalidPackageConfigurationError.js
+declare module 'metro-resolver/src/errors/InvalidPackageConfigurationError' {
+  /**
+   * Raised when a package contains an invalid `package.json` configuration.
+   */
+  class InvalidPackageConfigurationError extends Error {
+    reason: string;
+    packagePath: string;
+    constructor(
+      opts: Readonly<{
+        reason: string;
+        packagePath: string;
+      }>
+    );
+  }
+  export default InvalidPackageConfigurationError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/InvalidPackageError.js
+declare module 'metro-resolver/src/errors/InvalidPackageError' {
+  import type { FileCandidates } from 'metro-resolver/src/types';
+  class InvalidPackageError extends Error {
+    fileCandidates: FileCandidates;
+    indexCandidates: FileCandidates;
+    mainModulePath: string;
+    packageJsonPath: string;
+    constructor(opts: {
+      readonly fileCandidates: FileCandidates;
+      readonly indexCandidates: FileCandidates;
+      readonly mainModulePath: string;
+      readonly packageJsonPath: string;
+    });
+  }
+  export default InvalidPackageError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/errors/PackagePathNotExportedError.js
+declare module 'metro-resolver/src/errors/PackagePathNotExportedError' {
+  /**
+   * Raised when package exports do not define or permit a target subpath in the
+   * package for the given module.
+   */
+  class PackagePathNotExportedError extends Error {}
+  export default PackagePathNotExportedError;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/index.js
+declare module 'metro-resolver/src/index' {
+  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/index.js
+
+  export type {
+    AssetFileResolution,
+    CustomResolutionContext,
+    CustomResolver,
+    CustomResolverOptions,
+    DoesFileExist,
+    FileAndDirCandidates,
+    FileCandidates,
+    FileResolution,
+    FileSystemLookup,
+    ResolutionContext,
+    Resolution,
+    ResolveAsset,
+    Result,
+  } from 'metro-resolver/src/types';
+
+  // NOTE(cedric): the flow translation API can't resolve types when using inline requires in object properties
+  export { default as FailedToResolveNameError } from 'metro-resolver/src/errors/FailedToResolveNameError';
+  export { default as FailedToResolvePathError } from 'metro-resolver/src/errors/FailedToResolvePathError';
+  export { default as formatFileCandidates } from 'metro-resolver/src/errors/formatFileCandidates';
+  export { default as InvalidPackageError } from 'metro-resolver/src/errors/InvalidPackageError';
+  export { default as resolve } from 'metro-resolver/src/resolve';
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/PackageExportsResolve.js
+declare module 'metro-resolver/src/PackageExportsResolve' {
+  import type {
+    ExportMap,
+    ExportsField,
+    FileResolution,
+    ResolutionContext,
+  } from 'metro-resolver/src/types';
+  type NormalizedExporthMap = Map<string, null | string | ExportMap>;
+  export function resolvePackageTargetFromExports(
+    context: ResolutionContext,
+    packagePath: string,
+    modulePath: string,
+    packageRelativePath: string,
+    exportsField: ExportsField,
+    platform: string | null
+  ): FileResolution;
+  export function isSubpathDefinedInExports(
+    exportMap: NormalizedExporthMap,
+    subpath: string
+  ): boolean;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/PackageResolve.js
+declare module 'metro-resolver/src/PackageResolve' {
+  import type { PackageInfo, ResolutionContext } from 'metro-resolver/src/types';
+  /**
+   * Resolve the main entry point subpath for a package.
+   *
+   * Implements legacy (non-exports) package resolution behaviour based on the
+   * ["browser" field spec](https://github.com/defunctzombie/package-browser-field-spec).
+   */
+  export function getPackageEntryPoint(
+    context: ResolutionContext,
+    packageInfo: PackageInfo,
+    platform: string | null
+  ): string;
+  /**
+   * Get the resolved file path for the given import specifier based on any
+   * `package.json` rules. Returns `false` if the module should be
+   * [ignored](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module),
+   * and returns the original path if no `package.json` mapping is matched. Does
+   * not test file existence.
+   *
+   * Implements legacy (non-exports) package resolution behaviour based on the
+   * ["browser" field spec](https://github.com/defunctzombie/package-browser-field-spec).
+   */
+  export function redirectModulePath(
+    context: Readonly<{
+      getPackageForModule: ResolutionContext['getPackageForModule'];
+      mainFields: ResolutionContext['mainFields'];
+      originModulePath: ResolutionContext['originModulePath'];
+    }>,
+    modulePath: string
+  ): string | false;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/resolve.js
+declare module 'metro-resolver/src/resolve' {
+  import type { Resolution, ResolutionContext } from 'metro-resolver/src/types';
+  function resolve(
+    context: ResolutionContext,
+    moduleName: string,
+    platform: string | null
+  ): Resolution;
+  export default resolve;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/resolveAsset.js
+declare module 'metro-resolver/src/resolveAsset' {
+  import type { AssetResolution, ResolutionContext } from 'metro-resolver/src/types';
+  /**
+   * Resolve a file path as an asset. Returns the set of files found after
+   * expanding asset resolutions (e.g. `icon@2x.png`). Users may override this
+   * behaviour via `context.resolveAsset`.
+   */
+  function resolveAsset(context: ResolutionContext, filePath: string): AssetResolution | null;
+  export default resolveAsset;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/types.js
+declare module 'metro-resolver/src/types' {
+  import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
+  export type Result<TResolution, TCandidates> =
+    | {
+        readonly type: 'resolved';
+        readonly resolution: TResolution;
+      }
+    | {
+        readonly type: 'failed';
+        readonly candidates: TCandidates;
+      };
+  export type Resolution =
+    | FileResolution
+    | {
+        readonly type: 'empty';
+      };
+  export type SourceFileResolution = Readonly<{
+    type: 'sourceFile';
+    filePath: string;
+  }>;
+  export type AssetFileResolution = readonly string[];
+  export type AssetResolution = Readonly<{
+    type: 'assetFiles';
+    filePaths: AssetFileResolution;
+  }>;
+  export type FileResolution = AssetResolution | SourceFileResolution;
+  export type FileAndDirCandidates = {
+    readonly dir?: null | FileCandidates;
+    readonly file?: null | FileCandidates;
+  };
+  /**
+   * This is a way to describe what files we tried to look for when resolving
+   * a module name as file. This is mainly used for error reporting, so that
+   * we can explain why we cannot resolve a module.
+   */
+  export type FileCandidates =
+    | {
+        readonly type: 'asset';
+        readonly name: string;
+      }
+    | {
+        readonly type: 'sourceFile';
+        filePathPrefix: string;
+        readonly candidateExts: readonly string[];
+      };
+  export type ExportMap = Readonly<{
+    [subpathOrCondition: string]: string | ExportMap | null;
+  }>;
+  /** "exports" mapping where values may be legacy Node.js <13.7 array format. */
+  export type ExportMapWithFallbacks = Readonly<{
+    [subpath: string]: ExportMap[keyof ExportMap] | ExportValueWithFallback;
+  }>;
+  /** "exports" subpath value when in legacy Node.js <13.7 array format. */
+  export type ExportValueWithFallback =
+    | readonly (ExportMap | string)[]
+    | readonly (readonly any[])[];
+  export type ExportsField =
+    | string
+    | readonly string[]
+    | ExportValueWithFallback
+    | ExportMap
+    | ExportMapWithFallbacks;
+  export type PackageJson = Readonly<{
+    name?: string;
+    main?: string;
+    exports?: ExportsField;
+  }>;
+  export type PackageInfo = Readonly<{
+    packageJson: PackageJson;
+    rootPath: string;
+  }>;
+  export type PackageForModule = Readonly<
+    {
+      packageRelativePath: string;
+    } & PackageInfo
+  >;
+  /**
+   * Check existence of a single file.
+   */
+  export type DoesFileExist = (filePath: string) => boolean;
+  /**
+   * Performs a lookup against an absolute or project-relative path to determine
+   * whether it exists as a file or directory. Follows any symlinks, and returns
+   * a real absolute path on existence.
+   */
+  export type FileSystemLookup = (absoluteOrProjectRelativePath: string) =>
+    | {
+        exists: false;
+      }
+    | {
+        exists: true;
+        type?: 'f' | 'd';
+        realPath: string;
+      };
+  /**
+   * Given a directory path and the base asset name, return a list of all the
+   * asset file names that match the given base name in that directory. Return
+   * null if there's no such named asset. `platform` is used to identify
+   * platform-specific assets, ex. `foo.ios.js` instead of a generic `foo.js`.
+   */
+  export type ResolveAsset = (
+    dirPath: string,
+    assetName: string,
+    extension: string
+  ) => null | undefined | readonly string[];
+  export type ResolutionContext = Readonly<{
+    allowHaste: boolean;
+    assetExts: ReadonlySet<string>;
+    customResolverOptions: CustomResolverOptions;
+    disableHierarchicalLookup: boolean;
+    /**
+     * Determine whether a regular file exists at the given path.
+     *
+     * @deprecated, prefer `fileSystemLookup`
+     */
+    doesFileExist: DoesFileExist;
+    extraNodeModules?: null | {
+      [$$Key$$: string]: string;
+    };
+    /** Is resolving for a development bundle. */
+    dev: boolean;
+    /**
+     * Get the parsed contents of the specified `package.json` file.
+     */
+    getPackage: (packageJsonPath: string) => null | undefined | PackageJson;
+    /**
+     * Get the closest package scope, parsed `package.json` and relative subpath
+     * for a given absolute candidate path (which need not exist), or null if
+     * there is no package.json closer than the nearest node_modules directory.
+     *
+     * @deprecated See https://github.com/facebook/metro/commit/29c77bff31e2475a086bc3f04073f485da8f9ff0
+     */
+    getPackageForModule: (absoluteModulePath: string) => null | undefined | PackageForModule;
+    /**
+     * The dependency descriptor, within the origin module, corresponding to the
+     * current resolution request. This is provided for diagnostic purposes ONLY
+     * and may not be used for resolution purposes.
+     */
+    dependency?: TransformResultDependency;
+    /**
+     * Synchonously returns information about a given absolute path, including
+     * whether it exists, whether it is a file or directory, and its absolute
+     * real path.
+     */
+    fileSystemLookup: FileSystemLookup;
+    /**
+     * The ordered list of fields to read in `package.json` to resolve a main
+     * entry point based on the "browser" field spec.
+     */
+    mainFields: readonly string[];
+    /**
+     * Full path of the module that is requiring or importing the module to be
+     * resolved. This may not be the only place this dependency was found,
+     * as resolutions can be cached.
+     */
+    originModulePath: string;
+    nodeModulesPaths: readonly string[];
+    preferNativePlatform: boolean;
+    resolveAsset: ResolveAsset;
+    redirectModulePath: (modulePath: string) => string | false;
+    /**
+     * Given a name, this should return the full path to the file that provides
+     * a Haste module of that name. Ex. for `Foo` it may return `/smth/Foo.js`.
+     */
+    resolveHasteModule: (name: string) => null | undefined | string;
+    /**
+     * Given a name, this should return the full path to the package manifest that
+     * provides a Haste package of that name. Ex. for `Foo` it may return
+     * `/smth/Foo/package.json`.
+     */
+    resolveHastePackage: (name: string) => null | undefined | string;
+    resolveRequest?: null | undefined | CustomResolver;
+    sourceExts: readonly string[];
+    unstable_conditionNames: readonly string[];
+    unstable_conditionsByPlatform: Readonly<{
+      [platform: string]: readonly string[];
+    }>;
+    unstable_enablePackageExports: boolean;
+    unstable_logWarning: (message: string) => void;
+  }>;
+  export type CustomResolutionContext = Readonly<
+    {
+      resolveRequest: CustomResolver;
+    } & ResolutionContext
+  >;
+  export type CustomResolver = (
+    context: CustomResolutionContext,
+    moduleName: string,
+    platform: string | null
+  ) => Resolution;
+  export type CustomResolverOptions = {
+    readonly [$$Key$$: string]: any;
+  };
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/utils/isAssetFile.js
+declare module 'metro-resolver/src/utils/isAssetFile' {
+  /**
+   * Determine if a file path should be considered an asset file based on the
+   * given `assetExts`.
+   */
+  function isAssetFile(filePath: string, assetExts: ReadonlySet<string>): boolean;
+  export default isAssetFile;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-resolver/src/utils/toPosixPath.js
+declare module 'metro-resolver/src/utils/toPosixPath' {
+  /**
+   * Replace path separators in the passed string to coerce to a POSIX path. This
+   * is a no-op on POSIX systems.
+   */
+  function toPosixPath(relativePathOrSpecifier: string): string;
+  export default toPosixPath;
+}

--- a/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
@@ -51,6 +51,11 @@ declare module 'metro-runtime/src/modules/null-module' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
+// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
+declare module 'metro-runtime/src/modules/types' {
+  export * from 'metro-runtime/src/modules/types.flow';
+}
+
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/types.flow.js
 declare module 'metro-runtime/src/modules/types.flow' {
   export type ModuleMap = readonly [number, string][];

--- a/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro-runtime
 // metro-runtime has no entrypoint
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/asyncRequire.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/asyncRequire.js
 declare module 'metro-runtime/src/modules/asyncRequire' {
   type DependencyMapPaths =
     | null
@@ -17,12 +17,12 @@ declare module 'metro-runtime/src/modules/asyncRequire' {
   export default asyncRequire;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/empty-module.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/empty-module.js
 declare module 'metro-runtime/src/modules/empty-module' {
   // This has no exports
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/HMRClient.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/HMRClient.js
 declare module 'metro-runtime/src/modules/HMRClient' {
   import type { HmrUpdate } from 'metro-runtime/src/modules/types.flow';
   import EventEmitter from 'metro-runtime/src/modules/vendor/eventemitter3';
@@ -45,13 +45,13 @@ declare module 'metro-runtime/src/modules/HMRClient' {
   export default HMRClient;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/null-module.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/null-module.js
 declare module 'metro-runtime/src/modules/null-module' {
   const $$EXPORT_DEFAULT_DECLARATION$$: null;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/types.flow.js
 declare module 'metro-runtime/src/modules/types.flow' {
   export type ModuleMap = readonly [number, string][];
   export type Bundle = {
@@ -144,7 +144,7 @@ declare module 'metro-runtime/src/modules/types.flow' {
     | HmrErrorMessage;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/modules/vendor/eventemitter3.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
 declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
   /**
    * `object` should be in either of the following forms:
@@ -229,7 +229,7 @@ declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
   export default EventEmitter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-runtime/src/polyfills/require.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-runtime/src/polyfills/require.js
 declare module 'metro-runtime/src/polyfills/require' {
   type ArrayIndexable<T> = {
     readonly [indexer: number]: T;

--- a/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-source-map' {
   export * from 'metro-source-map/src/source-map';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/B64Builder.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/B64Builder.js
 declare module 'metro-source-map/src/B64Builder' {
   /**
    * Efficient builder for base64 VLQ mappings strings.
@@ -32,7 +32,7 @@ declare module 'metro-source-map/src/B64Builder' {
   export default B64Builder;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/BundleBuilder.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/BundleBuilder.js
 declare module 'metro-source-map/src/BundleBuilder' {
   import type { IndexMap, IndexMapSection, MixedSourceMap } from 'metro-source-map/src/source-map';
   export class BundleBuilder {
@@ -52,14 +52,14 @@ declare module 'metro-source-map/src/BundleBuilder' {
   export function createIndexMap(file: string, sections: IndexMapSection[]): IndexMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/composeSourceMaps.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/composeSourceMaps.js
 declare module 'metro-source-map/src/composeSourceMaps' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   function composeSourceMaps(maps: readonly MixedSourceMap[]): MixedSourceMap;
   export default composeSourceMaps;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/AbstractConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/AbstractConsumer.js
 declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
   import type {
     GeneratedPositionLookup,
@@ -82,7 +82,7 @@ declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
   export default AbstractConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/constants.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/constants.js
 declare module 'metro-source-map/src/Consumer/constants' {
   // import type { Number0, Number1 } from 'ob1';
   // NOTE(cedric): ob1 is not typed
@@ -101,7 +101,7 @@ declare module 'metro-source-map/src/Consumer/constants' {
   export function lookupBiasToString(x: LookupBias): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/createConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/createConsumer.js
 declare module 'metro-source-map/src/Consumer/createConsumer' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
@@ -109,7 +109,7 @@ declare module 'metro-source-map/src/Consumer/createConsumer' {
   export default createConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
 declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   import type { LookupBias } from 'metro-source-map/src/Consumer/constants';
@@ -141,12 +141,12 @@ declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
   export default DelegatingConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/index.js
 declare module 'metro-source-map/src/Consumer/index' {
   export { default as DelegatingConsumer } from 'metro-source-map/src/Consumer/DelegatingConsumer';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/MappingsConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/MappingsConsumer.js
 declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
   import type { BasicSourceMap } from 'metro-source-map/src/source-map';
   import type {
@@ -179,7 +179,7 @@ declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
   export default MappingsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
 declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
   function normalizeSourcePath(
     sourceInput: string,
@@ -190,7 +190,7 @@ declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
   export default normalizeSourcePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/positionMath.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/positionMath.js
 declare module 'metro-source-map/src/Consumer/positionMath' {
   import type { GeneratedOffset } from 'metro-source-map/src/Consumer/types.flow';
   // import type { Number0, Number1 } from 'ob1';
@@ -211,7 +211,7 @@ declare module 'metro-source-map/src/Consumer/positionMath' {
   >(pos: T, offset: GeneratedOffset): T;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/search.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/search.js
 declare module 'metro-source-map/src/Consumer/search' {
   export function greatestLowerBound<T, U>(
     elements: readonly T[],
@@ -220,7 +220,7 @@ declare module 'metro-source-map/src/Consumer/search' {
   ): null | undefined | number;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/SectionsConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/SectionsConsumer.js
 declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
   import type { IndexMap } from 'metro-source-map/src/source-map';
   import type {
@@ -248,7 +248,7 @@ declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
   export default SectionsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Consumer/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Consumer/types.flow.js
 declare module 'metro-source-map/src/Consumer/types.flow' {
   import type { IterationOrder, LookupBias } from 'metro-source-map/src/Consumer/constants';
   // import type { Number0, Number1 } from 'ob1';
@@ -292,7 +292,7 @@ declare module 'metro-source-map/src/Consumer/types.flow' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/encode.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/encode.js
 declare module 'metro-source-map/src/encode' {
   /**
    * Encodes a number to base64 VLQ format and appends it to the passed-in buffer
@@ -307,7 +307,7 @@ declare module 'metro-source-map/src/encode' {
   export default encode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/generateFunctionMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/generateFunctionMap.js
 declare module 'metro-source-map/src/generateFunctionMap' {
   import type * as _babel_types from '@babel/types';
   import type { FBSourceFunctionMap } from 'metro-source-map/src/source-map';
@@ -334,7 +334,7 @@ declare module 'metro-source-map/src/generateFunctionMap' {
   ): readonly RangeMapping[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/Generator.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/Generator.js
 declare module 'metro-source-map/src/Generator' {
   import type {
     BasicSourceMap,
@@ -418,7 +418,7 @@ declare module 'metro-source-map/src/Generator' {
   export default Generator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-source-map/src/source-map.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-source-map/src/source-map.js
 declare module 'metro-source-map/src/source-map' {
   import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
   import Generator from 'metro-source-map/src/Generator';

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -1,7 +1,6 @@
 // #region metro-transform-plugins
 declare module 'metro-transform-plugins' {
   export * from 'metro-transform-plugins/src/index';
-  export { default } from 'metro-transform-plugins/src/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js
@@ -139,8 +138,8 @@ declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
 
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
 declare module 'metro-transform-plugins/src/utils/createInlinePlatformChecks' {
-  import type * as _babel_types from '@babel/types';
   import type { Scope } from '@babel/traverse';
+  import type * as _babel_types from '@babel/types';
   type Types = typeof _babel_types;
   type PlatformChecks = {
     isPlatformNode: (

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -1,9 +1,10 @@
 // #region metro-transform-plugins
 declare module 'metro-transform-plugins' {
   export * from 'metro-transform-plugins/src/index';
+  export { default } from 'metro-transform-plugins/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/addParamsToDefineCall.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js
 declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
   /**
    * Simple way of adding additional parameters to the end of the define calls.
@@ -15,7 +16,7 @@ declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
   export default addParamsToDefineCall;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/constant-folding-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/constant-folding-plugin.js
 declare module 'metro-transform-plugins/src/constant-folding-plugin' {
   import type { PluginObj } from '@babel/core';
   import type $$IMPORT_TYPEOF_1$$ from '@babel/traverse';
@@ -29,7 +30,7 @@ declare module 'metro-transform-plugins/src/constant-folding-plugin' {
   export default constantFoldingPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/import-export-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/import-export-plugin.js
 declare module 'metro-transform-plugins/src/import-export-plugin' {
   import type * as _babel_types from '@babel/types';
   import type { PluginObj } from '@babel/core';
@@ -66,9 +67,9 @@ declare module 'metro-transform-plugins/src/import-export-plugin' {
   export default importExportPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/index.js
 declare module 'metro-transform-plugins/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/index.js
 
   // NOTE(cedric): this is quite a complicated CJS export, this can't be automatically typed
 
@@ -82,7 +83,7 @@ declare module 'metro-transform-plugins/src/index' {
   export function getTransformPluginCacheKeyFiles(): string[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/inline-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/inline-plugin.js
 declare module 'metro-transform-plugins/src/inline-plugin' {
   import type { PluginObj } from '@babel/core';
   import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
@@ -106,13 +107,15 @@ declare module 'metro-transform-plugins/src/inline-plugin' {
   export default inlinePlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/inline-requires-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/inline-requires-plugin.js
 declare module 'metro-transform-plugins/src/inline-requires-plugin' {
   import type * as _babel_core from '@babel/core';
   type Babel = typeof _babel_core;
   export type PluginOptions = Readonly<{
     ignoredRequires?: readonly string[];
     inlineableCalls?: readonly string[];
+    nonMemoizedModules?: readonly string[];
+    memoizeCalls?: boolean;
   }>;
   export type State = {
     opts?: PluginOptions;
@@ -124,7 +127,7 @@ declare module 'metro-transform-plugins/src/inline-requires-plugin' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
 declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
   import type * as _babel_types from '@babel/types';
   export type Options = {
@@ -134,7 +137,7 @@ declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
   export default normalizePseudoglobals;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
 declare module 'metro-transform-plugins/src/utils/createInlinePlatformChecks' {
   import type * as _babel_types from '@babel/types';
   import type { Scope } from '@babel/traverse';

--- a/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-transform-worker' {
   export * from 'metro-transform-worker/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-worker/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-worker/src/index.js
 declare module 'metro-transform-worker/src/index' {
   import type * as _babel_types from '@babel/types';
   import type { CustomTransformOptions, TransformProfile } from 'metro-babel-transformer';
@@ -52,6 +52,10 @@ declare module 'metro-transform-worker/src/index' {
     unstable_compactOutput: boolean;
     /** Enable `require.context` statements which can be used to import multiple files in a directory. */
     unstable_allowRequireContext: boolean;
+    /** With inlineRequires, enable a module-scope memo var and inline as (v || v=require('foo')) */
+    unstable_memoizeInlineRequires?: boolean;
+    /** With inlineRequires, do not memoize these module specifiers */
+    unstable_nonMemoizedInlineRequires?: readonly string[];
     /** Whether to rename scoped `require` functions to `_$$_REQUIRE`, usually an extraneous operation when serializing to iife (default). */
     unstable_renameRequire?: boolean;
   }>;
@@ -68,6 +72,8 @@ declare module 'metro-transform-worker/src/index' {
     platform?: null | string;
     type: Type;
     unstable_disableES6Transforms?: boolean;
+    unstable_memoizeInlineRequires?: boolean;
+    unstable_nonMemoizedInlineRequires?: readonly string[];
     unstable_transformProfile: TransformProfile;
   }>;
   export type Path = string;
@@ -113,7 +119,7 @@ declare module 'metro-transform-worker/src/index' {
   export { default as getCacheKey } from 'metro-cache-key';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-worker/src/utils/assetTransformer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-worker/src/utils/assetTransformer.js
 declare module 'metro-transform-worker/src/utils/assetTransformer' {
   import type { File } from '@babel/types';
   import type { BabelTransformerArgs } from 'metro-babel-transformer';
@@ -126,7 +132,7 @@ declare module 'metro-transform-worker/src/utils/assetTransformer' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro-transform-worker/src/utils/getMinifier.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro-transform-worker/src/utils/getMinifier.js
 declare module 'metro-transform-worker/src/utils/getMinifier' {
   import type { Minifier } from 'metro-transform-worker/src/index';
   function getMinifier(minifierPath: string): Minifier;

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro' {
   export { default } from 'metro/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Assets.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Assets.js
 declare module 'metro/src/Assets' {
   export type AssetInfo = {
     readonly files: string[];
@@ -70,7 +70,7 @@ declare module 'metro/src/Assets' {
   export function isAssetTypeAnImage(type: string): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Bundler.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Bundler.js
 declare module 'metro/src/Bundler' {
   import type { TransformResultWithSource } from 'metro/src/DeltaBundler';
   import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
@@ -100,7 +100,7 @@ declare module 'metro/src/Bundler' {
   export default Bundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Bundler/util.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Bundler/util.js
 declare module 'metro/src/Bundler/util' {
   import type { AssetDataWithoutFiles } from 'metro/src/Assets';
   import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
@@ -120,18 +120,18 @@ declare module 'metro/src/Bundler/util' {
   ): File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/cli-utils.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/cli-utils.js
 declare module 'metro/src/cli-utils' {
   export const watchFile: (filename: string, callback: () => any) => Promise<void>;
   export const makeAsyncCommand: <T>(command: (argv: T) => Promise<void>) => (argv: T) => void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/cli.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/cli.js
 declare module 'metro/src/cli' {
   // This has no exports
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/cli/parseKeyValueParamArray.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/cli/parseKeyValueParamArray.js
 declare module 'metro/src/cli/parseKeyValueParamArray' {
   function coerceKeyValueArray(keyValueArray: readonly string[]): {
     [key: string]: string;
@@ -139,7 +139,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
   export default coerceKeyValueArray;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/commands/build.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/build.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/build' {
 //   import type { ModuleObject } from "yargs";
@@ -151,7 +151,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/commands/dependencies.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/dependencies.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/dependencies' {
 //   import type { ModuleObject } from "yargs";
@@ -163,7 +163,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/commands/serve.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/serve.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/serve' {
 //   import type { ModuleObject } from "yargs";
@@ -175,7 +175,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler.js
 declare module 'metro/src/DeltaBundler' {
   import type {
     DeltaResult,
@@ -227,7 +227,7 @@ declare module 'metro/src/DeltaBundler' {
   export default DeltaBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/buildSubgraph.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/buildSubgraph.js
 declare module 'metro/src/DeltaBundler/buildSubgraph' {
   import type { RequireContext } from 'metro/src/lib/contextModule';
   import type {
@@ -251,7 +251,7 @@ declare module 'metro/src/DeltaBundler/buildSubgraph' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/DeltaCalculator.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/DeltaCalculator.js
 declare module 'metro/src/DeltaBundler/DeltaCalculator' {
   import type { DeltaResult, Options } from 'metro/src/DeltaBundler/types.flow';
   import { Graph } from 'metro/src/DeltaBundler/Graph';
@@ -290,7 +290,7 @@ declare module 'metro/src/DeltaBundler/DeltaCalculator' {
   export default DeltaCalculator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/getTransformCacheKey.js
 declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
   import type { TransformerConfig } from 'metro/src/DeltaBundler/Worker';
   function getTransformCacheKey(opts: {
@@ -301,7 +301,7 @@ declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
   export default getTransformCacheKey;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Graph.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Graph.js
 declare module 'metro/src/DeltaBundler/Graph' {
   /**
    * Portions of this code are based on the Synchronous Cycle Collection
@@ -430,14 +430,14 @@ declare module 'metro/src/DeltaBundler/Graph' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/mergeDeltas.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/mergeDeltas.js
 declare module 'metro/src/DeltaBundler/mergeDeltas' {
   import type { DeltaBundle } from 'metro-runtime/src/modules/types.flow';
   function mergeDeltas(delta1: DeltaBundle, delta2: DeltaBundle): DeltaBundle;
   export default mergeDeltas;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
 declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
   import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
   import type { Bundle } from 'metro-runtime/src/modules/types.flow';
@@ -450,7 +450,7 @@ declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
   export default baseJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
 declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
   import type { Module, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
   type Options = {
@@ -465,7 +465,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
   export default getAllFiles;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/getAssets.js
 declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
   import type { AssetData } from 'metro/src/Assets';
   import type { Module, ReadOnlyDependencies } from 'metro/src/DeltaBundler/types.flow';
@@ -483,7 +483,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
   export default getAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
 declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
@@ -501,7 +501,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
   ): ExplodedSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
 declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
   import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
@@ -529,13 +529,13 @@ declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
   export default getRamBundleInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL' {
   function getInlineSourceMappingURL(sourceMap: string): string;
   export default getInlineSourceMappingURL;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
@@ -558,14 +558,14 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
   export default getSourceMapInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies' {
   import type { ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
   function getTransitiveDependencies<T>(path: string, graph: ReadOnlyGraph<T>): Set<string>;
   export default getTransitiveDependencies;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
   import type { MixedOutput, Module } from 'metro/src/DeltaBundler/types.flow';
   import type { JsOutput } from 'metro-transform-worker';
@@ -588,7 +588,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
   export function wrapModule(module: Module, options: Options): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   function processModules(
@@ -606,7 +606,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
   export default processModules;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
 declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
   import type { EntryPointURL } from 'metro/src/HmrServer';
   import type { DeltaResult, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
@@ -630,7 +630,7 @@ declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
   export default hmrJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import { fromRawMappings, fromRawMappingsNonBlocking } from 'metro-source-map';
@@ -650,7 +650,7 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
   ): ReturnType<typeof fromRawMappingsNonBlocking>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
@@ -665,7 +665,7 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
   ): Promise<MixedSourceMap>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
@@ -679,7 +679,7 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
   ): Promise<string>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Transformer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Transformer.js
 declare module 'metro/src/DeltaBundler/Transformer' {
   import type { TransformResult, TransformResultWithSource } from 'metro/src/DeltaBundler';
   import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
@@ -708,7 +708,7 @@ declare module 'metro/src/DeltaBundler/types' {
   export * from 'metro/src/DeltaBundler/types.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/types.flow.js
 declare module 'metro/src/DeltaBundler/types.flow' {
   import type * as _babel_types from '@babel/types';
   import type { RequireContext } from 'metro/src/lib/contextModule';
@@ -851,16 +851,16 @@ declare module 'metro/src/DeltaBundler/types.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Worker.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Worker.js
 declare module 'metro/src/DeltaBundler/Worker' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Worker.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Worker.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/DeltaBundler/Worker.flow';
   export { default } from 'metro/src/DeltaBundler/Worker.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/Worker.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/Worker.flow.js
 declare module 'metro/src/DeltaBundler/Worker.flow' {
   import type { TransformResult } from 'metro/src/DeltaBundler/types.flow';
   import type { LogEntry } from 'metro-core/src/Logger';
@@ -890,7 +890,7 @@ declare module 'metro/src/DeltaBundler/Worker.flow' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/DeltaBundler/WorkerFarm.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/DeltaBundler/WorkerFarm.js
 declare module 'metro/src/DeltaBundler/WorkerFarm' {
   import type { TransformResult } from 'metro/src/DeltaBundler';
   import type { TransformerConfig, TransformOptions, Worker } from 'metro/src/DeltaBundler/Worker';
@@ -932,7 +932,7 @@ declare module 'metro/src/DeltaBundler/WorkerFarm' {
   export default WorkerFarm;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/HmrServer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/HmrServer.js
 declare module 'metro/src/HmrServer' {
   import type { GraphOptions } from 'metro/src/shared/types.flow';
   import type { ConfigT, RootPerfLogger } from 'metro-config';
@@ -1013,7 +1013,7 @@ declare module 'metro/src/HmrServer' {
   export default HmrServer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/IncrementalBundler.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/IncrementalBundler.js
 declare module 'metro/src/IncrementalBundler' {
   import type { DeltaResult, Graph, Module } from 'metro/src/DeltaBundler';
   import type {
@@ -1101,7 +1101,7 @@ declare module 'metro/src/IncrementalBundler' {
   export default IncrementalBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
 declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
   import type { GraphId } from 'metro/src/lib/getGraphId';
   class GraphNotFoundError extends Error {
@@ -1111,7 +1111,7 @@ declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
   export default GraphNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
 declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
   class ResourceNotFoundError extends Error {
     resourcePath: string;
@@ -1120,7 +1120,7 @@ declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
   export default ResourceNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
 declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
   import type { RevisionId } from 'metro/src/IncrementalBundler';
   class RevisionNotFoundError extends Error {
@@ -1130,9 +1130,9 @@ declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
   export default RevisionNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/index.js
 declare module 'metro/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/index.flow';
@@ -1161,7 +1161,7 @@ declare module 'metro/src/index' {
   export { default as Server } from 'metro/src/Server';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/index.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/index.flow.js
 declare module 'metro/src/index.flow' {
   import type * as _ws from 'ws';
   import type { ReadOnlyGraph } from 'metro/src/DeltaBundler';
@@ -1286,7 +1286,7 @@ declare module 'metro/src/index.flow' {
   export const attachMetroCli: (yargs: Yargs, options?: AttachMetroCLIOptions) => Yargs;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/BatchProcessor.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/BatchProcessor.js
 declare module 'metro/src/lib/BatchProcessor' {
   type ProcessBatch<TItem, TResult> = (batch: TItem[]) => Promise<TResult[]>;
   type BatchProcessorOptions = {
@@ -1324,7 +1324,7 @@ declare module 'metro/src/lib/BatchProcessor' {
   export default BatchProcessor;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/bundleToString.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/bundleToString.js
 declare module 'metro/src/lib/bundleToString' {
   import type { Bundle, BundleMetadata } from 'metro-runtime/src/modules/types.flow';
   /**
@@ -1337,7 +1337,7 @@ declare module 'metro/src/lib/bundleToString' {
   export default bundleToString;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/contextModule.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/contextModule.js
 declare module 'metro/src/lib/contextModule' {
   import type {
     ContextMode,
@@ -1360,7 +1360,7 @@ declare module 'metro/src/lib/contextModule' {
   export function fileMatchesContext(testPath: string, context: RequireContext): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/contextModuleTemplates.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/contextModuleTemplates.js
 declare module 'metro/src/lib/contextModuleTemplates' {
   import type { ContextMode } from 'metro/src/ModuleGraph/worker/collectDependencies';
   /**
@@ -1379,9 +1379,9 @@ declare module 'metro/src/lib/contextModuleTemplates' {
   ): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/CountingSet.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/CountingSet.js
 declare module 'metro/src/lib/CountingSet' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/CountingSet.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/CountingSet.js
 
   export interface ReadOnlyCountingSet<T> extends Iterable<T> {
     get size(): number;
@@ -1428,19 +1428,19 @@ declare module 'metro/src/lib/CountingSet' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/countLines.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/countLines.js
 declare module 'metro/src/lib/countLines' {
   const countLines: (string: string) => number;
   export default countLines;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/createModuleIdFactory.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/createModuleIdFactory.js
 declare module 'metro/src/lib/createModuleIdFactory' {
   function createModuleIdFactory(): (path: string) => number;
   export default createModuleIdFactory;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/createWebsocketServer.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/createWebsocketServer.js
 declare module 'metro/src/lib/createWebsocketServer' {
   import ws from 'ws';
   type WebsocketServiceInterface<T> = {
@@ -1475,13 +1475,13 @@ declare module 'metro/src/lib/createWebsocketServer' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/debounceAsyncQueue.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/debounceAsyncQueue.js
 declare module 'metro/src/lib/debounceAsyncQueue' {
   function debounceAsyncQueue<T>(fn: () => Promise<T>, delay: number): () => Promise<T>;
   export default debounceAsyncQueue;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/formatBundlingError.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/formatBundlingError.js
 declare module 'metro/src/lib/formatBundlingError' {
   import type { FormattedError } from 'metro-runtime/src/modules/types.flow';
   export type CustomError = Error & {
@@ -1498,7 +1498,7 @@ declare module 'metro/src/lib/formatBundlingError' {
   export default formatBundlingError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/getAppendScripts.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/getAppendScripts.js
 declare module 'metro/src/lib/getAppendScripts' {
   import type { Module } from 'metro/src/DeltaBundler';
   type Options<T extends number | string> = Readonly<{
@@ -1521,7 +1521,7 @@ declare module 'metro/src/lib/getAppendScripts' {
   export default getAppendScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/getGraphId.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/getGraphId.js
 declare module 'metro/src/lib/getGraphId' {
   import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
   import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
@@ -1539,13 +1539,13 @@ declare module 'metro/src/lib/getGraphId' {
   export default getGraphId;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/getMaxWorkers.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/getMaxWorkers.js
 declare module 'metro/src/lib/getMaxWorkers' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (workers: null | undefined | number) => number;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/getPreludeCode.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/getPreludeCode.js
 declare module 'metro/src/lib/getPreludeCode' {
   function getPreludeCode($$PARAM_0$$: {
     readonly extraVars?: {
@@ -1558,7 +1558,7 @@ declare module 'metro/src/lib/getPreludeCode' {
   export default getPreludeCode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/getPrependedScripts.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/getPrependedScripts.js
 declare module 'metro/src/lib/getPrependedScripts' {
   import type Bundler from 'metro/src/Bundler';
   import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
@@ -1584,7 +1584,7 @@ declare module 'metro/src/lib/getPrependedScripts' {
   export default getPrependedScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/JsonReporter.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/JsonReporter.js
 declare module 'metro/src/lib/JsonReporter' {
   import type { Writable } from 'stream';
   export type SerializedError = {
@@ -1610,7 +1610,7 @@ declare module 'metro/src/lib/JsonReporter' {
   export default JsonReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/logToConsole.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/logToConsole.js
 declare module 'metro/src/lib/logToConsole' {
   import type { Terminal } from 'metro-core';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
@@ -1622,7 +1622,7 @@ declare module 'metro/src/lib/logToConsole' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/parseCustomResolverOptions.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/parseCustomResolverOptions.js
 declare module 'metro/src/lib/parseCustomResolverOptions' {
   import type { CustomResolverOptions } from 'metro-resolver/src/types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
@@ -1633,7 +1633,7 @@ declare module 'metro/src/lib/parseCustomResolverOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/parseCustomTransformOptions.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/parseCustomTransformOptions.js
 declare module 'metro/src/lib/parseCustomTransformOptions' {
   import type { CustomTransformOptions } from 'metro-transform-worker';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
@@ -1644,7 +1644,7 @@ declare module 'metro/src/lib/parseCustomTransformOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/parseOptionsFromUrl.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/parseOptionsFromUrl.js
 declare module 'metro/src/lib/parseOptionsFromUrl' {
   import type { BundleOptions } from 'metro/src/shared/types.flow';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
@@ -1654,7 +1654,7 @@ declare module 'metro/src/lib/parseOptionsFromUrl' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/RamBundleParser.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/RamBundleParser.js
 declare module 'metro/src/lib/RamBundleParser' {
   /**
    * Implementation of a RAM bundle parser in JS.
@@ -1678,14 +1678,14 @@ declare module 'metro/src/lib/RamBundleParser' {
   export default RamBundleParser;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/relativizeSourceMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/relativizeSourceMap.js
 declare module 'metro/src/lib/relativizeSourceMap' {
   import type { MixedSourceMap } from 'metro-source-map';
   function relativizeSourceMapInline(sourceMap: MixedSourceMap, sourcesRoot: string): void;
   export default relativizeSourceMapInline;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/reporting.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/reporting.js
 declare module 'metro/src/lib/reporting' {
   import type { Terminal } from 'metro-core';
   import type { HealthCheckResult, WatcherStatus } from 'metro-file-map';
@@ -1842,23 +1842,28 @@ declare module 'metro/src/lib/reporting' {
    * calling this, add a new type of ReportableEvent instead, and implement a
    * proper handler in the reporter(s).
    */
+  export function logWarning(terminal: Terminal, format: string, ...args: any[]): void;
 
   /**
    * Similar to `logWarning`, but for messages that require the user to act.
    */
+  export function logError(terminal: Terminal, format: string, ...args: any[]): void;
+
+  /**
+   * Similar to `logWarning`, but for informational messages.
+   */
+  export function logInfo(terminal: Terminal, format: string, ...args: any[]): void;
 
   /**
    * A reporter that does nothing. Errors and warnings will be swallowed, that
    * is generally not what you want.
    */
-  export function logWarning(terminal: Terminal, format: string, ...args: any[]): void;
-  export function logError(terminal: Terminal, format: string, ...args: any[]): void;
   export const nullReporter: {
     update(): void;
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/splitBundleOptions.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/splitBundleOptions.js
 declare module 'metro/src/lib/splitBundleOptions' {
   import type { BundleOptions, SplitBundleOptions } from 'metro/src/shared/types.flow';
   /**
@@ -1868,7 +1873,7 @@ declare module 'metro/src/lib/splitBundleOptions' {
   export default splitBundleOptions;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/TerminalReporter.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/TerminalReporter.js
 declare module 'metro/src/lib/TerminalReporter' {
   import type { BundleDetails, ReportableEvent } from 'metro/src/lib/reporting';
   import type { Terminal } from 'metro-core';
@@ -1889,8 +1894,16 @@ declare module 'metro/src/lib/TerminalReporter' {
         totalFileCount: number;
       }
     | {
-        type: 'unstable_set_interaction_status';
-        status?: null | string;
+        type: 'unstable_server_log';
+        level?: 'info' | 'warn' | 'error';
+        data?: string | any[];
+      }
+    | {
+        type: 'unstable_server_menu_updated';
+        message: string;
+      }
+    | {
+        type: 'unstable_server_menu_cleared';
       };
   type BuildPhase = 'in_progress' | 'done' | 'failed';
   // NOTE(cedric): manually corrected, its an internal Flow type
@@ -1942,7 +1955,7 @@ declare module 'metro/src/lib/TerminalReporter' {
   export default TerminalReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/lib/transformHelpers.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/lib/transformHelpers.js
 declare module 'metro/src/lib/transformHelpers' {
   import type Bundler from 'metro/src/Bundler';
   import type {
@@ -1969,7 +1982,7 @@ declare module 'metro/src/lib/transformHelpers' {
   ): Promise<(from: string, dependency: TransformResultDependency) => BundlerResolution>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/ModuleGraph/worker/collectDependencies.js
 declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   import type { NodePath } from '@babel/traverse';
   import type {
@@ -2067,7 +2080,7 @@ declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   export default collectDependencies;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/ModuleGraph/worker/generateImportNames.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/ModuleGraph/worker/generateImportNames.js
 declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
   import type * as _babel_types from '@babel/types';
   /**
@@ -2081,7 +2094,7 @@ declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
   export default generateImportNames;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
 declare module 'metro/src/ModuleGraph/worker/JsFileWrapping' {
   import type * as _babel_types from '@babel/types';
   export const WRAP_NAME: '$$_REQUIRE';
@@ -2101,7 +2114,7 @@ declare module 'metro/src/ModuleGraph/worker/JsFileWrapping' {
   export function wrapPolyfill(fileAst: _babel_types.File): _babel_types.File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/DependencyGraph.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/DependencyGraph.js
 declare module 'metro/src/node-haste/DependencyGraph' {
   import type {
     BundlerResolution,
@@ -2187,7 +2200,7 @@ declare module 'metro/src/node-haste/DependencyGraph' {
   export default DependencyGraph;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
 declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
   import MetroFileMap from 'metro-file-map';
@@ -2203,7 +2216,7 @@ declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
   export default createFileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
 declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
   import type {
     BundlerResolution,
@@ -2308,7 +2321,7 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/lib/AssetPaths.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/lib/AssetPaths.js
 declare module 'metro/src/node-haste/lib/AssetPaths' {
   export type AssetPath = {
     assetName: string;
@@ -2328,7 +2341,7 @@ declare module 'metro/src/node-haste/lib/AssetPaths' {
   ): null | undefined | AssetPath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
 declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
   type PlatformFilePathParts = {
     dirPath: string;
@@ -2347,7 +2360,7 @@ declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
   export default parsePlatformFilePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/Module.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/Module.js
 declare module 'metro/src/node-haste/Module' {
   import type ModuleCache from 'metro/src/node-haste/ModuleCache';
   import type Package from 'metro/src/node-haste/Package';
@@ -2362,7 +2375,7 @@ declare module 'metro/src/node-haste/Module' {
   export default Module;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/ModuleCache.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/ModuleCache.js
 declare module 'metro/src/node-haste/ModuleCache' {
   import Module from 'metro/src/node-haste/Module';
   import Package from 'metro/src/node-haste/Package';
@@ -2415,7 +2428,7 @@ declare module 'metro/src/node-haste/ModuleCache' {
   export default ModuleCache;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/node-haste/Package.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/node-haste/Package.js
 declare module 'metro/src/node-haste/Package' {
   import type { PackageJson } from 'metro-resolver/src/types';
   class Package {
@@ -2429,7 +2442,7 @@ declare module 'metro/src/node-haste/Package' {
   export default Package;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Server.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Server.js
 declare module 'metro/src/Server' {
   import type { AssetData } from 'metro/src/Assets';
   import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
@@ -2620,7 +2633,7 @@ declare module 'metro/src/Server' {
       shallow: false;
       sourceMapUrl: null;
       sourceUrl: null;
-      sourcePaths: SourcePathsMode.Absolute;
+      sourcePaths: SourcePathsMode;
     } & typeof Server.DEFAULT_GRAPH_OPTIONS;
     _getServerRootDir(): string;
     _getEntryPointAbsolutePath(entryFile: string): string;
@@ -2631,7 +2644,7 @@ declare module 'metro/src/Server' {
   export default Server;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Server/MultipartResponse.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Server/MultipartResponse.js
 declare module 'metro/src/Server/MultipartResponse' {
   import type { IncomingMessage, ServerResponse } from 'http';
   type Data = string | Buffer | Uint8Array;
@@ -2656,7 +2669,7 @@ declare module 'metro/src/Server/MultipartResponse' {
   export default MultipartResponse;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/Server/symbolicate.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/Server/symbolicate.js
 declare module 'metro/src/Server/symbolicate' {
   import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
@@ -2679,15 +2692,15 @@ declare module 'metro/src/Server/symbolicate' {
   export default symbolicate;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/bundle.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/bundle.js
 declare module 'metro/src/shared/output/bundle' {
-  // See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/bundle.js
+  // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/bundle.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/shared/output/bundle.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/bundle.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/bundle.flow.js
 declare module 'metro/src/shared/output/bundle.flow' {
   import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
   import Server from 'metro/src/Server';
@@ -2703,7 +2716,7 @@ declare module 'metro/src/shared/output/bundle.flow' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/meta.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/meta.js
 declare module 'metro/src/shared/output/meta' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (
     code: Buffer | string,
@@ -2712,7 +2725,7 @@ declare module 'metro/src/shared/output/meta' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle.js
 declare module 'metro/src/shared/output/RamBundle' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
@@ -2726,7 +2739,7 @@ declare module 'metro/src/shared/output/RamBundle' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/as-assets.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/as-assets.js
 declare module 'metro/src/shared/output/RamBundle/as-assets' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type { OutputOptions } from 'metro/src/shared/types.flow';
@@ -2745,7 +2758,7 @@ declare module 'metro/src/shared/output/RamBundle/as-assets' {
   export default saveAsAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
 declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type {
@@ -2770,7 +2783,7 @@ declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
   ): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
 declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
   import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { IndexMap } from 'metro-source-map';
@@ -2784,13 +2797,13 @@ declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/magic-number.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/magic-number.js
 declare module 'metro/src/shared/output/RamBundle/magic-number' {
   const $$EXPORT_DEFAULT_DECLARATION$$: 0xfb0bd1e5;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/util.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/util.js
 declare module 'metro/src/shared/output/RamBundle/util' {
   import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { BasicSourceMap, IndexMap } from 'metro-source-map';
@@ -2817,7 +2830,7 @@ declare module 'metro/src/shared/output/RamBundle/util' {
   export function lineToLineSourceMap(source: string, filename?: string): BasicSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
 declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
   function writeSourcemap(
     fileName: string,
@@ -2827,12 +2840,12 @@ declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
   export default writeSourcemap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/unbundle.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/unbundle.js
 declare module 'metro/src/shared/output/unbundle' {
   export { default } from 'metro/src/shared/output/RamBundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/output/writeFile.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/output/writeFile.js
 declare module 'metro/src/shared/output/writeFile' {
   type WriteFn = (
     file: string,
@@ -2848,7 +2861,7 @@ declare module 'metro/src/shared/types' {
   export * from 'metro/src/shared/types.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.80.12/packages/metro/src/shared/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/shared/types.flow.js
 declare module 'metro/src/shared/types.flow' {
   import type {
     Options as DeltaBundlerOptions,

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -84,7 +84,7 @@ declare module 'metro/src/Bundler' {
   }>;
   class Bundler {
     _depGraph: DependencyGraph;
-    _readyPromise: Promise<void>;
+    _initializedPromise: Promise<void>;
     _transformer: Transformer;
     constructor(config: ConfigT, options?: BundlerOptions);
     getWatcher(): EventEmitter;
@@ -142,10 +142,13 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/build.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/build' {
-//   import type { ModuleObject } from "yargs";
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<ModuleObject, keyof ({
-//     handler: Function;
-//   })> & {
+//   import type { ModuleObject } from 'yargs';
+//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
+//     ModuleObject,
+//     keyof {
+//       handler: Function;
+//     }
+//   > & {
 //     handler: Function;
 //   };
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
@@ -154,10 +157,13 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/dependencies.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/dependencies' {
-//   import type { ModuleObject } from "yargs";
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<ModuleObject, keyof ({
-//     handler: Function;
-//   })> & {
+//   import type { ModuleObject } from 'yargs';
+//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
+//     ModuleObject,
+//     keyof {
+//       handler: Function;
+//     }
+//   > & {
 //     handler: Function;
 //   };
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
@@ -166,10 +172,13 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 // See: https://github.com/facebook/metro/blob/v0.81.0/packages/metro/src/commands/serve.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/serve' {
-//   import type { ModuleObject } from "yargs";
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<ModuleObject, keyof ({
-//     handler: Function;
-//   })> & {
+//   import type { ModuleObject } from 'yargs';
+//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
+//     ModuleObject,
+//     keyof {
+//       handler: Function;
+//     }
+//   > & {
 //     handler: Function;
 //   };
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
@@ -340,11 +349,6 @@ declare module 'metro/src/DeltaBundler/Graph' {
     modified: Map<string, Module<T>>;
     deleted: Set<string>;
   };
-  /**
-   * Internal data structure that the traversal logic uses to know which of the
-   * files have been modified. This allows to return the added modules before the
-   * modified ones (which is useful for things like Hot Module Reloading).
-   **/
   /**
    * Internal data structure that the traversal logic uses to know which of the
    * files have been modified. This allows to return the added modules before the
@@ -698,7 +702,7 @@ declare module 'metro/src/DeltaBundler/Transformer' {
       transformerOptions: TransformOptions,
       fileBuffer?: Buffer
     ): Promise<TransformResultWithSource>;
-    end(): void;
+    end(): Promise<void>;
   }
   export default Transformer;
 }
@@ -1052,7 +1056,7 @@ declare module 'metro/src/IncrementalBundler' {
     _revisionsByGraphId: Map<GraphId, Promise<GraphRevision>>;
     static revisionIdFromString: (str: string) => RevisionId;
     constructor(config: ConfigT, options?: IncrementalBundlerOptions);
-    end(): void;
+    end(): Promise<void>;
     getBundler(): Bundler;
     getDeltaBundler(): DeltaBundler;
     getRevision(revisionId: RevisionId): null | undefined | Promise<GraphRevision>;
@@ -1183,7 +1187,7 @@ declare module 'metro/src/index.flow' {
   import MetroServer from 'metro/src/Server';
   type MetroMiddleWare = {
     attachHmrServer: (httpServer: HttpServer | HttpsServer) => void;
-    end: () => void;
+    end: () => Promise<void>;
     metroServer: MetroServer;
     middleware: Middleware;
   };
@@ -1199,6 +1203,7 @@ declare module 'metro/src/index.flow' {
       }
     ) => void;
     onReady?: (server: HttpServer | HttpsServer) => void;
+    onClose?: () => void;
     secureServerOptions?: object;
     secure?: boolean;
     secureCert?: string;
@@ -2145,7 +2150,7 @@ declare module 'metro/src/node-haste/DependencyGraph' {
       string | symbol,
       Map<string | symbol, Map<string | symbol, Map<string | symbol, BundlerResolution>>>
     >;
-    _readyPromise: Promise<void>;
+    _initializedPromise: Promise<void>;
     constructor(
       config: ConfigT,
       options?: {
@@ -2259,6 +2264,7 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
     doesFileExist: DoesFileExist;
     emptyModulePath: string;
     extraNodeModules?: null | object;
+    fileSystemLookup: FileSystemLookup;
     getHasteModulePath: (
       name: string,
       platform: null | undefined | string
@@ -2281,7 +2287,6 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
       [platform: string]: readonly string[];
     }>;
     unstable_enablePackageExports: boolean;
-    unstable_fileSystemLookup?: null | FileSystemLookup;
   }>;
   export class ModuleResolver<TPackage extends Packageish> {
     _options: Options<TPackage>;


### PR DESCRIPTION
# Why

Metro `0.81.0` isn't out yet, but this upgrades `@expo/cli`'s Metro types to `0.81.0`. Mostly to check compatibility and latest changes.

## Full PR stack

- https://github.com/expo/expo/pull/32007
- https://github.com/expo/expo/pull/32010
- https://github.com/expo/expo/pull/32012
- 👉 https://github.com/expo/expo/pull/32013
- https://github.com/expo/expo/pull/32051

# How

- Bumped Metro types to `metro@0.81.0`

# Test Plan

See CI (type checks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
