### PR TITLE
[templates][iOS] Prevent breaking change for core autolinking

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -17,7 +17,7 @@ target 'HelloWorld' do
   use_expo_modules!
 
   if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
-    config = use_native_modules!
+    config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
   else
     config_command = [
       'node',
@@ -29,8 +29,9 @@ target 'HelloWorld' do
       '--platform',
       'ios'
     ]
-    config = use_native_modules!(config_command)
   end
+
+  config = use_native_modules!(config_command)
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/32161

# How

Only call `use_native_modules` once to avoid dangerous config plugin regex from breaking 

# Test Plan


1. `tar -zcvf expo-template-bare-minimum.tar.gz expo-template-bare-minimum`
2. `npx expo prebuild  --clean --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-bare-minimum.tar.gz`


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
