### PR TITLE
[ci] increase timeout for building bare-expo

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 🏗️ Build iOS project
         run: ./scripts/start-ios-e2e-test.ts --build
         working-directory: apps/bare-expo
-        timeout-minutes: 45
+        timeout-minutes: 55
         env:
           EXPO_DEBUG: 1
           NODE_ENV: production


### PR DESCRIPTION
# Why

i notice that test-suite ios build often gets timeout since 0.76 upgrade

# How

let's increase the timeout a little bit

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
