### PR TITLE
[expo-modules-core] Fix using enums as optional arguments.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix using enums as optional arguments. ([#32147](https://github.com/expo/expo/pull/32147) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Change JS return type for kotlin `null` to be `null` instead of `undefined`. ([#31301](https://github.com/expo/expo/pull/31301) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Swift `Enumerable`s did not correctly convert to JS values. ([#30191](https://github.com/expo/expo/pull/30191) by [@vonovak](https://github.com/vonovak))
 - [jest] Fix `uuid` mock in `jest-expo`. ([#29840](https://github.com/expo/expo/pull/29840) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -18,7 +18,7 @@ internal struct DynamicEnumType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
-    if var value = value as? any Enumerable {
+    if let value = value as? any Enumerable {
       return value
     }
     return try innerType.create(fromRawValue: value)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -18,6 +18,9 @@ internal struct DynamicEnumType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if var value = value as? any Enumerable {
+      return value
+    }
     return try innerType.create(fromRawValue: value)
   }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -18,6 +18,7 @@ internal struct DynamicEnumType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    // TODO: Remove if. The result should not be an enumerable, but it's converted in `MainValueConverter:21` to an enum.
     if let value = value as? any Enumerable {
       return value
     }


### PR DESCRIPTION
# Why

Fixes this crash in calendar tests.

![image](https://github.com/user-attachments/assets/4be087c3-62d4-4c06-85a1-9bb94adf42e0)


# How

The argument to the `getCalendarsAsync` is an optional enum. 
If it is passed, the edited function `unc cast<ValueType>` receives an Enumerable as a first argument, which cannot be passed into a `create(fromRawValue: )` constructor. 

Is it safe to just return the unwrapped enum? @tsapeta 

# Test Plan

Ensured unit tests pass, looking into adding a native test to ensure no regressions.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
