### PR TITLE
refactor(cli): update debugging workflow to support RNDT

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Added support to download template from npm when running prebuild. ([#31195](https://github.com/expo/expo/pull/31195) by [@kudo](https://github.com/kudo))
 - Add an optional New Architecture compatibility check for dependencies added via `install` command. ([#31222](https://github.com/expo/expo/pull/31222) by [@Simek](https://github.com/Simek))
 - Add support in `expo run android` for product flavors with custom app ids. ([#31756](https://github.com/expo/expo/pull/31756) by [@byCedric](https://github.com/byCedric))
+- Support Fusebox and React Native DevTools in Expo. ([#32029](https://github.com/expo/expo/pull/32029) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -16,7 +16,7 @@ export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
     logger: createLogger(chalk.bold('Debug:')),
     unstable_customInspectorMessageHandler: createHandlersFactory(metroBundler),
     unstable_experiments: {
-      enableOpenDebuggerRedirect: true,
+      enableNetworkInspector: true,
     },
   });
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 import { createHandlersFactory } from './createHandlersFactory';
 import { Log } from '../../../../log';
+import { env } from '../../../../utils/env';
 import { type MetroBundlerDevServer } from '../MetroBundlerDevServer';
 
 export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
@@ -16,7 +17,11 @@ export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
     logger: createLogger(chalk.bold('Debug:')),
     unstable_customInspectorMessageHandler: createHandlersFactory(metroBundler),
     unstable_experiments: {
+      // Enable the Network tab in React Native DevTools
       enableNetworkInspector: true,
+      // Only enable opening the browser version of React Native DevTools when debugging.
+      // This is useful when debugging the React Native DevTools by going to `/open-debugger` in the browser.
+      enableOpenDebuggerRedirect: env.EXPO_DEBUG,
     },
   });
 


### PR DESCRIPTION
# Why

These changes came after initial testing with Fusebox & RNDT on RN 0.76. This does NOT change the default debugger to be RNDT yet, pending facebook/react-native#46902.

# How

- Tweaked the "open js inspector" code to support Fusebox/RNDT better

# Test Plan

- `bun create expo@<canary> ./test-rndt`
- `cd ./test-rndt`
- `EXPO_USE_UNSTABLE_DEBUGGER=true bun expo start`
- Press `j` to open RNDT

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
