### PR TITLE
[sqlite] Removed `next` export

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bumped iOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))
 - Removed deprecated legacy expo-sqlite. ([#31766](https://github.com/expo/expo/pull/31766) by [@kudo](https://github.com/kudo))
+- Removed `next` export.
 
 ### 🎉 New features
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Bumped iOS deployment target to 15.1. ([#30840](https://github.com/expo/expo/pull/30840) by [@tsapeta](https://github.com/tsapeta))
 - Removed deprecated legacy expo-sqlite. ([#31766](https://github.com/expo/expo/pull/31766) by [@kudo](https://github.com/kudo))
-- Removed `next` export.
+- Removed `next` export. ([#32184](https://github.com/expo/expo/pull/32184) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🎉 New features
 

--- a/packages/expo-sqlite/next.d.ts
+++ b/packages/expo-sqlite/next.d.ts
@@ -1,1 +1,0 @@
-export * from './build/index';

--- a/packages/expo-sqlite/next.js
+++ b/packages/expo-sqlite/next.js
@@ -1,1 +1,0 @@
-module.exports = require('./build/index');

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -14,10 +14,6 @@
     "./async-storage": {
       "default": "./async-storage.js",
       "types": "./async-storage.d.ts"
-    },
-    "./next": {
-      "default": "./next.js",
-      "types": "./next.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Why

Since the `expo-sqlite` package only has `next` as the default export, and no longer the legacy implementation, I have also removed the export for it.
I'm not sure if this was left in on purpose or forgotten in #31766. @Kudo

# How

`next` export has been removed.

# Test Plan

CI runs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
