### PR TITLE
[home] Fix header back buttons

### DIFF
--- a/apps/expo-go/src/navigation/Navigation.tsx
+++ b/apps/expo-go/src/navigation/Navigation.tsx
@@ -113,7 +113,13 @@ function SettingsStackScreen() {
       initialRouteName="Settings"
       detachInactiveScreens={shouldDetachInactiveScreens}
       screenOptions={defaultNavigationOptions(themeName)}>
-      <SettingsStack.Screen name="Settings" component={SettingsScreen} />
+      <SettingsStack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={{
+          headerBackImage: () => <></>,
+        }}
+      />
     </SettingsStack.Navigator>
   );
 }

--- a/apps/expo-go/src/navigation/defaultNavigationOptions.tsx
+++ b/apps/expo-go/src/navigation/defaultNavigationOptions.tsx
@@ -20,7 +20,6 @@ export default (theme: ColorTheme): StackNavigationOptions => {
     },
     headerTintColor: theme === 'dark' ? darkTheme.icon.default : lightTheme.icon.default,
     headerBackButtonDisplayMode: 'minimal',
-    headerBackImage: () => <></>,
     headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
   };
 };

--- a/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
+++ b/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
@@ -27,6 +27,7 @@ const DiagnosticsStack = createStackNavigator<DiagnosticsStackRoutes>();
 
 export function DiagnosticsStackScreen() {
   const theme = useThemeName();
+
   return (
     <DiagnosticsStack.Navigator
       initialRouteName="Diagnostics"
@@ -36,6 +37,8 @@ export function DiagnosticsStackScreen() {
         component={DiagnosticsScreen}
         options={{
           title: 'Diagnostics',
+          headerBackButtonDisplayMode: 'minimal',
+          headerBackImage: () => <></>,
         }}
       />
       <DiagnosticsStack.Screen


### PR DESCRIPTION
# Why

When updating to React Navigation 7 we made a change that had an unintended consequence of hiding all navigation back buttons everywhere in the app.

## Before this PR

<img width="445" alt="image" src="https://github.com/user-attachments/assets/12a64cfa-0b9d-4afa-9514-eab33d1da58d">

## After this PR

<img width="445" alt="image" src="https://github.com/user-attachments/assets/f3b032bb-06c1-4a38-8903-1763d9bda493">

# How

I can see why this was added, because without it a back button is rendered on the root screen of a stack. For example:

<img width="445" alt="image" src="https://github.com/user-attachments/assets/dfecfee5-76ff-4ad4-82a0-80cb7f22a56e">

No, thanks! And if you press it:

<img width="445" alt="image" src="https://github.com/user-attachments/assets/2abcdcdc-8f29-45f8-8599-30de6d990b50">

Yikes. I'm not sure why this is happening - the first screen a stack of course should not have a back button! It's probably a weird quirk in Expo Go that we should get to the bottom of at some point, but cc @satya164 in case.

For now, I just disabled the back button entirely on the initial routes in each stack.

# Test Plan

Ran Expo Go against local home.