### PR TITLE
Update create-a-modal.mdx

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -332,11 +332,10 @@ The modal allows the user to choose an emoji from a list of available emoji. Cre
 import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
-type Props = {
+type Props = PropsWithChildren<{
   isVisible: boolean;
-  children?: React.ReactNode;
   onClose: () => void;
-};
+}>;
 
 export default function EmojiPicker({ isVisible, children, onClose }: Props) {
   return (

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -334,7 +334,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 type Props = {
   isVisible: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   onClose: () => void;
 };
 

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -330,6 +330,7 @@ The modal allows the user to choose an emoji from a list of available emoji. Cre
 {/* prettier-ignore */}
 ```tsx components/EmojiPicker.tsx|collapseHeight=430
 import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import { PropsWithChildren } from 'react';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 type Props = PropsWithChildren<{


### PR DESCRIPTION
Made children prop optional in Props type of Modal to accommodate cases where the component might render without children early on in the tutorial, while still allowing children to be passed in later.

# Why
In the "Create a Modal" tutorial, the children prop is used to pass a list of emoji components later in the tutorial. However, the modal needs to render without children in earlier steps. This change makes the children prop optional, allowing the modal to function without immediate child elements.


# How


I updated the Props type for the EmojiPicker component, making the children prop optional (children?: React.ReactNode). This change allows the modal to render without requiring children to be passed in immediately. This is useful since the emoji list (or other content) will be added in later steps of the tutorial.

# Test Plan

1. Render the `EmojiPicker` component without passing any `children`:
    ```jsx
    <EmojiPicker isVisible={isModalVisible} onClose={onModalClose} />
    ```
    - **Expected Result:** The modal should render without any content inside, and no errors should be thrown.

2. Render the `EmojiPicker` component with `children` (e.g., an emoji list):
    ```jsx
    <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
      <EmojiList />
    </EmojiPicker>
    ```
    - **Expected Result:** The emoji list (or other `children` elements) should render correctly inside the modal.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
