### PR TITLE
[iOS][core] Remove window synthesis in `EXAppDelegateWrapper`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Removed window synthesis in `EXAppDelegateWrapper` to fix crashes caused by deallocated `RCTFabricSurface`.
+
 ### 💡 Others
 
 ## 2.0.0-preview.0 — 2024-10-22

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -29,9 +29,6 @@
   EXExpoAppDelegate *_expoAppDelegate;
 }
 
-// Synthesize window, so the AppDelegate can synthesize it too.
-@synthesize window = _window;
-
 - (instancetype)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
# Why

`EXAppDelegateWrapper` was doing a `@synthesize` on an `UIWindow` created by `RCTAppDelegate`. Everything worked fine until this commit in RN: https://github.com/facebook/react-native/commit/391680fe844aad887e497912378c699aed13464b which replaced `self.window` with `_window` in two places. Because the `EXAppDelegateWrapper` synthesizes the window, `_window` in `RCTAppDelegate` was never set, so the root view controller was never attached to a window, causing the `RCTFabricSurface` to deallocate immediately after leaving the scope.

# How

Removed `@synthesize`, which is now safe to remove as we no longer need to refer to the window from the `AppDelegate` class.

# Test Plan

Creating and running a new project with the following commands
```shell
bun create expo ./test-canary --template blank@canary && cd ./test-canary && bun expo run ios
```
works as expected with this change