### PR TITLE
[docs] Usage-based pricing: convert examples into separate sections

### DIFF
--- a/docs/pages/billing/usage-based-pricing.mdx
+++ b/docs/pages/billing/usage-based-pricing.mdx
@@ -21,7 +21,7 @@ For EAS Build, a flat fee is charged for an individual build executed at higher-
 
 #### Example: EAS Build credit usage
 
-For example, consider an account subscribed to the Production plan that has 15 medium Android builds, and 10 large iOS builds in a billing period:
+Consider an account subscribed to the Production plan that has 15 medium Android builds, and 10 large iOS builds in a billing period:
 
 | Description             | Price | Quantity |  Total |
 | ----------------------- | ----: | -------: | -----: |
@@ -61,7 +61,7 @@ Each plan has a number of monthly updated users and global edge bandwidth includ
 
 > **Note**: The [On-demand plan](/billing/plans/#on-demand) includes the same amount of monthly updated users and global edge bandwidth as the Free plan.
 
-For example, let's consider a subscriber to the On-demand plan who deploys 20 updates of 5 MiB each via EAS Update to 10,000 users. The subscription to the plan includes 1,000 monthly updated users and 100 GiB per month. As a result, the subscriber's bill for extra usage will be:
+Consider a subscriber to the On-demand plan who deploys 20 updates of 5 MiB each via EAS Update to 10,000 users. The subscription to the plan includes 1,000 monthly updated users and 100 GiB per month. As a result, the subscriber's bill for extra usage will be:
 
 | Description           | Price           | Quantity |     Total |
 | --------------------- | --------------- | -------- | --------: |

--- a/docs/pages/billing/usage-based-pricing.mdx
+++ b/docs/pages/billing/usage-based-pricing.mdx
@@ -3,9 +3,6 @@ title: Usage-based pricing
 description: Learn how Expo applies usage-based billing for customers who exceed their plan quotas and how to monitor your EAS Build usage.
 ---
 
-import { CreditCard02Icon } from '@expo/styleguide-icons/outline/CreditCard02Icon';
-
-import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 Expo applies usage-based billing for customers who exceed their [plan](/billing/plans/) allowances. This enables our customers to use what they need without worrying about limitations or requiring contractual obligations.

--- a/docs/pages/billing/usage-based-pricing.mdx
+++ b/docs/pages/billing/usage-based-pricing.mdx
@@ -20,7 +20,9 @@ For EAS Build, a flat fee is charged for an individual build executed at higher-
 
 > **Note**: Builds that are canceled before any work is done are not charged.
 
-[Production, Enterprise, and Legacy plans](/billing/plans/#plans) subscribers receive credits for EAS Build. These credits can be used to offset the cost of builds. They are reset at the start of the billing period and expire at the end of that billing period.
+[Production, Enterprise, and Legacy plans](/billing/plans/#plans) subscribers receive credits for EAS Build. These credits can be used to offset the cost of builds. They are reset at the start of the billing period and expire at the end of that billing period. Visit our [pricing page](https://expo.dev/pricing) for more information on the pricing schedule for supported build platforms and the available resource classes.
+
+#### Example: EAS Build credit usage
 
 For example, consider an account subscribed to the Production plan that has 15 medium Android builds, and 10 large iOS builds in a billing period:
 
@@ -33,7 +35,9 @@ For example, consider an account subscribed to the Production plan that has 15 m
 
 Since the credit is included in the Production plan, the subscriber pays $0 for their 25 builds.
 
-Next, consider another example where the credit limit is exceeded:
+#### Example: EAS Build credit exceeded
+
+Consider another example where the credit limit is exceeded:
 
 | Description             | Price | Quantity |   Total |
 | ----------------------- | ----: | -------: | ------: |
@@ -46,13 +50,6 @@ Next, consider another example where the credit limit is exceeded:
 
 In this scenario, the subscriber pays $31 for 60 builds instead of $130 because the EAS Build Credit covers $99.
 
-<BoxLink
-  title="Pricing schedule"
-  description="Visit our pricing page for more information on the pricing schedule for supported build platforms and the available resource classes."
-  href="https://expo.dev/pricing"
-  Icon={CreditCard02Icon}
-/>
-
 ### EAS Update
 
 Usage-based pricing for EAS Update comprises two metrics: monthly updated users and global edge bandwidth.
@@ -61,7 +58,9 @@ Monthly updated users reflect the number of unique users who download an update 
 
 > **Note**: A monthly updated user counts only once per billing period, regardless of how many updates this user downloads.
 
-Each plan has a number of monthly updated users and global edge bandwidth included as part of the subscription. These differ for each plan and the most updated numbers. See our [Pricing page](https://expo.dev/pricing), for more information.
+Each plan has a number of monthly updated users and global edge bandwidth included as part of the subscription. These differ for each plan and the most updated numbers. See our [pricing page](https://expo.dev/pricing), for more information.
+
+#### Example: EAS Update usage
 
 > **Note**: The [On-demand plan](/billing/plans/#on-demand) includes the same amount of monthly updated users and global edge bandwidth as the Free plan.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback on [Discord](https://discord.com/channels/695411232856997968/1012054197409165387/1288641598254743603)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add section headings for EAS Build and EAS Update examples on the document page
- Remove BoxLink as it was breaking the flow after the second EAS Build example since the example section is separate from the main section's flow and move it to the EAS Build section

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-14 at 23 26 52@2x](https://github.com/user-attachments/assets/38532bd5-47ce-47ff-a628-fa651de34326)

![CleanShot 2024-10-14 at 23 27 23@2x](https://github.com/user-attachments/assets/b1d5a925-1470-4ec1-bc59-aa1d86603bf5)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
