### PR TITLE
remove dev client from router e2e runner

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@expo/dom-webview": "0.0.1",
     "expo": "~52.0.0-preview.0",
-    "expo-dev-client": "~5.0.0-preview.0",
     "expo-haptics": "~14.0.0",
     "expo-linking": "~7.0.0",
     "expo-router": "^4.0.0-preview.0",


### PR DESCRIPTION
# Why

- builds now work without dev client installed.
