### PR TITLE
[docs] Add missing tutinfo

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -73,7 +73,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 import { useState, useRef } from 'react';
- /* @tutinfo import { captureRef } from "react-native-view-shot";/* @end */
+/* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {
   /* @tutinfo Create an imageRef variable. */ const imageRef = useRef();/* @end */

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -73,7 +73,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 import { useState, useRef } from 'react';
-import { captureRef } from "react-native-view-shot";
+ /* @tutinfo import { captureRef } from "react-native-view-shot";/* @end */
 
 export default function Index() {
   /* @tutinfo Create an imageRef variable. */ const imageRef = useRef();/* @end */


### PR DESCRIPTION
# Why

There was a missing tutinfo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
