### PR TITLE
[docs] Fix incorrect `Step` formatting for H4s

### DIFF
--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -18,7 +18,7 @@ export const Step = ({ children, label }: Props) => {
         )}>
         {label}
       </HEADLINE>
-      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-h2:!-mt-1.5 prose-h3:!-mt-1 [&>*:last-child]:!mb-0">
+      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-0.5 [&>*:last-child]:!mb-0">
         {typeof children === 'string' ? <P>{children}</P> : children}
       </div>
     </div>

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -18,7 +18,7 @@ export const Step = ({ children, label }: Props) => {
         )}>
         {label}
       </HEADLINE>
-      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-0.5 [&>*:last-child]:!mb-0">
+      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-px [&>*:last-child]:!mb-0">
         {typeof children === 'string' ? <P>{children}</P> : children}
       </div>
     </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-13843

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the `Step` component to override the margin-top for `h4`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Preview for some of the pages where `Step` component is used with H4:

![CleanShot 2024-10-18 at 11 29 56@2x](https://github.com/user-attachments/assets/2abbc398-dc8c-4f0b-bab8-508a392945de)

![CleanShot 2024-10-18 at 11 31 24@2x](https://github.com/user-attachments/assets/c46e717f-06b2-494c-b047-2b9f60f91f7e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
