### PR TITLE
[E2E] Update TV dependencies

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -362,8 +362,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.75.2-0',
-        '@react-native-tvos/config-tv': '^0.0.10',
+        'react-native': 'npm:react-native-tvos@~0.76.0-0rc4',
+        '@react-native-tvos/config-tv': '^0.0.11',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

After 0.76 merge, align TV compile test dependencies with RN core 0.76 dependency.

# How

Update dependencies in `project.ts`

# Test Plan

CI should pass.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
