### PR TITLE
[Apple TV] Support expo-linking package

### DIFF
--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add tvOS to podspec. ([#32255](https://github.com/expo/expo/pull/32255) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 7.0.0 — 2024-10-22

--- a/packages/expo-linking/ios/ExpoLinking.podspec
+++ b/packages/expo-linking/ios/ExpoLinking.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -54,6 +54,7 @@ function getExpoDependencyChunks({
             'expo-blur',
             'expo-image',
             'expo-linear-gradient',
+            'expo-linking',
             'expo-localization',
             'expo-crypto',
             'expo-network',


### PR DESCRIPTION
# Why

Testing with canary builds from main shows that Apple TV apps using Expo Router are broken, because expo-linking is now required within the Expo Router code, and expo-linking was not being included in tvOS builds (even though our docs say it is supported).

# How

Only change needed was to add tvOS to the podspec.

# Test Plan

- Manually test with a test app
- Add expo-linking to the modules included in the TV compile CI

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
