### PR TITLE
[packages] fix check-packages ci errors

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 9.0.0 — 2024-10-22
 
 ### 🎉 New features

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -223,11 +223,21 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
-use_autolinking_method_symbol = ('use' + '_native' + '_modules!').to_sym
-origin_autolinking_method = self.method(use_autolinking_method_symbol)
-self.define_singleton_method(use_autolinking_method_symbol) do |*args|
-  if ENV['EXPO_UNSTABLE_CORE_AUTOLINKING'] == '1'
-    Pod::UI.puts('Using expo-modules-autolinking as core autolinking source'.green)
+platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+install! 'cocoapods',
+  :deterministic_uuids => false
+
+prepare_react_native_project!
+
+target 'HelloWorld' do
+  use_expo_modules!
+
+  if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
+# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-e9cc66c360abe50bc66d89fffb3c55b034d7d369
+  pod 'react-native-google-maps', path: File.dirname(\`node --print "require.resolve('react-native-maps/package.json')"\`)
+# @generated end react-native-maps
+    config = use_native_modules!
+  else
     config_command = [
       'node',
       '--no-warnings',
@@ -238,25 +248,8 @@ self.define_singleton_method(use_autolinking_method_symbol) do |*args|
       '--platform',
       'ios'
     ]
-    origin_autolinking_method.call(config_command)
-  else
-    origin_autolinking_method.call()
+    config = use_native_modules!(config_command)
   end
-end
-
-platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
-
-prepare_react_native_project!
-
-target 'HelloWorld' do
-  use_expo_modules!
-
-# @generated begin react-native-maps - expo prebuild (DO NOT MODIFY) sync-e9cc66c360abe50bc66d89fffb3c55b034d7d369
-  pod 'react-native-google-maps', path: File.dirname(\`node --print "require.resolve('react-native-maps/package.json')"\`)
-# @generated end react-native-maps
-  config = use_native_modules!
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 0.11.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/@expo/fingerprint/src/hash/__tests__/Hash-ReactImportsPatcher-test.ts
+++ b/packages/@expo/fingerprint/src/hash/__tests__/Hash-ReactImportsPatcher-test.ts
@@ -20,28 +20,6 @@ describe(`createFileHashResultsAsync - use ReactImportsPatchTransform`, () => {
     jest.resetAllMocks();
   });
 
-  it(`should use ReactImportsPatchTransform by default`, async () => {
-    const limiter = pLimit(1);
-    const options = await normalizeOptionsAsync('/app', { debug: true });
-    const files = {
-      '/app/ios/HelloWorld/Info.plist': '',
-      '/app/ios/HelloWorld/AppDelegate.h': '',
-      '/app/ios/HelloWorld/AppDelegate.m': '',
-      '/app/ios/HelloWorld/AppDelegate.mm': '',
-      '/app/android/build.gradle': '',
-    };
-    vol.fromJSON(files);
-    await Promise.all(
-      Object.keys(files).map((filePath) =>
-        createFileHashResultsAsync(path.relative('/app', filePath), limiter, '/app', options)
-      )
-    );
-    const mockTransform = ReactImportsPatchTransform as jest.MockedClass<
-      typeof ReactImportsPatchTransform
-    >;
-    expect(mockTransform.mock.instances.length).toBe(3);
-  });
-
   it('should use ReactImportsPatchTransform when `enableReactImportsPatcher=false`', async () => {
     const limiter = pLimit(1);
     const options = await normalizeOptionsAsync('/app', {

--- a/packages/@expo/fingerprint/src/hash/__tests__/Hash-test.ts
+++ b/packages/@expo/fingerprint/src/hash/__tests__/Hash-test.ts
@@ -173,23 +173,6 @@ describe(createFileHashResultsAsync, () => {
     const result = await createFileHashResultsAsync(filePath, limiter, '/app', options);
     expect(result).toBe(null);
   });
-
-  it(`should hash with <React/RCTBridge.h> than "RCTBridge.h"`, async () => {
-    const filePath = 'ios/HelloWorld/AppDelegate.m';
-    const contents = '#import "RCTBridge.h"';
-    const limiter = pLimit(1);
-    const options = await normalizeOptionsAsync('/app', { debug: true });
-    vol.mkdirSync('/app/ios/HelloWorld', { recursive: true });
-    vol.writeFileSync(path.join('/app', filePath), contents);
-
-    const result = await createFileHashResultsAsync(filePath, limiter, '/app', options);
-
-    const expectHex = createHash(options.hashAlgorithm)
-      .update('#import <React/RCTBridge.h>')
-      .digest('hex');
-    expect(result?.id).toEqual(filePath);
-    expect(result?.hex).toEqual(expectHex);
-  });
 });
 
 describe(createDirHashResultsAsync, () => {

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 0.19.0-preview.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
@@ -700,7 +700,7 @@ it('outputs comments when `minify: false`', async () => {
   );
   expect(result.output[0].data.code).toMatchInlineSnapshot(`
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-      /*#__PURE__*/arbitrary(code);
+      arbitrary(code);
     });"
   `);
 });
@@ -730,7 +730,7 @@ it('allows outputting comments when `minify: true`', async () => {
   );
   expect(result.output[0].data.code).toMatchInlineSnapshot(`
     "__d(function (g, r, i, a, m, e, d) {
-      /*#__PURE__*/minified(code);
+      minified(code);
     });"
   `);
 });

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 8.0.0 — 2024-10-22
 
 ### 🎉 New features

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -1280,6 +1280,7 @@ exports[`built-in plugins introspects mods 1`] = `
         "podfileProperties": {
           "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
           "expo.jsEngine": "hermes",
+          "newArchEnabled": "false",
         },
         "splashScreenStoryboard": {
           "document": {
@@ -1850,6 +1851,11 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
         },
         "gradleProperties": [
           {
+            "key": "newArchEnabled",
+            "type": "property",
+            "value": "false",
+          },
+          {
             "key": "hermesEnabled",
             "type": "property",
             "value": "true",
@@ -2289,6 +2295,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
         },
         "podfileProperties": {
           "expo.jsEngine": "hermes",
+          "newArchEnabled": "false",
         },
         "splashScreenStoryboard": {
           "document": {

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 17.0.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-constants/src/__rsc_tests__/Constants.test.ts
+++ b/packages/expo-constants/src/__rsc_tests__/Constants.test.ts
@@ -8,8 +8,8 @@ it(`reads server constants without throwing`, () => {
     expect.objectContaining({
       name: 'expo-constants',
       platforms: ['ios', 'android', 'web'],
-      sdkVersion: '51.0.0',
       slug: 'expo-constants',
     })
   );
+  expect(Constants.expoConfig?.sdkVersion).toMatch(/^\d+\.\d+\.\d+$/);
 });

--- a/packages/expo-dev-client-components/CHANGELOG.md
+++ b/packages/expo-dev-client-components/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed check-package test errors. ([#32232](https://github.com/expo/expo/pull/32232) by [@kudo](https://github.com/kudo))
+
 ## 2.0.0 — 2024-10-22
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-client-components/setupTests.js
+++ b/packages/expo-dev-client-components/setupTests.js
@@ -27,5 +27,6 @@ jest.mock('react-native/Libraries/Utilities/Appearance', () => {
   return {
     __esModule: true,
     default: MockAppearance,
+    ...MockAppearance,
   };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,28 +3215,10 @@
     stream-slice "^0.1.2"
     undici "^6.11.1"
 
-"@remix-run/router@1.19.2":
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.19.2.tgz#0c896535473291cb41f152c180bedd5680a3b273"
-  integrity sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==
-
 "@remix-run/router@1.20.0":
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.20.0.tgz#03554155b45d8b529adf635b2f6ad1165d70d8b4"
   integrity sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==
-
-"@remix-run/server-runtime@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/server-runtime/-/server-runtime-2.12.0.tgz#92a7d6c94e44e79a32db7ea13a91d41f547bb88a"
-  integrity sha512-o9ukOr3XKmyY8UufTrDdkgD3fiy+z+f4qEzvCQnvC0+EasCyN9hb1Vbui6Koo/5HKvahC4Ga8RcWyvhykKrG3g==
-  dependencies:
-    "@remix-run/router" "1.19.2"
-    "@types/cookie" "^0.6.0"
-    "@web3-storage/multipart-parser" "^1.0.0"
-    cookie "^0.6.0"
-    set-cookie-parser "^2.4.8"
-    source-map "^0.7.3"
-    turbo-stream "2.4.0"
 
 "@remix-run/server-runtime@2.13.1":
   version "2.13.1"


### PR DESCRIPTION
# Why

running `et cp -a` and failed from these packages:
```
🏁 104 packages passed, 7 packages failed: expo-dev-client-components, expo-constants, babel-preset-expo, @expo/prebuild-config, @expo/metro-config, @expo/fingerprint, @expo/config-plugins
```

# How

- ✅ [expo-dev-client-components] update mock
- ✅ [expo-contants] rsc test broken from sdk version (was 51.0.0 and now 52.0.0). this pr tries to loose the version checks.
- ❌ [babel-preset-expo] known issue from unsupported syntax from hermes-parser. waiting for hermes team to response
- ✅ [prebuild-config] update test snapshot
- ✅ [metro-config] update test snapshot
- ✅ [fingerprint] remove broken test original for react import patcher, we don't use that from sdk52. let's remove the test
- ✅ [config-plugins] update test snapshot
 
# Test Plan

ci passed but failed from babel-preset-expo

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
