### PR TITLE
[expo-updates] Move event emitting responsibility to module

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Move event emitting responsibility to module ([#32248](https://github.com/expo/expo/pull/32248) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.26.1 — 2024-10-22

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -2,8 +2,8 @@ package expo.modules.updates
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
-import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.events.IUpdatesEventManager
+import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updates.statemachine.UpdatesStateEvent
@@ -13,6 +13,7 @@ import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.lang.ref.WeakReference
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -43,8 +44,7 @@ class UpdatesStateMachineInstrumentationTest {
   // Test classes
   class TestStateChangeEventManager : IUpdatesEventManager {
     var lastContext: UpdatesStateContext? = null
-
-    override var eventEmitter: EventEmitter? = null
+    override var observer: WeakReference<IUpdatesEventManagerObserver>? = null
     override fun sendStateMachineContextEvent(context: UpdatesStateContext) {
       lastContext = context
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -2,7 +2,7 @@ package expo.modules.updates
 
 import android.content.Context
 import com.facebook.react.ReactApplication
-import expo.modules.kotlin.events.EventEmitter
+import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
@@ -151,13 +151,13 @@ class UpdatesController {
       }
     }
 
-    internal fun onEventListenerStartObserving(eventEmitter: EventEmitter?) {
-      singletonInstance?.eventManager?.eventEmitter = eventEmitter
+    internal fun setUpdatesEventManagerObserver(observer: WeakReference<IUpdatesEventManagerObserver>) {
+      singletonInstance?.eventManager?.observer = observer
       singletonInstance?.onEventListenerStartObserving()
     }
 
-    internal fun onEventListenerStopObserving() {
-      singletonInstance?.eventManager?.eventEmitter = null
+    internal fun removeUpdatesEventManagerObserver() {
+      singletonInstance?.eventManager?.observer = null
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -8,19 +8,26 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.updates.events.UpdatesJSEvent
+import expo.modules.kotlin.types.Enumerable
+import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogEntry
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.statemachine.UpdatesStateContext
+import java.lang.ref.WeakReference
 import java.util.Date
+
+enum class UpdatesJSEvent(val eventName: String) : Enumerable {
+  StateChange("Expo.nativeUpdatesStateChangeEvent")
+}
 
 /**
  * Exported module which provides to the JS runtime information about the currently running update
  * and updates state, along with methods to check for and download new updates, reload with the
  * newest downloaded update applied, and read/clear native log entries.
  */
-class UpdatesModule : Module() {
+class UpdatesModule : Module(), IUpdatesEventManagerObserver {
   private val logger: UpdatesLogger
     get() = UpdatesLogger(context)
 
@@ -30,21 +37,23 @@ class UpdatesModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoUpdates")
 
-    Events(
-      UpdatesJSEvent.StateChange.eventName
-    )
+    Events<UpdatesJSEvent>()
 
     Constants {
       UpdatesLogger(context).info("UpdatesModule: getConstants called", UpdatesErrorCode.None)
       UpdatesController.instance.getConstantsForModule().toModuleConstantsMap()
     }
 
-    OnStartObserving {
-      UpdatesController.onEventListenerStartObserving(appContext.eventEmitter(this@UpdatesModule))
+    OnStartObserving(UpdatesJSEvent.StateChange.eventName) {
+      UpdatesController.setUpdatesEventManagerObserver(WeakReference(this@UpdatesModule))
     }
 
-    OnStopObserving {
-      UpdatesController.onEventListenerStopObserving()
+    OnStopObserving(UpdatesJSEvent.StateChange.eventName) {
+      UpdatesController.removeUpdatesEventManagerObserver()
+    }
+
+    OnDestroy {
+      UpdatesController.removeUpdatesEventManagerObserver()
     }
 
     AsyncFunction("reload") { promise: Promise ->
@@ -239,5 +248,9 @@ class UpdatesModule : Module() {
         completionHandler
       )
     }
+  }
+
+  override fun onStateMachineContextEvent(context: UpdatesStateContext) {
+    sendEvent(UpdatesJSEvent.StateChange, Bundle().apply { putBundle("context", context.bundle) })
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/IUpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/IUpdatesEventManager.kt
@@ -1,13 +1,13 @@
 package expo.modules.updates.events
 
-import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.statemachine.UpdatesStateContext
+import java.lang.ref.WeakReference
 
-enum class UpdatesJSEvent(val eventName: String) {
-  StateChange("Expo.nativeUpdatesStateChangeEvent")
+interface IUpdatesEventManagerObserver {
+  fun onStateMachineContextEvent(context: UpdatesStateContext)
 }
 
 interface IUpdatesEventManager {
-  var eventEmitter: EventEmitter?
+  var observer: WeakReference<IUpdatesEventManagerObserver>?
   fun sendStateMachineContextEvent(context: UpdatesStateContext)
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/NoOpUpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/NoOpUpdatesEventManager.kt
@@ -1,9 +1,9 @@
 package expo.modules.updates.events
 
-import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.statemachine.UpdatesStateContext
+import java.lang.ref.WeakReference
 
 class NoOpUpdatesEventManager : IUpdatesEventManager {
-  override var eventEmitter: EventEmitter? = null
+  override var observer: WeakReference<IUpdatesEventManagerObserver>? = null
   override fun sendStateMachineContextEvent(context: UpdatesStateContext) {}
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/events/UpdatesEventManager.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/events/UpdatesEventManager.kt
@@ -1,31 +1,27 @@
 package expo.modules.updates.events
 
-import expo.modules.kotlin.events.EventEmitter
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.statemachine.UpdatesStateContext
+import java.lang.ref.WeakReference
 
 class UpdatesEventManager(private val logger: UpdatesLogger) : IUpdatesEventManager {
-  override var eventEmitter: EventEmitter? = null
+  override var observer: WeakReference<IUpdatesEventManagerObserver>? = null
 
   override fun sendStateMachineContextEvent(context: UpdatesStateContext) {
-    val eventName = UpdatesJSEvent.StateChange.eventName
+    logger.debug("Sending state machine context to observer")
 
-    val eventEmitter = eventEmitter
-    if (eventEmitter == null) {
-      logger.info(
-        "Could not emit $eventName event; no event emitter was found.",
-        UpdatesErrorCode.JSRuntimeError
-      )
+    val observer = observer?.get() ?: run {
+      logger.debug("Unable to send state machine context to observer, no observer", UpdatesErrorCode.JSRuntimeError)
       return
     }
 
     try {
-      eventEmitter.emit(eventName, context.writableMap)
-      logger.info("Emitted event: name = $eventName")
+      observer.onStateMachineContextEvent(context)
+      logger.debug("Sent state machine context to observer")
     } catch (e: Exception) {
       logger.error(
-        "Could not emit $eventName event",
+        "Could not send state machine context to observer",
         e,
         UpdatesErrorCode.JSRuntimeError
       )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
@@ -1,8 +1,6 @@
 package expo.modules.updates.statemachine
 
 import android.os.Bundle
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.WritableMap
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -113,17 +111,7 @@ class UpdatesStateContext private constructor(
     }
 
   /**
-   * Creates a WritableMap to be sent to JS on a state change.
-   */
-  val writableMap: WritableMap
-    get() {
-      val result = Arguments.createMap()
-      result.putMap("context", Arguments.fromBundle(bundle))
-      return result
-    }
-
-  /**
-   * Creates a Bundle to be returned to JS on a call to nativeStateMachineContext()
+   * Creates a Bundle to be synchronized with JS state
    */
   val bundle: Bundle
     get() {

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -540,7 +540,7 @@ describe('JS API tests', () => {
     Server.stop();
   });
 
-  it('downloads and runs update with JS API', async () => {
+  fit('downloads and runs update with JS API', async () => {
     const bundleFilename = 'bundle1.js';
     const newNotifyString = 'test-update-1';
     const hash = await Update.copyBundleToStaticFolder(
@@ -629,23 +629,29 @@ describe('JS API tests', () => {
     });
     await waitForAppToBecomeVisible();
 
-    // Check state
+    // Check state on launch
     const isUpdatePending = await testElementValueAsync('state.isUpdatePending');
     const isUpdateAvailable = await testElementValueAsync('state.isUpdateAvailable');
     const latestManifestId = await testElementValueAsync('state.latestManifest.id');
     const downloadedManifestId = await testElementValueAsync('state.downloadedManifest.id');
     const isRollback = await testElementValueAsync('state.isRollback');
-
     console.warn(`isUpdatePending = ${isUpdatePending}`);
     console.warn(`isUpdateAvailable = ${isUpdateAvailable}`);
     console.warn(`isRollback = ${isRollback}`);
     console.warn(`latestManifestId = ${latestManifestId}`);
     console.warn(`downloadedManifestId = ${downloadedManifestId}`);
+    jestExpect(isUpdateAvailable).toEqual('false');
+    jestExpect(isUpdatePending).toEqual('false');
+    jestExpect(isRollback).toEqual('false');
+    jestExpect(latestManifestId).toEqual('null');
+    jestExpect(downloadedManifestId).toEqual('null');
 
     const updatesExpoClientEmbeddedString = await testElementValueAsync('updates.expoClient');
     const constantsExpoConfigEmbeddedString = await testElementValueAsync('constants.expoConfig');
     console.warn(`updatesExpoClientEmbedded = ${updatesExpoClientEmbeddedString}`);
     console.warn(`constantsExpoConfigEmbedded = ${constantsExpoConfigEmbeddedString}`);
+    const updatesExpoConfigEmbedded = JSON.parse(updatesExpoClientEmbeddedString);
+    jestExpect(updatesExpoConfigEmbedded).not.toBeNull();
 
     // Now serve a manifest
     Server.start(Update.serverPort, protocolVersion);
@@ -660,12 +666,16 @@ describe('JS API tests', () => {
     const latestManifestId2 = await testElementValueAsync('state.latestManifest.id');
     const downloadedManifestId2 = await testElementValueAsync('state.downloadedManifest.id');
     const isRollback2 = await testElementValueAsync('state.isRollback');
-
     console.warn(`isUpdatePending2 = ${isUpdatePending2}`);
     console.warn(`isUpdateAvailable2 = ${isUpdateAvailable2}`);
     console.warn(`isRollback2 = ${isRollback2}`);
     console.warn(`latestManifestId2 = ${latestManifestId2}`);
     console.warn(`downloadedManifestId2 = ${downloadedManifestId2}`);
+    jestExpect(isUpdateAvailable2).toEqual('true');
+    jestExpect(isUpdatePending2).toEqual('false');
+    jestExpect(isRollback2).toEqual('false');
+    jestExpect(latestManifestId2).toEqual(manifest.id);
+    jestExpect(downloadedManifestId2).toEqual('null');
 
     // Download update and expect isUpdatePending to be true
     await pressTestButtonAsync('downloadUpdate');
@@ -676,12 +686,16 @@ describe('JS API tests', () => {
     const latestManifestId3 = await testElementValueAsync('state.latestManifest.id');
     const downloadedManifestId3 = await testElementValueAsync('state.downloadedManifest.id');
     const isRollback3 = await testElementValueAsync('state.isRollback');
-
     console.warn(`isUpdatePending3 = ${isUpdatePending3}`);
     console.warn(`isUpdateAvailable3 = ${isUpdateAvailable3}`);
     console.warn(`isRollback3 = ${isRollback3}`);
     console.warn(`latestManifestId3 = ${latestManifestId3}`);
     console.warn(`downloadedManifestId3 = ${downloadedManifestId3}`);
+    jestExpect(isUpdateAvailable3).toEqual('true');
+    jestExpect(isUpdatePending3).toEqual('true');
+    jestExpect(isRollback3).toEqual('false');
+    jestExpect(latestManifestId3).toEqual(manifest.id);
+    jestExpect(downloadedManifestId3).toEqual(manifest.id);
 
     // Terminate and relaunch app, we should be running the update, and back to the default state
     await device.terminateApp();
@@ -694,13 +708,18 @@ describe('JS API tests', () => {
     const downloadedManifestId4 = await testElementValueAsync('state.downloadedManifest.id');
     const isRollback4 = await testElementValueAsync('state.isRollback');
     const rollbackCommitTime4 = await testElementValueAsync('state.rollbackCommitTime');
-
     console.warn(`isUpdatePending4 = ${isUpdatePending4}`);
     console.warn(`isUpdateAvailable4 = ${isUpdateAvailable4}`);
     console.warn(`isRollback4 = ${isRollback4}`);
     console.warn(`latestManifestId4 = ${latestManifestId4}`);
     console.warn(`downloadedManifestId4 = ${downloadedManifestId4}`);
     console.warn(`rollbackCommitTime4 = ${rollbackCommitTime4}`);
+    jestExpect(isUpdateAvailable4).toEqual('false');
+    jestExpect(isUpdatePending4).toEqual('false');
+    jestExpect(isRollback4).toEqual('false');
+    jestExpect(latestManifestId4).toEqual('null');
+    jestExpect(downloadedManifestId4).toEqual('null');
+    jestExpect(rollbackCommitTime4).toEqual('null');
 
     const updatesExpoClientUpdateString = await testElementValueAsync('updates.expoClient');
     const constantsExpoConfigUpdateString = await testElementValueAsync('constants.expoConfig');
@@ -721,13 +740,18 @@ describe('JS API tests', () => {
     const downloadedManifestId5 = await testElementValueAsync('state.downloadedManifest.id');
     const isRollback5 = await testElementValueAsync('state.isRollback');
     const rollbackCommitTime5 = await testElementValueAsync('state.rollbackCommitTime');
-
     console.warn(`isUpdatePending5 = ${isUpdatePending5}`);
     console.warn(`isUpdateAvailable5 = ${isUpdateAvailable5}`);
     console.warn(`isRollback5 = ${isRollback5}`);
     console.warn(`latestManifestId5 = ${latestManifestId5}`);
     console.warn(`downloadedManifestId5 = ${downloadedManifestId5}`);
     console.warn(`rollbackCommitTime5 = ${rollbackCommitTime5}`);
+    jestExpect(isUpdateAvailable5).toEqual('true');
+    jestExpect(isUpdatePending5).toEqual('false');
+    jestExpect(isRollback5).toEqual('true');
+    jestExpect(latestManifestId5).toEqual('null');
+    jestExpect(downloadedManifestId5).toEqual('null');
+    jestExpect(rollbackCommitTime5).not.toEqual('null');
 
     // Terminate and relaunch app, we should be running the original bundle again, and back to the default state
     await device.terminateApp();
@@ -752,44 +776,6 @@ describe('JS API tests', () => {
     const constantsExpoConfigRollbackString = await testElementValueAsync('constants.expoConfig');
     console.warn(`updatesExpoConfigRollback = ${updatesExpoConfigRollbackString}`);
     console.warn(`constantsExpoConfigRollback = ${constantsExpoConfigRollbackString}`);
-
-    // Unpack expo config values and check them
-    const updatesExpoConfigEmbedded = JSON.parse(updatesExpoClientEmbeddedString);
-    jestExpect(updatesExpoConfigEmbedded).not.toBeNull();
-
-    // Verify correct behavior
-    // On launch
-    jestExpect(isUpdateAvailable).toEqual('false');
-    jestExpect(isUpdatePending).toEqual('false');
-    jestExpect(isRollback).toEqual('false');
-    jestExpect(latestManifestId).toEqual('null');
-    jestExpect(downloadedManifestId).toEqual('null');
-    // After check for update and getting a manifest
-    jestExpect(isUpdateAvailable2).toEqual('true');
-    jestExpect(isUpdatePending2).toEqual('false');
-    jestExpect(isRollback2).toEqual('false');
-    jestExpect(latestManifestId2).toEqual(manifest.id);
-    jestExpect(downloadedManifestId2).toEqual('null');
-    // After downloading the update
-    jestExpect(isUpdateAvailable3).toEqual('true');
-    jestExpect(isUpdatePending3).toEqual('true');
-    jestExpect(isRollback3).toEqual('false');
-    jestExpect(latestManifestId3).toEqual(manifest.id);
-    jestExpect(downloadedManifestId3).toEqual(manifest.id);
-    // After restarting
-    jestExpect(isUpdateAvailable4).toEqual('false');
-    jestExpect(isUpdatePending4).toEqual('false');
-    jestExpect(isRollback4).toEqual('false');
-    jestExpect(latestManifestId4).toEqual('null');
-    jestExpect(downloadedManifestId4).toEqual('null');
-    jestExpect(rollbackCommitTime4).toEqual('null');
-    // After check for update and getting a rollback
-    jestExpect(isUpdateAvailable5).toEqual('true');
-    jestExpect(isUpdatePending5).toEqual('false');
-    jestExpect(isRollback5).toEqual('true');
-    jestExpect(latestManifestId5).toEqual('null');
-    jestExpect(downloadedManifestId5).toEqual('null');
-    jestExpect(rollbackCommitTime5).not.toEqual('null');
 
     // Check for update, and expect isRollback to be true
     await pressTestButtonAsync('triggerParallelFetchAndDownload');

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -350,13 +350,13 @@ public class AppController: NSObject {
     }
   }
 
-  internal static func onEventListenerStartObserving(_ eventEmitter: EXEventEmitterService?) {
-    _sharedInstance?.eventManager.eventEmitter = eventEmitter
+  internal static func setUpdatesEventManagerObserver(_ observer: UpdatesEventManagerObserver) {
+    _sharedInstance?.eventManager.observer = observer
     _sharedInstance?.onEventListenerStartObserving()
   }
 
-  internal static func onEventListenerStopObserving() {
-    _sharedInstance?.eventManager.eventEmitter = nil
+  internal static func removeUpdatesEventManagerObserver() {
+    _sharedInstance?.eventManager.observer = nil
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/Events/NoOpUpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/NoOpUpdatesEventManager.swift
@@ -3,6 +3,6 @@
 import ExpoModulesCore
 
 internal class NoOpUpdatesEventManager: UpdatesEventManager {
-  internal weak var eventEmitter: EXEventEmitterService?
+  internal weak var observer: (any UpdatesEventManagerObserver)?
   func sendStateMachineContextEvent(context: UpdatesStateContext) {}
 }

--- a/packages/expo-updates/ios/EXUpdates/Events/QueueUpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/QueueUpdatesEventManager.swift
@@ -9,21 +9,15 @@ internal class QueueUpdatesEventManager: UpdatesEventManager {
     self.logger = logger
   }
 
-  internal weak var eventEmitter: EXEventEmitterService?
+  internal weak var observer: (any UpdatesEventManagerObserver)?
 
   internal func sendStateMachineContextEvent(context: UpdatesStateContext) {
-    logger.info(message: "sendUpdateStateAppContext()")
-    sendEventToAppContext(EXUpdatesStateChangeEventName, body: [
-      "context": context.json
-    ])
-  }
-
-  private func sendEventToAppContext(_ eventName: String, body: [String: Any?]) {
-    guard let eventEmitter = eventEmitter else {
-      logger.info(message: "EXUpdates: Could not emit event: name = \(eventName)", code: .jsRuntimeError)
+    logger.debug(message: "Sending state machine context to observer")
+    guard let observer = observer else {
+      logger.debug(message: "Unable to send state machine context to observer, no observer", code: .jsRuntimeError)
       return
     }
-    logger.debug(message: "sendEventToAppContext: \(eventName), \(body)")
-    eventEmitter.sendEvent(withName: eventName, body: body)
+    observer.onStateMachineContextEvent(context: context)
+    logger.debug(message: "Sent state machine context to observer")
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Events/UpdatesEventManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/Events/UpdatesEventManager.swift
@@ -2,7 +2,11 @@
 
 import ExpoModulesCore
 
+public protocol UpdatesEventManagerObserver: AnyObject {
+  func onStateMachineContextEvent(context: UpdatesStateContext)
+}
+
 public protocol UpdatesEventManager: AnyObject {
-  var eventEmitter: EXEventEmitterService? { get set }
+  var observer: UpdatesEventManagerObserver? { get set }
   func sendStateMachineContextEvent(context: UpdatesStateContext)
 }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -359,7 +359,6 @@ internal class UpdatesStateMachine {
       // Only change context if transition succeeds
       context = reducedContext(context, event)
       logger.info(message: "Updates state change: state = \(state), event = \(event.type), context = \(context)")
-      // Send context to JS
       sendContextToJS()
     }
   }

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -9,11 +9,10 @@ import ExpoModulesTestCore
 import EXManifests
 
 class TestStateChangeEventManager: UpdatesEventManager {
-  var appContext: ExpoModulesCore.AppContext? = nil
-
   var lastContext: UpdatesStateContext? = nil
+  weak var observer: (any EXUpdates.UpdatesEventManagerObserver)?
 
-  func sendUpdateStateAppContext(context: UpdatesStateContext) {
+  func sendStateMachineContextEvent(context: EXUpdates.UpdatesStateContext) {
     lastContext = context
   }
 }


### PR DESCRIPTION
# Why

In https://app.graphite.dev/github/pr/expo/expo/32226/updates-use-old-arch-to-run-e2e-tests, @kudo noticed that a few tests were failing.

The blame revs are my recent refactors to this functionality. The issue for iOS was that the weak reference was being released before events could be emitted. It's hard to tell exactly when this broke, but it was definitely due to my refactor. A secondary bug was that `OnStopObserving` isn't called during `reloadAsync` so it was not being dereferenced if made a strong reference.

# How

The fix is to instead keep a weak reference to the module itself, which is vaguely what a bunch of other modules do in NotificationCenter observers.
Then, also remove the observer in `OnDestroy`.
Then, use the new `sendEvent` method from the module itself rather than digging in the app context for the event emitter. (modern API)

# Test Plan

E2E tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
