### PR TITLE
[core][Android] Use event dispatcher with the `surfaceId`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -120,6 +120,7 @@
 - [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`. ([#31921](https://github.com/expo/expo/pull/31921) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Throws a descriptive error when trying to use a released `SharedObject`. ([#31922](https://github.com/expo/expo/pull/31922) by [@lukmccall](https://github.com/lukmccall))
 - Include error cause message in logger ([#31929](https://github.com/expo/expo/pull/31929), [#31953](https://github.com/expo/expo/pull/31953) by [@wschurman](https://github.com/wschurman))
+- [Android] Started using view's event dispatchers with the `surfaceId`.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -120,7 +120,7 @@
 - [Android] Renamed `SharedObject.deallocate` to `SharedObject.sharedObjectDidRelease`. ([#31921](https://github.com/expo/expo/pull/31921) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Throws a descriptive error when trying to use a released `SharedObject`. ([#31922](https://github.com/expo/expo/pull/31922) by [@lukmccall](https://github.com/lukmccall))
 - Include error cause message in logger ([#31929](https://github.com/expo/expo/pull/31929), [#31953](https://github.com/expo/expo/pull/31953) by [@wschurman](https://github.com/wschurman))
-- [Android] Started using view's event dispatchers with the `surfaceId`.
+- [Android] Started using view's event dispatchers with the `surfaceId`. ([#32227](https://github.com/expo/expo/pull/32227) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.events
 
+import android.view.View
 import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.records.Record
 
@@ -10,4 +11,5 @@ interface EventEmitter : expo.modules.core.interfaces.services.EventEmitter {
   fun emit(eventName: String, eventBody: Record?)
   fun emit(eventName: String, eventBody: Map<*, *>?)
   fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short? = null)
+  fun emit(view: View, eventName: String, eventBody: WritableMap?, coalescingKey: Short? = null)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.events
 
 import android.os.Bundle
+import android.view.View
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableNativeMap
@@ -96,15 +97,24 @@ open class KEventEmitterWrapper(
   override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {
     val context = reactContextHolder.get() ?: return
     UIManagerHelper.getEventDispatcherForReactTag(context, viewId)
-      ?.dispatchEvent(UIEvent(viewId, eventName, eventBody, coalescingKey))
+      ?.dispatchEvent(UIEvent(surfaceId = -1, viewId, eventName, eventBody, coalescingKey))
+  }
+
+  override fun emit(view: View, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {
+    val context = reactContextHolder.get() ?: return
+    val surfaceId = UIManagerHelper.getSurfaceId(view)
+    val viewId = view.id
+    UIManagerHelper.getEventDispatcherForReactTag(context, view.id)
+      ?.dispatchEvent(UIEvent(surfaceId, viewId, eventName, eventBody, coalescingKey))
   }
 
   private class UIEvent(
+    surfaceId: Int,
     viewId: Int,
     private val eventName: String,
     private val eventBody: WritableMap?,
     private val coalescingKey: Short?
-  ) : com.facebook.react.uimanager.events.Event<UIEvent>(viewId) {
+  ) : com.facebook.react.uimanager.events.Event<UIEvent>(surfaceId, viewId) {
     override fun getEventName(): String = normalizeEventName(eventName)
     override fun canCoalesce(): Boolean = coalescingKey != null
     override fun getCoalescingKey(): Short = coalescingKey ?: 0

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -46,7 +46,7 @@ open class ViewEvent<T>(
     appContext
       .callbackInvoker
       ?.emit(
-        viewId = view.id,
+        view = view,
         eventName = name,
         eventBody = convertEventBody(arg),
         coalescingKey = coalescingKey?.invoke(arg)


### PR DESCRIPTION
# Why

Start using view's event dispatchers with the `surfaceId`. It seems to work better and prevents events from disappearing during the view's initialization.

# How

The version without the surface id was deprecated a long time ago. 

# Test Plan

- bare-expo and image `test-suite` ✅ 