### PR TITLE
[doctor] Fix project setup check running on EAS Build and failing

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix project setup check running on EAS Build and failing ([#32106](https://github.com/expo/expo/pull/32106) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 ## 1.11.1 — 2024-10-15

--- a/packages/expo-doctor/src/checks/MetroConfigCheck.ts
+++ b/packages/expo-doctor/src/checks/MetroConfigCheck.ts
@@ -3,7 +3,7 @@ import { learnMore } from '../utils/TerminalLink';
 import { configExistsAsync, loadConfigAsync } from '../utils/metroConfigLoader';
 
 export class MetroConfigCheck implements DoctorCheck {
-  description = 'Check for issues with metro config';
+  description = 'Check for issues with Metro config';
 
   sdkVersionRange = '>=46.0.0';
 
@@ -29,7 +29,7 @@ export class MetroConfigCheck implements DoctorCheck {
       isSuccessful: !issues.length,
       issues,
       advice: issues.length
-        ? `Update your custom metro.config.js to extend @expo/metro-config.`
+        ? `Update your metro.config.js to extend @expo/metro-config.`
         : undefined,
     };
   }

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -32,7 +32,7 @@ export class ProjectSetupCheck implements DoctorCheck {
         )
       ) {
         issues.push(
-          'This project contains local Expo modules, but the "android" and "ios" directories inside the modules are gitignored. This is often due to overly general gitignore rules. Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level "android" and "ios" directories.'
+          `The "android" and/or "ios" directories (./modules/your-module/[android|ios]) for local Expo modules are gitignored, and they should not be. This is often due to overly general gitignore rules. Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level "android" and "ios" directories, and not those in the modules directory.`
         );
       }
     }

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -10,14 +10,17 @@ export class ProjectSetupCheck implements DoctorCheck {
 
   sdkVersionRange = '*';
 
-  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];
 
-    // ** check that expo modules native projects aren't getting gitignored **
+    /* Check that Expo modules native projects aren't getting gitignored.  Skip
+     * this check when running on an EAS Build worker, where we may or may not
+     * have git. */
 
-    if (fs.existsSync(path.join(projectRoot, 'modules'))) {
-      // Glob returns matching files and `git check-ignore` checks files, as well, but we want to check if the path is gitignored,
-      // so we pick vital files to match off of (e.g., .podspec, build.gradle).
+    if (fs.existsSync(path.join(projectRoot, 'modules')) && !process.env.EAS_BUILD) {
+      // Glob returns matching files and `git check-ignore` checks files, as
+      // well, but we want to check if the path is gitignored, so we pick vital
+      // files to match off of (e.g., .podspec, build.gradle).
       const keyFilePathsForModules = [
         path.join(projectRoot, 'modules', '**', 'ios', '*.podspec'),
         path.join(projectRoot, 'modules', '**', 'android', 'build.gradle'),
@@ -29,12 +32,12 @@ export class ProjectSetupCheck implements DoctorCheck {
         )
       ) {
         issues.push(
-          'This project contains local Expo modules, but the android/ios folders inside the modules are gitignored. These files are required to build your native module into your app. Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level android and ios folders.'
+          'This project contains local Expo modules, but the "android" and "ios" directories inside the modules are gitignored. This is often due to overly general gitignore rules. Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level "android" and "ios" directories.'
         );
       }
     }
 
-    // ** multiple lock file check **
+    /* Check for multiple lockfiles. */
 
     const lockfileCheckResults = await Promise.all(
       ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json'].map((lockfile) => {
@@ -48,9 +51,9 @@ export class ProjectSetupCheck implements DoctorCheck {
 
     if (lockfiles.length > 1) {
       issues.push(
-        `This project has multiple package manager lock files (${lockfiles.join(
+        `Multiple lock files detected (${lockfiles.join(
           ', '
-        )}). This may cause EAS build to restore dependencies with a different package manager from what you use in other environments.`
+        )}). This may result in unexpected behavior in CI environments, such as EAS Build, which infer the package manager from the lock file.`
       );
     }
 


### PR DESCRIPTION
# Why

If we try to run Git commands in doctor, this will typically not work on EAS Build because we don't actually clone the repo. So we'll get errors like this:

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/14a695a6-5ef0-4b9a-89c7-9a25ecaee8c2">

# How

Skip the check when running on EAS Build.

# Test Plan

Run the local doctor bin with `EAS_BUILD=true` env var set