### PR TITLE
[ci] Update codemention to 1.4.0

### DIFF
--- a/.github/workflows/codemention.yaml
+++ b/.github/workflows/codemention.yaml
@@ -9,6 +9,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: tobyhs/codemention@v1.3.0
+      - uses: tobyhs/codemention@v1.4.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Why

This pulls in [this change](https://github.com/tobyhs/codemention/pull/22) which changes the behavior to not mention the PR author. This feature was requested by various expo engineers.

Closes ENG-13773.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
