### PR TITLE
[dev-launcher][network-addons] respect react.debuggableVariants

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Added support for React Native 0.75. ([#30743](https://github.com/expo/expo/pull/30743), [#30828](https://github.com/expo/expo/pull/30828), [#31015](https://github.com/expo/expo/pull/31015) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Added other debuggable variants for network inspector by referring the `react.debuggableVariants`. ([#32014](https://github.com/expo/expo/pull/32014) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
+++ b/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
+  implementation("com.facebook.react:react-native-gradle-plugin")
 }
 
 java {

--- a/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
+++ b/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
+  implementation("com.facebook.react:react-native-gradle-plugin")
 }
 
 java {


### PR DESCRIPTION
# Why

support network inspector for other debuggable build variants.
close ENG-12174

# How

respect `react.debuggableVariants` than having fixed debug buildType. when `EX_UPDATES_NATIVE_DEBUG=1`, we will remove all `react.debuggableVariants`, so in this case we will refer to debug buildType still.

# Test Plan

android bare-expo + network inspector

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
