### PR TITLE
[install-expo-modules] fix launch regression

### DIFF
--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -28,8 +28,8 @@ const packageJSON = require('../package.json');
 
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
-  .arguments('<project-directory>')
-  .usage(`${chalk.green('<project-directory>')} [options]`)
+  .arguments('[project-directory]')
+  .usage(`${chalk.green('[project-directory]')} [options]`)
   .description('Install expo-modules into your project')
   .option('-s, --sdk-version <version>', 'Install specified expo-modules sdk version')
   .option('--non-interactive', 'Disable interactive prompts')
@@ -119,7 +119,7 @@ Install the Expo CLI integration?`;
 
 async function runAsync() {
   const { projectRoot, platformAndroid, platformIos } = await normalizeProjectRootAsync(
-    process.cwd()
+    program.args[0] || process.cwd()
   );
 
   const {

--- a/packages/install-expo-modules/src/utils/projectRoot.ts
+++ b/packages/install-expo-modules/src/utils/projectRoot.ts
@@ -4,9 +4,9 @@ import fs from 'fs/promises';
 import path from 'path';
 
 export async function normalizeProjectRootAsync(
-  projectRoot?: string
+  projectRoot: string
 ): Promise<{ projectRoot: string; platformAndroid: boolean; platformIos: boolean }> {
-  const root = path.dirname(findUpPackageJson(projectRoot ?? process.cwd()));
+  const root = path.dirname(findUpPackageJson(projectRoot));
   const platformAndroid = await pathExistsAsync(path.join(root, 'android'));
   const platformIos = await pathExistsAsync(path.join(root, 'ios'));
   return {


### PR DESCRIPTION
# Why

fixed a regression since #29603 where it requires a project-directory argument after that.

# How

use an optional argument for the `[project-directory]`

# Test Plan

before: `error: missing required argument 'project-directory'`
after: should install successfully

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
