### PR TITLE
[router] Fix maestro CI config

### DIFF
--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -14,7 +14,6 @@ jobs:
       E2E_ROUTER_USE_PUBLISHED_EXPO_GO: true
       E2E_ROUTER_SRC: expo-go-dev-maestro-router
       E2E_ROUTER_EXPO_PORT: 8081
-      E2E_EXPO_GO_APP: './expo-go.app'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Install dependencies
         run: YARN_IGNORE_SCRIPTS=true yarn --frozen-lockfile
 
-      - name: Install eas-cli
-        run: npx expo install eas-cli
-
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -73,31 +70,15 @@ jobs:
           # Start the build early by starting the build in the background
           curl --silent --output /dev/null --show-error --fail $BUNDLE_URL &
 
-      - name: Fix expo-linking
-        working-directory: apps/router-e2e
+      - name: Install latest Expo Go
+        working-directory: bin
         run: |
-          # The current Expo Go does not support the expo-linking on main
-          YARN_IGNORE_SCRIPTS=true yarn add expo-linking@sdk-50
+          ./expotools client-install -p ios -s 52.0.0
 
       - name: Setup maestro env
         run: |
           # Setup the maestro env
           echo "MAESTRO_APP_URL=exp://localhost:${E2E_ROUTER_EXPO_PORT}/--" >> $GITHUB_ENV
-
-      - name: Download latest Expo Go
-        working-directory: apps/router-e2e
-        env:
-          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-        run: |
-          eas_JSON=${npx eas-cli build:list --platform ios --simulator --non-interactive --json}
-          eas_download=${echo $eas_JSON | jq -r '.[0].artifacts.buildUrl'}
-          echo $file_url
-          curl -o "$E2E_EXPO_GO_APP" "$eas_download"
-
-      - name: Install latest Expo Go
-        working-directory: apps/router-e2e
-        run: |
-          xcrun simctl install Booted "$E2E_EXPO_GO_APP"
 
       - name: Run Maestro iOS tests
         working-directory: apps/router-e2e

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup maestro env
         run: |
           # Setup the maestro env
-          echo "MAESTRO_APP_URL=exp://localhost:${E2E_ROUTER_EXPO_PORT}/--;" >> $GITHUB_ENV
+          echo "MAESTRO_APP_URL=exp://localhost:${E2E_ROUTER_EXPO_PORT}/--" >> $GITHUB_ENV
 
       - name: Run Maestro iOS tests
         working-directory: apps/router-e2e

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -14,6 +14,7 @@ jobs:
       E2E_ROUTER_USE_PUBLISHED_EXPO_GO: true
       E2E_ROUTER_SRC: expo-go-dev-maestro-router
       E2E_ROUTER_EXPO_PORT: 8081
+      E2E_EXPO_GO_APP: './expo-go.app'
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +38,9 @@ jobs:
 
       - name: Install dependencies
         run: YARN_IGNORE_SCRIPTS=true yarn --frozen-lockfile
+
+      - name: Install eas-cli
+        run: npx expo install eas-cli
 
       - uses: actions/setup-java@v4
         with:
@@ -79,6 +83,21 @@ jobs:
         run: |
           # Setup the maestro env
           echo "MAESTRO_APP_URL=exp://localhost:${E2E_ROUTER_EXPO_PORT}/--" >> $GITHUB_ENV
+
+      - name: Download latest Expo Go
+        working-directory: apps/router-e2e
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+        run: |
+          eas_JSON=${npx eas-cli build:list --platform ios --simulator --non-interactive --json}
+          eas_download=${echo $eas_JSON | jq -r '.[0].artifacts.buildUrl'}
+          echo $file_url
+          curl -o "$E2E_EXPO_GO_APP" "$eas_download"
+
+      - name: Install latest Expo Go
+        working-directory: apps/router-e2e
+        run: |
+          xcrun simctl install Booted "$E2E_EXPO_GO_APP"
 
       - name: Run Maestro iOS tests
         working-directory: apps/router-e2e


### PR DESCRIPTION
# Why

Maestro is attempting to deep link to an invalid Expo Go URL, causing the tests to fail.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
