### PR TITLE
fix(et): do not use version prefix in templates

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -80,7 +80,7 @@ const publishCanaryProjectTemplates = new Task<TaskArgs>(
         const expoVersion = await sdkVersionAsync();
         const dependenciesToUpdate = {
           ...bundledNativeModules,
-          expo: `~${expoVersion}`,
+          expo: options.canary ? expoVersion : `~${expoVersion}`,
         };
 
         for (const template of templates) {


### PR DESCRIPTION
# Why

Follow-up from #32169 

# How

- Fixed expo template version

# Test Plan

See new canary

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
