### PR TITLE
[expo-updates][android] Use enum event in OnStartObserving and OnStopObserving

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### 🐛 Bug fixes
 
-- Move event emitting responsibility to module ([#32248](https://github.com/expo/expo/pull/32248) by [@wschurman](https://github.com/wschurman))
+- Move event emitting responsibility to module. ([#32248](https://github.com/expo/expo/pull/32248) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
+
+- Use enum event in OnStartObserving and OnStopObserving. ([#32252](https://github.com/expo/expo/pull/32252) by [@wschurman](https://github.com/wschurman))
 
 ## 0.26.1 — 2024-10-22
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -44,11 +44,11 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
       UpdatesController.instance.getConstantsForModule().toModuleConstantsMap()
     }
 
-    OnStartObserving(UpdatesJSEvent.StateChange.eventName) {
+    OnStartObserving(UpdatesJSEvent.StateChange) {
       UpdatesController.setUpdatesEventManagerObserver(WeakReference(this@UpdatesModule))
     }
 
-    OnStopObserving(UpdatesJSEvent.StateChange.eventName) {
+    OnStopObserving(UpdatesJSEvent.StateChange) {
       UpdatesController.removeUpdatesEventManagerObserver()
     }
 


### PR DESCRIPTION
# Why

This uses the new enum feature from https://app.graphite.dev//github/pr/expo/expo/32251

# How

Change params to enum

# Test Plan

E2E tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
