### PR TITLE
[core][android] Add enum event support to OnStartObserving and OnStopObserving

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -7,9 +7,6 @@ import expo.modules.kotlin.providers.AppContextProvider
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.CoroutineScope
-import kotlin.reflect.KProperty1
-import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.primaryConstructor
 
 abstract class Module : AppContextProvider {
 
@@ -54,25 +51,6 @@ abstract class Module : AppContextProvider {
   }
 
   abstract fun definition(): ModuleDefinitionData
-
-  private fun <T> convertEnumToString(enumValue: T): String where T : Enumerable, T : Enum<T> {
-    val enumClass = enumValue::class
-    val primaryConstructor = enumClass.primaryConstructor
-    if (primaryConstructor?.parameters?.size == 1) {
-      val parameterName = primaryConstructor.parameters.first().name
-      val parameterProperty = enumClass
-        .declaredMemberProperties
-        .find { it.name == parameterName }
-
-      requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter" }
-      require(parameterProperty.returnType.classifier == String::class) { "The enum parameter has to be a string." }
-
-      @Suppress("UNCHECKED_CAST")
-      return (parameterProperty as KProperty1<T, String>).get(enumValue)
-    }
-
-    return enumValue.name
-  }
 }
 
 @Suppress("FunctionName")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleUtils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleUtils.kt
@@ -1,0 +1,25 @@
+package expo.modules.kotlin.modules
+
+import expo.modules.kotlin.types.Enumerable
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.primaryConstructor
+
+internal fun <T> convertEnumToString(enumValue: T): String where T : Enumerable, T : Enum<T> {
+  val enumClass = enumValue::class
+  val primaryConstructor = enumClass.primaryConstructor
+  if (primaryConstructor?.parameters?.size == 1) {
+    val parameterName = primaryConstructor.parameters.first().name
+    val parameterProperty = enumClass
+      .declaredMemberProperties
+      .find { it.name == parameterName }
+
+    requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter" }
+    require(parameterProperty.returnType.classifier == String::class) { "The enum parameter has to be a string." }
+
+    @Suppress("UNCHECKED_CAST")
+    return (parameterProperty as KProperty1<T, String>).get(enumValue)
+  }
+
+  return enumValue.name
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -18,6 +18,7 @@ import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
+import expo.modules.kotlin.modules.convertEnumToString
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
@@ -474,6 +475,13 @@ open class ObjectDefinitionBuilder {
   }
 
   /**
+   * Creates module's lifecycle listener that is called right after the first event listener is added for given event.
+   */
+  fun <T> OnStartObserving(enum: T, body: () -> Unit) where T : Enumerable, T : Enum<T> {
+    OnStartObserving(convertEnumToString(enum), body)
+  }
+
+  /**
    * Creates module's lifecycle listener that is called right after the first event listener is added.
    */
   fun OnStartObserving(body: () -> Unit) {
@@ -497,6 +505,13 @@ open class ObjectDefinitionBuilder {
     ).also {
       eventObservers.add(it)
     }
+  }
+
+  /**
+   * Creates module's lifecycle listener that is called right after all event listeners are removed for given event.
+   */
+  fun <T> OnStopObserving(enum: T, body: () -> Unit) where T : Enumerable, T : Enum<T> {
+    OnStartObserving(convertEnumToString(enum), body)
   }
 
   /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -44,11 +44,11 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
       UpdatesController.instance.getConstantsForModule().toModuleConstantsMap()
     }
 
-    OnStartObserving(UpdatesJSEvent.StateChange.eventName) {
+    OnStartObserving(UpdatesJSEvent.StateChange) {
       UpdatesController.setUpdatesEventManagerObserver(WeakReference(this@UpdatesModule))
     }
 
-    OnStopObserving(UpdatesJSEvent.StateChange.eventName) {
+    OnStopObserving(UpdatesJSEvent.StateChange) {
       UpdatesController.removeUpdatesEventManagerObserver()
     }
 


### PR DESCRIPTION
# Why

- https://github.com/expo/expo/pull/23875 added support to use native enums for events for `sendEvent` and `Events`
- https://github.com/expo/expo/pull/27766 added support for specific events in OnStartObserving/OnStopObserving on iOS.
- https://github.com/expo/expo/pull/29012 added android support, but omitted support for the enum portion of the feature for these two methods.

This PR adds the same enum android support to OnStartObserving/OnStopObserving

# How

Factor out common code into internal utils file. Add enum equivalents of the methods.

# Test Plan

Used in expo-updates so the expo-updates e2e tests should be sufficient for testing. I don't believe there are any existing automated tests for these features.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
