### PR TITLE
[docs] refactor typography base to Tailwind

### DIFF
--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <p
-      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 emotion-0"
+      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute emotion-0 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10"
       data-text="true"
     >
       <svg
@@ -67,7 +67,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#base-level-heading"
     >
       <p
-        class="w-full !text-secondary hocus:!text-link emotion-1"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
         data-text="true"
       >
         Base level heading
@@ -79,7 +79,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#level-3-subheading"
     >
       <p
-        class="w-full !text-secondary hocus:!text-link emotion-1"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
         data-text="true"
       >
         Level 3 subheading
@@ -91,7 +91,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#code-heading-depth-1"
     >
       <code
-        class="w-full !text-secondary hocus:!text-link truncate !text-2xs emotion-3"
+        class="text-default leading-[1.6154] w-full !text-secondary hocus:!text-link truncate !text-2xs"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -978,17 +978,17 @@ properties.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1400,17 +1400,17 @@ value depending on the state of the credential.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1642,17 +1642,17 @@ refresh operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1931,17 +1931,17 @@ sign-in operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -2247,12 +2247,12 @@ sign-out operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
@@ -2538,17 +2538,17 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3000,17 +3000,17 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3413,17 +3413,17 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3724,17 +3724,17 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4052,17 +4052,17 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4225,17 +4225,17 @@ OAuth 2.0 protocol
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -6987,12 +6987,12 @@ Same as
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
@@ -7699,17 +7699,17 @@ This uses both
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8059,17 +8059,17 @@ code.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8330,17 +8330,17 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8522,17 +8522,17 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8643,17 +8643,17 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8770,17 +8770,17 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8936,12 +8936,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Parameter
               </th>
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Type
               </th>
@@ -9043,17 +9043,17 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -9319,17 +9319,17 @@ you don't get this value.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -10065,17 +10065,17 @@ exports[`APISection expo-pedometer 1`] = `
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -10652,17 +10652,17 @@ available on this device.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -10991,17 +10991,17 @@ On iOS, the
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -11262,17 +11262,17 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -11386,12 +11386,12 @@ in order to enable/disable the permission.
               class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Parameter
               </th>
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Type
               </th>
@@ -11601,17 +11601,17 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs last:border-r-0"
+              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -43,10 +43,10 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none emotion-1"
+    class="!shadow-none emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -58,7 +58,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -91,24 +91,24 @@ exports[`APISection expo-apple-authentication 1`] = `
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       <span
-        class="emotion-5"
+        class="leading-[1.6154] font-medium text-secondary"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
         data-text="true"
       >
         React.Element
         &lt;
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationbuttonprops"
         >
           AppleAuthenticationButtonProps
@@ -117,7 +117,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -128,16 +128,16 @@ available via the provided properties.
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       You should only attempt to render this if 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationisavailableasync"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -146,7 +146,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         true
@@ -154,7 +154,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         __DEV__ === true
@@ -164,12 +164,12 @@ a warning in development mode (
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         View
@@ -177,21 +177,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         style
@@ -199,7 +199,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         buttonStyle
@@ -207,7 +207,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         cornerRadius
@@ -218,7 +218,7 @@ button.
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
@@ -254,17 +254,18 @@ not appear on the screen.
         class="text-default w-full leading-normal last:mb-0"
       >
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             See:
-          </strong>
+          </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
             rel="noopener noreferrer"
             target="_blank"
@@ -279,15 +280,15 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="!text-secondary !font-medium emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !text-secondary !font-medium emotion-1"
         data-text="true"
       >
         <span
-          class="group emotion-26"
+          class="leading-[1.6154] text-inherit group"
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 text-inherit flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-secondary flex flex-row gap-2 items-center"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -328,10 +329,10 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-27"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-2"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -343,7 +344,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-29"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 buttonStyle
@@ -376,7 +377,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -386,11 +387,11 @@ for more details.
           </span>
            
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationbuttonstyle"
             >
               AppleAuthenticationButtonStyle
@@ -398,17 +399,17 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-27"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-2"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -420,7 +421,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-29"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 buttonType
@@ -453,7 +454,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -463,11 +464,11 @@ for more details.
           </span>
            
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationbuttontype"
             >
               AppleAuthenticationButtonType
@@ -475,17 +476,17 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-27"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-2"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -497,7 +498,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-29"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 cornerRadius
@@ -530,7 +531,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -545,20 +546,20 @@ for more details.
           </span>
            
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             number
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             style.borderRadius
@@ -567,10 +568,10 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-27"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-2"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -582,7 +583,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-29"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 onPress
@@ -615,7 +616,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -625,7 +626,7 @@ for more details.
           </span>
            
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <span
@@ -643,16 +644,16 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="#appleauthenticationisavailableasync"
           >
             <code
-              class="!inline emotion-6"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -663,10 +664,10 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-27"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-2"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -678,7 +679,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-29"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 style
@@ -711,7 +712,7 @@ in here.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -726,7 +727,7 @@ in here.
           </span>
            
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             StyleProp
@@ -737,7 +738,7 @@ in here.
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                 href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -751,7 +752,7 @@ in here.
               </span>
               <span>
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://reactnative.dev/docs/view-style-props"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -791,19 +792,19 @@ in here.
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             borderRadius
@@ -813,7 +814,7 @@ properties.
         </p>
       </div>
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -853,18 +854,18 @@ properties.
         </a>
       </h4>
       <ul
-        class="emotion-67"
+        class="text-default leading-[1.6154] list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
       >
         <li
-          class="emotion-68"
+          class="text-default text-[16px] font-normal leading-relaxed tracking-[-0.011rem] mb-2"
           data-text="true"
         >
           <code
-            class="emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://reactnative.dev/docs/view#props"
               rel="noopener noreferrer"
               target="_blank"
@@ -877,7 +878,7 @@ properties.
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -917,10 +918,10 @@ properties.
     </a>
   </h2>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -932,7 +933,7 @@ properties.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -1000,17 +1001,18 @@ properties.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 user
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -1020,17 +1022,17 @@ properties.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
 This should come from the user field of an 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="!inline emotion-6"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1045,7 +1047,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1084,14 +1086,15 @@ This should come from the user field of an
         
 
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             Note:
-          </strong>
+          </span>
            This method must be tested on a real device. On the iOS simulator it always throws an error.
         </p>
         
@@ -1125,22 +1128,22 @@ This should come from the user field of an
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1154,7 +1157,7 @@ This should come from the user field of an
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationcredentialstate"
             >
               AppleAuthenticationCredentialState
@@ -1172,16 +1175,16 @@ This should come from the user field of an
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationcredentialstate"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -1193,10 +1196,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -1208,7 +1211,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             isAvailableAsync()
@@ -1241,7 +1244,7 @@ value depending on the state of the credential.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
@@ -1273,22 +1276,22 @@ value depending on the state of the credential.
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1315,19 +1318,19 @@ value depending on the state of the credential.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A promise that fulfills with 
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           false
@@ -1337,10 +1340,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -1352,7 +1355,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             refreshAsync(options)
@@ -1420,21 +1423,22 @@ value depending on the state of the credential.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 options
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationrefreshoptions"
                 >
                   AppleAuthenticationRefreshOptions
@@ -1445,16 +1449,16 @@ value depending on the state of the credential.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="!inline emotion-6"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1469,7 +1473,7 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1502,22 +1506,22 @@ Calling this method will show the sign in modal before actually refreshing the u
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1531,7 +1535,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1549,16 +1553,16 @@ Calling this method will show the sign in modal before actually refreshing the u
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1567,7 +1571,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1578,10 +1582,10 @@ refresh operation.
     </div>
   </div>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -1593,7 +1597,7 @@ refresh operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             signInAsync(options)
@@ -1661,11 +1665,12 @@ refresh operation.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 options
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -1677,11 +1682,11 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationsigninoptions"
                 >
                   AppleAuthenticationSignInOptions
@@ -1692,16 +1697,16 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An optional 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="!inline emotion-6"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1716,7 +1721,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1725,7 +1730,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1735,14 +1740,14 @@ of these options at runtime.
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
 into your app, so you must store it for later use. It's best to store this information either
 server-side, or using 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="./securestore"
       >
         SecureStore
@@ -1750,11 +1755,11 @@ server-side, or using
       , so that the data persists across app installs.
 You can use 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationcredential"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -1790,22 +1795,22 @@ the user, since this remains the same for apps released by the same developer.
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1819,7 +1824,7 @@ the user, since this remains the same for apps released by the same developer.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1837,16 +1842,16 @@ the user, since this remains the same for apps released by the same developer.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1855,7 +1860,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1866,10 +1871,10 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -1881,7 +1886,7 @@ sign-in operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             signOutAsync(options)
@@ -1949,21 +1954,22 @@ sign-in operation.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 options
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationsignoutoptions"
                 >
                   AppleAuthenticationSignOutOptions
@@ -1974,16 +1980,16 @@ sign-in operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="!inline emotion-6"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -1998,7 +2004,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -2007,18 +2013,18 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
 Instead of using this method it is recommended to simply clear all the user's data collected
 from using 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="./#signinasync"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           signInAsync
@@ -2026,11 +2032,11 @@ from using
       </a>
        or 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="./#refreshasync"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           refreshAsync
@@ -2065,22 +2071,22 @@ from using
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -2094,7 +2100,7 @@ from using
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -2112,16 +2118,16 @@ from using
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2130,7 +2136,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2141,7 +2147,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -2181,10 +2187,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="emotion-27"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -2196,7 +2202,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-74"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-13"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2259,17 +2265,18 @@ sign-out operation.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 listener
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span
@@ -2313,18 +2320,18 @@ sign-out operation.
           </g>
         </svg>
         <span
-          class="emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-84"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           EventSubscription
@@ -2333,7 +2340,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -2373,10 +2380,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -2388,7 +2395,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2421,16 +2428,16 @@ sign-out operation.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       The object type returned from a successful call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2439,11 +2446,11 @@ sign-out operation.
       ,
 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2451,11 +2458,11 @@ sign-out operation.
       </a>
       , or 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2494,17 +2501,18 @@ which contains all of the pertinent user and credential information.
         class="text-default w-full leading-normal last:mb-0"
       >
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             See:
-          </strong>
+          </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
             rel="noopener noreferrer"
             target="_blank"
@@ -2553,17 +2561,18 @@ for more details.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 authorizationCode
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -2583,13 +2592,13 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   user
@@ -2604,17 +2613,18 @@ the app's server counterpart. Unlike
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 email
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -2634,12 +2644,12 @@ the app's server counterpart. Unlike
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   EMAIL
@@ -2657,22 +2667,23 @@ an Apple domain.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 fullName
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                     href="#appleauthenticationfullname"
                   >
                     AppleAuthenticationFullName
@@ -2692,26 +2703,26 @@ an Apple domain.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The user's name. May be 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   FULL_NAME
@@ -2728,17 +2739,18 @@ your app.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 identityToken
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -2758,7 +2770,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -2771,21 +2783,22 @@ your app.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 realUserStatus
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationuserdetectionstatus"
                 >
                   AppleAuthenticationUserDetectionStatus
@@ -2796,7 +2809,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -2809,17 +2822,18 @@ your app.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 state
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -2839,12 +2853,12 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   state
@@ -2853,7 +2867,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   state
@@ -2861,7 +2875,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
@@ -2876,17 +2890,18 @@ will be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 user
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -2896,7 +2911,7 @@ will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -2911,10 +2926,10 @@ developers.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -2926,7 +2941,7 @@ developers.
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -2959,13 +2974,13 @@ developers.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         null
@@ -3008,17 +3023,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 familyName
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3050,17 +3066,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 givenName
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3092,17 +3109,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 middleName
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3134,17 +3152,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 namePrefix
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3176,17 +3195,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 nameSuffix
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3218,17 +3238,18 @@ may be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 nickname
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <span>
@@ -3259,10 +3280,10 @@ may be
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -3274,7 +3295,7 @@ may be
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3307,16 +3328,16 @@ may be
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3355,17 +3376,18 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="text-default w-full leading-normal last:mb-0"
       >
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             See:
-          </strong>
+          </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3414,11 +3436,12 @@ for more details.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 requestedScopes
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -3430,11 +3453,11 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3446,14 +3469,14 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
@@ -3462,14 +3485,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   []
@@ -3484,11 +3507,12 @@ requests they will be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 state
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -3500,7 +3524,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -3510,7 +3534,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3518,7 +3542,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3535,17 +3559,18 @@ OAuth 2.0 protocol
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 user
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -3566,10 +3591,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -3581,7 +3606,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3614,16 +3639,16 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -3662,17 +3687,18 @@ None of these options are required.
         class="text-default w-full leading-normal last:mb-0"
       >
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             See:
-          </strong>
+          </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3721,11 +3747,12 @@ for more details.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 nonce
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -3737,7 +3764,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -3747,13 +3774,13 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3770,11 +3797,12 @@ for more details.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 requestedScopes
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -3786,11 +3814,11 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3802,14 +3830,14 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
@@ -3818,14 +3846,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="!inline emotion-6"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   []
@@ -3840,11 +3868,12 @@ requests they will be
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 state
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -3856,7 +3885,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -3866,7 +3895,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3874,7 +3903,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3890,10 +3919,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -3905,7 +3934,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -3938,16 +3967,16 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="!inline emotion-6"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -3986,17 +4015,18 @@ You must include the ID string of the user to sign out.
         class="text-default w-full leading-normal last:mb-0"
       >
         <p
-          class="mb-3.5 emotion-4"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          <strong
-            class="emotion-23"
+          <span
+            class="text-default leading-[1.6154] font-semibold"
+            data-text="true"
           >
             See:
-          </strong>
+          </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -4045,11 +4075,12 @@ for more details.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 state
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -4061,7 +4092,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -4071,7 +4102,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4079,7 +4110,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -4096,17 +4127,18 @@ OAuth 2.0 protocol
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 user
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -4127,10 +4159,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -4142,7 +4174,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="emotion-3"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             Subscription
@@ -4175,7 +4207,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -4216,17 +4248,18 @@ OAuth 2.0 protocol
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-23"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 remove
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="emotion-6"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
                 data-text="true"
               >
                 <span
@@ -4247,7 +4280,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -4260,7 +4293,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -4300,13 +4333,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -4318,7 +4351,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationButtonStyle
@@ -4351,16 +4384,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4369,11 +4402,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationButtonStyle Values
@@ -4384,7 +4417,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4396,7 +4429,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               WHITE
@@ -4429,13 +4462,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         White button with black text.
@@ -4445,7 +4478,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4457,7 +4490,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               WHITE_OUTLINE
@@ -4490,13 +4523,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4506,7 +4539,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4518,7 +4551,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               BLACK
@@ -4551,13 +4584,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Black button with white text.
@@ -4565,13 +4598,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -4583,7 +4616,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationButtonType
@@ -4616,16 +4649,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4634,11 +4667,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationButtonType Values
@@ -4649,7 +4682,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4661,7 +4694,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               SIGN_IN
@@ -4694,13 +4727,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4710,7 +4743,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4722,7 +4755,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               CONTINUE
@@ -4755,13 +4788,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         "Continue with Apple"
@@ -4774,18 +4807,18 @@ After calling this function, the listener will no longer receive any events from
         class="flex flex-row items-center mb-2"
       >
         <span
-          class="inline-flex items-center emotion-84"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
           data-text="true"
         >
           <span
-            class="!text-inherit !font-medium emotion-5"
+            class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
             data-text="true"
           >
             Only for:
              
           </span>
           <div
-            class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-347"
+            class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-34"
           >
             <svg
               class="opacity-80 icon-xs text-palette-blue12"
@@ -4805,7 +4838,7 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="emotion-348"
+              class="emotion-35"
             >
               iOS 13.2+
             </span>
@@ -4814,7 +4847,7 @@ After calling this function, the listener will no longer receive any events from
         </span>
       </div>
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -4826,7 +4859,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               SIGN_UP
@@ -4859,13 +4892,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         "Sign up with Apple"
@@ -4873,13 +4906,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -4891,7 +4924,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationCredentialState
@@ -4924,16 +4957,16 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -4971,17 +5004,18 @@ After calling this function, the listener will no longer receive any events from
           class="text-default w-full leading-normal last:mb-0"
         >
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
-            <strong
-              class="emotion-23"
+            <span
+              class="text-default leading-[1.6154] font-semibold"
+              data-text="true"
             >
               See:
-            </strong>
+            </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
               rel="noopener noreferrer"
               target="_blank"
@@ -4995,11 +5029,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationCredentialState Values
@@ -5010,7 +5044,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5022,7 +5056,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               REVOKED
@@ -5055,7 +5089,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5065,7 +5099,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5077,7 +5111,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               AUTHORIZED
@@ -5110,7 +5144,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5120,7 +5154,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5132,7 +5166,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               NOT_FOUND
@@ -5165,7 +5199,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5175,7 +5209,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5187,7 +5221,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               TRANSFERRED
@@ -5220,7 +5254,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5228,13 +5262,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -5246,7 +5280,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationOperation
@@ -5279,11 +5313,11 @@ for more details.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationOperation Values
@@ -5294,7 +5328,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5306,7 +5340,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               IMPLICIT
@@ -5339,13 +5373,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5355,7 +5389,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5367,7 +5401,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               LOGIN
@@ -5400,7 +5434,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5410,7 +5444,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5422,7 +5456,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               REFRESH
@@ -5455,7 +5489,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5465,7 +5499,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5477,7 +5511,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               LOGOUT
@@ -5510,7 +5544,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5518,13 +5552,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -5536,7 +5570,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationScope
@@ -5569,16 +5603,16 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="!inline emotion-6"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -5620,7 +5654,7 @@ for more details.
           
 
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -5660,17 +5694,18 @@ You will still need to handle null values for any fields you request.
           class="text-default w-full leading-normal last:mb-0"
         >
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
-            <strong
-              class="emotion-23"
+            <span
+              class="text-default leading-[1.6154] font-semibold"
+              data-text="true"
             >
               See:
-            </strong>
+            </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
               rel="noopener noreferrer"
               target="_blank"
@@ -5684,11 +5719,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationScope Values
@@ -5699,7 +5734,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5711,7 +5746,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               FULL_NAME
@@ -5744,7 +5779,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -5754,7 +5789,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5766,7 +5801,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               EMAIL
@@ -5799,7 +5834,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -5807,13 +5842,13 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -5825,7 +5860,7 @@ for more details.
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-3"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationUserDetectionStatus
@@ -5858,7 +5893,7 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
@@ -5893,17 +5928,18 @@ for more details.
           class="text-default w-full leading-normal last:mb-0"
         >
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
-            <strong
-              class="emotion-23"
+            <span
+              class="text-default leading-[1.6154] font-semibold"
+              data-text="true"
             >
               See:
-            </strong>
+            </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-7"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
               rel="noopener noreferrer"
               target="_blank"
@@ -5917,11 +5953,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 emotion-25"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-83"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           AppleAuthenticationUserDetectionStatus Values
@@ -5932,7 +5968,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -5944,7 +5980,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               UNSUPPORTED
@@ -5977,13 +6013,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -5993,7 +6029,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -6005,7 +6041,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               UNKNOWN
@@ -6038,13 +6074,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6054,7 +6090,7 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-66"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -6066,7 +6102,7 @@ for more details.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-318"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               LIKELY_REAL
@@ -6099,13 +6135,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-319"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6118,7 +6154,7 @@ for more details.
 exports[`APISection expo-barcode-scanner 1`] = `
 <div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -6158,7 +6194,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none emotion-1"
+    class="!shadow-none emotion-0"
   >
     <div
       class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
@@ -6193,17 +6229,18 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="text-default w-full leading-normal last:mb-0"
         >
           <p
-            class="mb-3.5 emotion-2"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
-            <strong
-              class="emotion-3"
+            <span
+              class="text-default leading-[1.6154] font-semibold"
+              data-text="true"
             >
               Deprecated
-            </strong>
+            </span>
              BarCodeScanner has been deprecated and will be removed in a future SDK version. Use 
             <code
-              class="!inline emotion-4"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
               data-text="true"
             >
               expo-camera
@@ -6211,21 +6248,21 @@ exports[`APISection expo-barcode-scanner 1`] = `
              instead.
 See 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://expo.fyi/barcode-scanner-to-expo-camera"
               rel="noopener noreferrer"
               target="_blank"
             >
               How to migrate from 
               <code
-                class="!inline emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                 data-text="true"
               >
                 expo-barcode-scanner
               </code>
                to 
               <code
-                class="!inline emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                 data-text="true"
               >
                 expo-camera
@@ -6238,7 +6275,7 @@ for more details.
       </blockquote>
     </div>
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -6250,7 +6287,7 @@ for more details.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-9"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             BarCodeScanner
@@ -6283,23 +6320,23 @@ for more details.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       <span
-        class="emotion-11"
+        class="leading-[1.6154] font-medium text-secondary"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="emotion-4"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
         data-text="true"
       >
         React.
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="https://react.dev/reference/react/Component"
           rel="noopener noreferrer"
           target="_blank"
@@ -6313,7 +6350,7 @@ for more details.
         </span>
         <span>
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="#barcodescannerprops"
           >
             BarCodeScannerProps
@@ -6328,15 +6365,15 @@ for more details.
     </p>
     <div>
       <p
-        class="!text-secondary !font-medium emotion-15"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !text-secondary !font-medium emotion-1"
         data-text="true"
       >
         <span
-          class="group emotion-16"
+          class="leading-[1.6154] text-inherit group"
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 text-inherit flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-secondary flex flex-row gap-2 items-center"
             href="#barcodescannerprops"
             id="barcodescannerprops"
           >
@@ -6377,10 +6414,10 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-17"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-8"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -6392,7 +6429,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-19"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 barCodeTypes
@@ -6425,7 +6462,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -6440,19 +6477,19 @@ for more details.
           </span>
            
           <code
-            class="emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             string[]
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           An array of bar code types. Usage: 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
@@ -6460,14 +6497,14 @@ for more details.
            where
 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             codeType
           </code>
            is one of these 
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="#supported-formats"
           >
             listed above
@@ -6479,12 +6516,12 @@ minimize battery usage.
         
 
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           For example: 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
@@ -6493,10 +6530,10 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-17"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-8"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -6508,7 +6545,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-19"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6541,7 +6578,7 @@ minimize battery usage.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -6556,11 +6593,11 @@ minimize battery usage.
           </span>
            
           <code
-            class="emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#barcodescannedcallback"
             >
               BarCodeScannedCallback
@@ -6568,13 +6605,13 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
 provided with an 
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="#barcodescannerresult"
           >
             BarCodeScannerResult
@@ -6615,24 +6652,25 @@ provided with an
             
 
             <p
-              class="mb-3.5 emotion-2"
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
               data-text="true"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 Note:
-              </strong>
+              </span>
                Passing 
               <code
-                class="!inline emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                 data-text="true"
               >
                 undefined
               </code>
                to the 
               <code
-                class="!inline emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6647,10 +6685,10 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 emotion-17"
+        class="!pb-4 [&>*:last-child]:!mb-0 emotion-2"
       >
         <h3
-          class="group emotion-8"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
@@ -6662,7 +6700,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere emotion-19"
+                class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-3"
                 data-text="true"
               >
                 type
@@ -6695,7 +6733,7 @@ data has been retrieved.
           </a>
         </h3>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           <span
@@ -6710,7 +6748,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <span>
@@ -6741,7 +6779,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="emotion-4"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
               data-text="true"
             >
               Type.back
@@ -6749,26 +6787,26 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="mb-3.5 emotion-2"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           Camera facing. Use one of 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             Type.front
           </code>
            or 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             Type.back
@@ -6776,7 +6814,7 @@ data has been retrieved.
           .
 Same as 
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             Camera.Constants.Type
@@ -6785,7 +6823,7 @@ Same as
         </p>
       </div>
       <h4
-        class="group emotion-51"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -6825,18 +6863,18 @@ Same as
         </a>
       </h4>
       <ul
-        class="emotion-52"
+        class="text-default leading-[1.6154] list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
       >
         <li
-          class="emotion-53"
+          class="text-default text-[16px] font-normal leading-relaxed tracking-[-0.011rem] mb-2"
           data-text="true"
         >
           <code
-            class="emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://reactnative.dev/docs/view#props"
               rel="noopener noreferrer"
               target="_blank"
@@ -6849,7 +6887,7 @@ Same as
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -6889,10 +6927,10 @@ Same as
     </a>
   </h2>
   <div
-    class="emotion-17"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -6904,7 +6942,7 @@ Same as
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-59"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-9"
             data-text="true"
           >
             usePermissions(options)
@@ -6967,11 +7005,12 @@ Same as
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 options
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -6983,11 +7022,11 @@ Same as
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#permissionhookoptions"
                 >
                   PermissionHookOptions
@@ -7013,20 +7052,20 @@ Same as
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Check or request permissions for the barcode scanner.
 This uses both 
       <code
-        class="!inline emotion-4"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         requestPermissionAsync
       </code>
        and 
       <code
-        class="!inline emotion-4"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         getPermissionsAsync
@@ -7060,18 +7099,18 @@ This uses both
           </g>
         </svg>
         <span
-          class="emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-67"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           [
@@ -7086,7 +7125,7 @@ This uses both
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7103,7 +7142,7 @@ This uses both
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7125,7 +7164,7 @@ This uses both
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                 href="#permissionresponse"
               >
                 PermissionResponse
@@ -7145,11 +7184,11 @@ This uses both
       class="mb-3.5 last:[&>*]:mb-0"
     >
       <p
-        class="!mt-1 emotion-15"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mt-1 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           <svg
@@ -7244,7 +7283,7 @@ This uses both
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -7284,10 +7323,10 @@ This uses both
     </a>
   </h2>
   <div
-    class="emotion-17"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -7299,7 +7338,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-59"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-9"
             data-text="true"
           >
             BarCodeScanner.getPermissionsAsync()
@@ -7332,7 +7371,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
@@ -7364,22 +7403,22 @@ This uses both
           </g>
         </svg>
         <span
-          class="emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-67"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7393,7 +7432,7 @@ This uses both
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -7411,16 +7450,16 @@ This uses both
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#permissionresponse"
         >
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             PermissionResponse
@@ -7431,10 +7470,10 @@ This uses both
     </div>
   </div>
   <div
-    class="emotion-17"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -7446,7 +7485,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-59"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-9"
             data-text="true"
           >
             BarCodeScanner.requestPermissionsAsync()
@@ -7479,7 +7518,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
@@ -7487,19 +7526,19 @@ This uses both
     
 
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="!inline emotion-4"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="!inline emotion-4"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         Info.plist
@@ -7533,22 +7572,22 @@ This uses both
           </g>
         </svg>
         <span
-          class="emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-67"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7562,7 +7601,7 @@ This uses both
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -7580,16 +7619,16 @@ This uses both
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#permissionresponse"
         >
           <code
-            class="!inline emotion-4"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             PermissionResponse
@@ -7600,10 +7639,10 @@ This uses both
     </div>
   </div>
   <div
-    class="emotion-17"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -7615,7 +7654,7 @@ This uses both
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-59"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-9"
             data-text="true"
           >
             BarCodeScanner.scanFromURLAsync(url, barCodeTypes)
@@ -7683,17 +7722,18 @@ This uses both
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 url
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -7703,7 +7743,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 URL to get the image from.
@@ -7716,11 +7756,12 @@ This uses both
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 barCodeTypes
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -7732,7 +7773,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string[]
@@ -7742,7 +7783,7 @@ This uses both
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 An array of bar code types. Defaults to all supported bar code types on
@@ -7782,14 +7823,15 @@ the platform.
                   
 
                   <p
-                    class="mb-3.5 emotion-2"
+                    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                     data-text="true"
                   >
-                    <strong
-                      class="emotion-3"
+                    <span
+                      class="text-default leading-[1.6154] font-semibold"
+                      data-text="true"
                     >
                       Note:
-                    </strong>
+                    </span>
                      Only QR codes are supported on iOS.
                   </p>
                   
@@ -7803,7 +7845,7 @@ the platform.
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
@@ -7835,22 +7877,22 @@ the platform.
           </g>
         </svg>
         <span
-          class="emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-67"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7864,7 +7906,7 @@ the platform.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#barcodescannerresult"
             >
               BarCodeScannerResult
@@ -7883,12 +7925,12 @@ the platform.
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         A possibly empty array of objects of the 
         <code
-          class="!inline emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           BarCodeScannerResult
@@ -7900,7 +7942,7 @@ code.
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -7940,10 +7982,10 @@ code.
     </a>
   </h2>
   <div
-    class="emotion-17"
+    class="emotion-2"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -7955,7 +7997,7 @@ code.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-9"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionResponse
@@ -7988,17 +8030,17 @@ code.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="emotion-15"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] emotion-1"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center emotion-66"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
         data-text="true"
       >
         PermissionResponse Properties
@@ -8040,17 +8082,18 @@ code.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 canAskAgain
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 boolean
@@ -8060,7 +8103,7 @@ code.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -8075,21 +8118,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 expires
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#permissionexpiration"
                 >
                   PermissionExpiration
@@ -8100,7 +8144,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -8113,17 +8157,18 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 granted
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 boolean
@@ -8133,7 +8178,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -8146,21 +8191,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 status
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#permissionstatus"
                 >
                   PermissionStatus
@@ -8171,7 +8217,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -8184,7 +8230,7 @@ in order to enable/disable the permission.
     <br />
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -8224,10 +8270,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8239,7 +8285,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodeBounds
@@ -8307,21 +8353,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 origin
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodepoint"
                 >
                   BarCodePoint
@@ -8332,7 +8379,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The origin point of the bounding box.
@@ -8345,21 +8392,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 size
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodesize"
                 >
                   BarCodeSize
@@ -8370,7 +8418,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The size of the bounding box.
@@ -8382,10 +8430,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8397,7 +8445,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-9"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             BarCodeEvent
@@ -8430,22 +8478,22 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="emotion-67"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
       data-text="true"
     >
       <span
-        class="emotion-66"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
         data-text="true"
       >
         Type:
          
       </span>
       <code
-        class="text-default emotion-4"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-default"
         data-text="true"
       >
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#barcodescannerresult"
         >
           BarCodeScannerResult
@@ -8453,7 +8501,7 @@ in order to enable/disable the permission.
       </code>
        
       <span
-        class="emotion-161"
+        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
         data-text="true"
       >
         extended by
@@ -8497,11 +8545,12 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 target
-              </strong>
+              </span>
               <br />
               <span
                 class="text-secondary pt-5 !text-[13px]"
@@ -8513,7 +8562,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -8534,10 +8583,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8549,7 +8598,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -8617,21 +8666,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 nativeEvent
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodeevent"
                 >
                   BarCodeEvent
@@ -8653,10 +8703,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8668,7 +8718,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodePoint
@@ -8701,7 +8751,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-2"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -8743,17 +8793,18 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 x
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -8763,12 +8814,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   x
@@ -8783,17 +8834,18 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 y
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -8803,12 +8855,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   y
@@ -8822,10 +8874,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8837,7 +8889,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -8902,21 +8954,22 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               <td
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
-                <strong
-                  class="emotion-3"
+                <span
+                  class="text-default leading-[1.6154] font-semibold"
+                  data-text="true"
                 >
                   params
-                </strong>
+                </span>
               </td>
               <td
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
-                  class="[&>span]:!text-inherit emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                   data-text="true"
                 >
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                     href="#barcodeevent"
                   >
                     BarCodeEvent
@@ -8930,10 +8983,10 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -8945,7 +8998,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodeScannerResult
@@ -9013,21 +9066,22 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 bounds
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodebounds"
                 >
                   BarCodeBounds
@@ -9038,12 +9092,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodebounds"
                 >
                   BarCodeBounds
@@ -9051,7 +9105,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  object.
 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   bounds
@@ -9059,7 +9113,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  in some case will be representing an empty rectangle.
 Moreover, 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   bounds
@@ -9075,21 +9129,22 @@ For some types, they will represent the area used by the scanner.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 cornerPoints
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#barcodepoint"
                 >
                   BarCodePoint
@@ -9101,27 +9156,27 @@ For some types, they will represent the area used by the scanner.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Corner points of the bounding box.
 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   cornerPoints
                 </code>
                  is not always available and may be empty. On iOS, for 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   code39
                 </code>
                  and 
                 <code
-                  class="!inline emotion-4"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                   data-text="true"
                 >
                   pdf417
@@ -9137,17 +9192,18 @@ you don't get this value.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 data
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -9157,7 +9213,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The parsed information encoded in the bar code.
@@ -9170,17 +9226,18 @@ you don't get this value.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 type
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 string
@@ -9190,7 +9247,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The barcode type.
@@ -9202,10 +9259,10 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -9217,7 +9274,7 @@ you don't get this value.
           class="inline"
         >
           <code
-            class="emotion-9"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             BarCodeSize
@@ -9285,17 +9342,18 @@ you don't get this value.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 height
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -9305,7 +9363,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The height value.
@@ -9318,17 +9376,18 @@ you don't get this value.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-3"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 width
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-4"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -9338,7 +9397,7 @@ you don't get this value.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-2"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 The width value.
@@ -9350,10 +9409,10 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-8"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -9365,7 +9424,7 @@ you don't get this value.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-9"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionHookOptions
@@ -9398,11 +9457,11 @@ you don't get this value.
       </a>
     </h3>
     <p
-      class="mb-3 emotion-67"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       <span
-        class="emotion-66"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
         data-text="true"
       >
         Literal Type:
@@ -9411,11 +9470,11 @@ you don't get this value.
       multiple types
     </p>
     <p
-      class="emotion-67"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
       data-text="true"
     >
       <span
-        class="emotion-66"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
         data-text="true"
       >
         Acceptable values are:
@@ -9423,13 +9482,13 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           PermissionHookBehavior
         </code>
         <span
-          class="emotion-228"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-quaternary"
           data-text="true"
         >
            | 
@@ -9437,7 +9496,7 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="emotion-4"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           Options
@@ -9446,7 +9505,7 @@ you don't get this value.
     </p>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -9486,13 +9545,13 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 emotion-1"
+    class="!p-0 emotion-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-8"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -9504,7 +9563,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-9"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               PermissionStatus
@@ -9537,11 +9596,11 @@ you don't get this value.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 emotion-15"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-1"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-66"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           PermissionStatus Values
@@ -9552,7 +9611,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-51"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -9564,7 +9623,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-237"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               DENIED
@@ -9597,13 +9656,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-238"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User has denied the permission.
@@ -9613,7 +9672,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-51"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -9625,7 +9684,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-237"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               GRANTED
@@ -9658,13 +9717,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-238"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User has granted the permission.
@@ -9674,7 +9733,7 @@ you don't get this value.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-51"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -9686,7 +9745,7 @@ you don't get this value.
             class="inline"
           >
             <code
-              class="!text-inherit emotion-237"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               UNDETERMINED
@@ -9719,13 +9778,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-3 emotion-238"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-3.5 emotion-2"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -9738,7 +9797,7 @@ you don't get this value.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -9778,10 +9837,10 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -9793,7 +9852,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-1"
             data-text="true"
           >
             getPermissionsAsync()
@@ -9826,7 +9885,7 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
@@ -9858,22 +9917,22 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <span
-          class="emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -9887,7 +9946,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -9903,24 +9962,24 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <div
       class="flex flex-row items-center mb-2"
     >
       <span
-        class="inline-flex items-center emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
         data-text="true"
       >
         <span
-          class="!text-inherit !font-medium emotion-12"
+          class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
           data-text="true"
         >
           Only for:
            
         </span>
         <div
-          class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-13"
+          class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none emotion-3"
         >
           <svg
             class="opacity-80 icon-xs text-palette-blue12"
@@ -9940,7 +9999,7 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="emotion-14"
+            class="emotion-4"
           >
             iOS
           </span>
@@ -9949,7 +10008,7 @@ exports[`APISection expo-pedometer 1`] = `
       </span>
     </div>
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -9961,7 +10020,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-1"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -10029,21 +10088,22 @@ exports[`APISection expo-pedometer 1`] = `
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 start
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -10056,7 +10116,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -10069,21 +10129,22 @@ exports[`APISection expo-pedometer 1`] = `
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 end
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -10096,7 +10157,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -10108,7 +10169,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Get the step count between two dates.
@@ -10140,22 +10201,22 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <span
-          class="emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10169,7 +10230,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#pedometerresult"
             >
               PedometerResult
@@ -10187,16 +10248,16 @@ exports[`APISection expo-pedometer 1`] = `
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#pedometerresult"
         >
           <code
-            class="!inline emotion-7"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             PedometerResult
@@ -10207,12 +10268,12 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         As 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
           rel="noopener noreferrer"
           target="_blank"
@@ -10255,7 +10316,7 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -10268,10 +10329,10 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -10283,7 +10344,7 @@ a start date that is more than seven days in the past returns only the available
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-1"
             data-text="true"
           >
             isAvailableAsync()
@@ -10316,7 +10377,7 @@ a start date that is more than seven days in the past returns only the available
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
@@ -10348,22 +10409,22 @@ a start date that is more than seven days in the past returns only the available
           </g>
         </svg>
         <span
-          class="emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10390,12 +10451,12 @@ a start date that is more than seven days in the past returns only the available
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <code
-          class="!inline emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           boolean
@@ -10406,10 +10467,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -10421,7 +10482,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-1"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -10454,7 +10515,7 @@ available on this device.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
@@ -10486,22 +10547,22 @@ available on this device.
           </g>
         </svg>
         <span
-          class="emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -10515,7 +10576,7 @@ available on this device.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -10531,10 +10592,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -10546,7 +10607,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-3"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere emotion-1"
             data-text="true"
           >
             watchStepCount(callback)
@@ -10614,21 +10675,22 @@ available on this device.
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 callback
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#pedometerupdatecallback"
                 >
                   PedometerUpdateCallback
@@ -10639,17 +10701,17 @@ available on this device.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
 provided with a single argument that is 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#pedometerresult"
                 >
                   <code
-                    class="!inline emotion-7"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                     data-text="true"
                   >
                     PedometerResult
@@ -10664,7 +10726,7 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Subscribe to pedometer updates.
@@ -10696,18 +10758,18 @@ provided with a single argument that is
           </g>
         </svg>
         <span
-          class="emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
           data-text="true"
         >
           Returns:
         </span>
       </div>
       <p
-        class="emotion-6"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="[&>span]:!text-inherit emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
           EventSubscription
@@ -10718,16 +10780,16 @@ provided with a single argument that is
       class="flex flex-col mt-1.5 mb-1 pl-6"
     >
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Returns a 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
           href="#subscription"
         >
           <code
-            class="!inline emotion-7"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             Subscription
@@ -10736,7 +10798,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="!inline emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
           data-text="true"
         >
           remove()
@@ -10777,19 +10839,19 @@ provided with a single argument that is
           
 
           <p
-            class="mb-3.5 emotion-4"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
               href="https://developer.android.com/health-and-fitness/guides/health-connect"
               rel="noopener noreferrer"
               target="_blank"
             >
               <code
-                class="!inline emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
                 data-text="true"
               >
                 Health Connect API
@@ -10798,7 +10860,7 @@ provided with a single argument that is
             .
 On iOS, the 
             <code
-              class="!inline emotion-7"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
               data-text="true"
             >
               getStepCountAsync
@@ -10812,7 +10874,7 @@ On iOS, the
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -10852,10 +10914,10 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="emotion-1"
+    class="emotion-0"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -10867,7 +10929,7 @@ On iOS, the
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-80"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionResponse
@@ -10900,17 +10962,17 @@ On iOS, the
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="emotion-82"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] emotion-13"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center emotion-5"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
         data-text="true"
       >
         PermissionResponse Properties
@@ -10952,17 +11014,18 @@ On iOS, the
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 canAskAgain
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 boolean
@@ -10972,7 +11035,7 @@ On iOS, the
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -10987,21 +11050,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 expires
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#permissionexpiration"
                 >
                   PermissionExpiration
@@ -11012,7 +11076,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -11025,17 +11089,18 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 granted
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 boolean
@@ -11045,7 +11110,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -11058,21 +11123,22 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 status
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                   href="#permissionstatus"
                 >
                   PermissionStatus
@@ -11083,7 +11149,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -11096,7 +11162,7 @@ in order to enable/disable the permission.
     <br />
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -11136,10 +11202,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="emotion-99"
+    class="emotion-14"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -11151,7 +11217,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-80"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             PedometerResult
@@ -11219,17 +11285,18 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 steps
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="[&>span]:!text-inherit emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                 data-text="true"
               >
                 number
@@ -11239,7 +11306,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -11251,10 +11318,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-99"
+    class="emotion-14"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -11266,7 +11333,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-80"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11300,7 +11367,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Callback function providing event result as an argument.
@@ -11337,21 +11404,22 @@ in order to enable/disable the permission.
               <td
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
-                <strong
-                  class="emotion-17"
+                <span
+                  class="text-default leading-[1.6154] font-semibold"
+                  data-text="true"
                 >
                   result
-                </strong>
+                </span>
               </td>
               <td
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
-                  class="[&>span]:!text-inherit emotion-7"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
                   data-text="true"
                 >
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-8"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
                     href="#pedometerresult"
                   >
                     PedometerResult
@@ -11365,10 +11433,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="emotion-99"
+    class="emotion-14"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -11380,7 +11448,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="wrap-anywhere emotion-80"
+            class="text-default leading-[1.6154] font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionExpiration
@@ -11413,11 +11481,11 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3 emotion-6"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       <span
-        class="emotion-5"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
         data-text="true"
       >
         Literal Type:
@@ -11426,17 +11494,17 @@ in order to enable/disable the permission.
       multiple types
     </p>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="emotion-6"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
       data-text="true"
     >
       <span
-        class="emotion-5"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
         data-text="true"
       >
         Acceptable values are:
@@ -11444,13 +11512,13 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           'never'
         </code>
         <span
-          class="emotion-121"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-quaternary"
           data-text="true"
         >
            | 
@@ -11458,7 +11526,7 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="emotion-7"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           number
@@ -11467,10 +11535,10 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="emotion-99"
+    class="emotion-14"
   >
     <h3
-      class="group emotion-2"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
@@ -11482,7 +11550,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="emotion-80"
+            class="text-default leading-[1.6154] font-medium"
             data-text="true"
           >
             Subscription
@@ -11515,7 +11583,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-3.5 emotion-4"
+      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -11556,17 +11624,18 @@ in order to enable/disable the permission.
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
-              <strong
-                class="emotion-17"
+              <span
+                class="text-default leading-[1.6154] font-semibold"
+                data-text="true"
               >
                 remove
-              </strong>
+              </span>
             </td>
             <td
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
-                class="emotion-7"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
                 data-text="true"
               >
                 <span
@@ -11587,7 +11656,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="mb-3.5 emotion-4"
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -11600,7 +11669,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="group emotion-0"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
@@ -11640,13 +11709,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 emotion-99"
+    class="!p-0 emotion-14"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="group emotion-2"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
@@ -11658,7 +11727,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="wrap-anywhere emotion-80"
+              class="text-default leading-[1.6154] font-medium wrap-anywhere"
               data-text="true"
             >
               PermissionStatus
@@ -11691,11 +11760,11 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 emotion-82"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mb-0 !border-b-0 emotion-13"
         data-text="true"
       >
         <span
-          class="text-inherit flex flex-row gap-2 items-center emotion-5"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
           data-text="true"
         >
           PermissionStatus Values
@@ -11706,7 +11775,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-136"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -11718,7 +11787,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-137"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               DENIED
@@ -11751,13 +11820,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-138"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User has denied the permission.
@@ -11767,7 +11836,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-136"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -11779,7 +11848,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-137"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               GRANTED
@@ -11812,13 +11881,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-138"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User has granted the permission.
@@ -11828,7 +11897,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="group emotion-136"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
@@ -11840,7 +11909,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="!text-inherit emotion-137"
+              class="text-default leading-[1.6154] !text-inherit"
               data-text="true"
             >
               UNDETERMINED
@@ -11873,13 +11942,13 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="mb-3 emotion-138"
+        class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 text-secondary mb-3"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-3.5 emotion-4"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -11892,7 +11961,7 @@ After calling this function, the listener will no longer receive any events from
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="emotion-0"
+    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -606,13 +606,9 @@ export const ParamsTableHeadRow = ({ hasDescription = true, mainCellLabel = 'Nam
 );
 
 function createInheritPermalink(baseNestingLevel: number) {
-  return createPermalinkedComponent(
-    createTextComponent(
-      TextElement.SPAN,
-      css({ fontSize: 'inherit', fontWeight: 'inherit', color: 'inherit' })
-    ),
-    { baseNestingLevel }
-  );
+  return createPermalinkedComponent(createTextComponent(TextElement.SPAN, 'text-inherit'), {
+    baseNestingLevel,
+  });
 }
 
 export const BoxSectionHeader = ({
@@ -631,10 +627,7 @@ export const BoxSectionHeader = ({
   const TextWrapper = exposeInSidebar ? createInheritPermalink(baseNestingLevel) : SPAN;
   return (
     <CALLOUT css={STYLES_NESTED_SECTION_HEADER} className={className}>
-      <TextWrapper
-        theme="secondary"
-        weight="medium"
-        className="text-inherit flex flex-row gap-2 items-center">
+      <TextWrapper weight="medium" className="text-secondary flex flex-row gap-2 items-center">
         {Icon && <Icon className="icon-sm text-icon-secondary" />}
         {text}
       </TextWrapper>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="mb-3.5 emotion-0"
+    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
     data-text="true"
   >
     This is the basic comment.
@@ -17,18 +17,18 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     class="flex flex-row items-center mb-2"
   >
     <span
-      class="inline-flex items-center emotion-0"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
       <span
-        class="!text-inherit !font-medium emotion-1"
+        class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
         data-text="true"
       >
         Only for:
          
       </span>
       <div
-        class="!bg-palette-green3 !text-palette-green12 !border-palette-green4 select-none emotion-2"
+        class="!bg-palette-green3 !text-palette-green12 !border-palette-green4 select-none emotion-0"
       >
         <svg
           class="opacity-80 icon-xs text-palette-green12"
@@ -48,7 +48,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           </g>
         </svg>
         <span
-          class="emotion-3"
+          class="emotion-1"
         >
           Android
         </span>
@@ -57,18 +57,18 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     </span>
   </div>
   <p
-    class="mb-3.5 emotion-4"
+    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-5"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="https://developer.android.com/google/play/installreferrer"
       rel="noopener noreferrer"
       target="_blank"
     >
       <code
-        class="!inline emotion-6"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
         data-text="true"
       >
         Install Referrer API
@@ -81,11 +81,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
     class="mb-3.5 last:[&>*]:mb-0"
   >
     <p
-      class="!mt-1 emotion-7"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] !mt-1 emotion-2"
       data-text="true"
     >
       <span
-        class="text-inherit flex flex-row gap-2 items-center emotion-8"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
         data-text="true"
       >
         <svg
@@ -169,7 +169,7 @@ exports[`APISectionUtils.CommentTextBlock component no comment 1`] = `<div />`;
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -195,7 +195,7 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -209,7 +209,7 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#appleauthenticationcredential"
     >
       AppleAuthenticationCredential
@@ -314,7 +314,7 @@ exports[`APISectionUtils.resolveTypeName alternative generic object notation 1`]
 exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent"
     rel="noopener noreferrer"
     target="_blank"
@@ -327,7 +327,7 @@ exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type array 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="#appleauthenticationscope"
   >
     AppleAuthenticationScope
@@ -345,7 +345,7 @@ exports[`APISectionUtils.resolveTypeName custom type non-linkable array 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys"
     rel="noopener noreferrer"
     target="_blank"
@@ -359,7 +359,7 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#fontresource"
     >
       FontResource
@@ -399,7 +399,7 @@ exports[`APISectionUtils.resolveTypeName function 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -424,7 +424,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -454,7 +454,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -479,7 +479,7 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -512,7 +512,7 @@ exports[`APISectionUtils.resolveTypeName generic type 1`] = `
 exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="#pagedinfo"
   >
     PagedInfo
@@ -524,7 +524,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#asset"
     >
       Asset
@@ -541,7 +541,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -555,7 +555,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#pagedinfo"
     >
       PagedInfo
@@ -567,7 +567,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="#asset"
       >
         Asset
@@ -628,7 +628,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
       rel="noopener noreferrer"
       target="_blank"
@@ -642,7 +642,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
         href="https://reactnative.dev/docs/view-style-props"
         rel="noopener noreferrer"
         target="_blank"
@@ -706,7 +706,7 @@ exports[`APISectionUtils.resolveTypeName tuple type 1`] = `
   [
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#sortbykey"
     >
       SortByKey
@@ -724,7 +724,7 @@ exports[`APISectionUtils.resolveTypeName union 1`] = `
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -750,7 +750,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#resultseterror"
     >
       ResultSetError
@@ -763,7 +763,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#resultset"
     >
       ResultSet
@@ -798,7 +798,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#assetref"
     >
       AssetRef
@@ -812,7 +812,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 emotion-0"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
       href="#assetref"
     >
       AssetRef

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -49,5 +49,8 @@ module.exports = {
       slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
       wave: 'wave 0.25s ease-in-out 4',
     },
+    boxShadow: {
+      kbd: '0 .1rem 0 1px var(--expo-theme-border-default)',
+    },
   }),
 };

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
@@ -19,7 +19,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm emotion-2"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
               data-text="true"
             >
               name
@@ -52,35 +52,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 emotion-3"
+        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
         data-text="true"
       >
         Type: 
         <code
-          class="emotion-2"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           string
         </code>
       </p>
       <p
-        class="mb-3.5 emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Name of your app.
       </p>
       <details
-        class="emotion-6"
+        class="emotion-1"
         id="bare-workflow"
       >
         <summary
-          class="group emotion-7"
+          class="group emotion-2"
         >
           <div
-            class="emotion-8"
+            class="emotion-3"
           >
             <svg
-              class="icon-sm text-icon-default emotion-9"
+              class="icon-sm text-icon-default emotion-4"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -101,7 +101,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="emotion-10"
+              class="text-default leading-[1.6154] font-medium"
               data-text="true"
             >
               Bare Workflow
@@ -137,10 +137,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 emotion-11"
+          class="last:[&>*]:!mb-1 emotion-5"
         >
           <p
-            class="mb-3.5 emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Edit the 'Display Name' field in Xcode
@@ -152,7 +152,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
@@ -164,7 +164,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm emotion-2"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
               data-text="true"
             >
               androidNavigationBar
@@ -197,35 +197,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 emotion-3"
+        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
         data-text="true"
       >
         Type: 
         <code
-          class="emotion-2"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           object
         </code>
       </p>
       <p
-        class="mb-3.5 emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="emotion-6"
+        class="emotion-1"
         id="expokit"
       >
         <summary
-          class="group emotion-7"
+          class="group emotion-2"
         >
           <div
-            class="emotion-8"
+            class="emotion-3"
           >
             <svg
-              class="icon-sm text-icon-default emotion-9"
+              class="icon-sm text-icon-default emotion-4"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -246,7 +246,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="emotion-10"
+              class="text-default leading-[1.6154] font-medium"
               data-text="true"
             >
               ExpoKit
@@ -282,10 +282,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 emotion-11"
+          class="last:[&>*]:!mb-1 emotion-5"
         >
           <p
-            class="mb-3.5 emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Set this property using AppConstants.java.
@@ -293,17 +293,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <details
-        class="emotion-6"
+        class="emotion-1"
         id="bare-workflow-1"
       >
         <summary
-          class="group emotion-7"
+          class="group emotion-2"
         >
           <div
-            class="emotion-8"
+            class="emotion-3"
           >
             <svg
-              class="icon-sm text-icon-default emotion-9"
+              class="icon-sm text-icon-default emotion-4"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -324,7 +324,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="emotion-10"
+              class="text-default leading-[1.6154] font-medium"
               data-text="true"
             >
               Bare Workflow
@@ -360,10 +360,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 emotion-11"
+          class="last:[&>*]:!mb-1 emotion-5"
         >
           <p
-            class="mb-3.5 emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Set this property using just Xcode
@@ -374,7 +374,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
@@ -386,7 +386,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm emotion-2"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                 data-text="true"
               >
                 visible
@@ -419,12 +419,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 emotion-3"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
           data-text="true"
         >
           Type: 
           <code
-            class="emotion-2"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             enum
@@ -440,23 +440,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="emotion-6"
+          class="emotion-1"
           id="expokit-1"
         >
           <summary
-            class="group emotion-7"
+            class="group emotion-2"
           >
             <div
-              class="emotion-8"
+              class="emotion-3"
             >
               <svg
-                class="icon-sm text-icon-default emotion-9"
+                class="icon-sm text-icon-default emotion-4"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -477,7 +477,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
             >
               <span
-                class="emotion-10"
+                class="text-default leading-[1.6154] font-medium"
                 data-text="true"
               >
                 ExpoKit
@@ -513,10 +513,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </summary>
           <div
-            class="last:[&>*]:!mb-1 emotion-11"
+            class="last:[&>*]:!mb-1 emotion-5"
           >
             <p
-              class="mb-3.5 emotion-1"
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
               data-text="true"
             >
               Set this property using Xcode.
@@ -527,7 +527,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
         >
           <p
-            class="group emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
@@ -539,7 +539,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="!px-1.5 !text-sm emotion-2"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                   data-text="true"
                 >
                   always
@@ -572,12 +572,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </p>
           <p
-            class="my-3 emotion-3"
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
             data-text="true"
           >
             Type: 
             <code
-              class="emotion-2"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
               data-text="true"
             >
               boolean
@@ -593,7 +593,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </code>
           </p>
           <p
-            class="mb-3.5 emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             Test sub-sub-property
@@ -604,7 +604,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
@@ -616,7 +616,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm emotion-2"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                 data-text="true"
               >
                 backgroundColor
@@ -649,12 +649,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 emotion-3"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
           data-text="true"
         >
           Type: 
           <code
-            class="emotion-2"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             string
@@ -670,7 +670,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -678,12 +678,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="mb-3.5 emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="!inline emotion-2"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
             data-text="true"
           >
             '#000000'
@@ -695,7 +695,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
     >
       <p
-        class="group emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
@@ -707,7 +707,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="!px-1.5 !text-sm emotion-2"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
               data-text="true"
             >
               intentFilters
@@ -740,35 +740,35 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </p>
       <p
-        class="my-3 emotion-3"
+        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
         data-text="true"
       >
         Type: 
         <code
-          class="emotion-2"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
           data-text="true"
         >
           array
         </code>
       </p>
       <p
-        class="mb-3.5 emotion-1"
+        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="emotion-6"
+        class="emotion-1"
         id="bare-workflow-2"
       >
         <summary
-          class="group emotion-7"
+          class="group emotion-2"
         >
           <div
-            class="emotion-8"
+            class="emotion-3"
           >
             <svg
-              class="icon-sm text-icon-default emotion-9"
+              class="icon-sm text-icon-default emotion-4"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -789,7 +789,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
-              class="emotion-10"
+              class="text-default leading-[1.6154] font-medium"
               data-text="true"
             >
               Bare Workflow
@@ -825,10 +825,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </summary>
         <div
-          class="last:[&>*]:!mb-1 emotion-11"
+          class="last:[&>*]:!mb-1 emotion-5"
         >
           <p
-            class="mb-3.5 emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
             This is set in AndroidManifest.xml directly.
@@ -839,7 +839,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="grid grid-cols-1 gap-2 mb-6"
       >
         <p
-          class="font-bold emotion-3"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary font-bold"
           data-text="true"
         >
           Example
@@ -849,7 +849,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           data-text="true"
         >
           <code
-            class="!text-3xs text-default block w-full !p-1.5 emotion-2"
+            class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] rounded-md border border-secondary bg-subtle px-1 py-0.5 !text-3xs text-default block w-full !p-1.5"
             data-text="true"
           >
             [
@@ -867,7 +867,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
@@ -879,7 +879,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm emotion-2"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                 data-text="true"
               >
                 autoVerify
@@ -912,12 +912,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 emotion-3"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
           data-text="true"
         >
           Type: 
           <code
-            class="emotion-2"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             boolean
@@ -933,7 +933,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-3.5 emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
@@ -943,7 +943,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
       >
         <p
-          class="group emotion-1"
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
@@ -955,7 +955,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="!px-1.5 !text-sm emotion-2"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                 data-text="true"
               >
                 data
@@ -988,12 +988,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </a>
         </p>
         <p
-          class="my-3 emotion-3"
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
           data-text="true"
         >
           Type: 
           <code
-            class="emotion-2"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
             array || object
@@ -1012,7 +1012,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="!mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1 emotion-0"
         >
           <p
-            class="group emotion-1"
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
@@ -1024,7 +1024,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="!px-1.5 !text-sm emotion-2"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
                   data-text="true"
                 >
                   host
@@ -1057,12 +1057,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </p>
           <p
-            class="my-3 emotion-3"
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
             data-text="true"
           >
             Type: 
             <code
-              class="emotion-2"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
               data-text="true"
             >
               string

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -1,6 +1,4 @@
-import { css, CSSObject } from '@emotion/react';
-import { typography } from '@expo/styleguide';
-import type { CSSProperties, ComponentType, PropsWithChildren } from 'react';
+import type { ComponentType, PropsWithChildren } from 'react';
 
 import { Code as PrismCodeBlock } from '~/components/base/code';
 import { Callout } from '~/ui/components/Callout';
@@ -12,13 +10,11 @@ type Config = ConfigStyles & {
 };
 
 type ConfigStyles = {
-  css?: CSSObject;
-  style?: CSSProperties;
+  className?: string;
 };
 
 type ComponentProps = PropsWithChildren<{
   className?: string;
-  style?: CSSProperties;
 }>;
 
 const markdownStyles: Record<string, Config | null> = {
@@ -39,36 +35,32 @@ const markdownStyles: Record<string, Config | null> = {
   },
   p: {
     Component: P,
-    style: { marginBottom: '1.5ch' },
+    className: 'mb-[1.5ch]',
   },
   strong: {
     Component: BOLD,
   },
   ul: {
     Component: UL,
-    style: { marginBottom: '1.5ch', paddingLeft: `1ch` },
+    className: 'mb-[1.5ch] pl-[1ch]',
   },
   ol: {
     Component: OL,
-    style: { marginBottom: '1.5ch', paddingLeft: `1ch` },
+    className: 'mb-[1.5ch] pl-[1ch]',
   },
   li: {
     Component: LI,
   },
   hr: {
     Component: 'hr',
-    css: typography.utility.hr,
-    style: {
-      margin: `2ch 0`,
-      marginTop: '3rem',
-    },
+    className: 'border-0 bg-palette-gray6 h-px mb-[2ch] mt-12',
   },
   blockquote: {
     Component: Callout,
   },
   img: {
     Component: 'img',
-    style: { width: '100%' },
+    className: 'w-full',
   },
   code: {
     Component: CODE,
@@ -118,9 +110,9 @@ function componentName({ Component }: Config) {
 }
 
 function createMarkdownComponent(config: Config): ComponentType<ComponentProps> {
-  const { Component, css: cssClassname, style } = config;
+  const { Component, className } = config;
   const MDXComponent = (props: ComponentProps) => (
-    <Component {...props} css={css(cssClassname)} style={style}>
+    <Component {...props} className={className}>
       {props.children}
     </Component>
   );

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -15,7 +15,7 @@ export const HeaderCell = ({ children, align = 'left', size = 'md' }: HeaderCell
       'px-4 py-3.5 font-medium text-secondary border-r border-secondary',
       convertAlignToClass(align),
       size === 'sm' ? 'text-3xs' : 'text-2xs',
-      '[&_code]:text-3xs',
+      '[&_code]:text-3xs [&_code]:text-secondary',
       'last:border-r-0'
     )}>
     {children}

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -69,8 +69,6 @@ export function createTextComponent(Element: TextElement, textClassName?: string
     } = props;
     const TextElementTag = tag ?? Element;
 
-    console.warn(textWeight, textTheme);
-
     return (
       <TextElementTag
         className={mergeClasses(

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -1,26 +1,24 @@
-import { css, CSSObject, SerializedStyles } from '@emotion/react';
-import { theme, typography, LinkBase, LinkBaseProps, mergeClasses } from '@expo/styleguide';
-import { spacing, borderRadius } from '@expo/styleguide-base';
-import * as React from 'react';
+import { LinkBase, LinkBaseProps, mergeClasses } from '@expo/styleguide';
+import { PropsWithChildren, ComponentType, Children, isValidElement } from 'react';
 
-import { TextComponentProps, TextElement } from './types';
+import { TextComponentProps, TextElement, TextTheme } from './types';
 
 import { AdditionalProps, HeadingType } from '~/common/headingManager';
 import { Permalink } from '~/ui/components/Permalink';
 
 export { AnchorContext } from './withAnchor';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 const CRAWLABLE_HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5'];
 const CRAWLABLE_TEXT = ['span', 'p', 'li', 'blockquote', 'code', 'pre'];
 
-type PermalinkedComponentProps = React.PropsWithChildren<
+type PermalinkedComponentProps = PropsWithChildren<
   { level?: number; id?: string } & AdditionalProps & TextComponentProps
 >;
 
-const isDev = process.env.NODE_ENV === 'development';
-
 export const createPermalinkedComponent = (
-  BaseComponent: React.ComponentType<React.PropsWithChildren<TextComponentProps>>,
+  BaseComponent: ComponentType<PropsWithChildren<TextComponentProps>>,
   options?: {
     baseNestingLevel?: number;
     sidebarType?: HeadingType;
@@ -30,8 +28,8 @@ export const createPermalinkedComponent = (
 ) => {
   const { baseNestingLevel, iconSize = 'sm', sidebarType = HeadingType.Text } = options || {};
   return ({ children, level, id, className, ...props }: PermalinkedComponentProps) => {
-    const cleanChildren = React.Children.map(children, child => {
-      if (React.isValidElement(child) && child?.props?.href) {
+    const cleanChildren = Children.map(children, child => {
+      if (isValidElement(child) && child?.props?.href) {
         isDev &&
           console.warn(
             `It looks like the header on this page includes a link, this is an invalid pattern, nested link will be removed!`,
@@ -58,11 +56,7 @@ export const createPermalinkedComponent = (
   };
 };
 
-export function createTextComponent(
-  Element: TextElement,
-  textStyle?: SerializedStyles,
-  skipBaseStyle: boolean = false
-) {
+export function createTextComponent(Element: TextElement, textClassName?: string) {
   function TextComponent(props: TextComponentProps) {
     const {
       testID,
@@ -75,15 +69,17 @@ export function createTextComponent(
     } = props;
     const TextElementTag = tag ?? Element;
 
+    console.warn(textWeight, textTheme);
+
     return (
       <TextElementTag
-        className={className}
-        css={[
-          !skipBaseStyle && baseTextStyle,
-          textStyle,
-          textWeight && { fontWeight: typography.utility.weight[textWeight].fontWeight },
-          textTheme && { color: theme.text[textTheme] },
-        ]}
+        className={mergeClasses(
+          'text-inherit text-default leading-[1.6154]',
+          textClassName,
+          getTextWeightClassName(textWeight),
+          getTextColorClassName(textTheme),
+          className
+        )}
         data-testid={testID}
         data-heading={(crawlable && CRAWLABLE_HEADINGS.includes(TextElementTag)) || undefined}
         data-text={(crawlable && CRAWLABLE_TEXT.includes(TextElementTag)) || undefined}
@@ -95,150 +91,6 @@ export function createTextComponent(
   return TextComponent;
 }
 
-const baseTextStyle = css({
-  ...typography.body.paragraph,
-  color: theme.text.default,
-});
-
-const linkStyled = css({
-  ...typography.utility.anchor,
-
-  // note(Cedric): transform prevents a 1px shift on hover on Safari
-  transform: 'translate3d(0,0,0)',
-
-  ':hover': {
-    textDecoration: 'underline',
-
-    code: {
-      textDecoration: 'inherit',
-    },
-  },
-
-  'span, code, strong, em, b, i': {
-    color: theme.text.link,
-  },
-});
-
-const codeStyle = css({
-  borderColor: theme.border.secondary,
-  borderRadius: borderRadius.sm,
-  wordBreak: 'unset',
-});
-
-export const kbdStyle = css({
-  fontWeight: 500,
-  color: theme.text.secondary,
-  padding: `0 ${spacing[1]}px`,
-  boxShadow: `0 0.1rem 0 1px ${theme.border.default}`,
-  borderRadius: borderRadius.sm,
-  position: 'relative',
-  display: 'inline-flex',
-  margin: 0,
-  minWidth: 22,
-  justifyContent: 'center',
-  top: -1,
-});
-
-const { h1, h2, h3, h4, h5 } = typography.headers.default;
-const codeInHeaderStyle = { '& code': { fontSize: '90%' } };
-
-const h1Style = {
-  ...h1,
-  fontWeight: 700,
-  marginTop: spacing[2],
-  marginBottom: spacing[2],
-  ...codeInHeaderStyle,
-};
-
-const h2Style = {
-  ...h2,
-  fontWeight: 700,
-  marginTop: spacing[8],
-  marginBottom: spacing[3.5],
-  '& a:focus-visible': { outlineOffset: spacing[1] },
-  ...codeInHeaderStyle,
-};
-
-const h3Style = {
-  ...h3,
-  fontWeight: 600,
-  marginTop: spacing[7],
-  marginBottom: spacing[3],
-  '& a:focus-visible': { outlineOffset: spacing[1] },
-  ...codeInHeaderStyle,
-};
-
-const h4Style = {
-  ...h4,
-  fontWeight: 600,
-  marginTop: spacing[6],
-  marginBottom: spacing[2],
-  ...codeInHeaderStyle,
-};
-
-const h5Style = {
-  ...h5,
-  fontWeight: 600,
-  marginTop: spacing[4],
-  marginBottom: spacing[1],
-  ...codeInHeaderStyle,
-};
-
-const paragraphStyle = {
-  strong: {
-    wordBreak: 'break-word',
-  },
-};
-
-const delStyle = {
-  textDecoration: 'line-through',
-  '& code': {
-    textDecoration: 'line-through',
-  },
-};
-
-export const H1 = createTextComponent(TextElement.H1, css(h1Style));
-export const RawH2 = createTextComponent(TextElement.H2, css(h2Style));
-export const H2 = createPermalinkedComponent(RawH2, { baseNestingLevel: 2 });
-export const RawH3 = createTextComponent(TextElement.H3, css(h3Style));
-export const H3 = createPermalinkedComponent(RawH3, { baseNestingLevel: 3 });
-export const RawH4 = createTextComponent(TextElement.H4, css(h4Style));
-export const H4 = createPermalinkedComponent(RawH4, { baseNestingLevel: 4 });
-export const RawH5 = createTextComponent(TextElement.H5, css(h5Style));
-export const H5 = createPermalinkedComponent(RawH5, { baseNestingLevel: 5 });
-
-export const P = createTextComponent(TextElement.P, css(paragraphStyle as CSSObject));
-export const CODE = createTextComponent(
-  TextElement.CODE,
-  css([typography.utility.inlineCode, codeStyle]),
-  true
-);
-export const LI = createTextComponent(TextElement.LI, css(typography.body.li));
-export const LABEL = createTextComponent(TextElement.SPAN, css(typography.body.label));
-export const HEADLINE = createTextComponent(TextElement.P, css(typography.body.headline));
-export const FOOTNOTE = createTextComponent(TextElement.P, css(typography.body.footnote));
-export const CAPTION = createTextComponent(TextElement.P, css(typography.body.caption));
-export const CALLOUT = createTextComponent(TextElement.P, css(typography.body.callout));
-export const BOLD = createTextComponent(TextElement.STRONG, css({ fontWeight: 600 }));
-export const DEMI = createTextComponent(TextElement.SPAN, css({ fontWeight: 500 }));
-export const SPAN = createTextComponent(TextElement.SPAN, css(typography.body.callout));
-
-export const UL = createTextComponent(
-  TextElement.UL,
-  css([typography.body.ul, { listStyle: 'disc' }])
-);
-export const OL = createTextComponent(
-  TextElement.OL,
-  css([typography.body.ol, { listStyle: 'decimal' }])
-);
-export const PRE = createTextComponent(TextElement.PRE, css(typography.utility.pre as CSSObject));
-export const KBD = createTextComponent(
-  TextElement.KBD,
-  css([typography.utility.pre as CSSObject, kbdStyle])
-);
-export const MONOSPACE = createTextComponent(TextElement.CODE);
-export const DEL = createTextComponent(TextElement.DEL, css(delStyle));
-
 const isExternalLink = (href?: string) => href?.includes('://');
 
 export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferrer?: boolean }) => {
@@ -246,8 +98,15 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
 
   return (
     <LinkBase
-      css={[!isStyled && linkStyled]}
-      className={mergeClasses('cursor-pointer decoration-0 hocus:opacity-80', className)}
+      className={mergeClasses(
+        'cursor-pointer decoration-0',
+        'hocus:opacity-80',
+        !isStyled &&
+          'font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline',
+        !isStyled &&
+          '[&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link',
+        className
+      )}
       {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
       openInNewTab={(!shouldLeakReferrer && openInNewTab) ?? isExternalLink(props.href)}
       {...rest}
@@ -255,3 +114,153 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
   );
 };
 A.displayName = 'Text(a)';
+
+function getTextWeightClassName(weight?: string) {
+  switch (weight) {
+    case 'black':
+      return 'font-black';
+    case 'semiBold':
+      return 'font-semiBold';
+    case 'medium':
+      return 'font-medium';
+    case 'regular':
+      return 'font-normal';
+    default:
+      return undefined;
+  }
+}
+
+function getTextColorClassName(theme?: TextTheme) {
+  switch (theme) {
+    case 'default':
+      return 'text-default';
+    case 'secondary':
+      return 'text-secondary';
+    case 'tertiary':
+      return 'text-tertiary';
+    case 'quaternary':
+      return 'text-quaternary';
+    case 'success':
+      return 'text-success';
+    case 'danger':
+      return 'text-danger';
+    case 'warning':
+      return 'text-warning';
+    case 'info':
+      return 'text-info';
+    case 'link':
+      return 'text-link';
+    default:
+      return undefined;
+  }
+}
+
+export const H1 = createTextComponent(
+  TextElement.H1,
+  mergeClasses(
+    'text-[31px] font-bold leading-[1.29] tracking-[-0.022rem]',
+    'my-2 [&_code]:text-[90%]',
+    'max-md-gutters:text-[27px] max-md-gutters:leading-[1.3333]',
+    'max-sm-gutters:text-[23px] max-sm-gutters:leading-[1.3913]'
+  )
+);
+export const RawH2 = createTextComponent(
+  TextElement.H2,
+  mergeClasses(
+    'text-[25px] font-bold leading-[1.4] tracking-[-0.021rem]',
+    'mt-8 mb-3.5 [&_code]:text-[90%]',
+    'max-md-gutters:text-[22px] max-md-gutters:leading-[1.409]',
+    'max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263]'
+  )
+);
+export const RawH3 = createTextComponent(
+  TextElement.H3,
+  mergeClasses(
+    'text-[20px] font-semibold leading-normal tracking-[-0.017rem]',
+    'mt-7 mb-3 [&_code]:text-[90%]',
+    'max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555]',
+    'max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed'
+  )
+);
+export const RawH4 = createTextComponent(
+  TextElement.H4,
+  mergeClasses(
+    'text-[16px] font-semibold leading-relaxed tracking-[-0.011rem]',
+    'mt-6 mb-2 [&_code]:text-[90%]'
+  )
+);
+export const RawH5 = createTextComponent(
+  TextElement.H5,
+  mergeClasses(
+    'text-[13px] font-medium leading-[1.5833] tracking-[-0.003rem]',
+    'mt-4 mb-1 [&_code]:text-[90%]'
+  )
+);
+
+export const P = createTextComponent(
+  TextElement.P,
+  'font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words'
+);
+export const CODE = createTextComponent(
+  TextElement.CODE,
+  mergeClasses(
+    'text-[13px] font-normal leading-[130%] tracking-[-0.003rem]',
+    'inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5'
+  )
+);
+export const LI = createTextComponent(
+  TextElement.LI,
+  mergeClasses('text-[16px] font-normal leading-relaxed tracking-[-0.011rem]', 'mb-2')
+);
+export const HEADLINE = createTextComponent(
+  TextElement.P,
+  'font-medium text-[16px] leading-[1.625] tracking-[-0.011rem]'
+);
+export const LABEL = createTextComponent(
+  TextElement.SPAN,
+  'font-medium text-[15px] leading-[1.6] tracking-[-0.009rem]'
+);
+export const CALLOUT = createTextComponent(
+  TextElement.P,
+  'font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]'
+);
+export const SPAN = createTextComponent(
+  TextElement.SPAN,
+  'font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]'
+);
+export const FOOTNOTE = createTextComponent(
+  TextElement.P,
+  'font-normal text-[13px] leading-[1.6154] tracking-[-0.003rem]'
+);
+export const CAPTION = createTextComponent(
+  TextElement.P,
+  'font-normal text-[12px] leading-[1.6154]'
+);
+export const BOLD = createTextComponent(TextElement.SPAN, 'font-semibold');
+export const DEMI = createTextComponent(TextElement.SPAN, 'font-medium');
+export const UL = createTextComponent(
+  TextElement.UL,
+  'list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4'
+);
+export const OL = createTextComponent(
+  TextElement.OL,
+  'list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4'
+);
+export const KBD = createTextComponent(
+  TextElement.KBD,
+  mergeClasses(
+    'relative -top-px inline-block min-h-[20px] min-w-[22px] rounded-sm border border-secondary bg-subtle px-1 shadow-kbd',
+    'text-center text-2xs font-semibold leading-[20px] text-secondary',
+    'dark:bg-element'
+  )
+);
+export const MONOSPACE = createTextComponent(TextElement.CODE);
+export const DEL = createTextComponent(
+  TextElement.DEL,
+  mergeClasses('line-through [&_code]:line-through')
+);
+
+export const H2 = createPermalinkedComponent(RawH2, { baseNestingLevel: 2 });
+export const H3 = createPermalinkedComponent(RawH3, { baseNestingLevel: 3 });
+export const H4 = createPermalinkedComponent(RawH4, { baseNestingLevel: 4 });
+export const H5 = createPermalinkedComponent(RawH5, { baseNestingLevel: 5 });


### PR DESCRIPTION
# Why

Stacked on: 
* #32189

# How

Refactor typography base elements to Tailwind styling, small tweaks, snapshots regenerate.

# Test Plan

The changes have been reviewed by running docs website locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-10-21 at 12 45 00](https://github.com/user-attachments/assets/a55b06f6-6a2d-43a7-a1c6-29041a3d7132)
