### PR TITLE
[doctor] re-enable --minify

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Re-enable `--minify` flag for ncc and add try-catch for better error handling. ([#32218](https://github.com/expo/expo/pull/32218) by [@betomoedano](https://github.com/betomoedano))
 - Fix project setup check running on EAS Build and failing ([#32106](https://github.com/expo/expo/pull/32106) by [@brentvatne](https://github.com/brentvatne))
 
 ## 1.11.1 — 2024-10-15

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "ncc build ./src/index.ts -o build/",
-    "build:prod": "ncc build ./src/index.ts -o build/ --no-cache --no-source-map-register",
+    "build:prod": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register",
     "prepare": "yarn run clean && yarn run build:prod",
     "clean": "expo-module clean",
     "lint": "expo-module lint",

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -232,6 +232,6 @@ export async function actionAsync(projectRoot: string) {
       Log.log(chalk.green(`Didn't find any issues with the project!`));
     }
   } catch (e: any) {
-    Log.exit(e);
+    Log.exception(e);
   }
 }

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -176,17 +176,10 @@ export async function actionAsync(projectRoot: string) {
     const projectConfig = getConfig(projectRoot);
 
     // expo-doctor relies on versioned CLI, which is only available for 44+
-    try {
-      if (ltSdkVersion(projectConfig.exp, '46.0.0')) {
-        Log.exit(
-          chalk.red(
-            `expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`
-          )
-        );
-        return;
-      }
-    } catch (e: any) {
-      Log.exit(e);
+    if (ltSdkVersion(projectConfig.exp, '46.0.0')) {
+      Log.exit(
+        chalk.red(`expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`)
+      );
       return;
     }
 

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -172,54 +172,66 @@ export function getChecksInScopeForProject(exp: ExpoConfig, pkg: PackageJSONConf
 export async function actionAsync(projectRoot: string) {
   await warnUponCmdExe();
 
-  const projectConfig = getConfig(projectRoot);
-
-  // expo-doctor relies on versioned CLI, which is only available for 44+
   try {
-    if (ltSdkVersion(projectConfig.exp, '46.0.0')) {
-      Log.exit(
-        chalk.red(`expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`)
-      );
-      return;
-    }
-  } catch (e: any) {
-    Log.exit(e);
-    return;
-  }
+    const projectConfig = getConfig(projectRoot);
 
-  const filteredChecks = getChecksInScopeForProject(projectConfig.exp, projectConfig.pkg);
-
-  const spinner = startSpinner(`Running ${filteredChecks.length} checks on your project...`);
-
-  const checkParams = { projectRoot, ...projectConfig };
-
-  const jobs = await runChecksAsync(filteredChecks, checkParams, printCheckResultSummaryOnComplete);
-
-  spinner.stop();
-
-  const failedJobs = jobs.filter((job) => !job.result.isSuccessful);
-
-  if (failedJobs.length) {
-    if (failedJobs.some((job) => job.result.issues?.length)) {
-      Log.log();
-      Log.log(chalk.underline('Detailed check results:'));
-      Log.log();
-      // actual issues will output in order of the sequence of tests, due to rules of Promise.all()
-      failedJobs.forEach((job) => printFailedCheckIssueAndAdvice(job));
-    }
-    // check if all checks failed due to a network error if the flag to override network errors is enabled
-    if (env.EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS) {
-      const failedJobsDueToNetworkError = failedJobs.filter((job) => isNetworkError(job.error));
-      if (failedJobsDueToNetworkError.length === failedJobs.length) {
-        Log.warn(
-          'One or more checks failed due to network errors, but EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS is enabled, so these errors will not fail Doctor. Run Doctor to retry these checks once the network is available.'
+    // expo-doctor relies on versioned CLI, which is only available for 44+
+    try {
+      if (ltSdkVersion(projectConfig.exp, '46.0.0')) {
+        Log.exit(
+          chalk.red(
+            `expo-doctor supports Expo SDK 46+. Use 'expo-cli doctor' for SDK 45 and lower.`
+          )
         );
         return;
       }
+    } catch (e: any) {
+      Log.exit(e);
+      return;
     }
-    Log.exit(chalk.red('One or more checks failed, indicating possible issues with the project.'));
-  } else {
-    Log.log();
-    Log.log(chalk.green(`Didn't find any issues with the project!`));
+
+    const filteredChecks = getChecksInScopeForProject(projectConfig.exp, projectConfig.pkg);
+
+    const spinner = startSpinner(`Running ${filteredChecks.length} checks on your project...`);
+
+    const checkParams = { projectRoot, ...projectConfig };
+
+    const jobs = await runChecksAsync(
+      filteredChecks,
+      checkParams,
+      printCheckResultSummaryOnComplete
+    );
+
+    spinner.stop();
+
+    const failedJobs = jobs.filter((job) => !job.result.isSuccessful);
+
+    if (failedJobs.length) {
+      if (failedJobs.some((job) => job.result.issues?.length)) {
+        Log.log();
+        Log.log(chalk.underline('Detailed check results:'));
+        Log.log();
+        // actual issues will output in order of the sequence of tests, due to rules of Promise.all()
+        failedJobs.forEach((job) => printFailedCheckIssueAndAdvice(job));
+      }
+      // check if all checks failed due to a network error if the flag to override network errors is enabled
+      if (env.EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS) {
+        const failedJobsDueToNetworkError = failedJobs.filter((job) => isNetworkError(job.error));
+        if (failedJobsDueToNetworkError.length === failedJobs.length) {
+          Log.warn(
+            'One or more checks failed due to network errors, but EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS is enabled, so these errors will not fail Doctor. Run Doctor to retry these checks once the network is available.'
+          );
+          return;
+        }
+      }
+      Log.exit(
+        chalk.red('One or more checks failed, indicating possible issues with the project.')
+      );
+    } else {
+      Log.log();
+      Log.log(chalk.green(`Didn't find any issues with the project!`));
+    }
+  } catch (e: any) {
+    Log.exit(e);
   }
 }


### PR DESCRIPTION
# Why

[ENG-13823 Re-enable `--minify` on ncc in doctor](https://linear.app/expo/issue/ENG-13823/re-enable-minify-on-ncc-in-doctor)

# How

Add `--minify` flag
Add `catch` to show the error properly

# Test Plan

Run doctor locally in production mode in a project without a package.json file. Verify the output is a readable error message.

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/69bdc978-98ab-414c-aad5-0c27d515cb6c">


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%2 0Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
