### PR TITLE
fix(cli): only test if web is supported through `react-dom`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -69,7 +69,7 @@
 - Detect network issues and enable offline mode with Undici errors. ([#31517](https://github.com/expo/expo/pull/31517) by [@byCedric](https://github.com/byCedric))
 - Resolve dom components entry relative to workspace root instead of project root. ([#31433](https://github.com/expo/expo/pull/31433) by [@byCedric](https://github.com/byCedric))
 - Use proper telemetry strategies for every command. ([#31281](https://github.com/expo/expo/pull/31281) by [@byCedric](https://github.com/byCedric))
-- Only test project web support through `react-dom`.
+- Only test project web support through `react-dom`. ([#32148](https://github.com/expo/expo/pull/32148) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Detect network issues and enable offline mode with Undici errors. ([#31517](https://github.com/expo/expo/pull/31517) by [@byCedric](https://github.com/byCedric))
 - Resolve dom components entry relative to workspace root instead of project root. ([#31433](https://github.com/expo/expo/pull/31433) by [@byCedric](https://github.com/byCedric))
 - Use proper telemetry strategies for every command. ([#31281](https://github.com/expo/expo/pull/31281) by [@byCedric](https://github.com/byCedric))
+- Only test project web support through `react-dom`.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -52,9 +52,6 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
   /** Exposed for testing. */
   async _ensureWebDependenciesInstalledAsync({ exp }: { exp: ExpoConfig }): Promise<boolean> {
     const requiredPackages: ResolvedPackage[] = [
-      // use react-native-web/package.json to skip node module cache issues when the user installs
-      // the package and attempts to resolve the module in the same process.
-      { file: 'react-native-web/package.json', pkg: 'react-native-web' },
       { file: 'react-dom/package.json', pkg: 'react-dom' },
     ];
 


### PR DESCRIPTION
# Why

This changes the `WebSupportProjectPrerequisite` to only test on `react-dom`, not `react-native-web`. Testing on `react-native-web` is irrelevant as an Expo project should be able to run without `react-native-web`, when not importing any of `react-native` (like the fixture from #32145).

# How

- Removed `react-native-web` as prerequisite for web support.

# Test Plan

See E2E test from #32145 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
