### PR TITLE
[image][Android] Add downscaling options to `useImage` hook

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [Android] Added support for rendering shared image refs. ([#31098](https://github.com/expo/expo/pull/31098) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for rendering shared refs of `Bitmap's`. ([#31440](https://github.com/expo/expo/pull/31440) by [@lukmccall](https://github.com/lukmccall))
 - Added `useImage` hook. ([#31171](https://github.com/expo/expo/pull/31171) by [@tsapeta](https://github.com/tsapeta))
-- Added downscaling options to `useImage` hook.
+- Added downscaling options to `useImage` hook. ([#32113](https://github.com/expo/expo/pull/32113) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Added support for rendering shared image refs. ([#31098](https://github.com/expo/expo/pull/31098) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added support for rendering shared refs of `Bitmap's`. ([#31440](https://github.com/expo/expo/pull/31440) by [@lukmccall](https://github.com/lukmccall))
 - Added `useImage` hook. ([#31171](https://github.com/expo/expo/pull/31171) by [@tsapeta](https://github.com/tsapeta))
+- Added downscaling options to `useImage` hook.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -29,6 +29,7 @@ import expo.modules.image.records.CachePolicy
 import expo.modules.image.records.ContentPosition
 import expo.modules.image.records.DecodeFormat
 import expo.modules.image.records.DecodedSource
+import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.Promise
@@ -113,9 +114,9 @@ class ExpoImageModule : Module() {
       }
     }
 
-    AsyncFunction("loadAsync") { source: SourceMap, promise: Promise ->
+    AsyncFunction("loadAsync") { source: SourceMap, options: ImageLoadOptions?, promise: Promise ->
       CoroutineScope(Dispatchers.Main).launch {
-        ImageLoadTask(appContext, source).load(promise)
+        ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load(promise)
       }
     }
 
@@ -173,7 +174,7 @@ class ExpoImageModule : Module() {
       return@AsyncFunction try {
         val file = target.get()
         file.absolutePath
-      } catch (e: Exception) {
+      } catch (_: Exception) {
         null
       }
     }
@@ -290,7 +291,7 @@ class ExpoImageModule : Module() {
       }
 
       Prop("accessible") { view: ExpoImageViewWrapper, accessible: Boolean? ->
-        view.accessible = accessible ?: false
+        view.accessible = accessible == true
       }
 
       Prop("accessibilityLabel") { view: ExpoImageViewWrapper, accessibilityLabel: String? ->
@@ -298,7 +299,7 @@ class ExpoImageModule : Module() {
       }
 
       Prop("focusable") { view: ExpoImageViewWrapper, isFocusable: Boolean? ->
-        view.isFocusableProp = isFocusable ?: false
+        view.isFocusableProp = isFocusable == true
       }
 
       Prop("priority") { view: ExpoImageViewWrapper, priority: Priority? ->
@@ -314,11 +315,11 @@ class ExpoImageModule : Module() {
       }
 
       Prop("allowDownscaling") { view: ExpoImageViewWrapper, allowDownscaling: Boolean? ->
-        view.allowDownscaling = allowDownscaling ?: true
+        view.allowDownscaling = allowDownscaling != false
       }
 
       Prop("autoplay") { view: ExpoImageViewWrapper, autoplay: Boolean? ->
-        view.autoplay = autoplay ?: true
+        view.autoplay = autoplay != false
       }
 
       Prop("decodeFormat") { view: ExpoImageViewWrapper, format: DecodeFormat? ->

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
@@ -2,9 +2,10 @@ package expo.modules.image
 
 import android.graphics.drawable.Drawable
 import com.bumptech.glide.Glide
-import expo.modules.kotlin.Promise
+import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -12,7 +13,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 
-open class ImageLoadTask(private val appContext: AppContext, private val source: SourceMap) {
+open class ImageLoadTask(private val appContext: AppContext, private val source: SourceMap, private val options: ImageLoadOptions) {
   private var task: Job? = null
 
   suspend fun load(promise: Promise) {
@@ -20,7 +21,13 @@ open class ImageLoadTask(private val appContext: AppContext, private val source:
       val deferred = async {
         val context = this@ImageLoadTask.appContext.reactContext ?: throw Exceptions.ReactContextLost()
         withContext(Dispatchers.IO) {
-          Glide.with(context).asDrawable().load(source.uri).submit().get()
+          Glide
+            .with(context)
+            .asDrawable()
+            .load(source.uri)
+            .centerInside()
+            .submit(options.maxWidth, options.maxHeight)
+            .get()
         }
       }
       task = deferred

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageLoadOptions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageLoadOptions.kt
@@ -1,0 +1,12 @@
+package expo.modules.image.records
+
+import com.bumptech.glide.request.target.Target.SIZE_ORIGINAL
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+data class ImageLoadOptions(
+  @Field
+  val maxWidth: Int = SIZE_ORIGINAL,
+  @Field
+  val maxHeight: Int = SIZE_ORIGINAL
+) : Record


### PR DESCRIPTION
# Why

`useImage` hook should provide an option to automatically downscale the loaded image, to help reducing the memory usage.
A followup to the https://github.com/expo/expo/pull/32018

# How

Configured Glide to respect provided dimensions. 

# Test Plan

- Example in NCL ✅ 