### PR TITLE
[docs] JS engine change unavailable in Expo go as of SDK 52

### DIFF
--- a/docs/pages/guides/configuring-js-engines.mdx
+++ b/docs/pages/guides/configuring-js-engines.mdx
@@ -10,6 +10,8 @@ JavaScript engines execute your application code and provide various features su
 
 ## Configuring the `jsEngine` through app config
 
+> **warning** Changing the JS engine is unavailable in Expo Go from SDK 52 (only the Hermes engine is available). A [development build](/develop/development-builds/introduction/) is required to use this customization.
+
 We recommend Hermes because it is purpose built and optimized for React Native apps, and it has the best debugging experience. If you are familiar with the tradeoffs of different JavaScript engines and would like to change away from Hermes, the [`jsEngine`](/versions/latest/config/app/#jsengine) field inside [app config](/workflow/configuration/) allows you to specify the JavaScript engine for your app. The default value is `hermes`.
 
 If you want to use JSC instead, set the `jsEngine` field in the app config:


### PR DESCRIPTION
# Why

from SDK 52 with the new arch support in expo-go, we will only support Hermes JS engine

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
