### PR TITLE
[updates][android] Run spotless check

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
@@ -12,7 +11,6 @@ import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.manifest.Update
 import expo.modules.updates.statemachine.UpdatesStateContext
 import java.io.File
-import java.lang.ref.WeakReference
 import java.util.Date
 import kotlin.time.Duration
 import kotlin.time.DurationUnit

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -2,7 +2,6 @@ package expo.modules.updates
 
 import android.content.Context
 import com.facebook.react.ReactApplication
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -13,7 +13,6 @@ import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogEntry
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
-import java.lang.ref.WeakReference
 import java.util.Date
 
 /**
@@ -45,7 +44,6 @@ class UpdatesModule : Module() {
     }
 
     OnStopObserving {
-
     }
 
     AsyncFunction("reload") { promise: Promise ->

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/IUpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/IUpdatesEventManager.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.events
 
 import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.statemachine.UpdatesStateContext
-import expo.modules.updates.statemachine.UpdatesStateEventType
 
 enum class UpdatesJSEvent(val eventName: String) {
   StateChange("Expo.nativeUpdatesStateChangeEvent")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/NoOpUpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/NoOpUpdatesEventManager.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.events
 
 import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.statemachine.UpdatesStateContext
-import expo.modules.updates.statemachine.UpdatesStateEventType
 
 class NoOpUpdatesEventManager : IUpdatesEventManager {
   override var eventEmitter: EventEmitter? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/UpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/UpdatesEventManager.kt
@@ -4,7 +4,6 @@ import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.statemachine.UpdatesStateContext
-import expo.modules.updates.statemachine.UpdatesStateEventType
 
 class UpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEventManager {
   override var eventEmitter: EventEmitter? = null


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/4c52f8ed432f2cc3569f93ebbcab77a90bb47f48 broke spotless lint check

# How

Run `./gradlew :expo-updates:spotlessApply`

# Test Plan

Android unit tests should be green 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
