### PR TITLE
[3/n] upgrade react-native 0.76

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -587,12 +587,12 @@ abstract class ReactNativeActivity :
   override fun requestPermissions(
     permissions: Array<String>,
     requestCode: Int,
-    listener: PermissionListener
+    listener: PermissionListener?
   ) {
     if (requestCode == ScopedPermissionsRequester.EXPONENT_PERMISSIONS_REQUEST) {
       val name = manifest!!.getName()
       scopedPermissionsRequester = ScopedPermissionsRequester(experienceKey!!)
-      scopedPermissionsRequester!!.requestPermissions(this, name ?: "", permissions, listener)
+      scopedPermissionsRequester!!.requestPermissions(this, name ?: "", permissions, listener!!)
     } else {
       super.requestPermissions(permissions, requestCode)
     }

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
@@ -24,7 +24,7 @@ class ScopedPermissionsService(context: Context, val experienceKey: ExperienceKe
 
   // We override this to inject scoped permissions even if the device doesn't support the runtime permissions.
   override fun askForManifestPermissions(permissions: Array<out String>, listener: PermissionsResponseListener) {
-    delegateRequestToActivity(permissions, listener)
+    delegateRequestToActivity(permissions as Array<String>, listener)
   }
 
   // We override this to scoped permissions in the headless mode.

--- a/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
+++ b/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
@@ -263,6 +263,10 @@ public class ReactAndroidCodeTransformer {
       String modifySource(String source) {
         // Make DevInternalSettings class "public"
         source = source.replace("\ninternal class DevInternalSettings", "\npublic class DevInternalSettings");
+        source = source.replace("companion object", "public companion object");
+        source = source.replace("interface Listener", "public interface Listener");
+        source = source.replace("fun onInternalSettingsChanged()", "public fun onInternalSettingsChanged()");
+        source = source.replace("override fun addMenuItem(title: String) = Unit", "override fun addMenuItem(title: String): Unit = Unit");
 
         return addBeforeEndOfClass(source, """
           private var exponentActivityId: Int = -1

--- a/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
+++ b/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidCodeTransformer.java
@@ -202,9 +202,8 @@ public class ReactAndroidCodeTransformer {
     });
     JAVA_FILES_TO_MODIFY.put("devsupport/BridgeDevSupportManager.java", null);
 
-    JAVA_FILES_TO_MODIFY.put("modules/core/ExceptionsManagerModule.java", new MethodVisitor() {
+    KOTLIN_FILES_TO_MODIFY.put("modules/core/ExceptionsManagerModule.kt", new KtMethodVisitor() {
 
-      @Override
       public Node visit(String methodName, MethodDeclaration n) {
         // In dev mode call the original methods. Otherwise open Expo error screen
         switch (methodName) {
@@ -263,7 +262,7 @@ public class ReactAndroidCodeTransformer {
       @Override
       String modifySource(String source) {
         // Make DevInternalSettings class "public"
-        source = source.replace("\nclass DevInternalSettings", "\npublic class DevInternalSettings");
+        source = source.replace("\ninternal class DevInternalSettings", "\npublic class DevInternalSettings");
 
         return addBeforeEndOfClass(source, """
           private var exponentActivityId: Int = -1
@@ -324,11 +323,6 @@ public class ReactAndroidCodeTransformer {
     replaceInFile(new File(projectRoot + REACT_ANDROID_DEST_ROOT + "/build.gradle.kts"),
             "$rootDir/node_modules/@react-native/codegen",
             "${project(\":packages:react-native:ReactAndroid\").projectDir.parent}/../react-native-codegen");
-
-    // This version also gets updated in android-tasks.js
-    replaceInFile(new File(projectRoot + REACT_ANDROID_DEST_ROOT + "/build.gradle.kts"),
-        "version = project.findProperty(\"VERSION_NAME\")?.toString()!!",
-        "version = \"" + sdkVersion + "\"");
 
     // RN uses a weird directory structure for soloader to build with Buck. Change this so that Android Studio doesn't complain.
     replaceInFile(new File(projectRoot + REACT_ANDROID_DEST_ROOT + "/build.gradle.kts"),

--- a/patches/@shopify+react-native-skia+1.4.2.patch
+++ b/patches/@shopify+react-native-skia+1.4.2.patch
@@ -1,0 +1,53 @@
+diff --git a/node_modules/@shopify/react-native-skia/.DS_Store b/node_modules/@shopify/react-native-skia/.DS_Store
+new file mode 100644
+index 0000000..b7fa5d4
+Binary files /dev/null and b/node_modules/@shopify/react-native-skia/.DS_Store differ
+diff --git a/node_modules/@shopify/react-native-skia/android/.DS_Store b/node_modules/@shopify/react-native-skia/android/.DS_Store
+new file mode 100644
+index 0000000..8f70268
+Binary files /dev/null and b/node_modules/@shopify/react-native-skia/android/.DS_Store differ
+diff --git a/node_modules/@shopify/react-native-skia/android/CMakeLists.txt b/node_modules/@shopify/react-native-skia/android/CMakeLists.txt
+index 5742abb..5047868 100644
+--- a/node_modules/@shopify/react-native-skia/android/CMakeLists.txt
++++ b/node_modules/@shopify/react-native-skia/android/CMakeLists.txt
+@@ -155,6 +155,7 @@ endif()
+ message("-- JSI     : " ${JSI_LIB})
+ 
+ unset(REACT_LIB CACHE)
++
+ if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+     # RN 0.71 distributes prebuilt binaries.
+     set (REACT_LIB ReactAndroid::react_nativemodule_core)
+@@ -227,15 +228,30 @@ message("-- TURBO   : " ${TURBOMODULES_LIB})
+ add_definitions(-DREACT_NATIVE_VERSION=${REACT_NATIVE_VERSION})
+ 
+ # Link
+-target_link_libraries(
++
++
++if(${REACT_NATIVE_VERSION} GREATER_EQUAL 76)
++    target_link_libraries(
++        ${PACKAGE_NAME}
++        ReactAndroid::reactnative
++    )
++else()
++    target_link_libraries(
+         ${PACKAGE_NAME}
+-        ${LOG_LIB}
+         ${FBJNI_LIBRARY}
+         ${REACT_LIB}
+         ${JSI_LIB}
+         ${REACTNATIVEJNI_LIB}
+         ${RUNTIMEEXECUTOR_LIB}
+         ${TURBOMODULES_LIB}
++    )
++endif()
++
++target_link_libraries(
++        ${PACKAGE_NAME}
++        ${LOG_LIB}
++        ${FBJNI_LIBRARY}
++        ${JSI_LIB}
+         ${SKIA_SVG_LIB}
+         ${SKIA_SKSHAPER_LIB}
+         ${SKIA_SKPARAGRAPH_LIB}


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/31957
Closes [ENG-13531](https://linear.app/expo/issue/ENG-13531)

# How

- Patch @shopify/react-native-skia
- Fix ReactNativeActivity permission function signature
- Update react-native-lab commit
- Update `ReactAndroidCodeTransformer`

# Test Plan

Expo Go on Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
