### PR TITLE
[babel-preset-expo] bump @react-native/babel-preset to 0.76.0-rc.4

### DIFF
--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-transform-parameters": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.76.0-rc.2",
+    "@react-native/babel-preset": "0.76.0-rc.4",
     "babel-plugin-react-native-web": "~0.19.10",
     "react-refresh": "^0.14.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,70 +2972,12 @@
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.76.0-rc.4.tgz#e60186944feff190ab9385400ecc1b95dc6d252b"
   integrity sha512-OuekvnmCCoCub3l23WDcZ893YSHHJ5dFBuhE4QvpR9N7NBquIxsEdne1tYv4bv10KKRaVqhkdkyHL51xzZARvg==
 
-"@react-native/babel-plugin-codegen@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.2.tgz#5c97ed572a4b6ec3eebfb1d457207a874c8e37d1"
-  integrity sha512-B+tLKulTsDJvwkX3ZbO7vj+Tb4kh0w4vvyNQrD+i9pa0ZbeaHiw8uu8hJm+V97DjHGJ6zV+8djnBgWazno/zFg==
-  dependencies:
-    "@react-native/codegen" "0.76.0-rc.2"
-
 "@react-native/babel-plugin-codegen@0.76.0-rc.4":
   version "0.76.0-rc.4"
   resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.4.tgz#4272227cac893f54674716d32390db2df29d0d26"
   integrity sha512-hFrkLQlwwUvaf7fhjvc9lbiPH3tBgeihmmuqbrAiTMEFsjySXJ414CuYAKKGNHC+DXxYwKzpDw1mWaW92Q1Lyw==
   dependencies:
     "@react-native/codegen" "0.76.0-rc.4"
-
-"@react-native/babel-preset@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.76.0-rc.2.tgz#63a3093b5e9f8c8d8acd6617cdc5d8fd5bc0ac20"
-  integrity sha512-WrK2o+3cDbntd8407MApQ+ByJrUGCQgkm3qhRvzKsgww6MS3/ykA2bzl11K3YrMIq51JC5MQJKF6JnGjK9lc9g==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/plugin-proposal-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-flow" "^7.24.7"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-transform-arrow-functions" "^7.24.7"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.4"
-    "@babel/plugin-transform-async-to-generator" "^7.24.7"
-    "@babel/plugin-transform-block-scoping" "^7.25.0"
-    "@babel/plugin-transform-class-properties" "^7.25.4"
-    "@babel/plugin-transform-classes" "^7.25.4"
-    "@babel/plugin-transform-computed-properties" "^7.24.7"
-    "@babel/plugin-transform-destructuring" "^7.24.8"
-    "@babel/plugin-transform-flow-strip-types" "^7.25.2"
-    "@babel/plugin-transform-for-of" "^7.24.7"
-    "@babel/plugin-transform-function-name" "^7.25.1"
-    "@babel/plugin-transform-literals" "^7.25.2"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.24.7"
-    "@babel/plugin-transform-modules-commonjs" "^7.24.8"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.24.7"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
-    "@babel/plugin-transform-numeric-separator" "^7.24.7"
-    "@babel/plugin-transform-object-rest-spread" "^7.24.7"
-    "@babel/plugin-transform-optional-catch-binding" "^7.24.7"
-    "@babel/plugin-transform-optional-chaining" "^7.24.8"
-    "@babel/plugin-transform-parameters" "^7.24.7"
-    "@babel/plugin-transform-private-methods" "^7.24.7"
-    "@babel/plugin-transform-private-property-in-object" "^7.24.7"
-    "@babel/plugin-transform-react-display-name" "^7.24.7"
-    "@babel/plugin-transform-react-jsx" "^7.25.2"
-    "@babel/plugin-transform-react-jsx-self" "^7.24.7"
-    "@babel/plugin-transform-react-jsx-source" "^7.24.7"
-    "@babel/plugin-transform-regenerator" "^7.24.7"
-    "@babel/plugin-transform-runtime" "^7.24.7"
-    "@babel/plugin-transform-shorthand-properties" "^7.24.7"
-    "@babel/plugin-transform-spread" "^7.24.7"
-    "@babel/plugin-transform-sticky-regex" "^7.24.7"
-    "@babel/plugin-transform-typescript" "^7.25.2"
-    "@babel/plugin-transform-unicode-regex" "^7.24.7"
-    "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.76.0-rc.2"
-    babel-plugin-transform-flow-enums "^0.0.2"
-    react-refresh "^0.14.0"
 
 "@react-native/babel-preset@0.76.0-rc.4":
   version "0.76.0-rc.4"
@@ -3087,20 +3029,6 @@
     babel-plugin-syntax-hermes-parser "^0.23.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
-
-"@react-native/codegen@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.76.0-rc.2.tgz#83ad8d55cbc50f980bae847c2eaecb9189e6e506"
-  integrity sha512-WFtED2zIM1BBbcQUnVzJ4/ZWU+SEkOPAi/Ul5M/G9ToKoPt2yWhTjf6lqo5DWA/5507PrykR+EmxJIw32vCJnQ==
-  dependencies:
-    "@babel/parser" "^7.25.3"
-    glob "^7.1.1"
-    hermes-parser "0.23.1"
-    invariant "^2.2.4"
-    jscodeshift "^0.14.0"
-    mkdirp "^0.5.1"
-    nullthrows "^1.1.1"
-    yargs "^17.6.2"
 
 "@react-native/codegen@0.76.0-rc.4":
   version "0.76.0-rc.4"


### PR DESCRIPTION
# Why

The tests were failing because `react-native-svg` is importing raw flow files from `react-native` and `@react-native/babel-preset@0.76.0-rc.2` could not parse it: https://github.com/facebook/react-native/issues/46601

# How

* Bump `@react-native/babel-preset` to 0.76.0-rc.4

# Test Plan

* run `yarn test` in `/packages/expo-dev-client-components`