### PR TITLE
[docs] APISection: render example code block headers

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -33,14 +33,16 @@ const attributes = {
 
 type CodeProps = PropsWithChildren<{
   className?: string;
+  title?: string;
 }>;
 
-export function Code({ className, children }: CodeProps) {
+export function Code({ className, children, title }: CodeProps) {
   const contentRef = useRef<HTMLPreElement>(null);
   const { preferredTheme, wordWrap } = useCodeBlockSettingsContext();
 
   const rootProps = getRootCodeBlockProps(children, className);
   const codeBlockData = parseValue(rootProps?.children?.toString() ?? '');
+  const codeBlockTitle = codeBlockData?.title ?? title;
 
   const [isExpanded, setExpanded] = useState(false);
   const [collapseBound, setCollapseBound] = useState<number | undefined>(undefined);
@@ -90,9 +92,9 @@ export function Code({ className, children }: CodeProps) {
     showExpand && !isExpanded && `!overflow-hidden`,
   ];
 
-  return codeBlockData?.title ? (
+  return codeBlockTitle ? (
     <Snippet>
-      <SnippetHeader title={codeBlockData.title} Icon={getIconForFile(codeBlockData.title)}>
+      <SnippetHeader title={codeBlockTitle} Icon={getIconForFile(codeBlockTitle)}>
         <CopyAction text={cleanCopyValue(codeBlockData.value)} />
         <SettingsAction />
       </SnippetHeader>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -3,7 +3,7 @@ import { shadows, theme, typography, mergeClasses } from '@expo/styleguide';
 import { borderRadius, breakpoints, spacing } from '@expo/styleguide-base';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
 import { slug } from 'github-slugger';
-import type { ComponentType } from 'react';
+import type { ComponentType, PropsWithChildren } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkSupsub from 'remark-supersub';
@@ -69,18 +69,25 @@ export enum TypeDocKind {
 export const DEFAULT_BASE_NESTING_LEVEL = 2;
 
 export type MDComponents = Components;
+export type CodeComponentProps = PropsWithChildren<{
+  className?: string;
+  node: { data?: { meta?: string } };
+}>;
 
 const getInvalidLinkMessage = (href: string) =>
   `Using "../" when linking other packages in doc comments produce a broken link! Please use "./" instead. Problematic link:\n\t${href}`;
 
 export const mdComponents: MDComponents = {
   blockquote: ({ children }) => <Callout>{children}</Callout>,
-  code: ({ children, className }) =>
-    className ? (
-      <PrismCodeBlock className={className}>{children}</PrismCodeBlock>
+  code: ({ className, children, node }: CodeComponentProps) => {
+    return className ? (
+      <PrismCodeBlock className={className} title={node?.data?.meta}>
+        {children}
+      </PrismCodeBlock>
     ) : (
       <CODE css={css({ display: 'inline' })}>{children}</CODE>
-    ),
+    );
+  },
   pre: ({ children }) => <>{children}</>,
   h1: ({ children }) => <H4 hideInSidebar>{children}</H4>,
   ul: ({ children }) => <UL className={ELEMENT_SPACING}>{children}</UL>,


### PR DESCRIPTION
# Why

Spotted that some of examples adds the code block title (which can be helpful), but the header are currently not rendered in API section, let's fix that.

# How

Make sure that the `meta` from MDX renderer node is correctly passed down to the component.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-10-15 at 12 22 08](https://github.com/user-attachments/assets/855a12bc-0c3f-4258-8777-bfd230326f77)
