### PR TITLE
[image] fix stopAnimating broken on downscaled images

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add missing `react-native-web` optional peer dependency for isolated modules. ([#30689](https://github.com/expo/expo/pull/30689) by [@byCedric](https://github.com/byCedric))
 - [Web] Fix type incompatibility between style prop and `@types/react-native-web` ([#31150](https://github.com/expo/expo/pull/31150) by [@adamhari](https://github.com/adamhari))
 - [iOS] Fixed `isAnimated` property always returning `true`. ([#31834](https://github.com/expo/expo/pull/31834) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed `stopAnimating` broken on downscaled animated images. ([#32053](https://github.com/expo/expo/pull/32053) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -104,8 +104,9 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
  */
 func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) -> UIImage {
   if image.sd_isAnimated,
-    let animatedImage = image as? AnimatedImage {
-    let animatedCoder = ResizedAnimatedCoder(image: animatedImage, size: size, scale: scale)
+    let animatedImage = image as? AnimatedImage,
+    let actualCoder = animatedImage.animatedCoder {
+    let animatedCoder = ResizedAnimatedCoder(actualCoder: actualCoder, size: size, scale: scale)
     if let result = AnimatedImage(animatedCoder: animatedCoder, scale: scale) {
       return result
     }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -102,23 +102,16 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
 /**
  Resizes the animated image to fit in the given size and scale.
  */
-func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage {
-  // If there are no image frames, only resize the main image.
-  guard let images = image.images else {
-    return resize(image: image, toSize: size, scale: scale)
+func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) -> UIImage {
+  if image.sd_isAnimated,
+    let animatedImage = image as? AnimatedImage {
+    let animatedCoder = ResizedAnimatedCoder(image: animatedImage, size: size, scale: scale)
+    if let result = AnimatedImage(animatedCoder: animatedCoder, scale: scale) {
+      return result
+    }
   }
 
-  // Resize all animated image frames.
-  let resizedImages = await concurrentMap(images) { image in
-    return resize(image: image, toSize: size, scale: scale)
-  }
-
-  // Create the new animated image with the resized frames.
-  // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
-  // so it should never happen in our case, but let's make sure to handle it gracefully.
-  if let newAnimatedImage = UIImage.animatedImage(with: resizedImages, duration: image.duration) {
-    return newAnimatedImage
-  }
+  // fallback to a resized static image
   return resize(image: image, toSize: size, scale: scale)
 }
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -222,12 +222,9 @@ public final class ImageView: ExpoView {
         contentFit: contentFit
       ).rounded(.up)
 
-      Task {
-        let image = await processImage(image, idealSize: idealSize, scale: scale)
-
-        applyContentPosition(contentSize: idealSize, containerSize: frame.size)
-        renderImage(image)
-      }
+      let image = processImage(image, idealSize: idealSize, scale: scale)
+      applyContentPosition(contentSize: idealSize, containerSize: frame.size)
+      renderImage(image)
     } else {
       displayPlaceholderIfNecessary()
     }
@@ -332,13 +329,13 @@ public final class ImageView: ExpoView {
     return SDImagePipelineTransformer(transformers: transformers)
   }
 
-  private func processImage(_ image: UIImage?, idealSize: CGSize, scale: Double) async -> UIImage? {
+  private func processImage(_ image: UIImage?, idealSize: CGSize, scale: Double) -> UIImage? {
     guard let image = image, !bounds.isEmpty else {
       return nil
     }
     // Downscale the image only when necessary
     if allowDownscaling && shouldDownscale(image: image, toSize: idealSize, scale: scale) {
-      return await resize(animatedImage: image, toSize: idealSize, scale: scale)
+      return resize(animatedImage: image, toSize: idealSize, scale: scale)
     }
     return image
   }

--- a/packages/expo-image/ios/ResizedAnimatedCoder.swift
+++ b/packages/expo-image/ios/ResizedAnimatedCoder.swift
@@ -1,0 +1,49 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SDWebImage
+
+/**
+ An animated image resizer that adjusts an already loaded `SDAnimatedImage`.
+ This is not a formal SDWebImage coder; it's used solely to leverage the SDWebImage loading pipeline.
+ */
+internal final class ResizedAnimatedCoder: SDImageIOAnimatedCoder {
+  private let image: SDAnimatedImage
+  private let size: CGSize
+  private let scale: Double
+
+  @available(*, unavailable)
+  required init(incrementalWithOptions options: [SDImageCoderOption: Any]? = nil) {
+    fatalError("Unsupported initializer")
+  }
+
+  @available(*, unavailable)
+  required init(animatedImageData: Data?, options: [SDImageCoderOption: Any]? = nil) {
+    fatalError("Unsupported initializer")
+  }
+
+  init(image: SDAnimatedImage, size: CGSize, scale: Double) {
+    self.image = image
+    self.size = size
+    self.scale = scale
+    super.init()
+  }
+
+  override func animatedImageFrame(at index: UInt) -> UIImage? {
+    guard let frame = image.animatedImageFrame(at: index) else {
+      return nil
+    }
+    return resize(image: frame, toSize: self.size, scale: self.scale)
+  }
+
+  override var animatedImageLoopCount: UInt {
+    return image.animatedImageLoopCount
+  }
+
+  override var animatedImageFrameCount: UInt {
+    return image.animatedImageFrameCount
+  }
+
+  override func animatedImageDuration(at index: UInt) -> TimeInterval {
+    return image.animatedImageDuration(at: index)
+  }
+}

--- a/packages/expo-image/ios/ResizedAnimatedCoder.swift
+++ b/packages/expo-image/ios/ResizedAnimatedCoder.swift
@@ -6,44 +6,63 @@ import SDWebImage
  An animated image resizer that adjusts an already loaded `SDAnimatedImage`.
  This is not a formal SDWebImage coder; it's used solely to leverage the SDWebImage loading pipeline.
  */
-internal final class ResizedAnimatedCoder: SDImageIOAnimatedCoder {
-  private let image: SDAnimatedImage
+internal final class ResizedAnimatedCoder: NSObject, SDAnimatedImageCoder {
+  private let actualCoder: SDAnimatedImageCoder
   private let size: CGSize
   private let scale: Double
 
-  @available(*, unavailable)
-  required init(incrementalWithOptions options: [SDImageCoderOption: Any]? = nil) {
+  // swiftlint:disable:next unavailable_function
+  init(animatedImageData data: Data?, options: [SDImageCoderOption: Any]? = nil) {
     fatalError("Unsupported initializer")
   }
 
-  @available(*, unavailable)
-  required init(animatedImageData: Data?, options: [SDImageCoderOption: Any]? = nil) {
-    fatalError("Unsupported initializer")
-  }
-
-  init(image: SDAnimatedImage, size: CGSize, scale: Double) {
-    self.image = image
+  init(actualCoder: SDAnimatedImageCoder, size: CGSize, scale: Double) {
+    self.actualCoder = actualCoder
     self.size = size
     self.scale = scale
     super.init()
   }
 
-  override func animatedImageFrame(at index: UInt) -> UIImage? {
-    guard let frame = image.animatedImageFrame(at: index) else {
+  // MARK: - SDImageCoder implementations
+
+  func canDecode(from data: Data?) -> Bool {
+    return actualCoder.canDecode(from: data)
+  }
+
+  func decodedImage(with data: Data?, options: [SDImageCoderOption: Any]? = nil) -> UIImage? {
+    return actualCoder.decodedImage(with: data, options: options)
+  }
+
+  func canEncode(to format: SDImageFormat) -> Bool {
+    return actualCoder.canEncode(to: format)
+  }
+
+  func encodedData(with image: UIImage?, format: SDImageFormat, options: [SDImageCoderOption: Any]? = nil) -> Data? {
+    return actualCoder.encodedData(with: image, format: format, options: options)
+  }
+
+  // MARK: - SDAnimatedImageProvider implementations
+
+  var animatedImageData: Data? {
+    return actualCoder.animatedImageData
+  }
+
+  var animatedImageFrameCount: UInt {
+    return actualCoder.animatedImageFrameCount
+  }
+
+  var animatedImageLoopCount: UInt {
+    return actualCoder.animatedImageLoopCount
+  }
+
+  func animatedImageFrame(at index: UInt) -> UIImage? {
+    guard let frame = actualCoder.animatedImageFrame(at: index) else {
       return nil
     }
     return resize(image: frame, toSize: self.size, scale: self.scale)
   }
 
-  override var animatedImageLoopCount: UInt {
-    return image.animatedImageLoopCount
-  }
-
-  override var animatedImageFrameCount: UInt {
-    return image.animatedImageFrameCount
-  }
-
-  override func animatedImageDuration(at index: UInt) -> TimeInterval {
-    return image.animatedImageDuration(at: index)
+  func animatedImageDuration(at index: UInt) -> TimeInterval {
+    return actualCoder.animatedImageDuration(at: index)
   }
 }


### PR DESCRIPTION
# Why

fixes #31176
close ENG-13297

# How

see #31176 for details, basically the case happens when the image is downscaled. it looks like an issue from UIKit. this pr tried to add a SDWebImage coder that we can leverage SDWebImage loading pipeline to resize the animated image.
> `Co-authored-by: DreamPiggy <lizhuoli1126@126.com>`

# Test Plan

- test repro
```js
import { Text, SafeAreaView, StyleSheet } from 'react-native';
import React, { useRef, useEffect, useState } from 'react';

import {Image} from 'expo-image'

export default function App() {
  const ref = useRef(null);
  const ref2 = useRef(null);

  const [isAnimating, setIsAnimating] = useState(true);

  useEffect(() => {
    setTimeout(() => {
      setIsAnimating(false);
      console.log('stop animating');
      ref.current.stopAnimating();
      ref2.current.stopAnimating();
    }, 1000)
  }, [ref])
  
  return (
    <SafeAreaView style={styles.container}>
      <Text style={styles.paragraph}>
        Animating: { isAnimating.toString() }
      </Text>
      <Text style={styles.paragraph}>
        AVIF:
      </Text>
      <Image ref={ref} source={{ uri: "https://colinbendell.github.io/webperf/animated-gif-decode/4.avif" }} style={{ height: 100, width: "100%"}} />

      <Text style={styles.paragraph}>
        WEBP:
      </Text>
      <Image ref={ref2} source={{ uri: "https://mathiasbynens.be/demo/animated-webp-supported.webp" }} style={{ height: 100, width: "100%"}} />
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    backgroundColor: '#ecf0f1',
    padding: 8,
  },
  paragraph: {
    margin: 24,
    fontSize: 18,
    fontWeight: 'bold',
    textAlign: 'center',
  },
});
```
- test static image downscaling

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
