### PR TITLE
[video][android] Fix `FullscreenPlayerActivity` not closing after re-opening app via app icon

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `FullscreenPlayerActivity` not closing when the system returned to the `MainActivity` after backgrounding and reopening the app via icon. ([#32044](https://github.com/expo/expo/pull/32044) by [@behenate](https://github.com/behenate))
 - [Android] Fix `Activity` auto-entering Picture in Picture after leaving the screen with video. ([#32043](https://github.com/expo/expo/pull/32043) by [@behenate](https://github.com/behenate))
 - [Android] Fix `startsPictureInPictureAutomatically` not working in fullscreen mode. ([#32043](https://github.com/expo/expo/pull/32043) by [@behenate](https://github.com/behenate))
 - [Android] Fix video pausing after auto-entering Picture in Picture. ([#32043](https://github.com/expo/expo/pull/32043) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -43,6 +43,7 @@ class FullscreenPlayerActivity : Activity() {
     }
     videoPlayer = videoView.videoPlayer
     videoPlayer?.changePlayerView(playerView)
+    VideoManager.registerFullscreenPlayerActivity(hashCode().toString(), this)
     applyAutoEnterPiP(this, videoView.autoEnterPiP)
   }
 
@@ -95,7 +96,8 @@ class FullscreenPlayerActivity : Activity() {
 
   override fun onDestroy() {
     super.onDestroy()
-    VideoManager.getVideoView(videoViewId).exitFullscreen()
+    videoView.exitFullscreen()
+    VideoManager.unregisterFullscreenPlayerActivity(hashCode().toString())
   }
 
   private fun setupFullscreenButton() {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -12,6 +12,7 @@ object VideoManager {
 
   // Used for sharing videoViews between VideoView and FullscreenPlayerActivity
   private var videoViews = mutableMapOf<String, VideoView>()
+  private var fullscreenPlayerActivities = mutableMapOf<String, FullscreenPlayerActivity>()
 
   // Keeps track of all existing VideoPlayers, and whether they are attached to a VideoView
   private var videoPlayersToVideoViews = mutableMapOf<VideoPlayer, MutableList<VideoView>>()
@@ -44,6 +45,14 @@ object VideoManager {
     audioFocusManager.unregisterPlayer(videoPlayer)
   }
 
+  fun registerFullscreenPlayerActivity(id: String, fullscreenActivity: FullscreenPlayerActivity) {
+    fullscreenPlayerActivities[id] = fullscreenActivity
+  }
+
+  fun unregisterFullscreenPlayerActivity(id: String) {
+    fullscreenPlayerActivities.remove(id)
+  }
+
   fun onVideoPlayerAttachedToView(videoPlayer: VideoPlayer, videoView: VideoView) {
     if (videoPlayersToVideoViews[videoPlayer]?.contains(videoView) == true) {
       return
@@ -73,6 +82,12 @@ object VideoManager {
   fun onAppForegrounded() {
     for (videoView in videoViews.values) {
       videoView.playerView.useController = videoView.useNativeControls
+    }
+
+    // Pressing the app icon will bring up the mainActivity instead of the fullscreen activity (at least for BareExpo)
+    // In this case we have to manually finish the fullscreen activity
+    for (fullscreenActivity in fullscreenPlayerActivities.values) {
+      fullscreenActivity.finish()
     }
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import expo.modules.kotlin.AppContext
 import expo.modules.video.player.VideoPlayer
+import java.lang.ref.WeakReference
 
 // Helper class used to keep track of all existing VideoViews and VideoPlayers
 @OptIn(UnstableApi::class)
@@ -12,7 +13,7 @@ object VideoManager {
 
   // Used for sharing videoViews between VideoView and FullscreenPlayerActivity
   private var videoViews = mutableMapOf<String, VideoView>()
-  private var fullscreenPlayerActivities = mutableMapOf<String, FullscreenPlayerActivity>()
+  private var fullscreenPlayerActivities = mutableMapOf<String, WeakReference<FullscreenPlayerActivity>>()
 
   // Keeps track of all existing VideoPlayers, and whether they are attached to a VideoView
   private var videoPlayersToVideoViews = mutableMapOf<VideoPlayer, MutableList<VideoView>>()
@@ -46,7 +47,7 @@ object VideoManager {
   }
 
   fun registerFullscreenPlayerActivity(id: String, fullscreenActivity: FullscreenPlayerActivity) {
-    fullscreenPlayerActivities[id] = fullscreenActivity
+    fullscreenPlayerActivities[id] = WeakReference(fullscreenActivity)
   }
 
   fun unregisterFullscreenPlayerActivity(id: String) {
@@ -87,7 +88,7 @@ object VideoManager {
     // Pressing the app icon will bring up the mainActivity instead of the fullscreen activity (at least for BareExpo)
     // In this case we have to manually finish the fullscreen activity
     for (fullscreenActivity in fullscreenPlayerActivities.values) {
-      fullscreenActivity.finish()
+      fullscreenActivity.get()?.finish()
     }
   }
 


### PR DESCRIPTION
# Why

When BareExpo is backgrounded and a fullscreen video is playing re-opening it using the app icon in the drawer will return to `MainActivity.kt` without closing the `FullscreenPlayerActivity`.

# How

All activities are now registered in `VideoManager` and closed when the `MainActivity` is resumed.

# Test Plan

Tested in BareExopo on a Pixel 8

