### PR TITLE
Fix tests for expo-location in bare-expo

### DIFF
--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -33,9 +33,7 @@
       "supportsTablet": true,
       "requireFullScreen": false,
       "entitlements": {
-        "com.apple.security.application-groups": [
-          "group.dev.expo.Payments"
-        ]
+        "com.apple.security.application-groups": ["group.dev.expo.Payments"]
       }
     },
     "web": {
@@ -68,7 +66,8 @@
       [
         "expo-location",
         {
-          "isAndroidBackgroundLocationEnabled": true
+          "isAndroidBackgroundLocationEnabled": true,
+          "isIosBackgroundLocationEnabled": true
         }
       ],
       [

--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -91,6 +91,7 @@
     <array>
       <string>fetch</string>
       <string>audio</string>
+      <string>location</string>
     </array>
     <key>UILaunchStoryboardName</key>
     <string>SplashScreen</string>

--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -249,11 +249,15 @@ export async function test(t) {
         timeout
       );
 
-      t.it('resolves when watchPositionAsync is running', async () => {
-        const subscriber = await Location.watchPositionAsync({}, () => {});
-        await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low });
-        subscriber.remove();
-      });
+      t.it(
+        'resolves when watchPositionAsync is running',
+        async () => {
+          const subscriber = await Location.watchPositionAsync({}, () => {});
+          await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low });
+          subscriber.remove();
+        },
+        timeout
+      );
     });
 
     describeWithPermissions('Location.getLastKnownPositionAsync()', () => {
@@ -277,7 +281,8 @@ export async function test(t) {
           t.expect(current).not.toBeNull();
           t.expect(lastKnown).not.toBeNull();
           t.expect(lastKnown.timestamp).toBeGreaterThanOrEqual(current.timestamp);
-        }
+        },
+        timeout
       );
 
       t.it('returns null if maxAge is zero', async () => {
@@ -337,13 +342,15 @@ export async function test(t) {
 
     describeWithPermissions('Location.watchPositionAsync()', () => {
       t.it('gets a result of the correct shape', async () => {
-        await new Promise(async (resolve, reject) => {
-          const subscriber = await Location.watchPositionAsync({}, (location) => {
-            testLocationShape(location);
-            subscriber.remove();
-            resolve();
+        let subscriber;
+        const location = await new Promise(async (resolve) => {
+          subscriber = await Location.watchPositionAsync({}, (location) => {
+            setTimeout(() => resolve(location));
           });
         });
+
+        subscriber.remove();
+        testLocationShape(location);
       });
 
       t.it('can be called simultaneously', async () => {


### PR DESCRIPTION
# Why

Fixes test-suite issues spotted during QA for iOS

# How

- Added `location` to `UIBackgroundModes` on iOS so the background location and geofencing tests pass
- Refactored one test for `watchPositionAsync` which was not unsubscribing the watcher
- Increased timeouts in tests that may take a bit more time

# Test Plan

`expo-location` tests in bare-expo are all green now