### PR TITLE
[clipboard][iOS] Fix test-suite

### DIFF
--- a/apps/test-suite/tests/Clipboard.js
+++ b/apps/test-suite/tests/Clipboard.js
@@ -75,13 +75,6 @@ export function test({ describe, expect, it, afterEach, ...t }) {
           const result = await Clipboard.getUrlAsync();
           expect(result).toEqual(exampleUrl);
         });
-
-        it('rejects a malformed url', async () => {
-          const malformedUrl = 'malformed url';
-          await throws(() => Clipboard.setUrlAsync(malformedUrl));
-          const hasUrl = await Clipboard.hasUrlAsync();
-          expect(hasUrl).toEqual(false);
-        });
       });
     }
 


### PR DESCRIPTION
# Why

Fixes:
![image](https://github.com/user-attachments/assets/0477ad70-43ba-46ff-a73d-4bfe5b6b5a02)


# How

The `URL` converter started to treat urls without schema as a file. So right, now it not possible to pass a malformed data to `setUrlAsync` function. 

# Test Plan

- test-suite ✅ 