### PR TITLE
chore(expo-dev-menu,expo-dev-launcher): Remove unused `semver` dependencies

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 - Refactor expo-updates context injection ([#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
+- Remove unused `semver` dependency.
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 - Refactor expo-updates context injection ([#31951](https://github.com/expo/expo/pull/31951) by [@wschurman](https://github.com/wschurman))
-- Remove unused `semver` dependency.
+- Remove unused `semver` dependency. ([#32063](https://github.com/expo/expo/pull/32063) by [@kitten](https://github.com/kitten))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -33,8 +33,7 @@
     "ajv": "8.11.0",
     "expo-dev-menu": "5.0.14",
     "expo-manifests": "~0.14.0",
-    "resolve-from": "^5.0.0",
-    "semver": "^7.6.0"
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-export-namespace-from": "^7.23.4",

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 - Removed deprecated code for SDK 49. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
+- Remove unused `semver` dependency.
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Removed `expo_patch_react_imports!` and align more stardard react-native project layout. ([#31700](https://github.com/expo/expo/pull/31700) by [@kudo](https://github.com/kudo))
 - Removed deprecated code for SDK 49. ([#31740](https://github.com/expo/expo/pull/31740) by [@kudo](https://github.com/kudo))
-- Remove unused `semver` dependency.
+- Remove unused `semver` dependency. ([#32063](https://github.com/expo/expo/pull/32063) by [@kitten](https://github.com/kitten))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -47,8 +47,7 @@
     ]
   },
   "dependencies": {
-    "expo-dev-menu-interface": "1.8.3",
-    "semver": "^7.5.4"
+    "expo-dev-menu-interface": "1.8.3"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.10",


### PR DESCRIPTION
# Why

I've discovered this by chance. Not sure how best to test this, but it seems the dependency on `semver` in `expo-dev-launcher` and `expo-dev-menu` isn't used anymore.

It seems that it was introduced in this change: https://github.com/expo/expo/commit/ca2c0598d2fce898402543e7fb5d6a7b9a399214
/ #16495

And later this change removed its usage:
https://github.com/expo/expo/commit/7f9ebcf161377ebc8ef400f172c6a0a5e7ceb03a
/ #24504

But the dependency was never removed.

On a side-note, there's also `resolve-from`. I haven't yet looked into where that's been added and then removed but it also seems to be unused. I've omitted it from this PR though for now.

# How

- Remove `semver` dependency from the two packages

# Test Plan

Since this only affects the plugin:
- Copy over / Pack & Install `expo-dev-launcher` and `expo-dev-menu` into a new Expo project
- Add resolutions accordingly and ensure `plugin/build` is up-to-date with this PR
- Run `expo prebuild`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
