### PR TITLE
[bare-expo] Sync `codeStyles` with `ktlint`

### DIFF
--- a/apps/bare-expo/android/.idea/codeStyles/Project.xml
+++ b/apps/bare-expo/android/.idea/codeStyles/Project.xml
@@ -188,7 +188,6 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="0" />
       <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
       <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="false" />


### PR DESCRIPTION
# Why

Syncs AS `codeStyles` with `ktlint` rules. 
