### PR TITLE
Fix either crashing with optionals

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix optionals conversion. ([#32239](https://github.com/expo/expo/pull/32239) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 2.0.0-preview.0 — 2024-10-22
@@ -50,7 +52,6 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix optionals conversion. ([#32239](https://github.com/expo/expo/pull/32239) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix using enums as optional arguments. ([#32147](https://github.com/expo/expo/pull/32147) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Change JS return type for kotlin `null` to be `null` instead of `undefined`. ([#31301](https://github.com/expo/expo/pull/31301) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Swift `Enumerable`s did not correctly convert to JS values. ([#30191](https://github.com/expo/expo/pull/30191) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix optionals conversion. ([#32239](https://github.com/expo/expo/pull/32239) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix using enums as optional arguments. ([#32147](https://github.com/expo/expo/pull/32147) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Change JS return type for kotlin `null` to be `null` instead of `undefined`. ([#31301](https://github.com/expo/expo/pull/31301) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Swift `Enumerable`s did not correctly convert to JS values. ([#30191](https://github.com/expo/expo/pull/30191) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicOptionalType.swift
@@ -25,7 +25,7 @@ internal struct DynamicOptionalType: AnyDynamicType {
     if jsValue.isUndefined() || jsValue.isNull() {
       return Optional<Any>.none as Any
     }
-    return try appContext.converter.toNative(jsValue, wrappedType)
+    return try wrappedType.cast(jsValue: jsValue, appContext: appContext)
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {


### PR DESCRIPTION
# Why

Fixes `.replace()` call on expo video.  Introduced by: https://github.com/expo/expo/pull/31141/files

# How

Using the root converter for optionals causes the `rawValue` type to never be unwrapped from optional.
This causes the `cast` in either to not function correctly. (Either.swift:53)

It ends up using a Record converter to to try and cast `Optional(Optional(ExpoModulesCore.Either<Swift.String, ExpoVideo.VideoSource>))`, which  is neither a dict or itself, so it casues`Conversions.ConvertingException<Self>(value)` 

# Test Plan

Tested this fixes the issue in video screen.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
