### PR TITLE
fix(cli): Fix experimental web exports for RSC.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix experimental web exports for RSC.
 - Fix RSC after RN upgrade. ([#32028](https://github.com/expo/expo/pull/32028) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix search params in RSC. ([#31641](https://github.com/expo/expo/pull/31641) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cache sharing across Expo Go and dev client. ([#31566](https://github.com/expo/expo/pull/31566) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix experimental web exports for RSC.
+- Fix experimental web exports for RSC. ([#32042](https://github.com/expo/expo/pull/32042) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix RSC after RN upgrade. ([#32028](https://github.com/expo/expo/pull/32028) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix search params in RSC. ([#31641](https://github.com/expo/expo/pull/31641) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cache sharing across Expo Go and dev client. ([#31566](https://github.com/expo/expo/pull/31566) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/embed/exportServer.ts
+++ b/packages/@expo/cli/src/export/embed/exportServer.ts
@@ -62,6 +62,7 @@ export async function exportStandaloneServerAsync(
   await exportApiRoutesStandaloneAsync(devServer, {
     files,
     platform: 'web',
+    apiRoutesOnly: true,
   });
 
   const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -199,17 +199,19 @@ export async function exportAppAsync(
             // If web exists, then write the template HTML file.
             files.set('index.html', {
               contents: html,
-              targetDomain: 'client',
+              targetDomain: devServer.isReactServerComponentsEnabled ? 'server' : 'client',
             });
           }
         })
       );
 
       if (devServer.isReactServerComponentsEnabled) {
-        if (!(platforms.includes('web') && useServerRendering)) {
+        const isWeb = platforms.includes('web');
+        if (!(isWeb && useServerRendering)) {
           await exportApiRoutesStandaloneAsync(devServer, {
             files,
             platform: 'web',
+            apiRoutesOnly: !isWeb,
           });
         }
       }
@@ -259,6 +261,7 @@ export async function exportAppAsync(
         await exportApiRoutesStandaloneAsync(devServer, {
           files,
           platform: 'web',
+          apiRoutesOnly: true,
         });
 
         // Output a placeholder index.html if one doesn't exist in the public directory.

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -409,8 +409,7 @@ export async function exportApiRoutesStandaloneAsync(
     // NOTE(kitten): For now, we always output source maps for API route exports
     includeSourceMaps: true,
     platform,
-    // Omit HTML files in web-only standalone exports.
-    apiRoutesOnly: apiRoutesOnly ?? platform !== 'web',
+    apiRoutesOnly,
   });
 
   // Add the api routes to the files to export.

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -394,9 +394,11 @@ export async function exportApiRoutesStandaloneAsync(
   {
     files = new Map(),
     platform,
+    apiRoutesOnly,
   }: {
     files?: ExportAssetMap;
     platform: string;
+    apiRoutesOnly: boolean;
   }
 ) {
   const { serverManifest } = await devServer.getServerManifestAsync();
@@ -407,7 +409,8 @@ export async function exportApiRoutesStandaloneAsync(
     // NOTE(kitten): For now, we always output source maps for API route exports
     includeSourceMaps: true,
     platform,
-    apiRoutesOnly: true,
+    // Omit HTML files in web-only standalone exports.
+    apiRoutesOnly: apiRoutesOnly ?? platform !== 'web',
   });
 
   // Add the api routes to the files to export.


### PR DESCRIPTION
# Why

- Support very basic single-route exports for websites using React Server Components.

# How

- Ensure the manifest has an index route.
