### PR TITLE
[haptics] fix regression from web

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Align web implementation exports as native to support DOM components when using `@expo/dom-webview`. ([#31662](https://github.com/expo/expo/pull/31662) by [@kudo](https://github.com/kudo))
+- Fixed bundling error on Web. ([#32183](https://github.com/expo/expo/pull/32183) by [@kudo](https://github.com/kudo))
 
 ## 13.0.1 — 2024-04-23
 

--- a/packages/expo-haptics/build/ExpoHaptics.d.ts.map
+++ b/packages/expo-haptics/build/ExpoHaptics.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoHaptics.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.ts"],"names":[],"mappings":";AAEA,wBAAkD"}
+{"version":3,"file":"ExpoHaptics.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.ts"],"names":[],"mappings":";AAEA,wBAA0D"}

--- a/packages/expo-haptics/src/ExpoHaptics.ts
+++ b/packages/expo-haptics/src/ExpoHaptics.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireOptionalNativeModule } from 'expo';
 
-export default requireNativeModule('ExpoHaptics');
+export default requireOptionalNativeModule('ExpoHaptics');

--- a/packages/expo-haptics/src/Haptics.ts
+++ b/packages/expo-haptics/src/Haptics.ts
@@ -14,7 +14,7 @@ import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
 export async function notificationAsync(
   type: NotificationFeedbackType = NotificationFeedbackType.Success
 ): Promise<void> {
-  if (!ExpoHaptics.notificationAsync) {
+  if (!ExpoHaptics?.notificationAsync) {
     throw new UnavailabilityError('Haptics', 'notificationAsync');
   }
   await ExpoHaptics.notificationAsync(type);
@@ -30,7 +30,7 @@ export async function notificationAsync(
 export async function impactAsync(
   style: ImpactFeedbackStyle = ImpactFeedbackStyle.Medium
 ): Promise<void> {
-  if (!ExpoHaptics.impactAsync) {
+  if (!ExpoHaptics?.impactAsync) {
     throw new UnavailabilityError('Haptic', 'impactAsync');
   }
   await ExpoHaptics.impactAsync(style);
@@ -42,7 +42,7 @@ export async function impactAsync(
  * @return A `Promise` which fulfils once native size haptics functionality is triggered.
  */
 export async function selectionAsync(): Promise<void> {
-  if (!ExpoHaptics.selectionAsync) {
+  if (!ExpoHaptics?.selectionAsync) {
     throw new UnavailabilityError('Haptic', 'selectionAsync');
   }
   await ExpoHaptics.selectionAsync();


### PR DESCRIPTION
# Why

fix web regression since https://github.com/expo/expo/commit/d85b0e9e1a58e1cecb2d2690c6e048255c0bbc86
originally it threw errors when execute haptics functions like `notificationAsync`, after d85b0e9e1a58e1cecb2d2690c6e048255c0bbc86, it throws error right after from bundling.

# How

use `requireOptionalNativeModule` to keep original behavior

# Test Plan

test-suite haptics on web

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
