### PR TITLE
[router]: Align @react-nativation/* package versions with sdk52

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@react-navigation/native-stack": "7.0.0-rc.28",
     "@react-navigation/routers": "7.0.0-rc.8",
     "@react-navigation/stack": "7.0.0-rc.27",
-    "react-native-screens": "4.0.0-beta.9",
+    "react-native-screens": "4.0.0-beta.12",
     "**/util": "~0.12.4"
   },
   "dependencies": {

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -71,7 +71,7 @@
     "expo"
   ],
   "peerDependencies": {
-    "@react-navigation/drawer": "7.0.0-rc.11",
+    "@react-navigation/drawer": "7.0.0-rc.31",
     "expo": "*",
     "expo-constants": "*",
     "expo-linking": "*",
@@ -91,7 +91,7 @@
     }
   },
   "devDependencies": {
-    "@react-navigation/drawer": "7.0.0-rc.11",
+    "@react-navigation/drawer": "7.0.0-rc.31",
     "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react": "^15.0.7",
     "@testing-library/react-native": "^12.5.1",
@@ -103,9 +103,9 @@
     "@expo/metro-runtime": "3.2.1",
     "@expo/server": "^0.4.0",
     "@radix-ui/react-slot": "1.0.1",
-    "@react-navigation/bottom-tabs": "7.0.0-rc.13",
-    "@react-navigation/native": "7.0.0-rc.6",
-    "@react-navigation/native-stack": "7.0.0-rc.8",
+    "@react-navigation/bottom-tabs": "7.0.0-rc.33",
+    "@react-navigation/native": "7.0.0-rc.20",
+    "@react-navigation/native-stack": "7.0.0-rc.28",
     "client-only": "^0.0.1",
     "expo-splash-screen": "0.27.4",
     "react-helmet-async": "^1.3.0",


### PR DESCRIPTION
# Why

d2caffd6de8caa075de257f6d9459462d5aee67a
- did not update the `expo-router/package.json` to the correct versions
- added an incorrect version of `react-native-screens` to the root `package.json