### PR TITLE
[NCL] Fix `CryptoScreen` on Android

### DIFF
--- a/apps/native-component-list/src/screens/CryptoScreen.tsx
+++ b/apps/native-component-list/src/screens/CryptoScreen.tsx
@@ -65,7 +65,6 @@ const DIGEST_STRING: FunctionDescription = {
       name: 'algorithm',
       type: 'string',
       values: [
-        CryptoDigestAlgorithm.MD2,
         CryptoDigestAlgorithm.MD5,
         CryptoDigestAlgorithm.SHA1,
         CryptoDigestAlgorithm.SHA256,


### PR DESCRIPTION
# Why

Fixes `CryptoScreen` on Android.
Fixes `digestString doesn’t work with MD2 encoding. Works ok with all other options`

# How

`MD2` hash is only supported on `iOS`. It's expected to not work on Android.

# Test Plan

- NCL ✅ 