### PR TITLE
feat: add new api to show contact details (read only) in system UI

### DIFF
--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -31,6 +31,12 @@ export default function ContactDetailScreen(props: any) {
       headerRight: () => (
         <HeaderContainerRight>
           <HeaderIconButton
+            name="document"
+            onPress={async () => {
+              Contacts.displayContactAsync(props.route.params.id);
+            }}
+          />
+          <HeaderIconButton
             name="share"
             onPress={async () => {
               Contacts.shareContactAsync(props.route.params.id, 'Call me :]');

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -298,6 +298,17 @@ class ContactsModule : Module() {
       contactPickingPromise = promise
       currentActivity.startActivityForResult(intent, RC_PICK_CONTACT)
     }
+
+    AsyncFunction("displayContactAsync") { contactId: String, promise: Promise ->
+      val uri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_URI, contactId)
+      val intent = Intent(Intent.ACTION_VIEW).apply {
+        setData(uri)
+      }
+      currentActivity.startActivity(intent)
+      promise.resolve(true)
+    }
+
+
   }
 
   private fun presentForm(contact: Contact, promise: Promise) {

--- a/packages/expo-contacts/src/Contacts.ts
+++ b/packages/expo-contacts/src/Contacts.ts
@@ -559,6 +559,20 @@ export type Container = {
 export { PermissionStatus, PermissionResponse, PermissionExpiration };
 
 /**
+ * Displays contact details from contacts book
+ * @example
+ * ```js
+ * await Contacts.getContactsAsync(contactId);
+ * ```
+ */
+export async function displayContactAsync(contactId: string): Promise<boolean> {
+  if (!ExpoContacts.displayContactAsync) {
+    throw new UnavailabilityError('Contacts', 'displayContactAsync');
+  }
+  return await ExpoContacts.displayContactAsync(contactId);
+}
+
+/**
  * Returns whether the Contacts API is enabled on the current device. This method does not check the app permissions.
  * @returns A promise that fulfills with a `boolean`, indicating whether the Contacts API is available on the current device. It always resolves to `false` on web.
  */


### PR DESCRIPTION
# Why

No API exixst to display contact details in a native UI

# How
implement new API to display contact details in a native UI

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
