### PR TITLE
[core][android] Add support for `onUserLeaveHint`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [Android] Add support for `onUserLeaveHint`. ([#32033](https://github.com/expo/expo/pull/32033) by [@behenate](https://github.com/behenate))
 - [Web] Modules are now registered in global. ([#29870](https://github.com/expo/expo/pull/29870) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Add support for passing SharedObjects as a function parameter. ([#30314](https://github.com/expo/expo/pull/30314) by [@aleqsio](https://github.com/aleqsio))
 - Added support for `startObserving` and `stopObserving` on the web. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
@@ -11,6 +11,8 @@ public interface ReactActivityLifecycleListener {
 
   default void onPause(Activity activity) {}
 
+  default void onUserLeaveHint(Activity activity) {}
+
   default void onDestroy(Activity activity) {}
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -283,6 +283,10 @@ class AppContext(
     hostingRuntimeContext.registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
   }
 
+  internal fun onUserLeaveHint() {
+    hostingRuntimeContext.registry.post(EventName.ON_USER_LEAVES_ACTIVITY)
+  }
+
   internal fun onHostDestroy() {
     currentActivity?.let {
       check(it is AppCompatActivity) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
@@ -25,6 +25,10 @@ class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener, A
     appContextHolder.get()?.onHostPause()
   }
 
+  override fun onUserLeaveHint(activity: Activity) {
+    appContextHolder.get()?.onUserLeaveHint()
+  }
+
   override fun onHostDestroy() {
     appContextHolder.get()?.onHostDestroy()
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventName.kt
@@ -27,5 +27,10 @@ enum class EventName {
   /**
    * Called when other activity returns
    */
-  ON_ACTIVITY_RESULT
+  ON_ACTIVITY_RESULT,
+
+  /**
+   * Called when the user is about to leave the activity
+   */
+  ON_USER_LEAVES_ACTIVITY
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -105,6 +105,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   }
 
   /**
+   * Creates module's lifecycle listener that is called right before user leaves the activity.
+   */
+  inline fun OnUserLeavesActivity(crossinline body: () -> Unit) {
+    eventListeners[EventName.ON_USER_LEAVES_ACTIVITY] = BasicEventListener(EventName.ON_USER_LEAVES_ACTIVITY) { body() }
+  }
+
+  /**
    * Creates module's lifecycle listener that is called right after the activity is destroyed.
    */
   inline fun OnActivityDestroys(crossinline body: () -> Unit) {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [Android] Add support for `onUserLeaveHint`. ([#32033](https://github.com/expo/expo/pull/32033) by [@behenate](https://github.com/behenate))
 - Add `expo/dom/entry` for internal DOM component registration. ([#31259](https://github.com/expo/expo/pull/31259) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable normal scrolling in DOM components by default on iOS. ([#31197](https://github.com/expo/expo/pull/31197) by [@EvanBacon](https://github.com/EvanBacon))
 - Add prototype members `set`, `delete`, `get`, `has`, `forEach`, `entries`, `keys`, `values`, `[Symbol.iterator]` to global `FormData` on native. ([#31117](https://github.com/expo/expo/pull/31117) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -203,6 +203,13 @@ class ReactActivityDelegateWrapper(
     return invokeDelegateMethod("onPause")
   }
 
+  override fun onUserLeaveHint() {
+    reactActivityLifecycleListeners.forEach { listener ->
+      listener.onUserLeaveHint(activity)
+    }
+    return invokeDelegateMethod("onUserLeaveHint")
+  }
+
   override fun onDestroy() {
     // If app is stopped before delayed `loadApp`, we should cancel the pending resume
     if (shouldEmitPendingResume) {


### PR DESCRIPTION
# Why

We added support for `onUserLeaveHint` to RN 0.76 for usage in `expo-video`, now we can use it.

# How

Added the support to the delegates and `ModuleDefinitionBuilder` as `OnUserLeavesActivity` similar to `onPause` event.

# Test Plan

Tested in BareExpo in Android 14 on a physical device
