### PR TITLE
test(cli): add `react-dom`-only web export test

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export/export-web-react-dom.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-web-react-dom.test.ts
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+import execa from 'execa';
+import klawSync from 'klaw-sync';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { runExportSideEffects } from './export-side-effects';
+import { bin, linkPackagesFromMonorepo, setupTestProjectWithOptionsAsync } from '../utils';
+
+runExportSideEffects();
+
+it(
+  'exports project using react-dom only',
+  async () => {
+    // Create a project from the blank template
+    const projectRoot = await setupTestProjectWithOptionsAsync(
+      'basic-export-react-dom',
+      'with-react-dom',
+      { reuseExisting: false }
+    );
+
+    // NOTE(cedric): this is required because the fix to make this pass is not published yet
+    // Link the packages from the monorepo
+    await linkPackagesFromMonorepo(projectRoot, ['expo']);
+
+    // Export the app
+    const exportDir = await exportApp(projectRoot);
+
+    // Ensure no React Native code is bundled
+    expect(await loadBundleFile(exportDir)).not.toContain('react-native');
+  },
+  // 1x App export could take 45s depending on how fast the bundler resolves
+  560 * 1000 * 2
+);
+
+async function exportApp(projectRoot: string) {
+  await execa('node', [bin, 'export', '--platform=web', '--output-dir=dist'], {
+    cwd: projectRoot,
+    env: {
+      NODE_ENV: 'production',
+      EXPO_USE_FAST_RESOLVER: 'true',
+    },
+  });
+
+  return path.join(projectRoot, 'dist');
+}
+
+function findFilesInPath(outputDir: string) {
+  return klawSync(outputDir)
+    .map((entry) =>
+      entry.path.includes('node_modules') || !entry.stats.isFile()
+        ? null
+        : path.posix.relative(outputDir, entry.path)
+    )
+    .filter(Boolean);
+}
+
+function loadBundleFile(outputDir: string) {
+  const exportedFiles = findFilesInPath(outputDir);
+  const exportedBundleFile = exportedFiles.find((file) => file?.startsWith('_expo/static/js/web/'));
+  if (!exportedBundleFile) {
+    throw new Error('Could not find the exported web bundle');
+  }
+
+  const bundleData = path.join(outputDir, exportedBundleFile);
+  return fs.promises.readFile(bundleData, 'utf8');
+}

--- a/packages/@expo/cli/e2e/fixtures/with-react-dom/App.js
+++ b/packages/@expo/cli/e2e/fixtures/with-react-dom/App.js
@@ -1,0 +1,3 @@
+export default function App() {
+  return <p>This is only using React DOM</p>;
+}

--- a/packages/@expo/cli/e2e/fixtures/with-react-dom/app.json
+++ b/packages/@expo/cli/e2e/fixtures/with-react-dom/app.json
@@ -1,0 +1,8 @@
+{
+  "android": {
+    "package": "com.example.reactdom"
+  },
+  "ios": {
+    "bundleIdentifier": "com.example.reactdom"
+  }
+}

--- a/packages/@expo/cli/e2e/fixtures/with-react-dom/index.js
+++ b/packages/@expo/cli/e2e/fixtures/with-react-dom/index.js
@@ -1,0 +1,5 @@
+import registerRootComponent from 'expo/src/launch/registerRootComponent';
+
+import App from './App';
+
+registerRootComponent(App);

--- a/packages/@expo/cli/e2e/fixtures/with-react-dom/metro.config.js
+++ b/packages/@expo/cli/e2e/fixtures/with-react-dom/metro.config.js
@@ -1,0 +1,12 @@
+/* eslint-env node */
+
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+// NOTE: Watchman (used locally but not in CI) has issues with finding modules in the expo/expo monorepo.
+config.resolver.useWatchman = false;
+
+module.exports = config;

--- a/packages/@expo/cli/e2e/fixtures/with-react-dom/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-react-dom/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "main": "index.js",
+  "dependencies": {
+    "@expo/metro-runtime": "^3.2.3",
+    "expo": "^51",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.19.3"
+  }
+}


### PR DESCRIPTION
# Why

This adds an export E2E test that ensures you can create a web export with just `react-dom`, it's using the "use package from source" ability from #32144.

The test itself tries to tests various packages, like `expo`, `@expo/cli`, and `@expo/config` to see if a web export can be made without `react-native-web`.

# How

- Added e2e test that ensures no `react-native` is present in the JS bundle
  - The test is checking if the string `react-native` is present in the code, while not optimal, I don't think we can improve this (unless we are using Atlas' data to ensure `react-native-web` was not imported)

# Test Plan

See e2e test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
