### PR TITLE
[4/n] upgrade react-native 0.76 

### DIFF
--- a/apps/bare-expo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/bare-expo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -630,7 +630,7 @@ PODS:
     - Yoga
   - EXUpdatesInterface (0.16.2):
     - ExpoModulesCore
-  - FBLazyVector (0.76.0-rc.4)
+  - FBLazyVector (0.76.0-rc.5)
   - fmt (9.1.0)
   - glog (0.3.5)
   - GoogleMaps (7.4.0):
@@ -639,9 +639,9 @@ PODS:
   - GoogleMaps/Maps (7.4.0):
     - GoogleMaps/Base
   - GooglePlaces (7.3.0)
-  - hermes-engine (0.76.0-rc.4):
-    - hermes-engine/Pre-built (= 0.76.0-rc.4)
-  - hermes-engine/Pre-built (0.76.0-rc.4)
+  - hermes-engine (0.76.0-rc.5):
+    - hermes-engine/Pre-built (= 0.76.0-rc.5)
+  - hermes-engine/Pre-built (0.76.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -690,33 +690,33 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.76.0-rc.4)
-  - RCTRequired (0.76.0-rc.4)
-  - RCTTypeSafety (0.76.0-rc.4):
-    - FBLazyVector (= 0.76.0-rc.4)
-    - RCTRequired (= 0.76.0-rc.4)
-    - React-Core (= 0.76.0-rc.4)
+  - RCTDeprecation (0.76.0-rc.5)
+  - RCTRequired (0.76.0-rc.5)
+  - RCTTypeSafety (0.76.0-rc.5):
+    - FBLazyVector (= 0.76.0-rc.5)
+    - RCTRequired (= 0.76.0-rc.5)
+    - React-Core (= 0.76.0-rc.5)
   - ReachabilitySwift (5.2.3)
-  - React (0.76.0-rc.4):
-    - React-Core (= 0.76.0-rc.4)
-    - React-Core/DevSupport (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-RCTActionSheet (= 0.76.0-rc.4)
-    - React-RCTAnimation (= 0.76.0-rc.4)
-    - React-RCTBlob (= 0.76.0-rc.4)
-    - React-RCTImage (= 0.76.0-rc.4)
-    - React-RCTLinking (= 0.76.0-rc.4)
-    - React-RCTNetwork (= 0.76.0-rc.4)
-    - React-RCTSettings (= 0.76.0-rc.4)
-    - React-RCTText (= 0.76.0-rc.4)
-    - React-RCTVibration (= 0.76.0-rc.4)
-  - React-callinvoker (0.76.0-rc.4)
-  - React-Core (0.76.0-rc.4):
+  - React (0.76.0-rc.5):
+    - React-Core (= 0.76.0-rc.5)
+    - React-Core/DevSupport (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-RCTActionSheet (= 0.76.0-rc.5)
+    - React-RCTAnimation (= 0.76.0-rc.5)
+    - React-RCTBlob (= 0.76.0-rc.5)
+    - React-RCTImage (= 0.76.0-rc.5)
+    - React-RCTLinking (= 0.76.0-rc.5)
+    - React-RCTNetwork (= 0.76.0-rc.5)
+    - React-RCTSettings (= 0.76.0-rc.5)
+    - React-RCTText (= 0.76.0-rc.5)
+    - React-RCTVibration (= 0.76.0-rc.5)
+  - React-callinvoker (0.76.0-rc.5)
+  - React-Core (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default (= 0.76.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -728,58 +728,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.76.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -796,7 +745,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.76.0-rc.4):
+  - React-Core/Default (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -813,7 +796,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.76.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -830,7 +813,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.76.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -847,7 +830,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.76.0-rc.4):
+  - React-Core/RCTImageHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -864,7 +847,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.76.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -881,7 +864,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.76.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -898,7 +881,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.76.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -915,7 +898,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.76.0-rc.4):
+  - React-Core/RCTTextHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -932,12 +915,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.76.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -949,37 +932,54 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.76.0-rc.4):
+  - React-Core/RCTWebSocket (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.76.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - RCTTypeSafety (= 0.76.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.76.0-rc.4)
+    - React-RCTImage (= 0.76.0-rc.5)
     - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.76.0-rc.4):
+  - React-cxxreact (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-    - React-timing (= 0.76.0-rc.4)
-  - React-debug (0.76.0-rc.4)
-  - React-defaultsnativemodule (0.76.0-rc.4):
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+    - React-timing (= 0.76.0-rc.5)
+  - React-debug (0.76.0-rc.5)
+  - React-defaultsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1004,7 +1004,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-domnativemodule (0.76.0-rc.4):
+  - React-domnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1026,7 +1026,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.76.0-rc.4):
+  - React-Fabric (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1037,21 +1037,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.76.0-rc.4)
-    - React-Fabric/attributedstring (= 0.76.0-rc.4)
-    - React-Fabric/componentregistry (= 0.76.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.76.0-rc.4)
-    - React-Fabric/components (= 0.76.0-rc.4)
-    - React-Fabric/core (= 0.76.0-rc.4)
-    - React-Fabric/dom (= 0.76.0-rc.4)
-    - React-Fabric/imagemanager (= 0.76.0-rc.4)
-    - React-Fabric/leakchecker (= 0.76.0-rc.4)
-    - React-Fabric/mounting (= 0.76.0-rc.4)
-    - React-Fabric/observers (= 0.76.0-rc.4)
-    - React-Fabric/scheduler (= 0.76.0-rc.4)
-    - React-Fabric/telemetry (= 0.76.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.76.0-rc.4)
-    - React-Fabric/uimanager (= 0.76.0-rc.4)
+    - React-Fabric/animations (= 0.76.0-rc.5)
+    - React-Fabric/attributedstring (= 0.76.0-rc.5)
+    - React-Fabric/componentregistry (= 0.76.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.76.0-rc.5)
+    - React-Fabric/components (= 0.76.0-rc.5)
+    - React-Fabric/core (= 0.76.0-rc.5)
+    - React-Fabric/dom (= 0.76.0-rc.5)
+    - React-Fabric/imagemanager (= 0.76.0-rc.5)
+    - React-Fabric/leakchecker (= 0.76.0-rc.5)
+    - React-Fabric/mounting (= 0.76.0-rc.5)
+    - React-Fabric/observers (= 0.76.0-rc.5)
+    - React-Fabric/scheduler (= 0.76.0-rc.5)
+    - React-Fabric/telemetry (= 0.76.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.76.0-rc.5)
+    - React-Fabric/uimanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1061,27 +1061,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.76.0-rc.4):
+  - React-Fabric/animations (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1101,7 +1081,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.76.0-rc.4):
+  - React-Fabric/attributedstring (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1121,7 +1101,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.76.0-rc.4):
+  - React-Fabric/componentregistry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1141,30 +1121,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.4)
-    - React-Fabric/components/root (= 0.76.0-rc.4)
-    - React-Fabric/components/view (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.4):
+  - React-Fabric/componentregistrynative (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1184,7 +1141,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.76.0-rc.4):
+  - React-Fabric/components (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.5)
+    - React-Fabric/components/root (= 0.76.0-rc.5)
+    - React-Fabric/components/view (= 0.76.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1204,7 +1184,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.76.0-rc.4):
+  - React-Fabric/components/root (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1225,7 +1225,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.76.0-rc.4):
+  - React-Fabric/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1245,7 +1245,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.76.0-rc.4):
+  - React-Fabric/dom (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1265,7 +1265,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.76.0-rc.4):
+  - React-Fabric/imagemanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1285,7 +1285,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.76.0-rc.4):
+  - React-Fabric/leakchecker (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1305,7 +1305,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.76.0-rc.4):
+  - React-Fabric/mounting (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1325,7 +1325,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.76.0-rc.4):
+  - React-Fabric/observers (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1336,7 +1336,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.76.0-rc.4)
+    - React-Fabric/observers/events (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1346,7 +1346,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.76.0-rc.4):
+  - React-Fabric/observers/events (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1366,7 +1366,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.76.0-rc.4):
+  - React-Fabric/scheduler (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1388,7 +1388,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.76.0-rc.4):
+  - React-Fabric/telemetry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1408,7 +1408,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.76.0-rc.4):
+  - React-Fabric/templateprocessor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1428,7 +1428,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.76.0-rc.4):
+  - React-Fabric/uimanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1439,28 +1439,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1471,7 +1450,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.76.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1483,8 +1483,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.76.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.4)
+    - React-FabricComponents/components (= 0.76.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1496,7 +1496,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.76.0-rc.4):
+  - React-FabricComponents/components (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1508,15 +1508,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.76.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.76.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/text (= 0.76.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.76.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.76.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/text (= 0.76.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1528,53 +1528,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.76.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1597,7 +1551,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.76.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1620,7 +1574,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.76.0-rc.4):
+  - React-FabricComponents/components/modal (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1643,7 +1597,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.76.0-rc.4):
+  - React-FabricComponents/components/rncore (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1666,7 +1620,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.76.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1689,7 +1643,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.76.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1712,7 +1666,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.76.0-rc.4):
+  - React-FabricComponents/components/text (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1735,7 +1689,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.76.0-rc.4):
+  - React-FabricComponents/components/textinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1758,26 +1712,72 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.76.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.76.0-rc.4)
-    - RCTTypeSafety (= 0.76.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.76.0-rc.5)
+    - RCTTypeSafety (= 0.76.0-rc.5)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.76.0-rc.4)
-  - React-featureflagsnativemodule (0.76.0-rc.4):
+  - React-featureflags (0.76.0-rc.5)
+  - React-featureflagsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1798,7 +1798,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-graphics (0.76.0-rc.4):
+  - React-graphics (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1806,19 +1806,19 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.76.0-rc.4):
+  - React-hermes (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
+    - React-perflogger (= 0.76.0-rc.5)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.76.0-rc.4):
+  - React-idlecallbacksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1840,7 +1840,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-ImageManager (0.76.0-rc.4):
+  - React-ImageManager (0.76.0-rc.5):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1849,47 +1849,47 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.76.0-rc.4):
+  - React-jserrorhandler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-cxxreact
     - React-debug
     - React-jsi
-  - React-jsi (0.76.0-rc.4):
+  - React-jsi (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.76.0-rc.4):
+  - React-jsiexecutor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
-  - React-jsinspector (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+  - React-jsinspector (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-  - React-jsitracing (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+  - React-jsitracing (0.76.0-rc.5):
     - React-jsi
-  - React-logger (0.76.0-rc.4):
+  - React-logger (0.76.0-rc.5):
     - glog
-  - React-Mapbuffer (0.76.0-rc.4):
+  - React-Mapbuffer (0.76.0-rc.5):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.76.0-rc.4):
+  - React-microtasksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2089,8 +2089,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-nativeconfig (0.76.0-rc.4)
-  - React-NativeModulesApple (0.76.0-rc.4):
+  - React-nativeconfig (0.76.0-rc.5)
+  - React-NativeModulesApple (0.76.0-rc.5):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -2101,16 +2101,16 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.76.0-rc.4):
+  - React-perflogger (0.76.0-rc.5):
     - DoubleConversion
     - RCT-Folly (= 2024.01.01.00)
-  - React-performancetimeline (0.76.0-rc.4):
+  - React-performancetimeline (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
     - React-timing
-  - React-RCTActionSheet (0.76.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.4)
-  - React-RCTAnimation (0.76.0-rc.4):
+  - React-RCTActionSheet (0.76.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.5)
+  - React-RCTAnimation (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -2118,7 +2118,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTAppDelegate (0.76.0-rc.4):
+  - React-RCTAppDelegate (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -2143,7 +2143,7 @@ PODS:
     - React-utils
     - ReactCodegen
     - ReactCommon
-  - React-RCTBlob (0.76.0-rc.4):
+  - React-RCTBlob (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -2156,7 +2156,7 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTFabric (0.76.0-rc.4):
+  - React-RCTFabric (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -2179,7 +2179,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.76.0-rc.4):
+  - React-RCTImage (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -2188,14 +2188,14 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTLinking (0.76.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+  - React-RCTLinking (0.76.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - React-RCTNetwork (0.76.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - React-RCTNetwork (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -2203,7 +2203,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTSettings (0.76.0-rc.4):
+  - React-RCTSettings (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -2211,24 +2211,24 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTText (0.76.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.76.0-rc.4)
+  - React-RCTText (0.76.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.76.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.76.0-rc.4):
+  - React-RCTVibration (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-rendererconsistency (0.76.0-rc.4)
-  - React-rendererdebug (0.76.0-rc.4):
+  - React-rendererconsistency (0.76.0-rc.5)
+  - React-rendererdebug (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.76.0-rc.4)
-  - React-RuntimeApple (0.76.0-rc.4):
+  - React-rncore (0.76.0-rc.5)
+  - React-RuntimeApple (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -2247,7 +2247,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.76.0-rc.4):
+  - React-RuntimeCore (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -2261,9 +2261,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.76.0-rc.4):
-    - React-jsi (= 0.76.0-rc.4)
-  - React-RuntimeHermes (0.76.0-rc.4):
+  - React-runtimeexecutor (0.76.0-rc.5):
+    - React-jsi (= 0.76.0-rc.5)
+  - React-RuntimeHermes (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -2274,7 +2274,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.76.0-rc.4):
+  - React-runtimescheduler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -2289,14 +2289,14 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.76.0-rc.4)
-  - React-utils (0.76.0-rc.4):
+  - React-timing (0.76.0-rc.5)
+  - React-utils (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.76.0-rc.4)
-  - ReactCodegen (0.76.0-rc.4):
+    - React-jsi (= 0.76.0-rc.5)
+  - ReactCodegen (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2316,46 +2316,46 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.76.0-rc.4):
-    - ReactCommon/turbomodule (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule (0.76.0-rc.4):
+  - ReactCommon (0.76.0-rc.5):
+    - ReactCommon/turbomodule (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/bridging (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/bridging (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/core (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-featureflags (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-utils (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-featureflags (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-utils (= 0.76.0-rc.5)
   - RNCAsyncStorage (1.23.1):
     - DoubleConversion
     - glog
@@ -3207,8 +3207,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BenchmarkingModule: 0be4117c4bf255d2e21df9e4a4a486ec89c8640f
-  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EASClient: 00a5bbc03a76fbcca972e7a4465f0e939d567e0d
   EXApplication: a329dec35dfc3ef30c64d1746698f209ef2b4db6
   EXAV: 1abd55830a134995b308d8ba9e3acbce67a2a666
@@ -3281,48 +3281,48 @@ SPEC CHECKSUMS:
   EXTaskManager: 080da17150fba107155b6800be1370dd1a252c39
   EXUpdates: 992e73bb96f83c8ed958949bb2475c883a3119ae
   EXUpdatesInterface: 8d16d1242225d0bdb4d8db788349b522aa8e0343
-  FBLazyVector: 20c5e40f776552291d12ea1f6cb14568aeccec92
-  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
+  FBLazyVector: de8eedeaa44513602f4e9c94b3547c3c43af0d40
+  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GooglePlaces: 0609463845250bbadafa1739938181e54dece439
-  hermes-engine: 367546049df3ab3b58c9b07dab01e9c7c5640728
+  hermes-engine: 83913a9bc12277c53ef984c8589efdfa3b68ca50
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
-  RCTDeprecation: ea1525e5eda35bb079a7ac260551c5e0468f9ee3
-  RCTRequired: c78ef50a39a3c8060e546760c46148d9abee6388
-  RCTTypeSafety: 1841770b2ab4e4325bfe2a6b5ddca520b3e6c40d
+  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCTDeprecation: 4192491a84930e9a001406df7eb570be2ec7320e
+  RCTRequired: b4fad98533fbfd85dd911f6bfecff1b08d19d87a
+  RCTTypeSafety: 09d6104052cd7e0afa56d58b21efa5e12c593a66
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
-  React: 0d0b01ad72a7d78942ecca7efef21261a95b571e
-  React-callinvoker: dfffa5cbc328b8c6c50a1175d0949a2625bc16d1
-  React-Core: d191ffc6bc41418035bb194dca150e45e5d1ac99
-  React-CoreModules: abc8746b32605f56185ae717ae3f0b495555e7cd
-  React-cxxreact: b27afedad262b3795b8e6159d08502914a1d92ed
-  React-debug: a4ea112a115069970382c851e1ac354a16ca3407
-  React-defaultsnativemodule: 126fdaa0eb715399ed0aa711cb99b7ada18df922
-  React-domnativemodule: fb6997c863510267771dba59a6622c88112b7f8d
-  React-Fabric: 242416dca2d51a1da7f408992cbd91aec4942690
-  React-FabricComponents: 53d72e46c374a2e3f35f805f5107f748df7697a0
-  React-FabricImage: dee871f91a383998b11dfc3316b637645b205495
-  React-featureflags: 876e6a0a475c8302c2578e9ccfabf1311d31e43f
-  React-featureflagsnativemodule: d67f70f301dab8c1d6a167ecbc5847ab94ddbdcd
-  React-graphics: e31951d62a49d732fb1ec5240df312a7eaeca1c5
-  React-hermes: af5811d0da319a1c8cf15c8382cbf8e61a8d95d6
-  React-idlecallbacksnativemodule: 5ba27b09fb7bed6ce3c59b102da86aaa84b437e5
-  React-ImageManager: ea3dd89ab916635458ff670085d2d1a9bf394794
-  React-jserrorhandler: eebcf043f7abba6c75ef7345277492d225163ed4
-  React-jsi: bd5273d25f83f1c4a656872422455c32357f367b
-  React-jsiexecutor: a908f2152653629e80721bef0030ff2c33d614c5
-  React-jsinspector: ed1e3ae3c861b2057cc8fe4d67b6b37081336488
-  React-jsitracing: b7b6dbd037ff3a7b971bb577c7c49fcf4fae162b
-  React-logger: ccab6d41424202fd511faa9a88bec12cadc83dfa
-  React-Mapbuffer: fe84c6dde7dab6dd8658bb18beb932c1b15c993a
-  React-microtasksnativemodule: b96aa3fc27ef864c183605decc24df15258cadfc
+  React: 7b0daf87159fb74a575f17841338575993b16fe7
+  React-callinvoker: 5a814c15bcea3bee56ed553bed0cdd4c6c0909d7
+  React-Core: 1b63f346b0c0ef34ac186cfa5dd5f2417e365dc8
+  React-CoreModules: 0ea5b0070a67846efeebf1b8ca617a35331bad83
+  React-cxxreact: c4d0bb73f052f9bd6e71a41e6fa1ffeda188fce1
+  React-debug: 71a6df9f66e18ed9d54c599abc0891ac6b557a02
+  React-defaultsnativemodule: b91b3db54e0f2adf162765cf6a23206dc5e437e2
+  React-domnativemodule: 76ea09978aa37e072fe89f6f38bd128a3e4282ad
+  React-Fabric: 77eb8316e14a015af3a4b1900a26cbd47dc90085
+  React-FabricComponents: 76dd7d0dc57823375e019b444d79ef607543fe3f
+  React-FabricImage: fff56283b24af6a59c7d37f5cd4a3f838ad21705
+  React-featureflags: bfec0de2042b2e8554e5b8e421093a8309117d5c
+  React-featureflagsnativemodule: 6ee9cf0cf2fea207ce4913cf753592655fa68ca0
+  React-graphics: 6cdd20e7bac68eba69c4186563890f9275ef99b0
+  React-hermes: 0fc678ca4c31c555f311a4178223f0785dc97562
+  React-idlecallbacksnativemodule: f6ed21f7481682da925165dccde6f36a7d286ace
+  React-ImageManager: 5411113b18db62f0bfc6271d4546e5c945a11931
+  React-jserrorhandler: bd06ea2d7e167ab2c1b9a36fdd3a1d38693c34f1
+  React-jsi: cd024064402b258d0aa779255349ab89993238c3
+  React-jsiexecutor: cd355e620e376f4b9604d68f71e535310ec3c2e9
+  React-jsinspector: 6f829b65c901b559223a6ed2e3340ab49136fa1e
+  React-jsitracing: dc06b7da8c86de529f3384ee15164866a320048f
+  React-logger: dc9eb8395b1341379fe9a4568c45bb7329629ae4
+  React-Mapbuffer: 69f179a8d7323c3bb2e027592390607cafd4cb8f
+  React-microtasksnativemodule: 10f19a8911990eeaa798ef6e35abd6f0015cbbe6
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
   react-native-safe-area-context: f1fda705dfe14355f41933debb5932887e234cc5
@@ -3330,33 +3330,33 @@ SPEC CHECKSUMS:
   react-native-slider: e1f4b4538f7de7417b626174874f4f58d4cf6c28
   react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688
   react-native-webview: 06f91954784dde28e1210f381c791f0c5f9bd9a2
-  React-nativeconfig: 38e9f8764eb61e31e11915c950cc97aedddb8736
-  React-NativeModulesApple: 32ae99d8d82da3efb18b96915467e9bc851fd866
-  React-perflogger: 8e26de3ec512cdd60a42a0058227c9c66ea87ee5
-  React-performancetimeline: abbed40b41e81667ca7094f64451861589de5f3e
-  React-RCTActionSheet: 6239d9d694dc8616c483b6bf129018ef21d88237
-  React-RCTAnimation: cafb6fba8338f1b5a86243dc487bb5ec92120c66
-  React-RCTAppDelegate: 82985692b0a56240b60f8186312e3de3d5be16a3
-  React-RCTBlob: 772c1e74f650f0b777845586992b892f552aa73c
-  React-RCTFabric: c5c6f5a611088b9b20f04990c71ca20806e80ed4
-  React-RCTImage: 53817bacd7932786539d9de7e07a2d0af3ebe918
-  React-RCTLinking: e6d6ee9c252074f493182da8d00e17324271f1b9
-  React-RCTNetwork: 58beae8ffa70ccdeed4f0b06fd26d8d90db6e658
-  React-RCTSettings: c62a98a91f269316316803043a42cc67ccbf17fc
-  React-RCTText: 344739a409a7883bd5666d7a8061aa666d46c840
-  React-RCTVibration: aec24eb8c13710f03a029f83b1f52278824d5a5f
-  React-rendererconsistency: ddf5bcdefef149701803b19b1e235b00a92cb43e
-  React-rendererdebug: d6c526a8c3753e7a3422d417e723da2ce55e7ea7
-  React-rncore: 7051b962a908eb640ebcb056805b23155c117c69
-  React-RuntimeApple: 6a88089b15029632c2658e092b377203dda72df3
-  React-RuntimeCore: ed1ff2106abfd1b66419c1e415beb4865aaff67c
-  React-runtimeexecutor: 208d438d0ca7101c1b8cafc46985e9a4321ca36d
-  React-RuntimeHermes: e6cf75963cef945ffb1efde63c2744649ab18c41
-  React-runtimescheduler: 8366a99028799f6fcc34e62b4d4174710976d42a
-  React-timing: 5c8f3f26b39635e9984c98d46c53c16aa10a4792
-  React-utils: 0ab6858c3bdff0219b119b881dcdd12d9b913769
-  ReactCodegen: b1c95a4f94d0e2a25e6f174357cf31292d46da6b
-  ReactCommon: 9cb3c46af4f75f0a61e40d24b54f8b848226dadf
+  React-nativeconfig: 04c807a93e08acef39d28736cdcd511f77d1573a
+  React-NativeModulesApple: cf9d53bbdc856ea409ae605f293085e4d1bd4584
+  React-perflogger: f1ccce85fdd94ae925ab7b315b1af8f4b0d9db4e
+  React-performancetimeline: d11db5784449e33aff086b1805e3ded3aa61a5e7
+  React-RCTActionSheet: 2ec40250c009777048731b4b421b54f493889cda
+  React-RCTAnimation: 86c3e5c31ed951e74a5381862d6a49ea493d64e6
+  React-RCTAppDelegate: 349d0236e04b0a02312361cb998708a902672f4e
+  React-RCTBlob: 1e0cc2c326425ca0d0190db55f3e73ed3f54c980
+  React-RCTFabric: cfbbfe5b38ff04a40b73f06fcb71f3b55da0faca
+  React-RCTImage: 075758c75aab89c8964a733177d3a0bd92785a87
+  React-RCTLinking: 966f69ed2f4a058829374d8dcc961ae193b4eff8
+  React-RCTNetwork: 62b1268ae7596c73a43d64a8e6e8e5da19666c78
+  React-RCTSettings: 5a1d1b1b1e991e660c44f383e2a1d10a99a190e1
+  React-RCTText: 76e1681e483b3d03f673076f27b1c8711f8a0537
+  React-RCTVibration: 02eac793150fcbf849232c232a1ca8ca362525fd
+  React-rendererconsistency: e5636962d7e86df51f57b5cc7cc681b1544e7385
+  React-rendererdebug: 83762d7627dbb1c735b7ef9853b726bcb939cdf6
+  React-rncore: 2765a9b04a9ef1cd28a56528783c9644ecde8a33
+  React-RuntimeApple: fee4dca6f9b2a0a879bbdcffcb1adce8b4eb2499
+  React-RuntimeCore: 08c53b33fa43a9ef689c5d2f8f47c7c22389420c
+  React-runtimeexecutor: 2d27e8c9dc9272a13ff61bb162440e21fe9d5a82
+  React-RuntimeHermes: d81c1857d13097bea77f654046f5f40d102414a5
+  React-runtimescheduler: 4814c52f8009cd3031ff8b29eda80569a529c493
+  React-timing: 3978fc03d275858cc95e69b9adbea5b05d48ecf8
+  React-utils: 7d83759a29992a76a3cc324948ef6d86415bc44e
+  ReactCodegen: 5a24561503c3b7d969513ea8e068ae3081cd72a5
+  ReactCommon: eaf4f987f18bba1f4ec674e2ed95b706e1559cd1
   RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 6ad936eee086dbe2aeb658994021770b46897d62
@@ -3372,7 +3372,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: c34fd315863887c7961e059efd9475e056bdd72d
-  Yoga: faaab08e21d56d9b7d5225d64fa23cdf72af2f74
+  Yoga: d27fe77b40d16ce8a8936a48c401f33ca4e15265
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 567bb58fe91a07874d34e36dc2ed989b409d33cd

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -60,7 +60,7 @@
     "native-component-list": "*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.15.4",

--- a/apps/expo-go/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/expo-go/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -318,7 +318,7 @@ PODS:
     - Yoga
   - EXUpdatesInterface (0.16.2):
     - ExpoModulesCore
-  - FBLazyVector (0.76.0-rc.4)
+  - FBLazyVector (0.76.0-rc.5)
   - FirebaseCore (11.3.0):
     - FirebaseCoreInternal (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
@@ -374,17 +374,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.76.0-rc.4):
-    - hermes-engine/cdp (= 0.76.0-rc.4)
-    - hermes-engine/Hermes (= 0.76.0-rc.4)
-    - hermes-engine/inspector (= 0.76.0-rc.4)
-    - hermes-engine/inspector_chrome (= 0.76.0-rc.4)
-    - hermes-engine/Public (= 0.76.0-rc.4)
-  - hermes-engine/cdp (0.76.0-rc.4)
-  - hermes-engine/Hermes (0.76.0-rc.4)
-  - hermes-engine/inspector (0.76.0-rc.4)
-  - hermes-engine/inspector_chrome (0.76.0-rc.4)
-  - hermes-engine/Public (0.76.0-rc.4)
+  - hermes-engine (0.76.0-rc.5):
+    - hermes-engine/cdp (= 0.76.0-rc.5)
+    - hermes-engine/Hermes (= 0.76.0-rc.5)
+    - hermes-engine/inspector (= 0.76.0-rc.5)
+    - hermes-engine/inspector_chrome (= 0.76.0-rc.5)
+    - hermes-engine/Public (= 0.76.0-rc.5)
+  - hermes-engine/cdp (0.76.0-rc.5)
+  - hermes-engine/Hermes (0.76.0-rc.5)
+  - hermes-engine/inspector (0.76.0-rc.5)
+  - hermes-engine/inspector_chrome (0.76.0-rc.5)
+  - hermes-engine/Public (0.76.0-rc.5)
   - JKBigInteger (0.0.6)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
@@ -445,33 +445,33 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.76.0-rc.4)
-  - RCTRequired (0.76.0-rc.4)
-  - RCTTypeSafety (0.76.0-rc.4):
-    - FBLazyVector (= 0.76.0-rc.4)
-    - RCTRequired (= 0.76.0-rc.4)
-    - React-Core (= 0.76.0-rc.4)
+  - RCTDeprecation (0.76.0-rc.5)
+  - RCTRequired (0.76.0-rc.5)
+  - RCTTypeSafety (0.76.0-rc.5):
+    - FBLazyVector (= 0.76.0-rc.5)
+    - RCTRequired (= 0.76.0-rc.5)
+    - React-Core (= 0.76.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.76.0-rc.4):
-    - React-Core (= 0.76.0-rc.4)
-    - React-Core/DevSupport (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-RCTActionSheet (= 0.76.0-rc.4)
-    - React-RCTAnimation (= 0.76.0-rc.4)
-    - React-RCTBlob (= 0.76.0-rc.4)
-    - React-RCTImage (= 0.76.0-rc.4)
-    - React-RCTLinking (= 0.76.0-rc.4)
-    - React-RCTNetwork (= 0.76.0-rc.4)
-    - React-RCTSettings (= 0.76.0-rc.4)
-    - React-RCTText (= 0.76.0-rc.4)
-    - React-RCTVibration (= 0.76.0-rc.4)
-  - React-callinvoker (0.76.0-rc.4)
-  - React-Core (0.76.0-rc.4):
+  - React (0.76.0-rc.5):
+    - React-Core (= 0.76.0-rc.5)
+    - React-Core/DevSupport (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-RCTActionSheet (= 0.76.0-rc.5)
+    - React-RCTAnimation (= 0.76.0-rc.5)
+    - React-RCTBlob (= 0.76.0-rc.5)
+    - React-RCTImage (= 0.76.0-rc.5)
+    - React-RCTLinking (= 0.76.0-rc.5)
+    - React-RCTNetwork (= 0.76.0-rc.5)
+    - React-RCTSettings (= 0.76.0-rc.5)
+    - React-RCTText (= 0.76.0-rc.5)
+    - React-RCTVibration (= 0.76.0-rc.5)
+  - React-callinvoker (0.76.0-rc.5)
+  - React-Core (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default (= 0.76.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -483,58 +483,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.76.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -551,7 +500,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.76.0-rc.4):
+  - React-Core/Default (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -568,7 +551,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.76.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -585,7 +568,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.76.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -602,7 +585,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.76.0-rc.4):
+  - React-Core/RCTImageHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -619,7 +602,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.76.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -636,7 +619,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.76.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -653,7 +636,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.76.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -670,7 +653,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.76.0-rc.4):
+  - React-Core/RCTTextHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -687,12 +670,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.76.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -704,37 +687,54 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.76.0-rc.4):
+  - React-Core/RCTWebSocket (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.76.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - RCTTypeSafety (= 0.76.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.76.0-rc.4)
+    - React-RCTImage (= 0.76.0-rc.5)
     - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.76.0-rc.4):
+  - React-cxxreact (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-    - React-timing (= 0.76.0-rc.4)
-  - React-debug (0.76.0-rc.4)
-  - React-defaultsnativemodule (0.76.0-rc.4):
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+    - React-timing (= 0.76.0-rc.5)
+  - React-debug (0.76.0-rc.5)
+  - React-defaultsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -759,7 +759,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-domnativemodule (0.76.0-rc.4):
+  - React-domnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -781,7 +781,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.76.0-rc.4):
+  - React-Fabric (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -792,21 +792,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.76.0-rc.4)
-    - React-Fabric/attributedstring (= 0.76.0-rc.4)
-    - React-Fabric/componentregistry (= 0.76.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.76.0-rc.4)
-    - React-Fabric/components (= 0.76.0-rc.4)
-    - React-Fabric/core (= 0.76.0-rc.4)
-    - React-Fabric/dom (= 0.76.0-rc.4)
-    - React-Fabric/imagemanager (= 0.76.0-rc.4)
-    - React-Fabric/leakchecker (= 0.76.0-rc.4)
-    - React-Fabric/mounting (= 0.76.0-rc.4)
-    - React-Fabric/observers (= 0.76.0-rc.4)
-    - React-Fabric/scheduler (= 0.76.0-rc.4)
-    - React-Fabric/telemetry (= 0.76.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.76.0-rc.4)
-    - React-Fabric/uimanager (= 0.76.0-rc.4)
+    - React-Fabric/animations (= 0.76.0-rc.5)
+    - React-Fabric/attributedstring (= 0.76.0-rc.5)
+    - React-Fabric/componentregistry (= 0.76.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.76.0-rc.5)
+    - React-Fabric/components (= 0.76.0-rc.5)
+    - React-Fabric/core (= 0.76.0-rc.5)
+    - React-Fabric/dom (= 0.76.0-rc.5)
+    - React-Fabric/imagemanager (= 0.76.0-rc.5)
+    - React-Fabric/leakchecker (= 0.76.0-rc.5)
+    - React-Fabric/mounting (= 0.76.0-rc.5)
+    - React-Fabric/observers (= 0.76.0-rc.5)
+    - React-Fabric/scheduler (= 0.76.0-rc.5)
+    - React-Fabric/telemetry (= 0.76.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.76.0-rc.5)
+    - React-Fabric/uimanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -816,27 +816,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.76.0-rc.4):
+  - React-Fabric/animations (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -856,7 +836,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.76.0-rc.4):
+  - React-Fabric/attributedstring (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -876,7 +856,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.76.0-rc.4):
+  - React-Fabric/componentregistry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -896,30 +876,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.4)
-    - React-Fabric/components/root (= 0.76.0-rc.4)
-    - React-Fabric/components/view (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.4):
+  - React-Fabric/componentregistrynative (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -939,7 +896,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.76.0-rc.4):
+  - React-Fabric/components (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.5)
+    - React-Fabric/components/root (= 0.76.0-rc.5)
+    - React-Fabric/components/view (= 0.76.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -959,7 +939,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.76.0-rc.4):
+  - React-Fabric/components/root (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -980,7 +980,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.76.0-rc.4):
+  - React-Fabric/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1000,7 +1000,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.76.0-rc.4):
+  - React-Fabric/dom (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1020,7 +1020,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.76.0-rc.4):
+  - React-Fabric/imagemanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1040,7 +1040,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.76.0-rc.4):
+  - React-Fabric/leakchecker (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1060,7 +1060,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.76.0-rc.4):
+  - React-Fabric/mounting (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1080,7 +1080,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.76.0-rc.4):
+  - React-Fabric/observers (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1091,7 +1091,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.76.0-rc.4)
+    - React-Fabric/observers/events (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1101,7 +1101,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.76.0-rc.4):
+  - React-Fabric/observers/events (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1121,7 +1121,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.76.0-rc.4):
+  - React-Fabric/scheduler (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1143,7 +1143,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.76.0-rc.4):
+  - React-Fabric/telemetry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1163,7 +1163,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.76.0-rc.4):
+  - React-Fabric/templateprocessor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1183,7 +1183,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.76.0-rc.4):
+  - React-Fabric/uimanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1194,28 +1194,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1226,7 +1205,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.76.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1238,8 +1238,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.76.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.4)
+    - React-FabricComponents/components (= 0.76.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1251,7 +1251,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.76.0-rc.4):
+  - React-FabricComponents/components (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1263,15 +1263,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.76.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.76.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/text (= 0.76.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.76.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.76.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/text (= 0.76.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1283,53 +1283,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.76.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1352,7 +1306,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.76.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1375,7 +1329,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.76.0-rc.4):
+  - React-FabricComponents/components/modal (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1398,7 +1352,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.76.0-rc.4):
+  - React-FabricComponents/components/rncore (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1421,7 +1375,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.76.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1444,7 +1398,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.76.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1467,7 +1421,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.76.0-rc.4):
+  - React-FabricComponents/components/text (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1490,7 +1444,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.76.0-rc.4):
+  - React-FabricComponents/components/textinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1513,26 +1467,72 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.76.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.76.0-rc.4)
-    - RCTTypeSafety (= 0.76.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.76.0-rc.5)
+    - RCTTypeSafety (= 0.76.0-rc.5)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.76.0-rc.4)
-  - React-featureflagsnativemodule (0.76.0-rc.4):
+  - React-featureflags (0.76.0-rc.5)
+  - React-featureflagsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1553,7 +1553,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-graphics (0.76.0-rc.4):
+  - React-graphics (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1561,19 +1561,19 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.76.0-rc.4):
+  - React-hermes (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
+    - React-perflogger (= 0.76.0-rc.5)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.76.0-rc.4):
+  - React-idlecallbacksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1595,7 +1595,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-ImageManager (0.76.0-rc.4):
+  - React-ImageManager (0.76.0-rc.5):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1604,52 +1604,52 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.76.0-rc.4):
-    - React-jsc/Fabric (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-  - React-jsc/Fabric (0.76.0-rc.4):
-    - React-jsi (= 0.76.0-rc.4)
-  - React-jserrorhandler (0.76.0-rc.4):
+  - React-jsc (0.76.0-rc.5):
+    - React-jsc/Fabric (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+  - React-jsc/Fabric (0.76.0-rc.5):
+    - React-jsi (= 0.76.0-rc.5)
+  - React-jserrorhandler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-cxxreact
     - React-debug
     - React-jsi
-  - React-jsi (0.76.0-rc.4):
+  - React-jsi (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.76.0-rc.4):
+  - React-jsiexecutor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
-  - React-jsinspector (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+  - React-jsinspector (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-  - React-jsitracing (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+  - React-jsitracing (0.76.0-rc.5):
     - React-jsi
-  - React-logger (0.76.0-rc.4):
+  - React-logger (0.76.0-rc.5):
     - glog
-  - React-Mapbuffer (0.76.0-rc.4):
+  - React-Mapbuffer (0.76.0-rc.5):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.76.0-rc.4):
+  - React-microtasksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1872,8 +1872,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-nativeconfig (0.76.0-rc.4)
-  - React-NativeModulesApple (0.76.0-rc.4):
+  - React-nativeconfig (0.76.0-rc.5)
+  - React-NativeModulesApple (0.76.0-rc.5):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1884,16 +1884,16 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.76.0-rc.4):
+  - React-perflogger (0.76.0-rc.5):
     - DoubleConversion
     - RCT-Folly (= 2024.01.01.00)
-  - React-performancetimeline (0.76.0-rc.4):
+  - React-performancetimeline (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
     - React-timing
-  - React-RCTActionSheet (0.76.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.4)
-  - React-RCTAnimation (0.76.0-rc.4):
+  - React-RCTActionSheet (0.76.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.5)
+  - React-RCTAnimation (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1901,7 +1901,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTAppDelegate (0.76.0-rc.4):
+  - React-RCTAppDelegate (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1926,7 +1926,7 @@ PODS:
     - React-utils
     - ReactCodegen
     - ReactCommon
-  - React-RCTBlob (0.76.0-rc.4):
+  - React-RCTBlob (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1939,7 +1939,7 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTFabric (0.76.0-rc.4):
+  - React-RCTFabric (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1962,7 +1962,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.76.0-rc.4):
+  - React-RCTImage (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1971,14 +1971,14 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTLinking (0.76.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+  - React-RCTLinking (0.76.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - React-RCTNetwork (0.76.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - React-RCTNetwork (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1986,7 +1986,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTSettings (0.76.0-rc.4):
+  - React-RCTSettings (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1994,24 +1994,24 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTText (0.76.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.76.0-rc.4)
+  - React-RCTText (0.76.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.76.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.76.0-rc.4):
+  - React-RCTVibration (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-rendererconsistency (0.76.0-rc.4)
-  - React-rendererdebug (0.76.0-rc.4):
+  - React-rendererconsistency (0.76.0-rc.5)
+  - React-rendererdebug (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.76.0-rc.4)
-  - React-RuntimeApple (0.76.0-rc.4):
+  - React-rncore (0.76.0-rc.5)
+  - React-RuntimeApple (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -2030,7 +2030,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.76.0-rc.4):
+  - React-RuntimeCore (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -2044,9 +2044,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.76.0-rc.4):
-    - React-jsi (= 0.76.0-rc.4)
-  - React-RuntimeHermes (0.76.0-rc.4):
+  - React-runtimeexecutor (0.76.0-rc.5):
+    - React-jsi (= 0.76.0-rc.5)
+  - React-RuntimeHermes (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -2057,7 +2057,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.76.0-rc.4):
+  - React-runtimescheduler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -2072,14 +2072,14 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.76.0-rc.4)
-  - React-utils (0.76.0-rc.4):
+  - React-timing (0.76.0-rc.5)
+  - React-utils (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.76.0-rc.4)
-  - ReactCodegen (0.76.0-rc.4):
+    - React-jsi (= 0.76.0-rc.5)
+  - ReactCodegen (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2099,46 +2099,46 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.76.0-rc.4):
-    - ReactCommon/turbomodule (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule (0.76.0-rc.4):
+  - ReactCommon (0.76.0-rc.5):
+    - ReactCommon/turbomodule (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/bridging (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/bridging (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/core (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-featureflags (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-utils (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-featureflags (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-utils (= 0.76.0-rc.5)
   - RNCAsyncStorage (1.23.1):
     - DoubleConversion
     - glog
@@ -3043,7 +3043,7 @@ SPEC CHECKSUMS:
   EXTaskManager: 080da17150fba107155b6800be1370dd1a252c39
   EXUpdates: 0914f15b9f0c1ab72587a6bc113979ee46120fd8
   EXUpdatesInterface: 8d16d1242225d0bdb4d8db788349b522aa8e0343
-  FBLazyVector: 20c5e40f776552291d12ea1f6cb14568aeccec92
+  FBLazyVector: de8eedeaa44513602f4e9c94b3547c3c43af0d40
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
   FirebaseCoreInternal: ac26d09a70c730e497936430af4e60fb0c68ec4e
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -3051,7 +3051,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: fbe4c0c72d1a9f2204a115f4b9bcbdee19ae6e97
+  hermes-engine: f911eaa8a6e749d6325c5b847d714064a9878bb8
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3062,36 +3062,36 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
-  RCTDeprecation: ea1525e5eda35bb079a7ac260551c5e0468f9ee3
-  RCTRequired: c78ef50a39a3c8060e546760c46148d9abee6388
-  RCTTypeSafety: 1841770b2ab4e4325bfe2a6b5ddca520b3e6c40d
+  RCTDeprecation: 4192491a84930e9a001406df7eb570be2ec7320e
+  RCTRequired: b4fad98533fbfd85dd911f6bfecff1b08d19d87a
+  RCTTypeSafety: 09d6104052cd7e0afa56d58b21efa5e12c593a66
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 0d0b01ad72a7d78942ecca7efef21261a95b571e
-  React-callinvoker: dfffa5cbc328b8c6c50a1175d0949a2625bc16d1
-  React-Core: 8471c8632fff23c34b3e5f393ddc15b2e2fc6986
-  React-CoreModules: abc8746b32605f56185ae717ae3f0b495555e7cd
-  React-cxxreact: b27afedad262b3795b8e6159d08502914a1d92ed
-  React-debug: a4ea112a115069970382c851e1ac354a16ca3407
-  React-defaultsnativemodule: 126fdaa0eb715399ed0aa711cb99b7ada18df922
-  React-domnativemodule: fb6997c863510267771dba59a6622c88112b7f8d
-  React-Fabric: 242416dca2d51a1da7f408992cbd91aec4942690
-  React-FabricComponents: 53d72e46c374a2e3f35f805f5107f748df7697a0
-  React-FabricImage: dee871f91a383998b11dfc3316b637645b205495
-  React-featureflags: 876e6a0a475c8302c2578e9ccfabf1311d31e43f
-  React-featureflagsnativemodule: d67f70f301dab8c1d6a167ecbc5847ab94ddbdcd
-  React-graphics: e31951d62a49d732fb1ec5240df312a7eaeca1c5
-  React-hermes: af5811d0da319a1c8cf15c8382cbf8e61a8d95d6
-  React-idlecallbacksnativemodule: 5ba27b09fb7bed6ce3c59b102da86aaa84b437e5
-  React-ImageManager: ea3dd89ab916635458ff670085d2d1a9bf394794
-  React-jsc: 9fbb640319f7a0adecf1682d7fc80cbad11158a0
-  React-jserrorhandler: eebcf043f7abba6c75ef7345277492d225163ed4
-  React-jsi: bd5273d25f83f1c4a656872422455c32357f367b
-  React-jsiexecutor: a908f2152653629e80721bef0030ff2c33d614c5
-  React-jsinspector: ed1e3ae3c861b2057cc8fe4d67b6b37081336488
-  React-jsitracing: b7b6dbd037ff3a7b971bb577c7c49fcf4fae162b
-  React-logger: ccab6d41424202fd511faa9a88bec12cadc83dfa
-  React-Mapbuffer: fe84c6dde7dab6dd8658bb18beb932c1b15c993a
-  React-microtasksnativemodule: b96aa3fc27ef864c183605decc24df15258cadfc
+  React: 7b0daf87159fb74a575f17841338575993b16fe7
+  React-callinvoker: 5a814c15bcea3bee56ed553bed0cdd4c6c0909d7
+  React-Core: 801d34f2ae6fab1e7de7430845582cc99b05e7b4
+  React-CoreModules: 0ea5b0070a67846efeebf1b8ca617a35331bad83
+  React-cxxreact: c4d0bb73f052f9bd6e71a41e6fa1ffeda188fce1
+  React-debug: 71a6df9f66e18ed9d54c599abc0891ac6b557a02
+  React-defaultsnativemodule: b91b3db54e0f2adf162765cf6a23206dc5e437e2
+  React-domnativemodule: 76ea09978aa37e072fe89f6f38bd128a3e4282ad
+  React-Fabric: 77eb8316e14a015af3a4b1900a26cbd47dc90085
+  React-FabricComponents: 76dd7d0dc57823375e019b444d79ef607543fe3f
+  React-FabricImage: fff56283b24af6a59c7d37f5cd4a3f838ad21705
+  React-featureflags: bfec0de2042b2e8554e5b8e421093a8309117d5c
+  React-featureflagsnativemodule: 6ee9cf0cf2fea207ce4913cf753592655fa68ca0
+  React-graphics: 6cdd20e7bac68eba69c4186563890f9275ef99b0
+  React-hermes: 0fc678ca4c31c555f311a4178223f0785dc97562
+  React-idlecallbacksnativemodule: f6ed21f7481682da925165dccde6f36a7d286ace
+  React-ImageManager: 5411113b18db62f0bfc6271d4546e5c945a11931
+  React-jsc: 65ca47ef73b263107fd290fe3c8930b133ae2ef7
+  React-jserrorhandler: bd06ea2d7e167ab2c1b9a36fdd3a1d38693c34f1
+  React-jsi: cd024064402b258d0aa779255349ab89993238c3
+  React-jsiexecutor: cd355e620e376f4b9604d68f71e535310ec3c2e9
+  React-jsinspector: 6f829b65c901b559223a6ed2e3340ab49136fa1e
+  React-jsitracing: dc06b7da8c86de529f3384ee15164866a320048f
+  React-logger: dc9eb8395b1341379fe9a4568c45bb7329629ae4
+  React-Mapbuffer: 69f179a8d7323c3bb2e027592390607cafd4cb8f
+  React-microtasksnativemodule: 10f19a8911990eeaa798ef6e35abd6f0015cbbe6
   react-native-maps: 2e6e9896195781327ee15b33e3e84bf73c08207a
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
@@ -3100,33 +3100,33 @@ SPEC CHECKSUMS:
   react-native-skia: c825cb272f6129fe148989eaf662c302d4f60587
   react-native-slider: e1f4b4538f7de7417b626174874f4f58d4cf6c28
   react-native-webview: 06f91954784dde28e1210f381c791f0c5f9bd9a2
-  React-nativeconfig: 38e9f8764eb61e31e11915c950cc97aedddb8736
-  React-NativeModulesApple: 32ae99d8d82da3efb18b96915467e9bc851fd866
-  React-perflogger: 8e26de3ec512cdd60a42a0058227c9c66ea87ee5
-  React-performancetimeline: abbed40b41e81667ca7094f64451861589de5f3e
-  React-RCTActionSheet: 6239d9d694dc8616c483b6bf129018ef21d88237
-  React-RCTAnimation: cafb6fba8338f1b5a86243dc487bb5ec92120c66
-  React-RCTAppDelegate: 82985692b0a56240b60f8186312e3de3d5be16a3
-  React-RCTBlob: 772c1e74f650f0b777845586992b892f552aa73c
-  React-RCTFabric: c5c6f5a611088b9b20f04990c71ca20806e80ed4
-  React-RCTImage: 53817bacd7932786539d9de7e07a2d0af3ebe918
-  React-RCTLinking: e6d6ee9c252074f493182da8d00e17324271f1b9
-  React-RCTNetwork: 58beae8ffa70ccdeed4f0b06fd26d8d90db6e658
-  React-RCTSettings: c62a98a91f269316316803043a42cc67ccbf17fc
-  React-RCTText: 344739a409a7883bd5666d7a8061aa666d46c840
-  React-RCTVibration: aec24eb8c13710f03a029f83b1f52278824d5a5f
-  React-rendererconsistency: ddf5bcdefef149701803b19b1e235b00a92cb43e
-  React-rendererdebug: d6c526a8c3753e7a3422d417e723da2ce55e7ea7
-  React-rncore: 7051b962a908eb640ebcb056805b23155c117c69
-  React-RuntimeApple: 6a88089b15029632c2658e092b377203dda72df3
-  React-RuntimeCore: ed1ff2106abfd1b66419c1e415beb4865aaff67c
-  React-runtimeexecutor: 208d438d0ca7101c1b8cafc46985e9a4321ca36d
-  React-RuntimeHermes: e6cf75963cef945ffb1efde63c2744649ab18c41
-  React-runtimescheduler: 8366a99028799f6fcc34e62b4d4174710976d42a
-  React-timing: 5c8f3f26b39635e9984c98d46c53c16aa10a4792
-  React-utils: 0ab6858c3bdff0219b119b881dcdd12d9b913769
-  ReactCodegen: fd245cb9d473b8cf51225ff0907feafada826e60
-  ReactCommon: 9cb3c46af4f75f0a61e40d24b54f8b848226dadf
+  React-nativeconfig: 04c807a93e08acef39d28736cdcd511f77d1573a
+  React-NativeModulesApple: cf9d53bbdc856ea409ae605f293085e4d1bd4584
+  React-perflogger: f1ccce85fdd94ae925ab7b315b1af8f4b0d9db4e
+  React-performancetimeline: d11db5784449e33aff086b1805e3ded3aa61a5e7
+  React-RCTActionSheet: 2ec40250c009777048731b4b421b54f493889cda
+  React-RCTAnimation: 86c3e5c31ed951e74a5381862d6a49ea493d64e6
+  React-RCTAppDelegate: 349d0236e04b0a02312361cb998708a902672f4e
+  React-RCTBlob: 1e0cc2c326425ca0d0190db55f3e73ed3f54c980
+  React-RCTFabric: cfbbfe5b38ff04a40b73f06fcb71f3b55da0faca
+  React-RCTImage: 075758c75aab89c8964a733177d3a0bd92785a87
+  React-RCTLinking: 966f69ed2f4a058829374d8dcc961ae193b4eff8
+  React-RCTNetwork: 62b1268ae7596c73a43d64a8e6e8e5da19666c78
+  React-RCTSettings: 5a1d1b1b1e991e660c44f383e2a1d10a99a190e1
+  React-RCTText: 76e1681e483b3d03f673076f27b1c8711f8a0537
+  React-RCTVibration: 02eac793150fcbf849232c232a1ca8ca362525fd
+  React-rendererconsistency: e5636962d7e86df51f57b5cc7cc681b1544e7385
+  React-rendererdebug: 83762d7627dbb1c735b7ef9853b726bcb939cdf6
+  React-rncore: 2765a9b04a9ef1cd28a56528783c9644ecde8a33
+  React-RuntimeApple: fee4dca6f9b2a0a879bbdcffcb1adce8b4eb2499
+  React-RuntimeCore: 08c53b33fa43a9ef689c5d2f8f47c7c22389420c
+  React-runtimeexecutor: 2d27e8c9dc9272a13ff61bb162440e21fe9d5a82
+  React-RuntimeHermes: d81c1857d13097bea77f654046f5f40d102414a5
+  React-runtimescheduler: 4814c52f8009cd3031ff8b29eda80569a529c493
+  React-timing: 3978fc03d275858cc95e69b9adbea5b05d48ecf8
+  React-utils: 7d83759a29992a76a3cc324948ef6d86415bc44e
+  ReactCodegen: 55951cf73f041f6db2a2b1e04c00f8ccb0900e7b
+  ReactCommon: eaf4f987f18bba1f4ec674e2ed95b706e1559cd1
   RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 6ad936eee086dbe2aeb658994021770b46897d62
@@ -3151,7 +3151,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: c24f990b03a68a7f6fe704b15dd487e7bb6b603e
   StripeUICore: f2d514e900c37436dc5427fdf2c29d68ab1c2935
   UMAppLoader: c34fd315863887c7961e059efd9475e056bdd72d
-  Yoga: faaab08e21d56d9b7d5225d64fa23cdf72af2f74
+  Yoga: d27fe77b40d16ce8a8936a48c401f33ca4e15265
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: a55dff50a80accf78a8db0aa86be957c63fdfc01

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -13,7 +13,10 @@
   "author": "Expo",
   "license": "MIT",
   "jest": {
-    "preset": "jest-expo/ios"
+    "preset": "jest-expo/ios",
+    "modulePathIgnorePatterns": [
+      "./ios/Pods"
+    ]
   },
   "dependencies": {
     "@apollo/client": "^3.4.10",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -63,7 +63,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "18.2.0",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/apps/fabric-tester/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/fabric-tester/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -113,12 +113,12 @@ PODS:
     - Yoga
   - EXUpdatesInterface (0.16.2):
     - ExpoModulesCore
-  - FBLazyVector (0.76.0-rc.4)
+  - FBLazyVector (0.76.0-rc.5)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.76.0-rc.4):
-    - hermes-engine/Pre-built (= 0.76.0-rc.4)
-  - hermes-engine/Pre-built (0.76.0-rc.4)
+  - hermes-engine (0.76.0-rc.5):
+    - hermes-engine/Pre-built (= 0.76.0-rc.5)
+  - hermes-engine/Pre-built (0.76.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -140,33 +140,33 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.76.0-rc.4)
-  - RCTRequired (0.76.0-rc.4)
-  - RCTTypeSafety (0.76.0-rc.4):
-    - FBLazyVector (= 0.76.0-rc.4)
-    - RCTRequired (= 0.76.0-rc.4)
-    - React-Core (= 0.76.0-rc.4)
+  - RCTDeprecation (0.76.0-rc.5)
+  - RCTRequired (0.76.0-rc.5)
+  - RCTTypeSafety (0.76.0-rc.5):
+    - FBLazyVector (= 0.76.0-rc.5)
+    - RCTRequired (= 0.76.0-rc.5)
+    - React-Core (= 0.76.0-rc.5)
   - ReachabilitySwift (5.2.2)
-  - React (0.76.0-rc.4):
-    - React-Core (= 0.76.0-rc.4)
-    - React-Core/DevSupport (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-RCTActionSheet (= 0.76.0-rc.4)
-    - React-RCTAnimation (= 0.76.0-rc.4)
-    - React-RCTBlob (= 0.76.0-rc.4)
-    - React-RCTImage (= 0.76.0-rc.4)
-    - React-RCTLinking (= 0.76.0-rc.4)
-    - React-RCTNetwork (= 0.76.0-rc.4)
-    - React-RCTSettings (= 0.76.0-rc.4)
-    - React-RCTText (= 0.76.0-rc.4)
-    - React-RCTVibration (= 0.76.0-rc.4)
-  - React-callinvoker (0.76.0-rc.4)
-  - React-Core (0.76.0-rc.4):
+  - React (0.76.0-rc.5):
+    - React-Core (= 0.76.0-rc.5)
+    - React-Core/DevSupport (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-RCTActionSheet (= 0.76.0-rc.5)
+    - React-RCTAnimation (= 0.76.0-rc.5)
+    - React-RCTBlob (= 0.76.0-rc.5)
+    - React-RCTImage (= 0.76.0-rc.5)
+    - React-RCTLinking (= 0.76.0-rc.5)
+    - React-RCTNetwork (= 0.76.0-rc.5)
+    - React-RCTSettings (= 0.76.0-rc.5)
+    - React-RCTText (= 0.76.0-rc.5)
+    - React-RCTVibration (= 0.76.0-rc.5)
+  - React-callinvoker (0.76.0-rc.5)
+  - React-Core (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default (= 0.76.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -178,58 +178,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.76.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -246,7 +195,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.76.0-rc.4):
+  - React-Core/Default (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -263,7 +246,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.76.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -280,7 +263,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.76.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -297,7 +280,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.76.0-rc.4):
+  - React-Core/RCTImageHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -314,7 +297,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.76.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -331,7 +314,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.76.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -348,7 +331,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.76.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -365,7 +348,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.76.0-rc.4):
+  - React-Core/RCTTextHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -382,12 +365,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.76.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -399,37 +382,54 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.76.0-rc.4):
+  - React-Core/RCTWebSocket (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.76.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - RCTTypeSafety (= 0.76.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.76.0-rc.4)
+    - React-RCTImage (= 0.76.0-rc.5)
     - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.76.0-rc.4):
+  - React-cxxreact (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-    - React-timing (= 0.76.0-rc.4)
-  - React-debug (0.76.0-rc.4)
-  - React-defaultsnativemodule (0.76.0-rc.4):
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+    - React-timing (= 0.76.0-rc.5)
+  - React-debug (0.76.0-rc.5)
+  - React-defaultsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -454,7 +454,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-domnativemodule (0.76.0-rc.4):
+  - React-domnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -476,7 +476,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.76.0-rc.4):
+  - React-Fabric (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -487,21 +487,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.76.0-rc.4)
-    - React-Fabric/attributedstring (= 0.76.0-rc.4)
-    - React-Fabric/componentregistry (= 0.76.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.76.0-rc.4)
-    - React-Fabric/components (= 0.76.0-rc.4)
-    - React-Fabric/core (= 0.76.0-rc.4)
-    - React-Fabric/dom (= 0.76.0-rc.4)
-    - React-Fabric/imagemanager (= 0.76.0-rc.4)
-    - React-Fabric/leakchecker (= 0.76.0-rc.4)
-    - React-Fabric/mounting (= 0.76.0-rc.4)
-    - React-Fabric/observers (= 0.76.0-rc.4)
-    - React-Fabric/scheduler (= 0.76.0-rc.4)
-    - React-Fabric/telemetry (= 0.76.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.76.0-rc.4)
-    - React-Fabric/uimanager (= 0.76.0-rc.4)
+    - React-Fabric/animations (= 0.76.0-rc.5)
+    - React-Fabric/attributedstring (= 0.76.0-rc.5)
+    - React-Fabric/componentregistry (= 0.76.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.76.0-rc.5)
+    - React-Fabric/components (= 0.76.0-rc.5)
+    - React-Fabric/core (= 0.76.0-rc.5)
+    - React-Fabric/dom (= 0.76.0-rc.5)
+    - React-Fabric/imagemanager (= 0.76.0-rc.5)
+    - React-Fabric/leakchecker (= 0.76.0-rc.5)
+    - React-Fabric/mounting (= 0.76.0-rc.5)
+    - React-Fabric/observers (= 0.76.0-rc.5)
+    - React-Fabric/scheduler (= 0.76.0-rc.5)
+    - React-Fabric/telemetry (= 0.76.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.76.0-rc.5)
+    - React-Fabric/uimanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -511,27 +511,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.76.0-rc.4):
+  - React-Fabric/animations (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -551,7 +531,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.76.0-rc.4):
+  - React-Fabric/attributedstring (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -571,7 +551,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.76.0-rc.4):
+  - React-Fabric/componentregistry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -591,30 +571,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.4)
-    - React-Fabric/components/root (= 0.76.0-rc.4)
-    - React-Fabric/components/view (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.4):
+  - React-Fabric/componentregistrynative (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -634,7 +591,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.76.0-rc.4):
+  - React-Fabric/components (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.5)
+    - React-Fabric/components/root (= 0.76.0-rc.5)
+    - React-Fabric/components/view (= 0.76.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -654,7 +634,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.76.0-rc.4):
+  - React-Fabric/components/root (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -675,7 +675,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.76.0-rc.4):
+  - React-Fabric/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -695,7 +695,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.76.0-rc.4):
+  - React-Fabric/dom (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -715,7 +715,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.76.0-rc.4):
+  - React-Fabric/imagemanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -735,7 +735,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.76.0-rc.4):
+  - React-Fabric/leakchecker (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -755,7 +755,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.76.0-rc.4):
+  - React-Fabric/mounting (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -775,7 +775,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.76.0-rc.4):
+  - React-Fabric/observers (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -786,7 +786,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.76.0-rc.4)
+    - React-Fabric/observers/events (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -796,7 +796,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.76.0-rc.4):
+  - React-Fabric/observers/events (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -816,7 +816,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.76.0-rc.4):
+  - React-Fabric/scheduler (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -838,7 +838,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.76.0-rc.4):
+  - React-Fabric/telemetry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -858,7 +858,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.76.0-rc.4):
+  - React-Fabric/templateprocessor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -878,7 +878,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.76.0-rc.4):
+  - React-Fabric/uimanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -889,28 +889,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -921,7 +900,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.76.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -933,8 +933,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.76.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.4)
+    - React-FabricComponents/components (= 0.76.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -946,7 +946,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.76.0-rc.4):
+  - React-FabricComponents/components (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -958,15 +958,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.76.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.76.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/text (= 0.76.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.76.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.76.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/text (= 0.76.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -978,53 +978,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.76.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1047,7 +1001,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.76.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1070,7 +1024,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.76.0-rc.4):
+  - React-FabricComponents/components/modal (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1093,7 +1047,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.76.0-rc.4):
+  - React-FabricComponents/components/rncore (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1116,7 +1070,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.76.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1139,7 +1093,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.76.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1162,7 +1116,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.76.0-rc.4):
+  - React-FabricComponents/components/text (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1185,7 +1139,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.76.0-rc.4):
+  - React-FabricComponents/components/textinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1208,26 +1162,72 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.76.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.76.0-rc.4)
-    - RCTTypeSafety (= 0.76.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.76.0-rc.5)
+    - RCTTypeSafety (= 0.76.0-rc.5)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.76.0-rc.4)
-  - React-featureflagsnativemodule (0.76.0-rc.4):
+  - React-featureflags (0.76.0-rc.5)
+  - React-featureflagsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1248,7 +1248,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-graphics (0.76.0-rc.4):
+  - React-graphics (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1256,19 +1256,19 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.76.0-rc.4):
+  - React-hermes (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
+    - React-perflogger (= 0.76.0-rc.5)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.76.0-rc.4):
+  - React-idlecallbacksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1290,7 +1290,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-ImageManager (0.76.0-rc.4):
+  - React-ImageManager (0.76.0-rc.5):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1299,47 +1299,47 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.76.0-rc.4):
+  - React-jserrorhandler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-cxxreact
     - React-debug
     - React-jsi
-  - React-jsi (0.76.0-rc.4):
+  - React-jsi (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.76.0-rc.4):
+  - React-jsiexecutor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
-  - React-jsinspector (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+  - React-jsinspector (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-  - React-jsitracing (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+  - React-jsitracing (0.76.0-rc.5):
     - React-jsi
-  - React-logger (0.76.0-rc.4):
+  - React-logger (0.76.0-rc.5):
     - glog
-  - React-Mapbuffer (0.76.0-rc.4):
+  - React-Mapbuffer (0.76.0-rc.5):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.76.0-rc.4):
+  - React-microtasksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1360,8 +1360,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-nativeconfig (0.76.0-rc.4)
-  - React-NativeModulesApple (0.76.0-rc.4):
+  - React-nativeconfig (0.76.0-rc.5)
+  - React-NativeModulesApple (0.76.0-rc.5):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1372,16 +1372,16 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.76.0-rc.4):
+  - React-perflogger (0.76.0-rc.5):
     - DoubleConversion
     - RCT-Folly (= 2024.01.01.00)
-  - React-performancetimeline (0.76.0-rc.4):
+  - React-performancetimeline (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
     - React-timing
-  - React-RCTActionSheet (0.76.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.4)
-  - React-RCTAnimation (0.76.0-rc.4):
+  - React-RCTActionSheet (0.76.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.5)
+  - React-RCTAnimation (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1389,7 +1389,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTAppDelegate (0.76.0-rc.4):
+  - React-RCTAppDelegate (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1414,7 +1414,7 @@ PODS:
     - React-utils
     - ReactCodegen
     - ReactCommon
-  - React-RCTBlob (0.76.0-rc.4):
+  - React-RCTBlob (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1427,7 +1427,7 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTFabric (0.76.0-rc.4):
+  - React-RCTFabric (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1450,7 +1450,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.76.0-rc.4):
+  - React-RCTImage (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1459,14 +1459,14 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTLinking (0.76.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+  - React-RCTLinking (0.76.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - React-RCTNetwork (0.76.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - React-RCTNetwork (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1474,7 +1474,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTSettings (0.76.0-rc.4):
+  - React-RCTSettings (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1482,24 +1482,24 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTText (0.76.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.76.0-rc.4)
+  - React-RCTText (0.76.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.76.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.76.0-rc.4):
+  - React-RCTVibration (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-rendererconsistency (0.76.0-rc.4)
-  - React-rendererdebug (0.76.0-rc.4):
+  - React-rendererconsistency (0.76.0-rc.5)
+  - React-rendererdebug (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.76.0-rc.4)
-  - React-RuntimeApple (0.76.0-rc.4):
+  - React-rncore (0.76.0-rc.5)
+  - React-RuntimeApple (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1518,7 +1518,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.76.0-rc.4):
+  - React-RuntimeCore (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1532,9 +1532,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.76.0-rc.4):
-    - React-jsi (= 0.76.0-rc.4)
-  - React-RuntimeHermes (0.76.0-rc.4):
+  - React-runtimeexecutor (0.76.0-rc.5):
+    - React-jsi (= 0.76.0-rc.5)
+  - React-RuntimeHermes (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1545,7 +1545,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.76.0-rc.4):
+  - React-runtimescheduler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1560,14 +1560,14 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.76.0-rc.4)
-  - React-utils (0.76.0-rc.4):
+  - React-timing (0.76.0-rc.5)
+  - React-utils (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.76.0-rc.4)
-  - ReactCodegen (0.76.0-rc.4):
+    - React-jsi (= 0.76.0-rc.5)
+  - ReactCodegen (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1587,46 +1587,46 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.76.0-rc.4):
-    - ReactCommon/turbomodule (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule (0.76.0-rc.4):
+  - ReactCommon (0.76.0-rc.5):
+    - ReactCommon/turbomodule (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/bridging (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/bridging (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/core (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-featureflags (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-utils (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-featureflags (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-utils (= 0.76.0-rc.5)
   - SDWebImage (5.19.1):
     - SDWebImage/Core (= 5.19.1)
   - SDWebImage/Core (5.19.1)
@@ -1937,74 +1937,74 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: 404356f2621ca76fd54e8c5c686091d0fa00cbc7
   EXUpdates: 992e73bb96f83c8ed958949bb2475c883a3119ae
   EXUpdatesInterface: 8d16d1242225d0bdb4d8db788349b522aa8e0343
-  FBLazyVector: 20c5e40f776552291d12ea1f6cb14568aeccec92
+  FBLazyVector: de8eedeaa44513602f4e9c94b3547c3c43af0d40
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
-  hermes-engine: 367546049df3ab3b58c9b07dab01e9c7c5640728
+  hermes-engine: 83913a9bc12277c53ef984c8589efdfa3b68ca50
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
-  RCTDeprecation: ea1525e5eda35bb079a7ac260551c5e0468f9ee3
-  RCTRequired: c78ef50a39a3c8060e546760c46148d9abee6388
-  RCTTypeSafety: 1841770b2ab4e4325bfe2a6b5ddca520b3e6c40d
+  RCTDeprecation: 4192491a84930e9a001406df7eb570be2ec7320e
+  RCTRequired: b4fad98533fbfd85dd911f6bfecff1b08d19d87a
+  RCTTypeSafety: 09d6104052cd7e0afa56d58b21efa5e12c593a66
   ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
-  React: 0d0b01ad72a7d78942ecca7efef21261a95b571e
-  React-callinvoker: dfffa5cbc328b8c6c50a1175d0949a2625bc16d1
-  React-Core: d191ffc6bc41418035bb194dca150e45e5d1ac99
-  React-CoreModules: abc8746b32605f56185ae717ae3f0b495555e7cd
-  React-cxxreact: b27afedad262b3795b8e6159d08502914a1d92ed
-  React-debug: a4ea112a115069970382c851e1ac354a16ca3407
-  React-defaultsnativemodule: 126fdaa0eb715399ed0aa711cb99b7ada18df922
-  React-domnativemodule: fb6997c863510267771dba59a6622c88112b7f8d
-  React-Fabric: 242416dca2d51a1da7f408992cbd91aec4942690
-  React-FabricComponents: 53d72e46c374a2e3f35f805f5107f748df7697a0
-  React-FabricImage: dee871f91a383998b11dfc3316b637645b205495
-  React-featureflags: 876e6a0a475c8302c2578e9ccfabf1311d31e43f
-  React-featureflagsnativemodule: d67f70f301dab8c1d6a167ecbc5847ab94ddbdcd
-  React-graphics: e31951d62a49d732fb1ec5240df312a7eaeca1c5
-  React-hermes: af5811d0da319a1c8cf15c8382cbf8e61a8d95d6
-  React-idlecallbacksnativemodule: 5ba27b09fb7bed6ce3c59b102da86aaa84b437e5
-  React-ImageManager: ea3dd89ab916635458ff670085d2d1a9bf394794
-  React-jserrorhandler: eebcf043f7abba6c75ef7345277492d225163ed4
-  React-jsi: bd5273d25f83f1c4a656872422455c32357f367b
-  React-jsiexecutor: a908f2152653629e80721bef0030ff2c33d614c5
-  React-jsinspector: ed1e3ae3c861b2057cc8fe4d67b6b37081336488
-  React-jsitracing: b7b6dbd037ff3a7b971bb577c7c49fcf4fae162b
-  React-logger: ccab6d41424202fd511faa9a88bec12cadc83dfa
-  React-Mapbuffer: fe84c6dde7dab6dd8658bb18beb932c1b15c993a
-  React-microtasksnativemodule: b96aa3fc27ef864c183605decc24df15258cadfc
-  React-nativeconfig: 38e9f8764eb61e31e11915c950cc97aedddb8736
-  React-NativeModulesApple: 32ae99d8d82da3efb18b96915467e9bc851fd866
-  React-perflogger: 8e26de3ec512cdd60a42a0058227c9c66ea87ee5
-  React-performancetimeline: abbed40b41e81667ca7094f64451861589de5f3e
-  React-RCTActionSheet: 6239d9d694dc8616c483b6bf129018ef21d88237
-  React-RCTAnimation: cafb6fba8338f1b5a86243dc487bb5ec92120c66
-  React-RCTAppDelegate: 82985692b0a56240b60f8186312e3de3d5be16a3
-  React-RCTBlob: 772c1e74f650f0b777845586992b892f552aa73c
-  React-RCTFabric: c5c6f5a611088b9b20f04990c71ca20806e80ed4
-  React-RCTImage: 53817bacd7932786539d9de7e07a2d0af3ebe918
-  React-RCTLinking: e6d6ee9c252074f493182da8d00e17324271f1b9
-  React-RCTNetwork: 58beae8ffa70ccdeed4f0b06fd26d8d90db6e658
-  React-RCTSettings: c62a98a91f269316316803043a42cc67ccbf17fc
-  React-RCTText: 344739a409a7883bd5666d7a8061aa666d46c840
-  React-RCTVibration: aec24eb8c13710f03a029f83b1f52278824d5a5f
-  React-rendererconsistency: ddf5bcdefef149701803b19b1e235b00a92cb43e
-  React-rendererdebug: d6c526a8c3753e7a3422d417e723da2ce55e7ea7
-  React-rncore: 7051b962a908eb640ebcb056805b23155c117c69
-  React-RuntimeApple: 6a88089b15029632c2658e092b377203dda72df3
-  React-RuntimeCore: ed1ff2106abfd1b66419c1e415beb4865aaff67c
-  React-runtimeexecutor: 208d438d0ca7101c1b8cafc46985e9a4321ca36d
-  React-RuntimeHermes: e6cf75963cef945ffb1efde63c2744649ab18c41
-  React-runtimescheduler: 8366a99028799f6fcc34e62b4d4174710976d42a
-  React-timing: 5c8f3f26b39635e9984c98d46c53c16aa10a4792
-  React-utils: 0ab6858c3bdff0219b119b881dcdd12d9b913769
-  ReactCodegen: 47dc7be065f718f0378e5a78499b6aeb98c85b49
-  ReactCommon: 9cb3c46af4f75f0a61e40d24b54f8b848226dadf
+  React: 7b0daf87159fb74a575f17841338575993b16fe7
+  React-callinvoker: 5a814c15bcea3bee56ed553bed0cdd4c6c0909d7
+  React-Core: 1b63f346b0c0ef34ac186cfa5dd5f2417e365dc8
+  React-CoreModules: 0ea5b0070a67846efeebf1b8ca617a35331bad83
+  React-cxxreact: c4d0bb73f052f9bd6e71a41e6fa1ffeda188fce1
+  React-debug: 71a6df9f66e18ed9d54c599abc0891ac6b557a02
+  React-defaultsnativemodule: b91b3db54e0f2adf162765cf6a23206dc5e437e2
+  React-domnativemodule: 76ea09978aa37e072fe89f6f38bd128a3e4282ad
+  React-Fabric: 77eb8316e14a015af3a4b1900a26cbd47dc90085
+  React-FabricComponents: 76dd7d0dc57823375e019b444d79ef607543fe3f
+  React-FabricImage: fff56283b24af6a59c7d37f5cd4a3f838ad21705
+  React-featureflags: bfec0de2042b2e8554e5b8e421093a8309117d5c
+  React-featureflagsnativemodule: 6ee9cf0cf2fea207ce4913cf753592655fa68ca0
+  React-graphics: 6cdd20e7bac68eba69c4186563890f9275ef99b0
+  React-hermes: 0fc678ca4c31c555f311a4178223f0785dc97562
+  React-idlecallbacksnativemodule: f6ed21f7481682da925165dccde6f36a7d286ace
+  React-ImageManager: 5411113b18db62f0bfc6271d4546e5c945a11931
+  React-jserrorhandler: bd06ea2d7e167ab2c1b9a36fdd3a1d38693c34f1
+  React-jsi: cd024064402b258d0aa779255349ab89993238c3
+  React-jsiexecutor: cd355e620e376f4b9604d68f71e535310ec3c2e9
+  React-jsinspector: 6f829b65c901b559223a6ed2e3340ab49136fa1e
+  React-jsitracing: dc06b7da8c86de529f3384ee15164866a320048f
+  React-logger: dc9eb8395b1341379fe9a4568c45bb7329629ae4
+  React-Mapbuffer: 69f179a8d7323c3bb2e027592390607cafd4cb8f
+  React-microtasksnativemodule: 10f19a8911990eeaa798ef6e35abd6f0015cbbe6
+  React-nativeconfig: 04c807a93e08acef39d28736cdcd511f77d1573a
+  React-NativeModulesApple: cf9d53bbdc856ea409ae605f293085e4d1bd4584
+  React-perflogger: f1ccce85fdd94ae925ab7b315b1af8f4b0d9db4e
+  React-performancetimeline: d11db5784449e33aff086b1805e3ded3aa61a5e7
+  React-RCTActionSheet: 2ec40250c009777048731b4b421b54f493889cda
+  React-RCTAnimation: 86c3e5c31ed951e74a5381862d6a49ea493d64e6
+  React-RCTAppDelegate: 349d0236e04b0a02312361cb998708a902672f4e
+  React-RCTBlob: 1e0cc2c326425ca0d0190db55f3e73ed3f54c980
+  React-RCTFabric: cfbbfe5b38ff04a40b73f06fcb71f3b55da0faca
+  React-RCTImage: 075758c75aab89c8964a733177d3a0bd92785a87
+  React-RCTLinking: 966f69ed2f4a058829374d8dcc961ae193b4eff8
+  React-RCTNetwork: 62b1268ae7596c73a43d64a8e6e8e5da19666c78
+  React-RCTSettings: 5a1d1b1b1e991e660c44f383e2a1d10a99a190e1
+  React-RCTText: 76e1681e483b3d03f673076f27b1c8711f8a0537
+  React-RCTVibration: 02eac793150fcbf849232c232a1ca8ca362525fd
+  React-rendererconsistency: e5636962d7e86df51f57b5cc7cc681b1544e7385
+  React-rendererdebug: 83762d7627dbb1c735b7ef9853b726bcb939cdf6
+  React-rncore: 2765a9b04a9ef1cd28a56528783c9644ecde8a33
+  React-RuntimeApple: fee4dca6f9b2a0a879bbdcffcb1adce8b4eb2499
+  React-RuntimeCore: 08c53b33fa43a9ef689c5d2f8f47c7c22389420c
+  React-runtimeexecutor: 2d27e8c9dc9272a13ff61bb162440e21fe9d5a82
+  React-RuntimeHermes: d81c1857d13097bea77f654046f5f40d102414a5
+  React-runtimescheduler: 4814c52f8009cd3031ff8b29eda80569a529c493
+  React-timing: 3978fc03d275858cc95e69b9adbea5b05d48ecf8
+  React-utils: 7d83759a29992a76a3cc324948ef6d86415bc44e
+  ReactCodegen: fc371ec636a81cdcbd13d8e8328064a8d1d88a64
+  ReactCommon: eaf4f987f18bba1f4ec674e2ed95b706e1559cd1
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: faaab08e21d56d9b7d5225d64fa23cdf72af2f74
+  Yoga: d27fe77b40d16ce8a8936a48c401f33ca4e15265
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 69838eb56567a89dd6f23695b5e8145f838df60d

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -22,7 +22,7 @@
     "expo-updates": "~0.25.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~51.0.0",
     "expo-clipboard": "~6.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -134,7 +134,7 @@
     "processing-js": "^1.6.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-maps": "1.18.0",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -436,12 +436,12 @@ PODS:
     - Yoga
   - EXUpdatesInterface (0.16.2):
     - ExpoModulesCore
-  - FBLazyVector (0.76.0-rc.4)
+  - FBLazyVector (0.76.0-rc.5)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.76.0-rc.4):
-    - hermes-engine/Pre-built (= 0.76.0-rc.4)
-  - hermes-engine/Pre-built (0.76.0-rc.4)
+  - hermes-engine (0.76.0-rc.5):
+    - hermes-engine/Pre-built (= 0.76.0-rc.5)
+  - hermes-engine/Pre-built (0.76.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -478,33 +478,33 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.76.0-rc.4)
-  - RCTRequired (0.76.0-rc.4)
-  - RCTTypeSafety (0.76.0-rc.4):
-    - FBLazyVector (= 0.76.0-rc.4)
-    - RCTRequired (= 0.76.0-rc.4)
-    - React-Core (= 0.76.0-rc.4)
+  - RCTDeprecation (0.76.0-rc.5)
+  - RCTRequired (0.76.0-rc.5)
+  - RCTTypeSafety (0.76.0-rc.5):
+    - FBLazyVector (= 0.76.0-rc.5)
+    - RCTRequired (= 0.76.0-rc.5)
+    - React-Core (= 0.76.0-rc.5)
   - ReachabilitySwift (5.0.0)
-  - React (0.76.0-rc.4):
-    - React-Core (= 0.76.0-rc.4)
-    - React-Core/DevSupport (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-RCTActionSheet (= 0.76.0-rc.4)
-    - React-RCTAnimation (= 0.76.0-rc.4)
-    - React-RCTBlob (= 0.76.0-rc.4)
-    - React-RCTImage (= 0.76.0-rc.4)
-    - React-RCTLinking (= 0.76.0-rc.4)
-    - React-RCTNetwork (= 0.76.0-rc.4)
-    - React-RCTSettings (= 0.76.0-rc.4)
-    - React-RCTText (= 0.76.0-rc.4)
-    - React-RCTVibration (= 0.76.0-rc.4)
-  - React-callinvoker (0.76.0-rc.4)
-  - React-Core (0.76.0-rc.4):
+  - React (0.76.0-rc.5):
+    - React-Core (= 0.76.0-rc.5)
+    - React-Core/DevSupport (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-RCTActionSheet (= 0.76.0-rc.5)
+    - React-RCTAnimation (= 0.76.0-rc.5)
+    - React-RCTBlob (= 0.76.0-rc.5)
+    - React-RCTImage (= 0.76.0-rc.5)
+    - React-RCTLinking (= 0.76.0-rc.5)
+    - React-RCTNetwork (= 0.76.0-rc.5)
+    - React-RCTSettings (= 0.76.0-rc.5)
+    - React-RCTText (= 0.76.0-rc.5)
+    - React-RCTVibration (= 0.76.0-rc.5)
+  - React-callinvoker (0.76.0-rc.5)
+  - React-Core (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default (= 0.76.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -516,58 +516,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.76.0-rc.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.76.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.76.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -584,7 +533,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.76.0-rc.4):
+  - React-Core/Default (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -601,7 +584,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.76.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -618,7 +601,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.76.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -635,7 +618,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.76.0-rc.4):
+  - React-Core/RCTImageHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -652,7 +635,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.76.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -669,7 +652,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.76.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -686,7 +669,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.76.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -703,7 +686,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.76.0-rc.4):
+  - React-Core/RCTTextHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -720,12 +703,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.76.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.76.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -737,37 +720,54 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.76.0-rc.4):
+  - React-Core/RCTWebSocket (0.76.0-rc.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.76.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.76.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - RCTTypeSafety (= 0.76.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.76.0-rc.4)
+    - React-RCTImage (= 0.76.0-rc.5)
     - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.76.0-rc.4):
+  - React-cxxreact (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-    - React-timing (= 0.76.0-rc.4)
-  - React-debug (0.76.0-rc.4)
-  - React-defaultsnativemodule (0.76.0-rc.4):
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+    - React-timing (= 0.76.0-rc.5)
+  - React-debug (0.76.0-rc.5)
+  - React-defaultsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -792,7 +792,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-domnativemodule (0.76.0-rc.4):
+  - React-domnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -814,7 +814,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.76.0-rc.4):
+  - React-Fabric (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -825,21 +825,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.76.0-rc.4)
-    - React-Fabric/attributedstring (= 0.76.0-rc.4)
-    - React-Fabric/componentregistry (= 0.76.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.76.0-rc.4)
-    - React-Fabric/components (= 0.76.0-rc.4)
-    - React-Fabric/core (= 0.76.0-rc.4)
-    - React-Fabric/dom (= 0.76.0-rc.4)
-    - React-Fabric/imagemanager (= 0.76.0-rc.4)
-    - React-Fabric/leakchecker (= 0.76.0-rc.4)
-    - React-Fabric/mounting (= 0.76.0-rc.4)
-    - React-Fabric/observers (= 0.76.0-rc.4)
-    - React-Fabric/scheduler (= 0.76.0-rc.4)
-    - React-Fabric/telemetry (= 0.76.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.76.0-rc.4)
-    - React-Fabric/uimanager (= 0.76.0-rc.4)
+    - React-Fabric/animations (= 0.76.0-rc.5)
+    - React-Fabric/attributedstring (= 0.76.0-rc.5)
+    - React-Fabric/componentregistry (= 0.76.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.76.0-rc.5)
+    - React-Fabric/components (= 0.76.0-rc.5)
+    - React-Fabric/core (= 0.76.0-rc.5)
+    - React-Fabric/dom (= 0.76.0-rc.5)
+    - React-Fabric/imagemanager (= 0.76.0-rc.5)
+    - React-Fabric/leakchecker (= 0.76.0-rc.5)
+    - React-Fabric/mounting (= 0.76.0-rc.5)
+    - React-Fabric/observers (= 0.76.0-rc.5)
+    - React-Fabric/scheduler (= 0.76.0-rc.5)
+    - React-Fabric/telemetry (= 0.76.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.76.0-rc.5)
+    - React-Fabric/uimanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -849,27 +849,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.76.0-rc.4):
+  - React-Fabric/animations (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -889,7 +869,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.76.0-rc.4):
+  - React-Fabric/attributedstring (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -909,7 +889,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.76.0-rc.4):
+  - React-Fabric/componentregistry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -929,30 +909,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.4)
-    - React-Fabric/components/root (= 0.76.0-rc.4)
-    - React-Fabric/components/view (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.4):
+  - React-Fabric/componentregistrynative (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -972,7 +929,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.76.0-rc.4):
+  - React-Fabric/components (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.76.0-rc.5)
+    - React-Fabric/components/root (= 0.76.0-rc.5)
+    - React-Fabric/components/view (= 0.76.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -992,7 +972,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.76.0-rc.4):
+  - React-Fabric/components/root (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1013,7 +1013,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.76.0-rc.4):
+  - React-Fabric/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1033,7 +1033,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.76.0-rc.4):
+  - React-Fabric/dom (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1053,7 +1053,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.76.0-rc.4):
+  - React-Fabric/imagemanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1073,7 +1073,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.76.0-rc.4):
+  - React-Fabric/leakchecker (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1093,7 +1093,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.76.0-rc.4):
+  - React-Fabric/mounting (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1113,7 +1113,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.76.0-rc.4):
+  - React-Fabric/observers (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1124,7 +1124,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.76.0-rc.4)
+    - React-Fabric/observers/events (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1134,7 +1134,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.76.0-rc.4):
+  - React-Fabric/observers/events (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1154,7 +1154,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.76.0-rc.4):
+  - React-Fabric/scheduler (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1176,7 +1176,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.76.0-rc.4):
+  - React-Fabric/telemetry (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1196,7 +1196,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.76.0-rc.4):
+  - React-Fabric/templateprocessor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1216,7 +1216,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.76.0-rc.4):
+  - React-Fabric/uimanager (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1227,28 +1227,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.76.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1259,7 +1238,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.76.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1271,8 +1271,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.76.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.4)
+    - React-FabricComponents/components (= 0.76.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1284,7 +1284,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.76.0-rc.4):
+  - React-FabricComponents/components (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1296,15 +1296,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.76.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.76.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.76.0-rc.4)
-    - React-FabricComponents/components/text (= 0.76.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.76.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.76.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.76.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.76.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.76.0-rc.5)
+    - React-FabricComponents/components/text (= 0.76.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.76.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.76.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1316,53 +1316,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.76.0-rc.4):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.76.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1385,7 +1339,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.76.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1408,7 +1362,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.76.0-rc.4):
+  - React-FabricComponents/components/modal (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1431,7 +1385,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.76.0-rc.4):
+  - React-FabricComponents/components/rncore (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1454,7 +1408,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.76.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1477,7 +1431,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.76.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1500,7 +1454,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.76.0-rc.4):
+  - React-FabricComponents/components/text (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1523,7 +1477,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.76.0-rc.4):
+  - React-FabricComponents/components/textinput (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1546,26 +1500,72 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.76.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.76.0-rc.4)
-    - RCTTypeSafety (= 0.76.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.76.0-rc.5):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.76.0-rc.5)
+    - RCTTypeSafety (= 0.76.0-rc.5)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.76.0-rc.4)
-  - React-featureflagsnativemodule (0.76.0-rc.4):
+  - React-featureflags (0.76.0-rc.5)
+  - React-featureflagsnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1586,7 +1586,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-graphics (0.76.0-rc.4):
+  - React-graphics (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1594,19 +1594,19 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.76.0-rc.4):
+  - React-hermes (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.76.0-rc.4)
+    - React-jsiexecutor (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
+    - React-perflogger (= 0.76.0-rc.5)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.76.0-rc.4):
+  - React-idlecallbacksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1628,7 +1628,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-ImageManager (0.76.0-rc.4):
+  - React-ImageManager (0.76.0-rc.5):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1637,47 +1637,47 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.76.0-rc.4):
+  - React-jserrorhandler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-cxxreact
     - React-debug
     - React-jsi
-  - React-jsi (0.76.0-rc.4):
+  - React-jsi (0.76.0-rc.5):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.76.0-rc.4):
+  - React-jsiexecutor (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-jsinspector
-    - React-perflogger (= 0.76.0-rc.4)
-  - React-jsinspector (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+  - React-jsinspector (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-runtimeexecutor (= 0.76.0-rc.4)
-  - React-jsitracing (0.76.0-rc.4):
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-runtimeexecutor (= 0.76.0-rc.5)
+  - React-jsitracing (0.76.0-rc.5):
     - React-jsi
-  - React-logger (0.76.0-rc.4):
+  - React-logger (0.76.0-rc.5):
     - glog
-  - React-Mapbuffer (0.76.0-rc.4):
+  - React-Mapbuffer (0.76.0-rc.5):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.76.0-rc.4):
+  - React-microtasksnativemodule (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1698,8 +1698,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-nativeconfig (0.76.0-rc.4)
-  - React-NativeModulesApple (0.76.0-rc.4):
+  - React-nativeconfig (0.76.0-rc.5)
+  - React-NativeModulesApple (0.76.0-rc.5):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1710,16 +1710,16 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.76.0-rc.4):
+  - React-perflogger (0.76.0-rc.5):
     - DoubleConversion
     - RCT-Folly (= 2024.01.01.00)
-  - React-performancetimeline (0.76.0-rc.4):
+  - React-performancetimeline (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
     - React-timing
-  - React-RCTActionSheet (0.76.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.4)
-  - React-RCTAnimation (0.76.0-rc.4):
+  - React-RCTActionSheet (0.76.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.76.0-rc.5)
+  - React-RCTAnimation (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1727,7 +1727,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTAppDelegate (0.76.0-rc.4):
+  - React-RCTAppDelegate (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1752,7 +1752,7 @@ PODS:
     - React-utils
     - ReactCodegen
     - ReactCommon
-  - React-RCTBlob (0.76.0-rc.4):
+  - React-RCTBlob (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1765,7 +1765,7 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTFabric (0.76.0-rc.4):
+  - React-RCTFabric (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1788,7 +1788,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.76.0-rc.4):
+  - React-RCTImage (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1797,14 +1797,14 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTLinking (0.76.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
+  - React-RCTLinking (0.76.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - React-RCTNetwork (0.76.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - React-RCTNetwork (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1812,7 +1812,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTSettings (0.76.0-rc.4):
+  - React-RCTSettings (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1820,24 +1820,24 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTText (0.76.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.76.0-rc.4)
+  - React-RCTText (0.76.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.76.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.76.0-rc.4):
+  - React-RCTVibration (0.76.0-rc.5):
     - RCT-Folly (= 2024.01.01.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-rendererconsistency (0.76.0-rc.4)
-  - React-rendererdebug (0.76.0-rc.4):
+  - React-rendererconsistency (0.76.0-rc.5)
+  - React-rendererdebug (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.76.0-rc.4)
-  - React-RuntimeApple (0.76.0-rc.4):
+  - React-rncore (0.76.0-rc.5)
+  - React-RuntimeApple (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1856,7 +1856,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.76.0-rc.4):
+  - React-RuntimeCore (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1870,9 +1870,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.76.0-rc.4):
-    - React-jsi (= 0.76.0-rc.4)
-  - React-RuntimeHermes (0.76.0-rc.4):
+  - React-runtimeexecutor (0.76.0-rc.5):
+    - React-jsi (= 0.76.0-rc.5)
+  - React-RuntimeHermes (0.76.0-rc.5):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1883,7 +1883,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.76.0-rc.4):
+  - React-runtimescheduler (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1898,14 +1898,14 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.76.0-rc.4)
-  - React-utils (0.76.0-rc.4):
+  - React-timing (0.76.0-rc.5)
+  - React-utils (0.76.0-rc.5):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.76.0-rc.4)
-  - ReactCodegen (0.76.0-rc.4):
+    - React-jsi (= 0.76.0-rc.5)
+  - ReactCodegen (0.76.0-rc.5):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1925,46 +1925,46 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.76.0-rc.4):
-    - ReactCommon/turbomodule (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule (0.76.0-rc.4):
+  - ReactCommon (0.76.0-rc.5):
+    - ReactCommon/turbomodule (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/bridging (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.76.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/bridging (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-  - ReactCommon/turbomodule/core (0.76.0-rc.4):
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+  - ReactCommon/turbomodule/core (0.76.0-rc.5):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.76.0-rc.4)
-    - React-cxxreact (= 0.76.0-rc.4)
-    - React-debug (= 0.76.0-rc.4)
-    - React-featureflags (= 0.76.0-rc.4)
-    - React-jsi (= 0.76.0-rc.4)
-    - React-logger (= 0.76.0-rc.4)
-    - React-perflogger (= 0.76.0-rc.4)
-    - React-utils (= 0.76.0-rc.4)
+    - React-callinvoker (= 0.76.0-rc.5)
+    - React-cxxreact (= 0.76.0-rc.5)
+    - React-debug (= 0.76.0-rc.5)
+    - React-featureflags (= 0.76.0-rc.5)
+    - React-jsi (= 0.76.0-rc.5)
+    - React-logger (= 0.76.0-rc.5)
+    - React-perflogger (= 0.76.0-rc.5)
+    - React-utils (= 0.76.0-rc.5)
   - SDWebImage (5.19.1):
     - SDWebImage/Core (= 5.19.1)
   - SDWebImage/Core (5.19.1)
@@ -2273,77 +2273,77 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: 404356f2621ca76fd54e8c5c686091d0fa00cbc7
   EXUpdates: 992e73bb96f83c8ed958949bb2475c883a3119ae
   EXUpdatesInterface: 8d16d1242225d0bdb4d8db788349b522aa8e0343
-  FBLazyVector: 20c5e40f776552291d12ea1f6cb14568aeccec92
+  FBLazyVector: de8eedeaa44513602f4e9c94b3547c3c43af0d40
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 367546049df3ab3b58c9b07dab01e9c7c5640728
+  hermes-engine: 83913a9bc12277c53ef984c8589efdfa3b68ca50
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
-  RCTDeprecation: ea1525e5eda35bb079a7ac260551c5e0468f9ee3
-  RCTRequired: c78ef50a39a3c8060e546760c46148d9abee6388
-  RCTTypeSafety: 1841770b2ab4e4325bfe2a6b5ddca520b3e6c40d
+  RCTDeprecation: 4192491a84930e9a001406df7eb570be2ec7320e
+  RCTRequired: b4fad98533fbfd85dd911f6bfecff1b08d19d87a
+  RCTTypeSafety: 09d6104052cd7e0afa56d58b21efa5e12c593a66
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  React: 0d0b01ad72a7d78942ecca7efef21261a95b571e
-  React-callinvoker: dfffa5cbc328b8c6c50a1175d0949a2625bc16d1
-  React-Core: d191ffc6bc41418035bb194dca150e45e5d1ac99
-  React-CoreModules: abc8746b32605f56185ae717ae3f0b495555e7cd
-  React-cxxreact: b27afedad262b3795b8e6159d08502914a1d92ed
-  React-debug: a4ea112a115069970382c851e1ac354a16ca3407
-  React-defaultsnativemodule: 126fdaa0eb715399ed0aa711cb99b7ada18df922
-  React-domnativemodule: fb6997c863510267771dba59a6622c88112b7f8d
-  React-Fabric: 242416dca2d51a1da7f408992cbd91aec4942690
-  React-FabricComponents: 53d72e46c374a2e3f35f805f5107f748df7697a0
-  React-FabricImage: dee871f91a383998b11dfc3316b637645b205495
-  React-featureflags: 876e6a0a475c8302c2578e9ccfabf1311d31e43f
-  React-featureflagsnativemodule: d67f70f301dab8c1d6a167ecbc5847ab94ddbdcd
-  React-graphics: e31951d62a49d732fb1ec5240df312a7eaeca1c5
-  React-hermes: af5811d0da319a1c8cf15c8382cbf8e61a8d95d6
-  React-idlecallbacksnativemodule: 5ba27b09fb7bed6ce3c59b102da86aaa84b437e5
-  React-ImageManager: ea3dd89ab916635458ff670085d2d1a9bf394794
-  React-jserrorhandler: eebcf043f7abba6c75ef7345277492d225163ed4
-  React-jsi: bd5273d25f83f1c4a656872422455c32357f367b
-  React-jsiexecutor: a908f2152653629e80721bef0030ff2c33d614c5
-  React-jsinspector: ed1e3ae3c861b2057cc8fe4d67b6b37081336488
-  React-jsitracing: b7b6dbd037ff3a7b971bb577c7c49fcf4fae162b
-  React-logger: ccab6d41424202fd511faa9a88bec12cadc83dfa
-  React-Mapbuffer: fe84c6dde7dab6dd8658bb18beb932c1b15c993a
-  React-microtasksnativemodule: b96aa3fc27ef864c183605decc24df15258cadfc
-  React-nativeconfig: 38e9f8764eb61e31e11915c950cc97aedddb8736
-  React-NativeModulesApple: 32ae99d8d82da3efb18b96915467e9bc851fd866
-  React-perflogger: 8e26de3ec512cdd60a42a0058227c9c66ea87ee5
-  React-performancetimeline: abbed40b41e81667ca7094f64451861589de5f3e
-  React-RCTActionSheet: 6239d9d694dc8616c483b6bf129018ef21d88237
-  React-RCTAnimation: cafb6fba8338f1b5a86243dc487bb5ec92120c66
-  React-RCTAppDelegate: 82985692b0a56240b60f8186312e3de3d5be16a3
-  React-RCTBlob: 772c1e74f650f0b777845586992b892f552aa73c
-  React-RCTFabric: c5c6f5a611088b9b20f04990c71ca20806e80ed4
-  React-RCTImage: 53817bacd7932786539d9de7e07a2d0af3ebe918
-  React-RCTLinking: e6d6ee9c252074f493182da8d00e17324271f1b9
-  React-RCTNetwork: 58beae8ffa70ccdeed4f0b06fd26d8d90db6e658
-  React-RCTSettings: c62a98a91f269316316803043a42cc67ccbf17fc
-  React-RCTText: 344739a409a7883bd5666d7a8061aa666d46c840
-  React-RCTVibration: aec24eb8c13710f03a029f83b1f52278824d5a5f
-  React-rendererconsistency: ddf5bcdefef149701803b19b1e235b00a92cb43e
-  React-rendererdebug: d6c526a8c3753e7a3422d417e723da2ce55e7ea7
-  React-rncore: 7051b962a908eb640ebcb056805b23155c117c69
-  React-RuntimeApple: 6a88089b15029632c2658e092b377203dda72df3
-  React-RuntimeCore: ed1ff2106abfd1b66419c1e415beb4865aaff67c
-  React-runtimeexecutor: 208d438d0ca7101c1b8cafc46985e9a4321ca36d
-  React-RuntimeHermes: e6cf75963cef945ffb1efde63c2744649ab18c41
-  React-runtimescheduler: 8366a99028799f6fcc34e62b4d4174710976d42a
-  React-timing: 5c8f3f26b39635e9984c98d46c53c16aa10a4792
-  React-utils: 0ab6858c3bdff0219b119b881dcdd12d9b913769
-  ReactCodegen: 47dc7be065f718f0378e5a78499b6aeb98c85b49
-  ReactCommon: 9cb3c46af4f75f0a61e40d24b54f8b848226dadf
+  React: 7b0daf87159fb74a575f17841338575993b16fe7
+  React-callinvoker: 5a814c15bcea3bee56ed553bed0cdd4c6c0909d7
+  React-Core: 1b63f346b0c0ef34ac186cfa5dd5f2417e365dc8
+  React-CoreModules: 0ea5b0070a67846efeebf1b8ca617a35331bad83
+  React-cxxreact: c4d0bb73f052f9bd6e71a41e6fa1ffeda188fce1
+  React-debug: 71a6df9f66e18ed9d54c599abc0891ac6b557a02
+  React-defaultsnativemodule: b91b3db54e0f2adf162765cf6a23206dc5e437e2
+  React-domnativemodule: 76ea09978aa37e072fe89f6f38bd128a3e4282ad
+  React-Fabric: 77eb8316e14a015af3a4b1900a26cbd47dc90085
+  React-FabricComponents: 76dd7d0dc57823375e019b444d79ef607543fe3f
+  React-FabricImage: fff56283b24af6a59c7d37f5cd4a3f838ad21705
+  React-featureflags: bfec0de2042b2e8554e5b8e421093a8309117d5c
+  React-featureflagsnativemodule: 6ee9cf0cf2fea207ce4913cf753592655fa68ca0
+  React-graphics: 6cdd20e7bac68eba69c4186563890f9275ef99b0
+  React-hermes: 0fc678ca4c31c555f311a4178223f0785dc97562
+  React-idlecallbacksnativemodule: f6ed21f7481682da925165dccde6f36a7d286ace
+  React-ImageManager: 5411113b18db62f0bfc6271d4546e5c945a11931
+  React-jserrorhandler: bd06ea2d7e167ab2c1b9a36fdd3a1d38693c34f1
+  React-jsi: cd024064402b258d0aa779255349ab89993238c3
+  React-jsiexecutor: cd355e620e376f4b9604d68f71e535310ec3c2e9
+  React-jsinspector: 6f829b65c901b559223a6ed2e3340ab49136fa1e
+  React-jsitracing: dc06b7da8c86de529f3384ee15164866a320048f
+  React-logger: dc9eb8395b1341379fe9a4568c45bb7329629ae4
+  React-Mapbuffer: 69f179a8d7323c3bb2e027592390607cafd4cb8f
+  React-microtasksnativemodule: 10f19a8911990eeaa798ef6e35abd6f0015cbbe6
+  React-nativeconfig: 04c807a93e08acef39d28736cdcd511f77d1573a
+  React-NativeModulesApple: cf9d53bbdc856ea409ae605f293085e4d1bd4584
+  React-perflogger: f1ccce85fdd94ae925ab7b315b1af8f4b0d9db4e
+  React-performancetimeline: d11db5784449e33aff086b1805e3ded3aa61a5e7
+  React-RCTActionSheet: 2ec40250c009777048731b4b421b54f493889cda
+  React-RCTAnimation: 86c3e5c31ed951e74a5381862d6a49ea493d64e6
+  React-RCTAppDelegate: 349d0236e04b0a02312361cb998708a902672f4e
+  React-RCTBlob: 1e0cc2c326425ca0d0190db55f3e73ed3f54c980
+  React-RCTFabric: cfbbfe5b38ff04a40b73f06fcb71f3b55da0faca
+  React-RCTImage: 075758c75aab89c8964a733177d3a0bd92785a87
+  React-RCTLinking: 966f69ed2f4a058829374d8dcc961ae193b4eff8
+  React-RCTNetwork: 62b1268ae7596c73a43d64a8e6e8e5da19666c78
+  React-RCTSettings: 5a1d1b1b1e991e660c44f383e2a1d10a99a190e1
+  React-RCTText: 76e1681e483b3d03f673076f27b1c8711f8a0537
+  React-RCTVibration: 02eac793150fcbf849232c232a1ca8ca362525fd
+  React-rendererconsistency: e5636962d7e86df51f57b5cc7cc681b1544e7385
+  React-rendererdebug: 83762d7627dbb1c735b7ef9853b726bcb939cdf6
+  React-rncore: 2765a9b04a9ef1cd28a56528783c9644ecde8a33
+  React-RuntimeApple: fee4dca6f9b2a0a879bbdcffcb1adce8b4eb2499
+  React-RuntimeCore: 08c53b33fa43a9ef689c5d2f8f47c7c22389420c
+  React-runtimeexecutor: 2d27e8c9dc9272a13ff61bb162440e21fe9d5a82
+  React-RuntimeHermes: d81c1857d13097bea77f654046f5f40d102414a5
+  React-runtimescheduler: 4814c52f8009cd3031ff8b29eda80569a529c493
+  React-timing: 3978fc03d275858cc95e69b9adbea5b05d48ecf8
+  React-utils: 7d83759a29992a76a3cc324948ef6d86415bc44e
+  ReactCodegen: fc371ec636a81cdcbd13d8e8328064a8d1d88a64
+  ReactCommon: eaf4f987f18bba1f4ec674e2ed95b706e1559cd1
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: faaab08e21d56d9b7d5225d64fa23cdf72af2f74
+  Yoga: d27fe77b40d16ce8a8936a48c401f33ca4e15265
 
 PODFILE CHECKSUM: ccd8b50eabcb4ae3ee16e1484faf98baa32b0b75
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "native-component-list": "*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -25,7 +25,7 @@
     "expo-speech": "~12.0.2",
     "expo-sqlite": "~14.0.3",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.12",
     "react-native-webview": "13.8.6"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -11,7 +11,7 @@
     "expo": "~51.0.0",
     "expo-router": "^3.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "devDependencies": {
     "babel-preset-expo": "~11.0.0"

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-gesture-handler": "~2.20.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react": "18.3.1",
     "@react-navigation/bottom-tabs": "7.0.0-rc.33",
     "@react-navigation/core": "7.0.0-rc.15",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -55,7 +55,7 @@
     "@expo/rudder-sdk-node": "^1.1.1",
     "@expo/spawn-async": "^1.7.2",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.76.0-rc.4",
+    "@react-native/dev-middleware": "0.76.0-rc.5",
     "@urql/core": "^2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -42,7 +42,7 @@
     "@expo/config-types": "^51.0.0",
     "@expo/image-utils": "^0.5.0",
     "@expo/json-file": "^8.3.0",
-    "@react-native/normalize-colors": "0.76.0-rc.4",
+    "@react-native/normalize-colors": "0.76.0-rc.5",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.0",
     "resolve-from": "^5.0.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-transform-parameters": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.76.0-rc.2",
+    "@react-native/babel-preset": "0.76.0-rc.5",
     "babel-plugin-react-native-web": "~0.19.13",
     "react-refresh": "^0.14.2"
   },

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -260,7 +260,7 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro supports reanimated worklets 1`] = `
-"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
+"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AACA,SAAAA,sBAA6BA,CAAEC,QAAA,EAE7BC,OAAO,CAACC,GAAG,CAAC,kCAAkC,CAAC,CACjD\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
 function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
@@ -289,7 +289,7 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro+hermes supports reanimated worklets 1`] = `
-"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AAAA,SAAAA,uBAAAC,QAAA,EAAAC,OAAA,CAAAC,GAAA,qCACA\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
+"var _worklet_14307677064221_init_data={code:"function someWorklet_workletJs1(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"names\\":[\\"someWorklet_workletJs1\\",\\"greeting\\",\\"console\\",\\"log\\"],\\"sources\\":[\\"[mock]/worklet.js\\"],\\"mappings\\":\\"AACA,SAAAA,sBAA6BA,CAAEC,QAAA,EAE7BC,OAAO,CAACC,GAAG,CAAC,kCAAkC,CAAC,CACjD\\",\\"ignoreList\\":[]}",version:"[GLOBAL]"};var someWorklet=
 function(){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherSettings.kt
@@ -2,21 +2,18 @@ package com.facebook.react.devsupport
 
 import android.content.Context
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
+import expo.modules.devlauncher.react.DevLauncherPackagerConnectionSettings
 
 internal class DevLauncherSettings(
   context: Context,
   debugServerHost: String
 ) : DevMenuSettingsBase(context) {
-  private var connectionSettings = PackagerConnectionSettings(context)
+  private var connectionSettings = DevLauncherPackagerConnectionSettings(context, debugServerHost)
   override val packagerConnectionSettings: PackagerConnectionSettings
     get() = connectionSettings
 
   // Implemented here so `this` is not leaked
   init {
-    // We can't extend PackagerConnectionSettings anymore, because now it's final class
-    // So we need to update the debugServerHost on init
-    packagerConnectionSettings.debugServerHost = debugServerHost
-
     mPreferences.registerOnSharedPreferenceChangeListener(this)
   }
 

--- a/packages/expo-dev-launcher/android/src/react-native-74/main/expo/modules/devlauncher/react/DevLauncherPackagerConnectionSettings.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/main/expo/modules/devlauncher/react/DevLauncherPackagerConnectionSettings.kt
@@ -1,0 +1,13 @@
+package expo.modules.devlauncher.react
+
+import android.content.Context
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+
+class DevLauncherPackagerConnectionSettings(
+  context: Context,
+  private var serverIp: String
+) : PackagerConnectionSettings(context) {
+  override var debugServerHost: String
+    get() = serverIp
+    set(value) {}
+}

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -51,7 +51,7 @@
     "graphql": "^16.0.1",
     "graphql-request": "^3.6.1",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-query": "^3.34.16",
     "url": "^0.11.0"
   },

--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactSettings.kt
@@ -5,6 +5,7 @@ package com.facebook.react.devsupport
 import android.content.Context
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
+import expo.modules.devmenu.react.DevMenuPackagerConnectionSettings
 
 /**
  * Class representing react's internal [DevInternalSettings] class, which we want to replace to change [packagerConnectionSettings] and others settings.
@@ -16,14 +17,10 @@ internal class DevMenuReactSettings(
   context: Context,
   serverIp: String
 ) : DevMenuSettingsBase(context) {
-  override val packagerConnectionSettings = PackagerConnectionSettings(context)
+  override val packagerConnectionSettings = DevMenuPackagerConnectionSettings(serverIp, context)
 
   // Implemented here so `this` is not leaked
   init {
-    // We can't extend PackagerConnectionSettings anymore, because now it's final class
-    // So we need to update the debugServerHost on init
-    packagerConnectionSettings.debugServerHost = serverIp
-
     mPreferences.registerOnSharedPreferenceChangeListener(this)
   }
 }

--- a/packages/expo-dev-menu/android/src/react-native-74/main/expo/modules/devmenu/react/DevMenuPackagerConnectionSettings.kt
+++ b/packages/expo-dev-menu/android/src/react-native-74/main/expo/modules/devmenu/react/DevMenuPackagerConnectionSettings.kt
@@ -1,0 +1,17 @@
+package expo.modules.devmenu.react
+
+import android.content.Context
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+
+/**
+ * Class representing react's internal [PackagerConnectionSettings] class, which we want to replace to change bundler's url.
+ * It is only use when [expo.modules.devmenu.DevMenuReactNativeHost.getUseDeveloperSupport] returns true.
+ */
+class DevMenuPackagerConnectionSettings(
+  private val serverIp: String,
+  applicationContext: Context
+) : PackagerConnectionSettings(applicationContext) {
+  override var debugServerHost: String
+    get() = serverIp
+    set(host: String) {}
+}

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -62,7 +62,7 @@
     "graphql": "^15.3.0",
     "graphql-tag": "^2.10.1",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.76.0-rc.4",
+    "@react-native/normalize-colors": "0.76.0-rc.5",
     "debug": "^4.3.2"
   },
   "devDependencies": {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
@@ -13,7 +13,7 @@ import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 /**
  * A trigger representing an incoming remote Firebase notification.
  */
-class FirebaseNotificationTrigger(private val remoteMessage: RemoteMessage) : NotificationTrigger {
+class FirebaseNotificationTrigger(val remoteMessage: RemoteMessage) : NotificationTrigger {
 
   private constructor(parcel: Parcel) : this(
     parcel.readParcelable(FirebaseNotificationTrigger::class.java.classLoader)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
@@ -13,7 +13,7 @@ import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 /**
  * A trigger representing an incoming remote Firebase notification.
  */
-class FirebaseNotificationTrigger(val remoteMessage: RemoteMessage) : NotificationTrigger {
+class FirebaseNotificationTrigger(private val remoteMessage: RemoteMessage) : NotificationTrigger {
 
   private constructor(parcel: Parcel) : this(
     parcel.readParcelable(FirebaseNotificationTrigger::class.java.classLoader)

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.76.0-rc.4",
+    "@react-native/normalize-colors": "0.76.0-rc.5",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -86,7 +86,7 @@
   "lottie-react-native": "7.0.0",
   "react": "18.3.1",
   "react-dom": "18.3.1",
-  "react-native": "0.76.0-rc.4",
+  "react-native": "0.76.0-rc.5",
   "react-native-web": "~0.19.13",
   "react-native-gesture-handler": "~2.20.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -88,7 +88,7 @@
     "expo-module-scripts": "^3.5.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "peerDependencies": {
     "@expo/dom-webview": "*",

--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -51,7 +51,6 @@ function getPlatformPreset(displayOptions, extensions, platform, { isServer, isR
       [upstreamBabelJest]: [
         'babel-jest',
         {
-          plugins: ['babel-plugin-syntax-hermes-parser'],
           caller: {
             name: 'metro',
             bundler: 'metro',

--- a/templates/expo-template-bare-minimum/android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/expo-template-bare-minimum/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "~51.0.8",
     "expo-status-bar": "~1.12.1",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~51.0.8",
     "expo-status-bar": "~1.12.1",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "~51.0.8",
     "expo-status-bar": "~1.12.1",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.4"
+    "react-native": "0.76.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -32,7 +32,7 @@
     "expo-web-browser": "~13.0.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-gesture-handler": "~2.20.0",
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.11.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~13.0.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.0-rc.4",
+    "react-native": "0.76.0-rc.5",
     "react-native-reanimated": "~3.15.0",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,70 +2972,12 @@
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.76.0-rc.5.tgz#504be51b21776b00e3db9a6e4a752e6301acf888"
   integrity sha512-YzWP9Js2wioQ3BzDCpTGrehhAAt4yjeeG/AmHZzPF9wL/XPzNWeQKl7TXBRGHg+W/sJNgQgjxZzpNmX5lUs2CA==
 
-"@react-native/babel-plugin-codegen@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.2.tgz#5c97ed572a4b6ec3eebfb1d457207a874c8e37d1"
-  integrity sha512-B+tLKulTsDJvwkX3ZbO7vj+Tb4kh0w4vvyNQrD+i9pa0ZbeaHiw8uu8hJm+V97DjHGJ6zV+8djnBgWazno/zFg==
-  dependencies:
-    "@react-native/codegen" "0.76.0-rc.2"
-
 "@react-native/babel-plugin-codegen@0.76.0-rc.5":
   version "0.76.0-rc.5"
   resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.5.tgz#7cb0ca0997865e2e59790228dcc2d991e265a695"
   integrity sha512-1KfxrVGP9Gy75bDVUgriKj/ZDHnhC32pKddgZsSntwyBSqrYNI8vkhGsazYVh8WyPl9WIuNqE0DNrggdm1plmQ==
   dependencies:
     "@react-native/codegen" "0.76.0-rc.5"
-
-"@react-native/babel-preset@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.76.0-rc.2.tgz#63a3093b5e9f8c8d8acd6617cdc5d8fd5bc0ac20"
-  integrity sha512-WrK2o+3cDbntd8407MApQ+ByJrUGCQgkm3qhRvzKsgww6MS3/ykA2bzl11K3YrMIq51JC5MQJKF6JnGjK9lc9g==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/plugin-proposal-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-flow" "^7.24.7"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-transform-arrow-functions" "^7.24.7"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.4"
-    "@babel/plugin-transform-async-to-generator" "^7.24.7"
-    "@babel/plugin-transform-block-scoping" "^7.25.0"
-    "@babel/plugin-transform-class-properties" "^7.25.4"
-    "@babel/plugin-transform-classes" "^7.25.4"
-    "@babel/plugin-transform-computed-properties" "^7.24.7"
-    "@babel/plugin-transform-destructuring" "^7.24.8"
-    "@babel/plugin-transform-flow-strip-types" "^7.25.2"
-    "@babel/plugin-transform-for-of" "^7.24.7"
-    "@babel/plugin-transform-function-name" "^7.25.1"
-    "@babel/plugin-transform-literals" "^7.25.2"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.24.7"
-    "@babel/plugin-transform-modules-commonjs" "^7.24.8"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.24.7"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
-    "@babel/plugin-transform-numeric-separator" "^7.24.7"
-    "@babel/plugin-transform-object-rest-spread" "^7.24.7"
-    "@babel/plugin-transform-optional-catch-binding" "^7.24.7"
-    "@babel/plugin-transform-optional-chaining" "^7.24.8"
-    "@babel/plugin-transform-parameters" "^7.24.7"
-    "@babel/plugin-transform-private-methods" "^7.24.7"
-    "@babel/plugin-transform-private-property-in-object" "^7.24.7"
-    "@babel/plugin-transform-react-display-name" "^7.24.7"
-    "@babel/plugin-transform-react-jsx" "^7.25.2"
-    "@babel/plugin-transform-react-jsx-self" "^7.24.7"
-    "@babel/plugin-transform-react-jsx-source" "^7.24.7"
-    "@babel/plugin-transform-regenerator" "^7.24.7"
-    "@babel/plugin-transform-runtime" "^7.24.7"
-    "@babel/plugin-transform-shorthand-properties" "^7.24.7"
-    "@babel/plugin-transform-spread" "^7.24.7"
-    "@babel/plugin-transform-sticky-regex" "^7.24.7"
-    "@babel/plugin-transform-typescript" "^7.25.2"
-    "@babel/plugin-transform-unicode-regex" "^7.24.7"
-    "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.76.0-rc.2"
-    babel-plugin-transform-flow-enums "^0.0.2"
-    react-refresh "^0.14.0"
 
 "@react-native/babel-preset@0.76.0-rc.5":
   version "0.76.0-rc.5"
@@ -3087,20 +3029,6 @@
     babel-plugin-syntax-hermes-parser "^0.23.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
-
-"@react-native/codegen@0.76.0-rc.2":
-  version "0.76.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.76.0-rc.2.tgz#83ad8d55cbc50f980bae847c2eaecb9189e6e506"
-  integrity sha512-WFtED2zIM1BBbcQUnVzJ4/ZWU+SEkOPAi/Ul5M/G9ToKoPt2yWhTjf6lqo5DWA/5507PrykR+EmxJIw32vCJnQ==
-  dependencies:
-    "@babel/parser" "^7.25.3"
-    glob "^7.1.1"
-    hermes-parser "0.23.1"
-    invariant "^2.2.4"
-    jscodeshift "^0.14.0"
-    mkdirp "^0.5.1"
-    nullthrows "^1.1.1"
-    yargs "^17.6.2"
 
 "@react-native/codegen@0.76.0-rc.5":
   version "0.76.0-rc.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,10 +2967,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.4.tgz#c0097491c3ec7c7c34397d72c44501d615354dcd"
   integrity sha512-M8c+NORkGZzKUXB+yT6pq6+wWZUZK9HhVtuMz8Y5Co4tnOSJ86KhhJsM3RI1rPuUvmyzGc0jeJpkB3ul8X1XNw==
 
-"@react-native/assets-registry@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.76.0-rc.4.tgz#e60186944feff190ab9385400ecc1b95dc6d252b"
-  integrity sha512-OuekvnmCCoCub3l23WDcZ893YSHHJ5dFBuhE4QvpR9N7NBquIxsEdne1tYv4bv10KKRaVqhkdkyHL51xzZARvg==
+"@react-native/assets-registry@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.76.0-rc.5.tgz#504be51b21776b00e3db9a6e4a752e6301acf888"
+  integrity sha512-YzWP9Js2wioQ3BzDCpTGrehhAAt4yjeeG/AmHZzPF9wL/XPzNWeQKl7TXBRGHg+W/sJNgQgjxZzpNmX5lUs2CA==
 
 "@react-native/babel-plugin-codegen@0.76.0-rc.2":
   version "0.76.0-rc.2"
@@ -2979,12 +2979,12 @@
   dependencies:
     "@react-native/codegen" "0.76.0-rc.2"
 
-"@react-native/babel-plugin-codegen@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.4.tgz#4272227cac893f54674716d32390db2df29d0d26"
-  integrity sha512-hFrkLQlwwUvaf7fhjvc9lbiPH3tBgeihmmuqbrAiTMEFsjySXJ414CuYAKKGNHC+DXxYwKzpDw1mWaW92Q1Lyw==
+"@react-native/babel-plugin-codegen@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.0-rc.5.tgz#7cb0ca0997865e2e59790228dcc2d991e265a695"
+  integrity sha512-1KfxrVGP9Gy75bDVUgriKj/ZDHnhC32pKddgZsSntwyBSqrYNI8vkhGsazYVh8WyPl9WIuNqE0DNrggdm1plmQ==
   dependencies:
-    "@react-native/codegen" "0.76.0-rc.4"
+    "@react-native/codegen" "0.76.0-rc.5"
 
 "@react-native/babel-preset@0.76.0-rc.2":
   version "0.76.0-rc.2"
@@ -3037,10 +3037,10 @@
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/babel-preset@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.76.0-rc.4.tgz#ac996b52a7ecc8e1886dff17714a14e6db580583"
-  integrity sha512-4vuLhlwQQjPUpOyX/wqiNdMNqZdVKYTIx8Mu304n+vPc6pqtK5EIVPkq4f5iZIfndmPkrA7sk6UWGnuBSk9HwA==
+"@react-native/babel-preset@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.76.0-rc.5.tgz#0f88b419795b2acdbf3d7562f8e7d43c3d8d66fb"
+  integrity sha512-/Xd7dnfKxCPOulpATGeElxBH6TK3j2f0MW4FsSvm1U/aYUNIhJFrMNZ113dN8KaDfrE9SlUq0tyjGH7eBV73RA==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3083,7 +3083,7 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.76.0-rc.4"
+    "@react-native/babel-plugin-codegen" "0.76.0-rc.5"
     babel-plugin-syntax-hermes-parser "^0.23.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
@@ -3102,10 +3102,10 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/codegen@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.76.0-rc.4.tgz#43657a725fe5e36acbd87d760e3c4497da9078fb"
-  integrity sha512-2Czo9Sc8TXPihA1JPltH/blkW50Tlcn1xEmq0NVuaftGT891TNuEiVkk8jwasBdip2IaDbjApsk6kHk4BwsgjQ==
+"@react-native/codegen@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.76.0-rc.5.tgz#f45acd626f711fc3c05e833db973df81708583fd"
+  integrity sha512-cxNI8Q2K3Ts4ycos6lWcAYcwF7HgtVLE0+vN+is6G9c32cd8hU/PY47/k7vw9Rk72liOiw41mbLgenQvssvg7w==
   dependencies:
     "@babel/parser" "^7.25.3"
     glob "^7.1.1"
@@ -3116,34 +3116,34 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.0-rc.4.tgz#f21e7cd25824eb9c5c1ef2fa97d42476b2b6c1ba"
-  integrity sha512-NjfKvt/tShvF0O4dD1/HlBpwMgHfiKy0gEHuiVeFo+stYDTlxiAgJ5KQo9dUrajKZ3h6lsiea72s4s6sqImihw==
+"@react-native/community-cli-plugin@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.0-rc.5.tgz#5e4a819adc0de6251f48167a7b38905b01869db7"
+  integrity sha512-oLd/Ok8mggc1k0UNSAsiYeG0Lpv0t9i0m60F3a1NdwmT8TdU1V5Jgx2GOAHmYBXotT8QVsd9pG9VskgZh7FKuA==
   dependencies:
-    "@react-native/dev-middleware" "0.76.0-rc.4"
-    "@react-native/metro-babel-transformer" "0.76.0-rc.4"
+    "@react-native/dev-middleware" "0.76.0-rc.5"
+    "@react-native/metro-babel-transformer" "0.76.0-rc.5"
     chalk "^4.0.0"
     execa "^5.1.1"
     invariant "^2.2.4"
-    metro "^0.81.0-alpha.2"
-    metro-config "^0.81.0-alpha.2"
-    metro-core "^0.81.0-alpha.2"
+    metro "^0.81.0"
+    metro-config "^0.81.0"
+    metro-core "^0.81.0"
     node-fetch "^2.2.0"
     readline "^1.3.0"
 
-"@react-native/debugger-frontend@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.76.0-rc.4.tgz#e97b8b4f2c9593dabe9b3069463e66da9925e22b"
-  integrity sha512-vxNImDIFJhHM8RCat8OA3Gzd6mPa45HB9W2f+frZ/f5qMEkIAFXnFsd77naHlawqsfAnTg1mXYpcKtqyA7IuIw==
+"@react-native/debugger-frontend@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.76.0-rc.5.tgz#5ca6415bfc770bcbdb6bd9da2c0372521d8da94c"
+  integrity sha512-KMoBRkVOvld4mFzZMZupVpyr1nEd24FrEXA0nMcn5XZOunsbZjtonF/QJjnkT+qdXuSFhUL6EQEaZbI60+OMkw==
 
-"@react-native/dev-middleware@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.76.0-rc.4.tgz#7dfc073b1e540e7c002c50ecbce12ebc1fefdb8e"
-  integrity sha512-cClh4XdamRTLsk53mcnPr6gpoQVN5ejWcD+a3vd0eyRaHFzAEkpaXt2uXQ7Fx2Gus7EXJSzRgWg5kP2E+Kpdgg==
+"@react-native/dev-middleware@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.76.0-rc.5.tgz#7c5b7ce51ad4502b3214fa56edab1db8613ea9f1"
+  integrity sha512-bVTLvwj8O6mwOuQwbz6IJ3F+8NVAsgNnTxiaEenhzXvNeX0YejAxVq2mvdsKIQZSen+c45QpUGOgc2NmbuIG4A==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.76.0-rc.4"
+    "@react-native/debugger-frontend" "0.76.0-rc.5"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3154,40 +3154,40 @@
     serve-static "^1.13.1"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.76.0-rc.4.tgz#dbec27385f47eb6f69dc7ce62165eba0a71f5c74"
-  integrity sha512-SPRsBa1HIKFsKsLFTUMt/6xYPnyqU6lVQAfD5TX7MLakw7rpXrAAJrMlNHXmLODMr/hdVlmgp+yv9bBVoBf0QA==
+"@react-native/gradle-plugin@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.76.0-rc.5.tgz#fe8fa4440e3f9d06c4e47001a6bede96c7b0261f"
+  integrity sha512-k0M5dOHDrWCvUSPL1zi4YgkDMZ5LUnA1bmVsYf+nzXpdOVU8zL/fx8KOfuNAjK+PTyFqusSvcx+vCWXS5hbHcw==
 
-"@react-native/js-polyfills@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.76.0-rc.4.tgz#bc86e527053609ea7f42b013472283e6ebcaf0c6"
-  integrity sha512-7er67QR5hIbbPRs+IVwBiwjTr0aBOUw6QMno3Z1OVth19m1Sd4gUAee1jYtTsF3QwAZg76uXLd3BmjbCxdzDFg==
+"@react-native/js-polyfills@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.76.0-rc.5.tgz#ec022e04e8867eccff90e1b89c6cbba037aa0aca"
+  integrity sha512-J7qgIzLERJW6UD8jzSLPMKLNlVdVclNIYfM/BkP8PA+QEp1ip9lwsiiH3hz3jHbqF3FVawK35NrjGavU0khzBA==
 
-"@react-native/metro-babel-transformer@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.0-rc.4.tgz#081451a36d31ec3ba6fe8e5f67fc05333a642a6a"
-  integrity sha512-qKqcMOBsQm0COFNdB/LB57hOwgs3fO7Zi6vIvxtEG58/3wFyQLBc5htE0Yeg+kgsHreB0fKSqqCJT+ckH2cm7Q==
+"@react-native/metro-babel-transformer@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.0-rc.5.tgz#c3cf3a623533c0c776fd387ba95bae3640411eca"
+  integrity sha512-GQmLcxNO89v98+fvwNxdWRcS/bw6He5igQb23VGS32M7UgJmoXKLn7lOq5eZw6UjF/wOHcbJy2NFD4Ncu4OEQg==
   dependencies:
     "@babel/core" "^7.25.2"
-    "@react-native/babel-preset" "0.76.0-rc.4"
+    "@react-native/babel-preset" "0.76.0-rc.5"
     hermes-parser "0.23.1"
     nullthrows "^1.1.1"
 
-"@react-native/normalize-colors@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.76.0-rc.4.tgz#d2496773f6fae8031eb1ded86503974c3a7b3090"
-  integrity sha512-7tdht5x6Hqb+fJgQsGmRWy46VBWlm2ntu6C3f4hiaEEyZMu2VbzoE6z0LSBJt2QW6aPA3/6vAwTW9nyLEoXs0g==
+"@react-native/normalize-colors@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.76.0-rc.5.tgz#4350fbaa1b476a128cb8a7ae1e05b14767587170"
+  integrity sha512-7BjijjVp8z3ALjWxkM76XPHhXKhDo/rYxgHF5GWA5lflXnKHmW1TtcR0aYO24cIyZ4s4+dVD86/ruL/xS7Se/g==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.76.0-rc.4":
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.76.0-rc.4.tgz#e99e6a19062cf5b1c93213aecf427f9dd738a6a8"
-  integrity sha512-XK5fQcPPWOWWJA0+X8kZ0GyJh2yPogq7cG7W0whsIia9xRXG0YFsvqsWpRc0Kj1hv2Euyz1LzUiWpoSsRa0C3w==
+"@react-native/virtualized-lists@0.76.0-rc.5":
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.76.0-rc.5.tgz#367a837abf89b475a1622e896fa0ea5ffe0b8406"
+  integrity sha512-BYrI8OuMh2t31FSHpsle0wceJnR+AtqITQT5L+uMWPyUewmHozkdeSlpDGF95+O/5QFAnDxyzZWEgPj5GcG35w==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -9216,12 +9216,24 @@ hermes-estree@0.23.1:
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.23.1.tgz#d0bac369a030188120ee7024926aabe5a9f84fdb"
   integrity sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==
 
+hermes-estree@0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.24.0.tgz#487dc1ddc0bae698c2d79f34153ac9bf62d7b3c0"
+  integrity sha512-LyoXLB7IFzeZW0EvAbGZacbxBN7t6KKSDqFJPo3Ydow7wDlrDjXwsdiAHV6XOdvEN9MEuWXsSIFN4tzpyrXIHw==
+
 hermes-parser@0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.23.1.tgz#e5de648e664f3b3d84d01b48fc7ab164f4b68205"
   integrity sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==
   dependencies:
     hermes-estree "0.23.1"
+
+hermes-parser@0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.24.0.tgz#2ed19d079efc0848eb1f800f0c393a074c4696fb"
+  integrity sha512-IJooSvvu2qNRe7oo9Rb04sUT4omtZqZqf9uq9WM25Tb6v3usmvA93UqfnnoWs5V0uYjEl9Al6MNU10MCGKLwpg==
+  dependencies:
+    hermes-estree "0.24.0"
 
 hogan.js@^3.0.2:
   version "3.0.2"
@@ -11518,59 +11530,59 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-transformer@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.81.0-alpha.2.tgz#b4e3173c342c986c0b98acd72c64ee4da4c37ee1"
-  integrity sha512-OGjDXZGthGnMKH6GGrCYomXl5JT3CXhbPQe9Q0T2+AvFG5OYj4/SAhxqPZ0LgJ+aGAubCD30WoYJ+CZ0H1eEmg==
+metro-babel-transformer@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.81.0.tgz#cf468eafea52e4d8a77844eb7257f8a76e9d9d94"
+  integrity sha512-Dc0QWK4wZIeHnyZ3sevWGTnnSkIDDn/SWyfrn99zbKbDOCoCYy71PAn9uCRrP/hduKLJQOy+tebd63Rr9D8tXg==
   dependencies:
     "@babel/core" "^7.25.2"
     flow-enums-runtime "^0.0.6"
-    hermes-parser "0.23.1"
+    hermes-parser "0.24.0"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.81.0-alpha.2.tgz#85dff024d894b44f9d61422786063074e6345403"
-  integrity sha512-XE6LdsTrz5lBWznCKUBGrGlwQrbrHp37Q0SLRgG3xGDI33QmGD8U9DdY4siyGUdo+JD+h1T1RfAM72zWefn9Sw==
+metro-cache-key@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.81.0.tgz#5db34fa1a323a2310205bda7abd0df9614e36f45"
+  integrity sha512-qX/IwtknP9bQZL78OK9xeSvLM/xlGfrs6SlUGgHvrxtmGTRSsxcyqxR+c+7ch1xr05n62Gin/O44QKg5V70rNQ==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-cache@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.81.0-alpha.2.tgz#044d1132c66ffb6f49a4c5c70591296e0125908f"
-  integrity sha512-fAnaC/PTY0CxG4oaHWYd6JIKUF7lPswHEQvrAcULohdc7qdaOlLZwhIn5+IbhGoi2wYmygNtJAQ75dmaW5udQw==
+metro-cache@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.81.0.tgz#90470d10d190ad708f04c6e337eec2c7cddb3db0"
+  integrity sha512-DyuqySicHXkHUDZFVJmh0ygxBSx6pCKUrTcSgb884oiscV/ROt1Vhye+x+OIHcsodyA10gzZtrVtxIFV4l9I4g==
   dependencies:
     exponential-backoff "^3.1.1"
     flow-enums-runtime "^0.0.6"
-    metro-core "0.81.0-alpha.2"
+    metro-core "0.81.0"
 
-metro-config@0.81.0-alpha.2, metro-config@^0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.81.0-alpha.2.tgz#a110744b72c1397d818568b3b4dc8e096fb58393"
-  integrity sha512-HcAxiXW3nahJBKB2RmM7v+Y1hDsBw0tQWIksmIoRTEm6LqF0XbrONEg0MS5sGvWSe3TH3+hG/CWA9Brs9kuKuA==
+metro-config@0.81.0, metro-config@^0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.81.0.tgz#8f8074033cb7e9ddb5b0459642adf6880bc9fbc1"
+  integrity sha512-6CinEaBe3WLpRlKlYXXu8r1UblJhbwD6Gtnoib5U8j6Pjp7XxMG9h/DGMeNp9aGLDu1OieUqiXpFo7O0/rR5Kg==
   dependencies:
     connect "^3.6.5"
     cosmiconfig "^5.0.5"
     flow-enums-runtime "^0.0.6"
     jest-validate "^29.6.3"
-    metro "0.81.0-alpha.2"
-    metro-cache "0.81.0-alpha.2"
-    metro-core "0.81.0-alpha.2"
-    metro-runtime "0.81.0-alpha.2"
+    metro "0.81.0"
+    metro-cache "0.81.0"
+    metro-core "0.81.0"
+    metro-runtime "0.81.0"
 
-metro-core@0.81.0-alpha.2, metro-core@^0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.81.0-alpha.2.tgz#bf997b05bda00491194c95934ce5b1374f8d093e"
-  integrity sha512-U8bknkQK0a15F5ZPku5QP/ZmnYxhbYY5X+Pw0Gx+rpkeWf8vdfB+4r/usuzIh9kaZErZHTZNEMI7dZ4/4boRpQ==
+metro-core@0.81.0, metro-core@^0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.81.0.tgz#d0b634f9cf97849b7730c59457ab7a439811d4c8"
+  integrity sha512-CVkM5YCOAFkNMvJai6KzA0RpztzfEKRX62/PFMOJ9J7K0uq/UkOFLxcgpcncMIrfy0PbfEj811b69tjULUQe1Q==
   dependencies:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.81.0-alpha.2"
+    metro-resolver "0.81.0"
 
-metro-file-map@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.81.0-alpha.2.tgz#450310f28da447f6e6438acf1bc387895c58d416"
-  integrity sha512-bR/V5oKIk2OTNpTx9Xy2pYKDEUYbngUs/YsLFDkK4YFuO1FDJZxTcPr6sgMSJignz/AC2gx/oO3zpbO7I3GKJQ==
+metro-file-map@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.81.0.tgz#af0ccf4f8db4fd8429f78f231faa49dde2c402c3"
+  integrity sha512-zMDI5uYhQCyxbye/AuFx/pAbsz9K+vKL7h1ShUXdN2fz4VUPiyQYRsRqOoVG1DsiCgzd5B6LW0YW77NFpjDQeg==
   dependencies:
     anymatch "^3.0.3"
     debug "^2.2.0"
@@ -11586,62 +11598,62 @@ metro-file-map@0.81.0-alpha.2:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-minify-terser@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.81.0-alpha.2.tgz#bd844986ef08f6c5f7ae57828ae973256bb27000"
-  integrity sha512-cAqqFWP5UO0ImNu7c3xIrXCLltvm9OIng2kIe/+nU9CC70K7pATxdtWpC0PA9dt2MsfY2583i3pu/rr5qIY0Yw==
+metro-minify-terser@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.81.0.tgz#8b0abe977d63a99b99fa94d53678ef3170d5b659"
+  integrity sha512-U2ramh3W822ZR1nfXgIk+emxsf5eZSg10GbQrT0ZizImK8IZ5BmJY+BHRIkQgHzWFpExOVxC7kWbGL1bZALswA==
   dependencies:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.81.0-alpha.2.tgz#30402262f96ee1f1aa43408b1f91508a50da1be5"
-  integrity sha512-C4KGAki0jeUq1wqFrsD0R6FgmYL+6weDuze/5SolMmBflaU03hY9ZiQUsNuEWgU7+OG+A0q6PBwcskBUXBpW6Q==
+metro-resolver@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.81.0.tgz#141f4837e1e0c5a1810ea02f2d9be3c9f6cf3766"
+  integrity sha512-Uu2Q+buHhm571cEwpPek8egMbdSTqmwT/5U7ZVNpK6Z2ElQBBCxd7HmFAslKXa7wgpTO2FAn6MqGeERbAtVDUA==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-runtime@0.81.0-alpha.2, metro-runtime@^0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.81.0-alpha.2.tgz#216f02d5473799379403db71a0a6ec1b791197f6"
-  integrity sha512-uP+7ejq7R+WOV39TucJsgeRalA8jlw5l3JtID+Iu8zZvzJT0WO4VlINAFVS5n6Xk7tK+dkqGH1oF0lst1X+qNw==
+metro-runtime@0.81.0, metro-runtime@^0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.81.0.tgz#63af9b3fec15d1f307d89ef4881f5ba2c592291e"
+  integrity sha512-6oYB5HOt37RuGz2eV4A6yhcl+PUTwJYLDlY9vhT+aVjbUWI6MdBCf69vc4f5K5Vpt+yOkjy+2LDwLS0ykWFwYw==
   dependencies:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
-metro-source-map@0.81.0-alpha.2, metro-source-map@^0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.81.0-alpha.2.tgz#c8264efda5e312cb87a9b0ac78b7eb0e6808c92a"
-  integrity sha512-R5obOY4guE8D2fckCjoYrf+NHWwiorOBPSLr9jXLKXqdo7c3dCG9Fp9U1vJc4qKTJjhHN+bHND/+Ih8UPHH9zg==
+metro-source-map@0.81.0, metro-source-map@^0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.81.0.tgz#ca83964124bb227d5f0bdb1ee304dbfe635f869e"
+  integrity sha512-TzsVxhH83dyxg4A4+L1nzNO12I7ps5IHLjKGZH3Hrf549eiZivkdjYiq/S5lOB+p2HiQ+Ykcwtmcja95LIC62g==
   dependencies:
     "@babel/traverse" "^7.25.3"
     "@babel/traverse--for-generate-function-map" "npm:@babel/traverse@^7.25.3"
     "@babel/types" "^7.25.2"
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-symbolicate "0.81.0-alpha.2"
+    metro-symbolicate "0.81.0"
     nullthrows "^1.1.1"
-    ob1 "0.81.0-alpha.2"
+    ob1 "0.81.0"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.81.0-alpha.2.tgz#7aebb285b516b03df09ac8b3cc57611f7642db94"
-  integrity sha512-S5v09d93mg3C8iGwAZwhDwiDg5kW7DnGi9OOvb8+gtBJ9EzxV9/z3BPG1NFkzQ/ymnIEUcaQ1N8BpEgrXnsI6g==
+metro-symbolicate@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.81.0.tgz#b7b1eae8bfd6ad2a922fa2bcb9f2144e464adafb"
+  integrity sha512-C/1rWbNTPYp6yzID8IPuQPpVGzJ2rbWYBATxlvQ9dfK5lVNoxcwz77hjcY8ISLsRRR15hyd/zbjCNKPKeNgE1Q==
   dependencies:
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-source-map "0.81.0-alpha.2"
+    metro-source-map "0.81.0"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.81.0-alpha.2.tgz#7fd204f91975c4dc8145d613b54f982ec892ba84"
-  integrity sha512-VtK38ytQ9mK1v/JOm1wW1AvZjO/Fsd8krNZy6riRj2fstcKkNx6LL1j5TtwINBUjCY1WPrpunQtG+Wc98LMiHQ==
+metro-transform-plugins@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.81.0.tgz#614c0e50593df545487b3f3383fed810c608fb32"
+  integrity sha512-uErLAPBvttGCrmGSCa0dNHlOTk3uJFVEVWa5WDg6tQ79PRmuYRwzUgLhVzn/9/kyr75eUX3QWXN79Jvu4txt6Q==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.25.0"
@@ -11650,29 +11662,29 @@ metro-transform-plugins@0.81.0-alpha.2:
     flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.81.0-alpha.2.tgz#a18a386139c9e74e189e5bc94c6d6028aba35ba7"
-  integrity sha512-DBzR0gf7rBB42NDFuZ9hfTrvpSNDnKSHsp+TKMBtsVRtb3UpbnuH1iiO7HNV7Dro5E8nNjkYuUnLE6tC6CNFYQ==
+metro-transform-worker@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.81.0.tgz#43e63c95014f36786f0e1a132c778c6392950de7"
+  integrity sha512-HrQ0twiruhKy0yA+9nK5bIe3WQXZcC66PXTvRIos61/EASLAP2DzEmW7IxN/MGsfZegN2UzqL2CG38+mOB45vg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.25.0"
     "@babel/parser" "^7.25.3"
     "@babel/types" "^7.25.2"
     flow-enums-runtime "^0.0.6"
-    metro "0.81.0-alpha.2"
-    metro-babel-transformer "0.81.0-alpha.2"
-    metro-cache "0.81.0-alpha.2"
-    metro-cache-key "0.81.0-alpha.2"
-    metro-minify-terser "0.81.0-alpha.2"
-    metro-source-map "0.81.0-alpha.2"
-    metro-transform-plugins "0.81.0-alpha.2"
+    metro "0.81.0"
+    metro-babel-transformer "0.81.0"
+    metro-cache "0.81.0"
+    metro-cache-key "0.81.0"
+    metro-minify-terser "0.81.0"
+    metro-source-map "0.81.0"
+    metro-transform-plugins "0.81.0"
     nullthrows "^1.1.1"
 
-metro@0.81.0-alpha.2, metro@^0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.81.0-alpha.2.tgz#69059bda8f4194809d206cfae89ff2f06a53e5a7"
-  integrity sha512-ZfL5IjEEuMtM5A5tVKL2LNv/WO6Gj1RhdIsW+3uz3BB0Y/ZqMdfp61qVWNCV7kGWMqunee3ER0P1EUuPHfIb0Q==
+metro@0.81.0, metro@^0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.81.0.tgz#cffe9b7d597728dee8b57903ca155417b7c13a4f"
+  integrity sha512-kzdzmpL0gKhEthZ9aOV7sTqvg6NuTxDV8SIm9pf9sO8VVEbKrQk5DNcwupOUjgPPFAuKUc2NkT0suyT62hm2xg==
   dependencies:
     "@babel/code-frame" "^7.24.7"
     "@babel/core" "^7.25.2"
@@ -11690,24 +11702,24 @@ metro@0.81.0-alpha.2, metro@^0.81.0-alpha.2:
     error-stack-parser "^2.0.6"
     flow-enums-runtime "^0.0.6"
     graceful-fs "^4.2.4"
-    hermes-parser "0.23.1"
+    hermes-parser "0.24.0"
     image-size "^1.0.2"
     invariant "^2.2.4"
     jest-worker "^29.6.3"
     jsc-safe-url "^0.2.2"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.81.0-alpha.2"
-    metro-cache "0.81.0-alpha.2"
-    metro-cache-key "0.81.0-alpha.2"
-    metro-config "0.81.0-alpha.2"
-    metro-core "0.81.0-alpha.2"
-    metro-file-map "0.81.0-alpha.2"
-    metro-resolver "0.81.0-alpha.2"
-    metro-runtime "0.81.0-alpha.2"
-    metro-source-map "0.81.0-alpha.2"
-    metro-symbolicate "0.81.0-alpha.2"
-    metro-transform-plugins "0.81.0-alpha.2"
-    metro-transform-worker "0.81.0-alpha.2"
+    metro-babel-transformer "0.81.0"
+    metro-cache "0.81.0"
+    metro-cache-key "0.81.0"
+    metro-config "0.81.0"
+    metro-core "0.81.0"
+    metro-file-map "0.81.0"
+    metro-resolver "0.81.0"
+    metro-runtime "0.81.0"
+    metro-source-map "0.81.0"
+    metro-symbolicate "0.81.0"
+    metro-transform-plugins "0.81.0"
+    metro-transform-worker "0.81.0"
     mime-types "^2.1.27"
     nullthrows "^1.1.1"
     serialize-error "^2.1.0"
@@ -12376,10 +12388,10 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-ob1@0.81.0-alpha.2:
-  version "0.81.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.81.0-alpha.2.tgz#45ac7fc423577fee88425476908793905df6a3c5"
-  integrity sha512-wii3uNfV58CK6KzM6o1HzlUAYZJbsbNm3dQHMQJeTok6jZzF/aDYZrbuI4U4V4HkKxrHL2QgRf2rKDlDU9Au9g==
+ob1@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.81.0.tgz#dc3154cca7aa9c2eb58f5ac63e9ee23ff4c6f520"
+  integrity sha512-6Cvrkxt1tqaRdWqTAMcVYEiO5i1xcF9y7t06nFdjFqkfPsEloCf8WwhXdwBpNUkVYSQlSGS7cDgVQR86miBfBQ==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
@@ -13745,19 +13757,19 @@ react-native-webview@13.8.6:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native@0.76.0-rc.4:
-  version "0.76.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.76.0-rc.4.tgz#8b012193df71bc66766402690450af77f6630706"
-  integrity sha512-DpYitSAVwtsGccL2UB8jJWtEk7xRVBTdN/Z3YaY2hpoZvMgvAXo1hf5ZBaIR2RqQsNbs95oq3ReO4YnRRidRCQ==
+react-native@0.76.0-rc.5:
+  version "0.76.0-rc.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.76.0-rc.5.tgz#f277faf7d7b73cb4f1324c6ff3b3f9cad77c8587"
+  integrity sha512-o9ePfa3BBrcbNjZs2Z7bPxFgHJnbl3fjHfiB1IQu4Yjpw9cSzC7+8Kalz6aW+MYIYrGJKTlbrDCvvz90kGYHPg==
   dependencies:
     "@jest/create-cache-key-function" "^29.6.3"
-    "@react-native/assets-registry" "0.76.0-rc.4"
-    "@react-native/codegen" "0.76.0-rc.4"
-    "@react-native/community-cli-plugin" "0.76.0-rc.4"
-    "@react-native/gradle-plugin" "0.76.0-rc.4"
-    "@react-native/js-polyfills" "0.76.0-rc.4"
-    "@react-native/normalize-colors" "0.76.0-rc.4"
-    "@react-native/virtualized-lists" "0.76.0-rc.4"
+    "@react-native/assets-registry" "0.76.0-rc.5"
+    "@react-native/codegen" "0.76.0-rc.5"
+    "@react-native/community-cli-plugin" "0.76.0-rc.5"
+    "@react-native/gradle-plugin" "0.76.0-rc.5"
+    "@react-native/js-polyfills" "0.76.0-rc.5"
+    "@react-native/normalize-colors" "0.76.0-rc.5"
+    "@react-native/virtualized-lists" "0.76.0-rc.5"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"
@@ -13773,8 +13785,8 @@ react-native@0.76.0-rc.4:
     jest-environment-node "^29.6.3"
     jsc-android "^250231.0.0"
     memoize-one "^5.0.0"
-    metro-runtime "^0.81.0-alpha.2"
-    metro-source-map "^0.81.0-alpha.2"
+    metro-runtime "^0.81.0"
+    metro-source-map "^0.81.0"
     mkdirp "^0.5.1"
     nullthrows "^1.1.1"
     pretty-format "^29.7.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/32064
Closes [ENG-13531](https://linear.app/expo/issue/ENG-13531)

# How

- update package versions
  - `react-native 0.76.0-rc.4 -> 0.76.0-rc.5` 
  - Bump gradle to 8.10.2 
- Revert DevLauncher and DevClient PackagerConnectionSettings changes from https://github.com/expo/expo/pull/31552 

# Test Plan

bare-expo ios / android
fabric ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
