### PR TITLE
[core] fix deadlock issue on old arch

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Fixed iOS reload crash on New Architecture mode. ([#31789](https://github.com/expo/expo/pull/31789) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed views using the incorrect `AppContext` instance. ([#31897](https://github.com/expo/expo/pull/31897) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed crashes on the New Architecture when dispatching events during the props update. ([#31971](https://github.com/expo/expo/pull/31971) by [@tsapeta](https://github.com/tsapeta))
+- Fixed `registerAdditionalModuleClasses` deadlock issue on old architecture mode. ([#32209](https://github.com/expo/expo/pull/32209) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -325,7 +325,11 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     }
   }
 
-  [bridge registerAdditionalModuleClasses:moduleClasses];
+  if (bridge.isLoading) {
+    [bridge registerModulesForClasses:moduleClasses];
+  } else {
+    [bridge registerAdditionalModuleClasses:moduleClasses];
+  }
 }
 
 - (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSString *)appId


### PR DESCRIPTION
# Why

fix deadlock issue in `registerAdditionalModuleClasses`

# How

since https://github.com/facebook/react-native/commit/bfb0319ce0c7, when initializes the bridge, the js thead will wait for main thread (inspector executor thread) to finish. expo-modules-core has `requiresMainQueueSetup=true`, when it calls `registerAdditionalModuleClasses`, it will have deadlock.
this pr tries to use the internal `registerModulesForClasses` that we original used for `RCTWebSocketExecutor` without locking. this only applies when loading=true, that would reduce risk of broken thread-safety.

# Test Plan

ios bare-expo on old arch

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
