### PR TITLE
fix(et): do not use version prefix in template when publishing canary

### DIFF
--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -6,7 +6,7 @@ import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { getPackageByName, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
-import { Parcel, TaskArgs } from '../types';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, green } = chalk;
 const MODULE_TEMPLATE_PKG_NAME = 'expo-module-template';
@@ -22,7 +22,7 @@ export const updateModuleTemplate = new Task<TaskArgs>(
     dependsOn: [selectPackagesToPublish],
     filesToStage: [`packages/${MODULE_TEMPLATE_PKG_NAME}/${TEMPLATE_PACKAGE_JSON_FILENAME}`],
   },
-  async (parcels: Parcel[]) => {
+  async (parcels: Parcel[], options: CommandOptions) => {
     logger.info('\n🆙 Updating the module template...');
 
     const dependencies = parcels.filter((parcel) =>
@@ -43,11 +43,12 @@ export const updateModuleTemplate = new Task<TaskArgs>(
       return;
     }
 
-    await updateTemplatePackageJsonAsync(moduleTemplatePkg, dependencies);
+    await updateTemplatePackageJsonAsync(options, moduleTemplatePkg, dependencies);
   }
 );
 
 async function updateTemplatePackageJsonAsync(
+  options: Pick<CommandOptions, 'canary'>,
   templatePkg: Package,
   dependencies: Parcel[]
 ): Promise<void> {
@@ -62,7 +63,7 @@ async function updateTemplatePackageJsonAsync(
       continue;
     }
 
-    const newVersionRange = '^' + newVersion;
+    const newVersionRange = options.canary ? newVersion : `^${newVersion}`;
 
     logger.log(
       `   Updating dev dependency on ${green(pkg.packageName)}:`,


### PR DESCRIPTION
# Why

This broke our latest canaries, canary versions must not have a version range prefix. You can check this at: https://npmgraph.js.org/?q=expo-template-blank%4052.0.0-canary-20241018-75a0b25, the hash of the version from `expo-template-blank` does not match `expo`.

> `bun create expo ./broken-canary --template blank@52.0.0-canary-20241018-75a0b25`

# How

- Do not use version range prefixes for canary releases

# Test Plan

Publish new canaries

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
