### PR TITLE
Fix requestAuthorizationOptions crash with reloadAsync

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] fix crash if expo-update reload happens while Notifications.requestPermissionsAsync() is showing native dialog ([#32096](https://github.com/expo/expo/pull/32096) by [@mfazekas](https://github.com/mfazekas))
 - [android] `createNotificationChannel` could return incorrect channel information ([#32000](https://github.com/expo/expo/pull/32000) by [@vonovak](https://github.com/vonovak))
 - [android] fix notifications with `ChannelAwareTrigger` not being presented ([#31999](https://github.com/expo/expo/pull/31999) by [@vonovak](https://github.com/vonovak))
 - export `PermissionStatus` as value, not as type ([#31968](https://github.com/expo/expo/pull/31968) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
@@ -111,7 +111,7 @@ static NSDictionary *_requestedPermissions;
 {
   EX_WEAKIFY(self);
   [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:options completionHandler:^(BOOL granted, NSError * _Nullable error) {
-    EX_STRONGIFY(self);
+    EX_ENSURE_STRONGIFY(self);
     // getPermissions blocks method queue on which this callback is being executed
     // so we have to dispatch to another queue.
     dispatch_async(self.methodQueue, ^{


### PR DESCRIPTION

# Why

Fixes: #32073 

# How

Use EX_ENSURE_STRONGIFY in requestAuthorizationOptions, as expo-update's reloadAsync causes EXNotificationPermissionsModule to be recreated. This releases EXUserFacingNotificationsPermissionsRequester, so we need to check for nil.

# Test Plan

Used the example app in the bug report to ensure that we no longer crash when showing and notification approve system dialog, while reload the expo with expo-update-s reloadAsync

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
