### PR TITLE
Remove unnecessary space

### DIFF
--- a/packages/expo-doctor/src/checks/PackageManagerVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageManagerVersionCheck.ts
@@ -43,7 +43,7 @@ async function checkNpmVersionAsync(): Promise<string | null> {
 }
 
 export class PackageManagerVersionCheck implements DoctorCheck {
-  description = 'Check npm/ yarn versions';
+  description = 'Check npm/yarn versions';
 
   sdkVersionRange = '*';
 


### PR DESCRIPTION
# Why

I think the additional space looks like a mistake and it stands out as odd. I removed the additional space so the slash is used in a normal manner.

The [style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#do-not-add-a-space-between-the-words-and-) also seems to indicate this is the proper use of the slash.

# How

I simply edited the check description.

I did this because the space between `npm/ yarn` was annoying.

# Test Plan

I did not test this change.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
