### PR TITLE
[picker] Patch to support RN `0.76`

### DIFF
--- a/patches/@react-native-picker+picker+2.8.1.patch
+++ b/patches/@react-native-picker+picker+2.8.1.patch
@@ -1,0 +1,61 @@
+diff --git a/node_modules/@react-native-picker/picker/android/src/main/jni/CMakeLists.txt b/node_modules/@react-native-picker/picker/android/src/main/jni/CMakeLists.txt
+index db67583..3013f61 100644
+--- a/node_modules/@react-native-picker/picker/android/src/main/jni/CMakeLists.txt
++++ b/node_modules/@react-native-picker/picker/android/src/main/jni/CMakeLists.txt
+@@ -35,25 +35,37 @@ target_include_directories(
+   ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
+ )
+ 
+-target_link_libraries(
+-  ${LIB_TARGET_NAME}
+-  fbjni
+-  folly_runtime
+-  glog
+-  jsi
+-  react_codegen_rncore
+-  react_debug
+-  react_nativemodule_core
+-  react_render_componentregistry
+-  react_utils
+-  react_render_core
+-  react_render_debug
+-  react_render_graphics
+-  react_render_mapbuffer
+-  rrc_view
+-  turbomodulejsijni
+-  yoga
+-)
++find_package(ReactAndroid REQUIRED CONFIG)
++find_package(fbjni REQUIRED CONFIG)
++
++if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76) 
++  target_link_libraries(
++    ${LIB_TARGET_NAME}
++    ReactAndroid::reactnative
++    ReactAndroid::jsi
++    fbjni::fbjni
++  )
++else()
++  target_link_libraries(
++    ${LIB_TARGET_NAME}
++    fbjni
++    folly_runtime
++    glog
++    jsi
++    react_codegen_rncore
++    react_debug
++    react_nativemodule_core
++    react_render_componentregistry
++    react_utils
++    react_render_core
++    react_render_debug
++    react_render_graphics
++    react_render_mapbuffer
++    rrc_view
++    turbomodulejsijni
++    yoga
++  )
++endif()
+ 
+ target_compile_options(
+   ${LIB_TARGET_NAME}


### PR DESCRIPTION
# Why

Patches `@react-native-picker/picker` to support RN `0.76`
