### PR TITLE
[go] Add support for `expo-video`

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent
 
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import expo.modules.application.ApplicationModule
 import expo.modules.asset.AssetModule
 import expo.modules.av.AVModule
@@ -84,6 +85,7 @@ import expo.modules.taskManager.TaskManagerModule
 import expo.modules.taskManager.TaskManagerPackage
 import expo.modules.trackingtransparency.TrackingTransparencyModule
 import expo.modules.updates.UpdatesPackage
+import expo.modules.video.VideoModule
 import expo.modules.videothumbnails.VideoThumbnailsModule
 import expo.modules.webbrowser.WebBrowserModule
 
@@ -120,6 +122,7 @@ object ExperiencePackagePicker : ModulesProvider {
     return EXPO_MODULES_PACKAGES
   }
 
+  @OptIn(UnstableReactNativeAPI::class)
   override fun getModulesList(): List<Class<out Module>> = listOf(
     AVModule::class.java,
     ApplicationModule::class.java,
@@ -192,6 +195,7 @@ object ExperiencePackagePicker : ModulesProvider {
     TaskManagerModule::class.java,
     TrackingTransparencyModule::class.java,
     VideoThumbnailsModule::class.java,
+    VideoModule::class.java,
     VideoViewModule::class.java,
     WebBrowserModule::class.java,
     BrightnessModule::class.java

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -135,7 +135,8 @@
       android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:theme="@style/Theme.Exponent.Light"
-      android:windowSoftInputMode="adjustResize">
+      android:windowSoftInputMode="adjustResize"
+      android:supportsPictureInPicture="true">
     </activity>
 
     <activity


### PR DESCRIPTION
# Why

Expo Go on Android doesn't support `expo-video` (works ok on iOS)

# How

Added expo-video package to `ExperiencePackagePicker.kt` , updated the `AndroidManifest.xml` of Expo Go to support PiP for the `ExperienceActivity`.

I tried looking it up and AFAIK Adding the PiP permission shouldn't require changes on the PlayStore side, but I don't have any experience with it, so approve with caution 😅 

# Test Plan

Tested in  Expo Go on Android and iOS 
