### PR TITLE
Fix android CI

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.UUID
 
+private const val PLAYBACK_STATUS_UPDATE = "playbackStatusUpdate"
+private const val AUDIO_SAMPLE_UPDATE = "audioSampleUpdate"
+
 @UnstableApi
 class AudioPlayer(
   context: Context,
@@ -135,7 +138,7 @@ class AudioPlayer(
     withContext(Dispatchers.Main) {
       val data = currentStatus()
       val body = map?.let { data + it } ?: data
-      emit("onPlaybackStatusUpdate", body)
+      emit(PLAYBACK_STATUS_UPDATE, body)
     }
 
   private fun sendAudioSampleUpdate(sample: List<Float>) {
@@ -145,7 +148,7 @@ class AudioPlayer(
       ),
       "timestamp" to player.currentPosition
     )
-    emit("onAudioSampleUpdate", body)
+    emit(AUDIO_SAMPLE_UPDATE, body)
   }
 
   private fun playbackStateToString(state: Int): String {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -18,6 +18,8 @@ import java.io.IOException
 import java.util.UUID
 import kotlin.math.ln
 
+private const val RECORDING_STATUS_UPDATE = "recordingStatusUpdate"
+
 class AudioRecorder(
   private val context: Context,
   appContext: AppContext,
@@ -63,12 +65,8 @@ class AudioRecorder(
   }
 
   fun record() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      if (isPaused) {
-        recorder.resume()
-      } else {
-        recorder.start()
-      }
+    if (isPaused) {
+      recorder.resume()
     } else {
       recorder.start()
     }
@@ -78,14 +76,10 @@ class AudioRecorder(
   }
 
   fun pauseRecording() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      recorder.pause()
-      durationAlreadyRecorded = getAudioRecorderDurationMillis()
-      isRecording = false
-      isPaused = true
-    } else {
-      stopRecording()
-    }
+    recorder.pause()
+    durationAlreadyRecorded = getAudioRecorderDurationMillis()
+    isRecording = false
+    isPaused = true
   }
 
   fun stopRecording(): Bundle {
@@ -183,7 +177,7 @@ class AudioRecorder(
       else -> "An unknown recording error occurred"
     }
     emit(
-      "onRecordingStatusUpdate",
+      RECORDING_STATUS_UPDATE,
       mapOf(
         "isFinished" to true,
         "hasError" to true,

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -27,12 +27,12 @@ enum class InterruptionMode(val value: String) : Enumerable {
 // Data class because we want `equals`
 data class RecordingOptions(
   @Field val extension: String,
-  @Field val sampleRate: Double?
+  @Field val sampleRate: Double?,
   @Field val numberOfChannels: Double?,
   @Field val bitRate: Double?,
   @Field val outputFormat: AndroidOutputFormat?,
   @Field val audioEncoder: AndroidAudioEncoder?,
-  @Field val maxFileSize: Int?,
+  @Field val maxFileSize: Int?
 ) : Record
 
 enum class AndroidOutputFormat(val value: String) : Enumerable {


### PR DESCRIPTION
# Why
I mistakenly deleted a comma from a data class constructor. 

# How
Fixed the typo. Also noticed we can remove some version checks since the RN upgrade and extracted the event names into constants like I have done on iOS and web. 

# Test Plan
bare-expo. Builds and runs and the audio examples are working.
