### PR TITLE
chore: update typescript to 5.6.3

### DIFF
--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -44,6 +44,6 @@
     "jest-watch-typeahead": "2.2.1",
     "resolve-workspace-root": "^2.0.0",
     "ts-jest": "~29.0.4",
-    "typescript": "^5.1.3"
+    "typescript": "^5.6.3"
   }
 }

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -33,7 +33,7 @@
     "@types/node-fetch": "^2.5.12",
     "eslint-config-universe": "^13.0.0",
     "expo-module-scripts": "^3.0.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.6.3"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15916,10 +15916,10 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+typescript@^5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
+  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 ua-parser-js@^0.7.30, ua-parser-js@^0.7.33:
   version "0.7.33"


### PR DESCRIPTION
# Why

to use new TS features such as [Inferred Type Predicates](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html) and more

# How

update the dep

# Test Plan

not sure yet

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
