### PR TITLE
[router]: Fix no-sitemap e2e test

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export/no-sitemap.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/no-sitemap.test.ts
@@ -46,10 +46,6 @@ describe('static-rendering with no sitemap', () => {
         })
         .filter(Boolean);
 
-      expect(
-        files.find((file) => file?.match(/\_expo\/static\/js\/web\/index-.*\.js/))
-      ).toBeDefined();
-
       // The wrapper should not be included as a route.
       expect(files).not.toContain('+html.html');
       expect(files).not.toContain('_layout.html');


### PR DESCRIPTION
# Why

Fix test by removing condition. This test is a duplicate of `static-rendering.test.ts` so this condition isn't needed.