### PR TITLE
[image][Android] Bump glide to `4.16.0`

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-  def GLIDE_VERSION = "4.13.2"
+  def GLIDE_VERSION = "4.16.0"
 
   implementation 'com.facebook.react:react-android'
 


### PR DESCRIPTION
# Why

Bumps Glide to `4.16.0`
