### PR TITLE
[bare][Android] Add lottie

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -57,6 +57,7 @@
     "expo-network-addons": "~0.6.0",
     "expo-notifications": "~0.28.0",
     "expo-splash-screen": "~0.27.0",
+    "lottie-react-native": "7.0.0",
     "native-component-list": "*",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
# Why

Adds lottie to `bare-expo`. 
It's not linked if it isn't inside the `package.json` of the project. 

# Test Plan

- bare-expo ✅ 