### PR TITLE
[mail][clipboard] Replace deprecated method `Html.fromHtml(string)`

### DIFF
--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -218,12 +218,8 @@ class ClipboardModule : Module() {
 }
 
 private fun plainTextFromHtml(htmlContent: String): String {
-  val styledText: Spanned = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+  val styledText: Spanned =
     Html.fromHtml(htmlContent, FROM_HTML_MODE_LEGACY)
-  } else {
-    @Suppress("DEPRECATION")
-    Html.fromHtml(htmlContent)
-  }
   val chars = CharArray(styledText.length)
   TextUtils.getChars(styledText, 0, styledText.length, chars, 0)
   return String(chars)

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
@@ -34,7 +34,7 @@ class MailComposerModule : Module() {
           .putCcRecipients(Intent.EXTRA_CC)
           .putBccRecipients(Intent.EXTRA_BCC)
           .putSubject(Intent.EXTRA_SUBJECT)
-          .putBody(Intent.EXTRA_TEXT, options.isHtml ?: false)
+          .putBody(Intent.EXTRA_TEXT, options.isHtml == true)
           .putAttachments(
             Intent.EXTRA_STREAM,
             application

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailIntentBuilder.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailIntentBuilder.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import android.text.Html
+import android.text.Html.FROM_HTML_MODE_COMPACT
 import android.util.Log
 import androidx.core.content.FileProvider
 import java.io.File
@@ -57,7 +58,7 @@ class MailIntentBuilder(
   fun putBody(intentName: String, isBodyHtml: Boolean) = apply {
     options.body?.let {
       val body = if (isBodyHtml) {
-        Html.fromHtml(options.body)
+        Html.fromHtml(options.body, FROM_HTML_MODE_COMPACT)
       } else {
         options.body
       }


### PR DESCRIPTION
# Why

Replaces deprecated method `Html.fromHtml(string)`

