### PR TITLE
[updates] use old arch to run e2e tests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed updates E2E tests. ([#32226](https://github.com/expo/expo/pull/32226) by [@kudo](https://github.com/kudo))
+
 ## 0.26.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android launch crash when R8 is enabled. ([#32226](https://github.com/expo/expo/pull/32226) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Fixed updates E2E tests. ([#32226](https://github.com/expo/expo/pull/32226) by [@kudo](https://github.com/kudo))

--- a/packages/expo-updates/android/proguard-rules.pro
+++ b/packages/expo-updates/android/proguard-rules.pro
@@ -3,5 +3,5 @@
 }
 
 -keepclassmembers class com.facebook.react.devsupport.ReleaseDevSupportManager {
-  private final com.facebook.react.bridge.DefaultJSExceptionHandler mDefaultJSExceptionHandler;
+  private final com.facebook.react.bridge.DefaultJSExceptionHandler defaultJSExceptionHandler;
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -120,7 +120,7 @@ class ErrorRecovery(
       }
     }
     val devSupportManagerClass = devSupportManager.javaClass
-    previousExceptionHandler = devSupportManagerClass.getDeclaredField("mDefaultJSExceptionHandler").let { field ->
+    previousExceptionHandler = devSupportManagerClass.getDeclaredField("defaultJSExceptionHandler").let { field ->
       field.isAccessible = true
       val previousValue = field[devSupportManager]
       field[devSupportManager] = defaultJSExceptionHandler
@@ -152,7 +152,7 @@ class ErrorRecovery(
       }
 
       val devSupportManagerClass = devSupportManager.javaClass
-      devSupportManagerClass.getDeclaredField("mDefaultJSExceptionHandler").let { field ->
+      devSupportManagerClass.getDeclaredField("defaultJSExceptionHandler").let { field ->
         field.isAccessible = true
         field[devSupportManager] = previousExceptionHandler
       }

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -474,6 +474,7 @@ function transformAppJsonForE2E(
       owner: 'expo-ci',
       runtimeVersion,
       plugins,
+      newArchEnabled: false,
       android: { ...appJson.expo.android, package: 'dev.expo.updatese2e' },
       ios: { ...appJson.expo.ios, bundleIdentifier: 'dev.expo.updatese2e' },
       updates: {
@@ -555,6 +556,7 @@ export function transformAppJsonForUpdatesDisabledE2E(
       owner: 'expo-ci',
       runtimeVersion,
       plugins,
+      newArchEnabled: false,
       android: { ...appJson.expo.android, package: 'dev.expo.updatese2e' },
       ios: { ...appJson.expo.ios, bundleIdentifier: 'dev.expo.updatese2e' },
       extra: {


### PR DESCRIPTION
# Why

fixed broken updates e2e https://github.com/expo/expo/actions/runs/11447105225/job/31847719450

# How

- since new arch is by default enabled and detox does not support new arch yet, we should keep old arch to run updates e2e.
- fixed android error recovery crash issue because of react-native 0.76 kotlin migration. we should also update the reflection name.

# Test Plan

updates e2e ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
