### PR TITLE
Update apple-developer-program-roles-and-permissions.mdx

### DIFF
--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -7,7 +7,7 @@ description: Learn about the Apple Developer account membership requirements for
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-An Apple Developer account with *App-Manager Role* is required to create iOS device builds on EAS. This account allows you to generate [app signing credentials](/app-signing/managed-credentials/#generating-app-signing-credentials) such as certificates, identifiers, and profiles, submit the app for review, and manage app's distribution.
+An Apple Developer account with at least App-Manager Role is required to create iOS device builds on EAS. This account allows you to generate [app signing credentials](/app-signing/managed-credentials/#generating-app-signing-credentials) such as certificates, identifiers, and profiles, submit the app for review, and manage app's distribution.
 
 An Apple Developer user profile must have **Access to Certificates, Identifiers, and Profiles** enabled in their App Store Connect user permissions to generate app signing credentials. If the Apple Developer account is an individual account, only the authorized user of the account can have this access. For an organization Apple Developer account, multiple team members can have this access, but some organizations may choose to limit this access to certain team members.
 

--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -7,7 +7,7 @@ description: Learn about the Apple Developer account membership requirements for
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-An Apple Developer account is required to create iOS device builds on EAS. This account allows you to generate [app signing credentials](/app-signing/managed-credentials/#generating-app-signing-credentials) such as certificates, identifiers, and profiles, submit the app for review, and manage app's distribution.
+An Apple Developer account with *App-Manager Role* is required to create iOS device builds on EAS. This account allows you to generate [app signing credentials](/app-signing/managed-credentials/#generating-app-signing-credentials) such as certificates, identifiers, and profiles, submit the app for review, and manage app's distribution.
 
 An Apple Developer user profile must have **Access to Certificates, Identifiers, and Profiles** enabled in their App Store Connect user permissions to generate app signing credentials. If the Apple Developer account is an individual account, only the authorized user of the account can have this access. For an organization Apple Developer account, multiple team members can have this access, but some organizations may choose to limit this access to certain team members.
 


### PR DESCRIPTION
Make clear that the Apple User need to be a App-Manager and not only a Developer.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
