### PR TITLE
[expo-go] Drop crashlytics version

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
   dependencies {
     classpath expoLibs.android.gradle.plugin
     classpath 'com.google.gms:google-services:4.3.5'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.6'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 


### PR DESCRIPTION
# Why
Attempts to fix the problem mentioned [here](https://exponent-internal.slack.com/archives/CNHBN8LNS/p1729652651648019). This issue was previously [reported](https://github.com/firebase/firebase-android-sdk/issues/4682) and seems to have regressed. Dropping the version to the one mentioned to have fixed the problem seems to build fine with `EAS_BUILD=1 ./gradlew assembleRelease`

# How
Drop crashlytics version to `2.9.5`

# Test Plan
expo go builds in release.
