### PR TITLE
[expo-updates][android] Fix missing function call in UpdatesModule OnStopObserving

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -44,6 +44,7 @@ class UpdatesModule : Module() {
     }
 
     OnStopObserving {
+      UpdatesController.onEventListenerStopObserving()
     }
 
     AsyncFunction("reload") { promise: Promise ->


### PR DESCRIPTION
# Why

Noticed in https://app.graphite.dev/github/pr/expo/expo/32132/updates-android-Run-spotless-check that I forgot to add this line.

# How

Add line. Same as iOS.

# Test Plan

Run e2e test locally, still passes. Reload is a hard thing to test in e2e so that's the only place the lack of this line would've manifested.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
