### PR TITLE
[templates] Add support for opting out of core autolinking

### DIFF
--- a/templates/expo-template-bare-minimum/android/settings.gradle
+++ b/templates/expo-template-bare-minimum/android/settings.gradle
@@ -4,17 +4,21 @@ pluginManagement {
 plugins { id("com.facebook.react.settings") }
 
 extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
-  def command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
-    'react-native-config',
-    '--json',
-    '--platform',
-    'android'
-  ].toList()
-  ex.autolinkLibrariesFromCommand(command)
+  if (System.getenv('EXPO_USE_COMMUNITY_AUTOLINKING') == '1') {
+    ex.autolinkLibrariesFromCommand()
+  } else {
+    def command = [
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'react-native-config',
+      '--json',
+      '--platform',
+      'android'
+    ].toList()
+    ex.autolinkLibrariesFromCommand(command)
+  }
 }
 
 rootProject.name = 'HelloWorld'

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -16,17 +16,21 @@ prepare_react_native_project!
 target 'HelloWorld' do
   use_expo_modules!
 
-  config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
-    'react-native-config',
-    '--json',
-    '--platform',
-    'ios'
-  ]
-  config = use_native_modules!(config_command)
+  if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
+    config = use_native_modules!
+  else
+    config_command = [
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'react-native-config',
+      '--json',
+      '--platform',
+      'ios'
+    ]
+    config = use_native_modules!(config_command)
+  end
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']


### PR DESCRIPTION
# Why

Closes ENG-13703

Now that core autoliking is enabled by default we should provide a way for our users to opt ot of this feature and use the slower community version.

Docs update here -> https://github.com/expo/expo/pull/32164

# How
 
Add `EXPO_USE_COMMUNITY_AUTOLINKING` env var check to use the community autoliking
 

# Test Plan

1. `tar -zcvf expo-template-bare-minimum.tar.gz expo-template-bare-minimum`
2. `npx expo prebuild  --clean --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-bare-minimum.tar.gz`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
