### PR TITLE
[expo-updates][android] Fix failure message for manifest filter mismatch

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -575,7 +575,7 @@ class FileDownloader(
 
       val update = UpdateFactory.getUpdate(preManifest, responseHeaderData, extensions, configuration)
       if (!SelectionPolicies.matchesFilters(update.updateEntity!!, responseHeaderData.manifestFilters)) {
-        callback.onFailure(Exception("Manifest filters that do not manifest content for downloaded manifest"))
+        callback.onFailure(Exception("Manifest filters do not match manifest content for downloaded manifest"))
       } else {
         callback.onSuccess(UpdateResponsePart.ManifestUpdateResponsePart(update))
       }


### PR DESCRIPTION
# Why

Noticed while adding errors for the iOS implementation that this one in android had a typo. This fixes the typo.

Closes ENG-13778.

# How

Update message.

# Test Plan

Inspect, ensure it matches iOS.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
