### PR TITLE
docs: fix missing word in modules section

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -31,7 +31,7 @@ Navigate to your project directory (the one that contains the **package.json** f
 
 <Terminal cmd={['$ npx create-expo-module@latest --local']} />
 
-Then, if your project doesn't native projects generated (**android** and **ios** directories), run the following command, otherwise skip this command:
+Then, if your project doesn't have native projects generated (**android** and **ios** directories), run the following command, otherwise skip this command:
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 


### PR DESCRIPTION
Add the missing word "have" in the "Modules" section.

# Why


This PR addresses a minor issue in the Expo Modules API: Get started [here](https://docs.expo.dev/modules/get-started/), specifically in the "Modules" section, where a"have" was missing. The added word helps clarify the instruction or explanation, ensuring better readability for developers.


# How

<!--
Added the missing word in the "Modules" section.
-->

<img width="1009" alt="Screenshot 2024-10-21 at 1 52 58 PM" src="https://github.com/user-attachments/assets/bafa1cf9-ad60-4aa8-882a-62bf1e3eff2d">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
