### PR TITLE
[expo] Upgrade react-native-svg to 15.8.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2573,7 +2573,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.8.0-rc.1):
+  - RNSVG (15.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2593,9 +2593,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.8.0-rc.1)
+    - RNSVG/common (= 15.8.0)
     - Yoga
-  - RNSVG/common (15.8.0-rc.1):
+  - RNSVG/common (15.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3365,7 +3365,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
   RNReanimated: f258d9ce122d59e36be8e516c40ed773ee46b687
   RNScreens: 01b042df69d92d82bd7f614715f0d7f8a888b3af
-  RNSVG: 08750404f92a36162a92522cc77dee437be1d257
+  RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.12",
-    "react-native-svg": "15.8.0-rc.1",
+    "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",
     "react-native-webview": "13.12.2",
     "test-suite": "*"

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2356,7 +2356,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.8.0-rc.1):
+  - RNSVG (15.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2376,9 +2376,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.8.0-rc.1)
+    - RNSVG/common (= 15.8.0)
     - Yoga
-  - RNSVG/common (15.8.0-rc.1):
+  - RNSVG/common (15.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3051,7 +3051,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 36f7a28f6317504b2d0523a87b29cc0544c025a4
+  hermes-engine: 8591fd98afb7f00d0441619461da0bdd116bdc5b
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3135,7 +3135,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
   RNReanimated: f258d9ce122d59e36be8e516c40ed773ee46b687
   RNScreens: 01b042df69d92d82bd7f614715f0d7f8a888b3af
-  RNSVG: 08750404f92a36162a92522cc77dee437be1d257
+  RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -77,7 +77,7 @@
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.12",
-    "react-native-svg": "15.8.0-rc.1",
+    "react-native-svg": "15.8.0",
     "react-native-webview": "13.12.2",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -143,7 +143,7 @@
     "react-native-reanimated": "~3.15.4",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.12",
-    "react-native-svg": "15.8.0-rc.1",
+    "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.2",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-reanimated": "~3.15.4",
   "react-native-screens": "4.0.0-beta.12",
   "react-native-safe-area-context": "4.11.0",
-  "react-native-svg": "15.8.0-rc.1",
+  "react-native-svg": "15.8.0",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.12.2",
   "sentry-expo": "~7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13587,10 +13587,10 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha512-haw7VtcK0Vg1p7CTE8vzhltICPhfuzLUNR1m9Rh55VYEGkD3o765Y5YTu88iA32uV/hMhJUopP5Tex/SvNidoA==
 
-react-native-svg@15.8.0-rc.1:
-  version "15.8.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.8.0-rc.1.tgz#01b607711855c22bfd449ca979c2b3ee40f9fa8d"
-  integrity sha512-d3CuNNeWuMqzej8hF+GsAUl45PNYfRsn8I56dTmFdbLBWgdCXkUV+1N97i8Fi/hsKDhDW/Ki+G5gMJn0qa6PQg==
+react-native-svg@15.8.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.8.0.tgz#9b5fd4f5cf5675197b3f4cbfcc77c215de2b9502"
+  integrity sha512-KHJzKpgOjwj1qeZzsBjxNdoIgv2zNCO9fVcoq2TEhTRsVV5DGTZ9JzUZwybd7q4giT/H3RdtqC3u44dWdO0Ffw==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/issues/31957
Related to https://github.com/expo/expo/pull/31567

# How

Bump react-native-svg to latest 

# Test Plan

- Expo Go NCL 
- Bare expo 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
