### PR TITLE
fix(cli): add fixes for rsc after React Native upgrade

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@expo/dom-webview": "0.0.1",
     "expo": "~51.0.0",
+    "expo-dev-client": "~4.0.0",
     "expo-haptics": "~13.0.1",
     "expo-linking": "~6.3.0",
     "expo-router": "^3.0.0",

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix RSC after RN upgrade.
+- Fix RSC after RN upgrade. ([#32028](https://github.com/expo/expo/pull/32028) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix search params in RSC. ([#31641](https://github.com/expo/expo/pull/31641) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cache sharing across Expo Go and dev client. ([#31566](https://github.com/expo/expo/pull/31566) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix exporting index files for server hosting in Expo Router. ([#31543](https://github.com/expo/expo/pull/31543) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix RSC after RN upgrade.
 - Fix search params in RSC. ([#31641](https://github.com/expo/expo/pull/31641) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cache sharing across Expo Go and dev client. ([#31566](https://github.com/expo/expo/pull/31566) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix exporting index files for server hosting in Expo Router. ([#31543](https://github.com/expo/expo/pull/31543) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/__tests__/export/react-native-canary.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/react-native-canary.test.ts
@@ -31,6 +31,7 @@ describe('exports with react native canary', () => {
             E2E_ROUTER_SRC: 'react-native-canary',
             E2E_ROUTER_ASYNC: 'development',
             EXPO_USE_FAST_RESOLVER: 'true',
+            EXPO_USE_METRO_REQUIRE: '1'
           },
         }
       );
@@ -82,6 +83,6 @@ describe('exports with react native canary', () => {
     // Minified mark
     expect(bundle).not.toMatch('__d((function(g,r,');
     // Canary comment. This needs to be updated with each canary.
-    expect(bundle).toMatch('SignedSource<<69d0cc554d77cddb1c779dfbdf569505>>');
+    expect(bundle).toMatch('canary-full/react/cjs/react.production.js');
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -102,11 +102,7 @@ export function createFastResolver({
       | 'resolveAsset'
       | 'unstable_conditionNames'
       | 'unstable_conditionsByPlatform'
-    > & {
-      unstable_fileSystemLookup?: (
-        filePath: string
-      ) => { exists: false } | { exists: true; type: 'f' | 'd'; realPath: string };
-    },
+    >,
     moduleName: string,
     platform: string | null
   ): Resolution {
@@ -130,7 +126,11 @@ export function createFastResolver({
           ]),
         ]
       : [];
-    const { unstable_fileSystemLookup } = context;
+    const { unstable_fileSystemLookup } = context as {
+      unstable_fileSystemLookup?: (
+        filePath: string
+      ) => { exists: false } | { exists: true; type: 'f' | 'd'; realPath: string };
+    };
     if (!unstable_fileSystemLookup) {
       throw new Error('Metro API unstable_fileSystemLookup is required for fast resolver');
     }

--- a/packages/@expo/cli/src/start/server/metro/createJResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createJResolver.ts
@@ -10,12 +10,9 @@
  */
 import type { JSONObject as PackageJSON } from '@expo/json-file';
 import assert from 'assert';
-import fs from 'fs';
 import { dirname, isAbsolute, resolve as pathResolve } from 'path';
 import { sync as resolveSync, SyncOpts as UpstreamResolveOptions } from 'resolve';
 import * as resolve from 'resolve.exports';
-
-import { directoryExistsSync, fileExistsSync } from '../../../utils/dir';
 
 /**
  * Allows transforming parsed `package.json` contents.
@@ -95,35 +92,15 @@ const defaultResolver = (
     enablePackageExports,
     blockList = [],
     ...options
-  }: Omit<ResolverOptions, 'defaultResolver' | 'getPackageForModule'>
+  }: Omit<ResolverOptions, 'defaultResolver' | 'getPackageForModule'> & {
+    isDirectory: (file: string) => boolean;
+    isFile: (file: string) => boolean;
+    pathExists: (file: string) => boolean;
+  }
 ): string => {
   // @ts-expect-error
   const resolveOptions: UpstreamResolveOptionsWithConditions = {
     ...options,
-
-    isDirectory(file) {
-      if (blockList.some((regex) => regex.test(file))) {
-        return false;
-      }
-      return directoryExistsSync(file);
-    },
-    isFile(file) {
-      if (blockList.some((regex) => regex.test(file))) {
-        return false;
-      }
-      return fileExistsSync(file);
-    },
-    pathExists(file) {
-      if (blockList.some((regex) => regex.test(file))) {
-        return false;
-      }
-      try {
-        fs.accessSync(path, fs.constants.F_OK);
-        return true; // File exists
-      } catch {
-        return false; // File doesn't exist
-      }
-    },
     preserveSymlinks: options.preserveSymlinks,
     defaultResolver,
   };

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { getMetroServerRoot } from '@expo/config/paths';
 import chalk from 'chalk';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -17,7 +18,6 @@ import { Log } from '../../../log';
 import { stripAnsi } from '../../../utils/ansi';
 import { CommandError, SilentError } from '../../../utils/errors';
 import { createMetroEndpointAsync } from '../getStaticRenderFunctions';
-import { getMetroServerRoot } from '@expo/config/paths';
 
 function fill(width: number): string {
   return Array(width).join(' ');
@@ -311,11 +311,7 @@ function parseErrorStack(
 
       if (frame.file) {
         // SSR will sometimes have absolute paths followed by `.bundle?...`, we need to try and make them relative paths and append a dev server URL.
-        if (
-          frame.file.startsWith('/') &&
-          frame.file.includes('bundle?') &&
-          !URL.canParse(frame.file)
-        ) {
+        if (frame.file.startsWith('/') && frame.file.includes('bundle?') && !canParse(frame.file)) {
           // Malformed stack file from SSR. Attempt to repair.
           frame.file = 'https://localhost:8081/' + path.relative(serverRoot, frame.file);
         }
@@ -327,4 +323,14 @@ function parseErrorStack(
       };
     })
     .filter((frame) => frame.file && !frame.file.includes('node_modules'));
+}
+
+function canParse(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Mock out js console polyfill for server environments.
+- Mock out js console polyfill for server environments. ([#32028](https://github.com/expo/expo/pull/32028) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed `ReferenceError: Property 'React' doesn't exist.` crash when a DOM component includes `import React from 'react';`. ([#31469](https://github.com/expo/expo/pull/31469) by [@kudo](https://github.com/kudo))
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Mock out js console polyfill for server environments.
 - Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed `ReferenceError: Property 'React' doesn't exist.` crash when a DOM component includes `import React from 'react';`. ([#31469](https://github.com/expo/expo/pull/31469) by [@kudo](https://github.com/kudo))
 

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -32,6 +32,13 @@ function reactClientReferencesPlugin() {
                     // Do nothing for code that isn't marked as a client component.
                     return;
                 }
+                // HACK: Mock out the polyfill that doesn't run through the normal bundler pipeline.
+                if (filePath.endsWith('@react-native/js-polyfills/console.js')) {
+                    // Clear the body
+                    path.node.body = [];
+                    path.node.directives = [];
+                    return;
+                }
                 const outputKey = url_1.default.pathToFileURL(filePath).href;
                 // We need to add all of the exports to support `export * from './module'` which iterates the keys of the module.
                 const proxyModule = [

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -39,6 +39,14 @@ export function reactClientReferencesPlugin(): babel.PluginObj {
           return;
         }
 
+        // HACK: Mock out the polyfill that doesn't run through the normal bundler pipeline.
+        if (filePath.endsWith('@react-native/js-polyfills/console.js')) {
+          // Clear the body
+          path.node.body = [];
+          path.node.directives = [];
+          return;
+        }
+
         const outputKey = url.pathToFileURL(filePath).href;
 
         // We need to add all of the exports to support `export * from './module'` which iterates the keys of the module.


### PR DESCRIPTION
# Why

- Fix fast resolver with new Metro resolver context functions.
- Force `@react-native/js-polyfills/console.js` to be an empty module when bundling for react-server on native.
- Fix server symbolication.
- Add expo-dev-client to router-e2e to fix existing bugs with React Native that prevent running without dev client.

