### PR TITLE
[docs] Document how users can opt out of core autolinking

### DIFF
--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -210,4 +210,7 @@ It's also necessary to include supported platforms in the `platforms` array — 
 - It's also significantly faster, even though the module resolution algorithm is more complex to be more reliable and match the Node's module resolution.
 - Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
 - Last but not least, it integrates well with all the features offered by Expo Modules APIs.
-- If you would like to use the React Native community CLI autolinking instead of Expo's Autolinking, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+
+### Opting out of Expo Autolinking
+
+Starting from SDK 52, Expo Autolinking comes enabled by default, if you would like to use the React Native community CLI autolinking instead, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -210,4 +210,4 @@ It's also necessary to include supported platforms in the `platforms` array — 
 - It's also significantly faster, even though the module resolution algorithm is more complex to be more reliable and match the Node's module resolution.
 - Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
 - Last but not least, it integrates well with all the features offered by Expo Modules APIs.
-- If you would like to use the React Native community CLI autolinking instead of Expo's Autolinking set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+- If you would like to use the React Native community CLI autolinking instead of Expo's Autolinking, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -204,9 +204,10 @@ All projects created with the `npx create-expo-app` command are already configur
 The module resolution algorithm searches only for packages that contain the [Expo module config](/modules/module-config/) file (**expo-module.config.json**) at the root directory, next to the **package.json** file.
 It's also necessary to include supported platforms in the `platforms` array — if the platform for which the autolinking algorithm is run is not present in this array, it's just skipped in the search results.
 
-### How is it different from React Native autolinking?
+### How is it different from React Native community autolinking?
 
 - Expo Autolinking comes in with built-in support for monorepos, Yarn workspaces and transitive dependencies.
 - It's also significantly faster, even though the module resolution algorithm is more complex to be more reliable and match the Node's module resolution.
 - Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
 - Last but not least, it integrates well with all the features offered by Expo Modules APIs.
+- If you would like to use the React Native community autolinking instead of Expo's Autolinking set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -204,10 +204,10 @@ All projects created with the `npx create-expo-app` command are already configur
 The module resolution algorithm searches only for packages that contain the [Expo module config](/modules/module-config/) file (**expo-module.config.json**) at the root directory, next to the **package.json** file.
 It's also necessary to include supported platforms in the `platforms` array — if the platform for which the autolinking algorithm is run is not present in this array, it's just skipped in the search results.
 
-### How is it different from React Native community autolinking?
+### How is it different from React Native community CLI autolinking?
 
 - Expo Autolinking comes in with built-in support for monorepos, Yarn workspaces and transitive dependencies.
 - It's also significantly faster, even though the module resolution algorithm is more complex to be more reliable and match the Node's module resolution.
 - Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
 - Last but not least, it integrates well with all the features offered by Expo Modules APIs.
-- If you would like to use the React Native community autolinking instead of Expo's Autolinking set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+- If you would like to use the React Native community CLI autolinking instead of Expo's Autolinking set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/32161
Closes ENG-13703

# How

This should only be merged once we release SDK52

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
