### PR TITLE
[eslint-config-expo] Fix linting error in default metro config

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Enable node globals for `metro.config.js`
+- Enable node globals for `metro.config.js` ([#32203](https://github.com/expo/expo/pull/32203) by [@kadikraman](https://github.com/kadikraman))
 
 ### 💡 Others
 

--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Enable node globals for `metro.config.js`
+
 ### 💡 Others
 
 ## 7.1.2 — 2024-04-24

--- a/packages/eslint-config-expo/utils/core.js
+++ b/packages/eslint-config-expo/utils/core.js
@@ -68,5 +68,11 @@ module.exports = {
         'import/order': 'off',
       },
     },
+    {
+      files: ['metro.config.js'],
+      env: {
+        node: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
# Why

Resolves ENG-13872

To repro:
```sh
npx create-expo-app my-app
cd my-app
npx expo lint
npx expo customize # and choose the metro config
npm run lint
```

<img width="565" alt="Screenshot 2024-10-21 at 17 48 52" src="https://github.com/user-attachments/assets/2c2e67a4-95fc-4561-ab0a-99b99c0870c9">


# How

Enable node globals for `metro.config.js`

# Test Plan

Tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
