### PR TITLE
[doctor] Remove fields from CNG check that are needed outside of native projects

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove `updates` and `jsEngine` from unintentionally-not-CNG check, since they are used by non-native code as well ([#322006](https://github.com/expo/expo/pull/322006) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.11.2 — 2024-10-17

--- a/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
+++ b/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
@@ -13,14 +13,12 @@ const appConfigFieldsToSyncWithNative = [
   'scheme',
   'userInterfaceStyle',
   'splash',
-  'updates',
   'orientation',
   'backgroundColor',
   'primaryColor',
   'notification',
   'androidStatusBar',
   'androidNavigationBar',
-  'jsEngine',
   'locales',
 ];
 


### PR DESCRIPTION
# Why
- `eas update` requires `updates.url` to be present in order to run
- `npx expo export` requires `jsEngine` if you're using JSC

# How
Removed these from the list

# Test Plan
Make sure the command still works

