### PR TITLE
[docs] Fix VideBoxLink and steps components usage

### DIFF
--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -23,6 +23,8 @@ This guide covers common keyboard interactions and how to manage them effectivel
 
 ## Keyboard handling basics
 
+The following sections explain how to handle keyboard interactions with common APIs.
+
 ### Keyboard avoiding view
 
 The `KeyboardAvoidingView` is a component that automatically adjusts a keyboard's height, position, or bottom padding based on the keyboard height to remain visible while it is displayed.

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -15,6 +15,8 @@ In this tutorial, we are going to build a module that stores the user's preferre
   description="Learn how to create a native module with the Expo Modules API to extend your apps capabilities by accessing native Android and iOS APIs."
 />
 
+---
+
 ## 1. Initialize a new module
 
 First, we'll create a new module. On this page we will use the name `expo-settings`/`ExpoSettings`. You can name it whatever you like, just adjust the instructions accordingly:

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -24,6 +24,8 @@ The iOS library is inspired by the Android library, so they both have a very sim
   description="In this video you will learn how to wrap native libraries using Expo Modules API."
 />
 
+---
+
 <Step label="1">
 
 ## Create a new module


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #32005

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `<hr />` in procedural guides where `VideoBoxLink` is used before steps.
- Also add one-line context in Keyboard handling guide between an H2 section and a sub-section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
