### PR TITLE
[notification][Android] Remove unused method

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFirebaseMessagingDelegate.kt
@@ -58,7 +58,7 @@ class ExpoFirebaseMessagingDelegate(context: Context) : FirebaseMessagingDelegat
     content: INotificationContent,
     notificationTrigger: FirebaseNotificationTrigger
   ): NotificationRequest {
-    val data = notificationTrigger.getRemoteMessage().data
+    val data = notificationTrigger.remoteMessage.data
     return ScopedNotificationRequest(
       identifier,
       content,

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/delegates/ScopedExpoPresentationDelegate.kt
@@ -53,7 +53,7 @@ class ScopedExpoPresentationDelegate(context: Context) : ExpoPresentationDelegat
       return super.getNotifyId(request)
     }
     val experienceId = if (request.trigger is FirebaseNotificationTrigger) {
-      (request.trigger as FirebaseNotificationTrigger).getRemoteMessage().data["scopeKey"]
+      (request.trigger as FirebaseNotificationTrigger).remoteMessage.data["scopeKey"]
     } else if (request is ScopedNotificationRequest) {
       request.experienceScopeKeyString
     } else {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt
@@ -20,8 +20,6 @@ class FirebaseNotificationTrigger(val remoteMessage: RemoteMessage) : Notificati
       ?: throw IllegalArgumentException("RemoteMessage from readParcelable must not be null")
   )
 
-  fun getRemoteMessage(): RemoteMessage = remoteMessage
-
   @RequiresApi(api = Build.VERSION_CODES.O)
   override fun getNotificationChannel(): String? {
     val channelId = remoteMessage.notification?.channelId ?: remoteMessage.data["channelId"]


### PR DESCRIPTION
# Why

Removes unused method and fixes CI.
```
> Task :expo-notifications:compileDebugKotlin FAILED
e: file:///home/runner/work/expo/expo/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt:16:35 Platform declaration clash: The following declarations have the same JVM signature (getRemoteMessage()Lcom/google/firebase/messaging/RemoteMessage;):
    fun `<get-remoteMessage>`(): RemoteMessage defined in expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger
    fun getRemoteMessage(): RemoteMessage defined in expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger
e: file:///home/runner/work/expo/expo/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.kt:23:3 Platform declaration clash: The following declarations have the same JVM signature (getRemoteMessage()Lcom/google/firebase/messaging/RemoteMessage;):
    fun `<get-remoteMessage>`(): RemoteMessage defined in expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger
    fun getRemoteMessage(): RemoteMessage defined in expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger
```