### PR TITLE
[cli]: Support DevServer automatically choosing a free port in non-interactive terminals

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Add an optional New Architecture compatibility check for dependencies added via `install` command. ([#31222](https://github.com/expo/expo/pull/31222) by [@Simek](https://github.com/Simek))
 - Add support in `expo run android` for product flavors with custom app ids. ([#31756](https://github.com/expo/expo/pull/31756) by [@byCedric](https://github.com/byCedric))
 - Support Fusebox and React Native DevTools in Expo. ([#32029](https://github.com/expo/expo/pull/32029) by [@byCedric](https://github.com/byCedric))
+- Support DevServer automatically choosing a free port in non-interactive terminals.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Add an optional New Architecture compatibility check for dependencies added via `install` command. ([#31222](https://github.com/expo/expo/pull/31222) by [@Simek](https://github.com/Simek))
 - Add support in `expo run android` for product flavors with custom app ids. ([#31756](https://github.com/expo/expo/pull/31756) by [@byCedric](https://github.com/byCedric))
 - Support Fusebox and React Native DevTools in Expo. ([#32029](https://github.com/expo/expo/pull/32029) by [@byCedric](https://github.com/byCedric))
-- Support DevServer automatically choosing a free port in non-interactive terminals.
+- Support DevServer automatically choosing a free port in non-interactive terminals. ([#32112](https://github.com/expo/expo/pull/32112) by [@marklawlor](https://github.com/marklawlor))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import freeportAsync from 'freeport-async';
 
 import { getRunningProcess } from '../getRunningProcess';
@@ -58,7 +57,11 @@ describe(choosePortAsync, () => {
       command: 'npx expo',
     });
     jest.mocked(confirmAsync).mockResolvedValueOnce(true);
-    const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
+    const port = await choosePortAsync('/', {
+      defaultPort: 8081,
+      reuseExistingPort: false,
+      forceInteractive: true,
+    });
     expect(port).toBe(8082);
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
@@ -70,7 +73,11 @@ describe(choosePortAsync, () => {
       command: 'npx expo',
     });
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
+    const port = await choosePortAsync('/', {
+      defaultPort: 8081,
+      reuseExistingPort: false,
+      forceInteractive: true,
+    });
     expect(port).toBe(null);
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
@@ -82,8 +89,27 @@ describe(choosePortAsync, () => {
       command: 'npx expo',
     });
     jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    const port = await choosePortAsync('/me', { defaultPort: 8081, reuseExistingPort: true });
+    const port = await choosePortAsync('/me', {
+      defaultPort: 8081,
+      reuseExistingPort: true,
+      forceInteractive: true,
+    });
     expect(port).toBe(null);
     expect(confirmAsync).not.toBeCalled();
+  });
+  it(`chooses the next port automatically when in a non-interactive terminal`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/other/project',
+      command: 'npx expo',
+    });
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    const port = await choosePortAsync('/', {
+      defaultPort: 8081,
+      reuseExistingPort: false,
+    });
+    expect(port).toBe(8082);
+    expect(confirmAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -98,6 +98,7 @@ describe(choosePortAsync, () => {
     expect(confirmAsync).not.toBeCalled();
   });
   it(`chooses the next port automatically when in a non-interactive terminal`, async () => {
+    // Jest runs in a non-interactive terminal
     jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -72,10 +72,13 @@ export async function choosePortAsync(
     defaultPort,
     host,
     reuseExistingPort,
+    forceInteractive,
   }: {
     defaultPort: number;
     host?: string;
     reuseExistingPort?: boolean;
+    /* Override the checks for interactive mode. Used for testing where the terminal is always non-interactive */
+    forceInteractive?: boolean;
   }
 ): Promise<number | null> {
   try {
@@ -111,7 +114,7 @@ export async function choosePortAsync(
 
     Log.log(`\u203A ${message}`);
 
-    if (!isInteractive()) {
+    if (!forceInteractive && !isInteractive()) {
       return port;
     }
 

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -4,6 +4,7 @@ import freeportAsync from 'freeport-async';
 import { env } from './env';
 import { CommandError } from './errors';
 import * as Log from '../log';
+import { isInteractive } from './interactive';
 
 /** Get a free port or assert a CLI command error. */
 export async function getFreePortAsync(rangeStart: number): Promise<number> {
@@ -109,6 +110,11 @@ export async function choosePortAsync(
     }
 
     Log.log(`\u203A ${message}`);
+
+    if (!isInteractive()) {
+      return port;
+    }
+
     const { confirmAsync } = require('./prompts') as typeof import('./prompts');
     const change = await confirmAsync({
       message: `Use port ${port} instead?`,


### PR DESCRIPTION
# Why

The RSC playwright e2e tests are currently failing due to multiple dev servers attempting to use the same port. As the terminal is non-interactive, the second server crashes when a new port is not able to be selected.

This fixes an issue with the E2E playwright tests overlapping and failing, but the actual cause of that failure is a different issue (they are running in sync and not being stopped correctly). However this change would allow us to run them in parallel.


# How

Updated the code so in a non-interactive terminal the next port is chosen automatically

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
