### PR TITLE
[tools] Use expo-modules-autolinking react-native-config command

### DIFF
--- a/tools/src/vendoring/index.ts
+++ b/tools/src/vendoring/index.ts
@@ -91,9 +91,13 @@ export async function listAvailableVendoredModulesAsync(
  * @returns Object with module names as keys and their versions as values.
  */
 async function listExpoGoAutoLinkingModulesAsync(): Promise<Record<string, string>> {
-  const { stdout } = await spawnAsync('npx', ['react-native', 'config'], {
-    cwd: EXPO_GO_DIR,
-  });
+  const { stdout } = await spawnAsync(
+    'npx',
+    ['expo-modules-autolinking', 'react-native-config', '--json'],
+    {
+      cwd: EXPO_GO_DIR,
+    }
+  );
   const { dependencies } = JSON.parse(stdout);
   const result = {};
   for (const [moduleName, moduleInfo] of Object.entries<Record<string, any>>(dependencies)) {


### PR DESCRIPTION
# Why

After upgrading React Native to 0.76, `et update-vendored-module` stopped working with the following output:

```
✗ et uvm -o
There was an error running update-vendored-module command: npx exited with non-zero code: 1

STDERR:

⚠️ react-native depends on @react-native-community/cli for cli commands. To fix update your package.json to include:


  "devDependencies": {
    "@react-native-community/cli": "latest",
  }
```

# How

Instead of adding `@react-native-community/cli` to the dev dependencies, I replaced our usage of `npx react-native config` command with `npx expo-modules-autolinking react-native-config`.

# Test Plan

`et update-vendored-module -o` now works as expected