### PR TITLE
[expo-go] Add method to request local network access

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -23,36 +23,36 @@ PODS:
     - Yoga
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (0.13.0):
+  - EASClient (0.13.1):
     - ExpoModulesCore
-  - EASClient/Tests (0.13.0):
+  - EASClient/Tests (0.13.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXApplication (6.0.0):
+  - EXApplication (6.0.1):
     - ExpoModulesCore
   - EXAV (15.0.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
-  - EXBarCodeScanner (14.0.0):
+  - EXBarCodeScanner (14.0.1):
     - EXImageLoader
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - EXConstants (17.0.0):
+  - EXConstants (17.0.1):
     - ExpoModulesCore
   - EXImageLoader (5.0.0):
     - ExpoModulesCore
     - React-Core
   - EXJSONUtils (0.14.0)
   - EXJSONUtils/Tests (0.14.0)
-  - EXManifests (0.15.0):
+  - EXManifests (0.15.1):
     - ExpoModulesCore
-  - EXManifests/Tests (0.15.0):
+  - EXManifests/Tests (0.15.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - EXNotifications (0.29.0):
     - ExpoModulesCore
-  - Expo (52.0.0-preview.0):
+  - Expo (52.0.0-preview.1):
     - ExpoModulesCore
   - expo-dev-client (5.0.0-preview.0):
     - EXManifests
@@ -60,10 +60,10 @@ PODS:
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (5.0.0):
+  - expo-dev-launcher (5.0.1):
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 5.0.0)
+    - expo-dev-launcher/Main (= 5.0.1)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -89,7 +89,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Main (5.0.0):
+  - expo-dev-launcher/Main (5.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-launcher/Unsafe
@@ -118,7 +118,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Tests (5.0.0):
+  - expo-dev-launcher/Tests (5.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -151,7 +151,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Unsafe (5.0.0):
+  - expo-dev-launcher/Unsafe (5.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -179,10 +179,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu (6.0.0):
+  - expo-dev-menu (6.0.1):
     - DoubleConversion
-    - expo-dev-menu/Main (= 6.0.0)
-    - expo-dev-menu/ReactNativeCompatibles (= 6.0.0)
+    - expo-dev-menu/Main (= 6.0.1)
+    - expo-dev-menu/ReactNativeCompatibles (= 6.0.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -203,7 +203,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - expo-dev-menu-interface (1.9.0)
-  - expo-dev-menu/Main (6.0.0):
+  - expo-dev-menu/Main (6.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu-interface
@@ -229,7 +229,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (6.0.0):
+  - expo-dev-menu/ReactNativeCompatibles (6.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -250,7 +250,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/SafeAreaView (6.0.0):
+  - expo-dev-menu/SafeAreaView (6.0.1):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -272,7 +272,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Tests (6.0.0):
+  - expo-dev-menu/Tests (6.0.1):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -297,7 +297,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/UITests (6.0.0):
+  - expo-dev-menu/UITests (6.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -320,7 +320,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Vendored (6.0.0):
+  - expo-dev-menu/Vendored (6.0.1):
     - DoubleConversion
     - expo-dev-menu/SafeAreaView
     - glog
@@ -342,40 +342,40 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoAppleAuthentication (7.0.0):
+  - ExpoAppleAuthentication (7.0.1):
     - ExpoModulesCore
   - ExpoAsset (11.0.0):
     - ExpoModulesCore
   - ExpoAudio (0.2.0):
     - ExpoModulesCore
-  - ExpoBackgroundFetch (13.0.0):
+  - ExpoBackgroundFetch (13.0.1):
     - ExpoModulesCore
-  - ExpoBattery (9.0.0):
+  - ExpoBattery (9.0.1):
     - ExpoModulesCore
-  - ExpoBlur (14.0.0):
+  - ExpoBlur (14.0.1):
     - ExpoModulesCore
-  - ExpoBrightness (13.0.0):
+  - ExpoBrightness (13.0.1):
     - ExpoModulesCore
-  - ExpoCalendar (14.0.0):
+  - ExpoCalendar (14.0.1):
     - ExpoModulesCore
   - ExpoCamera (16.0.0):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - ExpoCellular (7.0.0):
+  - ExpoCellular (7.0.1):
     - ExpoModulesCore
   - ExpoClipboard (7.0.0):
     - ExpoModulesCore
   - ExpoClipboard/Tests (7.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoContacts (14.0.0):
+  - ExpoContacts (14.0.1):
     - ExpoModulesCore
-  - ExpoCrypto (14.0.0):
+  - ExpoCrypto (14.0.1):
     - ExpoModulesCore
-  - ExpoDevice (7.0.0):
+  - ExpoDevice (7.0.1):
     - ExpoModulesCore
-  - ExpoDocumentPicker (13.0.0):
+  - ExpoDocumentPicker (13.0.1):
     - ExpoModulesCore
   - ExpoDomWebView (0.0.1):
     - ExpoModulesCore
@@ -404,16 +404,16 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-  - ExpoImageManipulator (13.0.0):
+  - ExpoImageManipulator (13.0.1):
     - EXImageLoader
     - ExpoModulesCore
     - SDWebImageWebPCoder
   - ExpoImagePicker (16.0.0):
     - ExpoModulesCore
-  - ExpoInsights (0.8.0):
+  - ExpoInsights (0.8.1):
     - EASClient
     - ExpoModulesCore
-  - ExpoKeepAwake (14.0.0):
+  - ExpoKeepAwake (14.0.1):
     - ExpoModulesCore
   - ExpoLinearGradient (14.0.0):
     - ExpoModulesCore
@@ -421,13 +421,13 @@ PODS:
     - ExpoModulesCore
   - ExpoLivePhoto (0.0.1):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (15.0.0):
+  - ExpoLocalAuthentication (15.0.1):
     - ExpoModulesCore
   - ExpoLocalization (16.0.0):
     - ExpoModulesCore
-  - ExpoLocation (18.0.0):
+  - ExpoLocation (18.0.1):
     - ExpoModulesCore
-  - ExpoMailComposer (14.0.0):
+  - ExpoMailComposer (14.0.1):
     - ExpoModulesCore
   - ExpoMaps (0.6.0):
     - ExpoModulesCore
@@ -440,7 +440,7 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (2.0.0-preview.0):
+  - ExpoModulesCore (2.0.0-preview.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -463,7 +463,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesCore/Tests (2.0.0-preview.0):
+  - ExpoModulesCore/Tests (2.0.0-preview.1):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -573,7 +573,7 @@ PODS:
   - EXTaskManager (12.0.0):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.26.0):
+  - EXUpdates (0.26.1):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -600,7 +600,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXUpdates/Tests (0.26.0):
+  - EXUpdates/Tests (0.26.1):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -3258,55 +3258,55 @@ SPEC CHECKSUMS:
   BenchmarkingModule: 0be4117c4bf255d2e21df9e4a4a486ec89c8640f
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  EASClient: 7159c5f83e018efc818f460766c9a5940fbe5b80
-  EXApplication: dba7d1b232c10712c9443f07fa8d29e6d14c2939
+  EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
+  EXApplication: e1ad9c950c98b2b134578092c948b10b403f3ea7
   EXAV: 8996468e7e113e59d13c6530a0f5f54ee542439e
-  EXBarCodeScanner: 841325ad77586098203338a5af859932539ae2bc
-  EXConstants: c411a7e78e660d63445e55d0df589c0c4b07c02a
+  EXBarCodeScanner: 98bfb848dc71d57a51b8d9ab8e2cd98b95cc2ae7
+  EXConstants: c74958e9232c8c2a8d27537fc555253297ff7a3c
   EXImageLoader: 759063a65ab016b836f73972d3bb25404888713d
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
-  EXManifests: 18b49c1bf3298592516c37b7b00c36a13d6ce1d6
+  EXManifests: d2859eb09b260b4e819299782fb5e43da36e248b
   EXNotifications: cf4e8acb21fa1101bcf39433a1179eb8005413c6
-  Expo: eb3865ce59dc01d663134882a383111c0b97f570
+  Expo: c2884243735806707b488e97bd39be1d41ae6861
   expo-dev-client: 1330e6f0c6b7d1304895fe94092cdc66560e4077
-  expo-dev-launcher: 8eb2ae71f09ff9ea516080bafc6e234cdbf93d43
-  expo-dev-menu: b33b373afec903ae0c029071d3bc783caf6d4a47
+  expo-dev-launcher: befd0323d4ae270f4147689638f7f3f8e7910dec
+  expo-dev-menu: 1df2a0e4c990bcd360b4c7266bbdfcd0624ef074
   expo-dev-menu-interface: 6f83f3119a91557e1d04cf43d6320ef545082fd4
-  ExpoAppleAuthentication: ab000e376f6821488b11cdbecca3ca04c49474d8
+  ExpoAppleAuthentication: 59b0f5cf600284dd03b0d595c112acd067e0eb69
   ExpoAsset: 9de2f325e8c97a4c6c2bc85e507ae7f0809c91aa
   ExpoAudio: 8926a8ffff9d48460d31e177937e41348ec5f271
-  ExpoBackgroundFetch: 7508057586bcc86155d86e9c697f2af499bcf20a
-  ExpoBattery: 73368a54caf210a589638a6fb9438120f23195f9
-  ExpoBlur: 66591f1f9aec3aeb20ffaa33851d2e9a9b7f07f1
-  ExpoBrightness: b52d15f22efd59c10991ecaa2a5636a56cecc602
-  ExpoCalendar: d709c5f4e834a668ce86a782eb772b98eaf2be12
+  ExpoBackgroundFetch: 66626717d7d9266cb858b5d872b67c993975cc31
+  ExpoBattery: 71bb388c37c3bcd0e87077e06e95780ea34fa6c8
+  ExpoBlur: 562b3da84d3cd79016c411671eaf71a404266415
+  ExpoBrightness: 2afff5bb0637535d648544679fbcc222a852ddc2
+  ExpoCalendar: f43595a52437a6e1b71d1c2b1ad046d75fd9c777
   ExpoCamera: e7f3fba9e3f59d04a77f999019376b2d56d48dba
-  ExpoCellular: a6c10b82141ae95074f16231f1ca77dc2674c058
+  ExpoCellular: c7ae03fd9480e6a4296a5632c35ab00ddaea4783
   ExpoClipboard: 166ca8c13ca1041f5ba619a211f59427ab5da8a7
-  ExpoContacts: 603aa80879971c147053dac6c3771a577e39aea7
-  ExpoCrypto: 67dbd6958be9df1e6077ee1e6c7014cdee34b9ed
-  ExpoDevice: f4bff8c5150358b7f8f4e914de60977ad3e3ac21
-  ExpoDocumentPicker: a292e2cd0be7825316e7508f3770045cec8cd991
+  ExpoContacts: cd2db2a7d5b0f249785903e031f595c231b91b51
+  ExpoCrypto: 8465f71eb3798c194c0a509d4a76e5c429656d83
+  ExpoDevice: e24dd19a43065182eb246bc0e7f84186862f1e83
+  ExpoDocumentPicker: 4a89fd8a0cb90010214a416c858d7dece1c1eb10
   ExpoDomWebView: 71d9f0808dce43b9f36b45a8c091c242dfa7b372
   ExpoFileSystem: d8b51caca86749a132c8ffde46be9a175e46b819
   ExpoFont: 2fb6d98e0a5352bebcaa568d6bfbba0e0f2e0097
   ExpoGL: 25f19d2db3ad0e48ee43b16e0272c0e526968c1d
   ExpoHaptics: e636188d1d5f7ccb79f3c1bfab47aaf5a1768c73
   ExpoImage: bd04fd6e5f97d2a29284bd7113cc51d7c206d17d
-  ExpoImageManipulator: e88e86d4ff8548ef1b54054cdfb7c7b3bc5a6ee5
+  ExpoImageManipulator: bd71d33c53ec0d1bef814b3efb28b88c054a87a5
   ExpoImagePicker: 6977a8aa31e7fc21d209e9a5f0772f360f5f5f50
-  ExpoInsights: 5d7c908e9117d007309868441ec3088741a8dcd3
-  ExpoKeepAwake: 0f50926d48b0f24419892b1563a1c6eeb49208cc
+  ExpoInsights: 98f3aeaafd8481e5c0983ce3a59ebd594f1339aa
+  ExpoKeepAwake: 783e68647b969b210a786047c3daa7b753dcac1f
   ExpoLinearGradient: 9bc3195e1aecea3e5ee91d0d739cdb47b20ba014
-  ExpoLinking: e5dce4ddb623560b00753edc4ba2ec980302af2f
+  ExpoLinking: 61a395847864e89b29786eaa11ecebd10799ed4e
   ExpoLivePhoto: e50e26d529b71b998c948db4d2d4e9f7b7b088f3
-  ExpoLocalAuthentication: 102413438d936ac1f2b9f72643f1ab60928a37b5
+  ExpoLocalAuthentication: fb519b5d39df0cc216e43fef3cc8e2db1930a01e
   ExpoLocalization: 8e37268a715b82b36fbb5e361efd5fe65a39c208
-  ExpoLocation: 3aa81e9f7efc0fda4900a9e216db812dcc7cc11f
-  ExpoMailComposer: 30fc9c04216fef55c5d5a9c622c01b8f357030fb
+  ExpoLocation: ac6a2c6605acfb9b70f765ea32d561dab51d481b
+  ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMaps: 93bc6b609c60685b591a788a20615e0921f29b40
   ExpoMediaLibrary: a85e3fcc6a85ede0ae2dae2577b8cf02d1051bbb
-  ExpoModulesCore: 19cc64a73f9a617413e700e3f3632f8dff86f555
+  ExpoModulesCore: db0f28809c964dd0cc17cd9c16cb6af681439332
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: 786e4a0f27543c9c70d595d24f59759167da854b
   ExpoPrint: a4fa04b75b2ed341916b80ec28a226c81571bcf0
@@ -3328,7 +3328,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: d4ec68b42681be3036ead40fe90689cc659ebdd8
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: 429965d990a8102f57f21a1f2c61a5ebc86f52d2
-  EXUpdates: c5dd769e44e4af3edfe25c496b068410c89383fe
+  EXUpdates: 8657eb1c34691a4298b1c1004f03bb9c2d6a385f
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   FBLazyVector: 319d66555ce769137a84559a19fb8197733a68e1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: ExpoAppDelegate {
 
     window?.makeKeyAndVisible()
   }
-  
+
   override func applicationDidBecomeActive(_ application: UIApplication) {
     super.applicationDidBecomeActive(application)
     Task {

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -36,4 +36,15 @@ class AppDelegate: ExpoAppDelegate {
 
     window?.makeKeyAndVisible()
   }
+  
+  override func applicationDidBecomeActive(_ application: UIApplication) {
+    super.applicationDidBecomeActive(application)
+    Task {
+      do {
+        try await requestLocalNetworkAuthorization()
+      } catch {
+        log.error(error)
+      }
+    }
+  }
 }

--- a/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
+++ b/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
@@ -15,7 +15,7 @@ func requestLocalNetworkAuthorization() async throws -> Bool {
   let parameters = NWParameters()
   parameters.includePeerToPeer = true
   let browser = NWBrowser(for: .bonjour(type: type, domain: nil), using: parameters)
-
+  // swiftlint:disable:next closure_body_length
   return try await withTaskCancellationHandler {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
       class LocalState {

--- a/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
+++ b/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
@@ -17,6 +17,7 @@ func requestLocalNetworkAuthorization() async throws -> Bool {
   let browser = NWBrowser(for: .bonjour(type: type, domain: nil), using: parameters)
   // swiftlint:disable:next closure_body_length
   return try await withTaskCancellationHandler {
+    // swiftlint:disable:next closure_body_length
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
       class LocalState {
         var didResume = false

--- a/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
+++ b/apps/expo-go/ios/Client/RequestLocalNetworkAccess.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Network
+import OSLog
+
+private let type = "_preflight_check._tcp"
+
+/// Code taken from https://gist.github.com/mac-cain13/fa684f54a7ae1bba8669e78d28611784
+@discardableResult 
+func requestLocalNetworkAuthorization() async throws -> Bool {
+  let queue = DispatchQueue(label: "host.exp.localNetworkAuthCheck")
+  
+  let listener = try NWListener(using: NWParameters(tls: .none, tcp: NWProtocolTCP.Options()))
+  listener.service = NWListener.Service(name: UUID().uuidString, type: type)
+  listener.newConnectionHandler = { _ in } // Must be set or else the listener will error with POSIX error 22
+  
+  let parameters = NWParameters()
+  parameters.includePeerToPeer = true
+  let browser = NWBrowser(for: .bonjour(type: type, domain: nil), using: parameters)
+  
+  return try await withTaskCancellationHandler {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
+      class LocalState {
+        var didResume = false
+      }
+      let local = LocalState()
+      @Sendable func resume(with result: Result<Bool, Error>) {
+        if local.didResume {
+          return
+        }
+        local.didResume = true
+        
+        // Teardown listener and browser
+        listener.stateUpdateHandler = { _ in }
+        browser.stateUpdateHandler = { _ in }
+        browser.browseResultsChangedHandler = { _, _ in }
+        listener.cancel()
+        browser.cancel()
+        
+        continuation.resume(with: result)
+      }
+      
+      // Do not setup listener/browser is we're already cancelled, it does work but logs a lot of very ugly errors
+      if Task.isCancelled {
+        resume(with: .failure(CancellationError()))
+        return
+      }
+      
+      listener.stateUpdateHandler = { newState in
+        switch newState {
+        case .setup:
+          return
+        case .ready:
+          return
+        case .cancelled:
+          resume(with: .failure(CancellationError()))
+        case .failed(let error):
+          resume(with: .failure(error))
+        case .waiting(let error):
+          resume(with: .failure(error))
+        @unknown default:
+          return
+        }
+      }
+      listener.start(queue: queue)
+      
+      browser.stateUpdateHandler = { newState in
+        switch newState {
+        case .setup:
+          return
+        case .ready:
+          return
+        case .cancelled:
+          resume(with: .failure(CancellationError()))
+        case .failed(let error):
+          resume(with: .failure(error))
+        case let .waiting(error):
+          switch error {
+          case .dns(DNSServiceErrorType(kDNSServiceErr_PolicyDenied)):
+            resume(with: .success(false))
+          default:
+            resume(with: .failure(error))
+          }
+        @unknown default:
+          return
+        }
+      }
+      
+      browser.browseResultsChangedHandler = { results, changes in
+        if results.isEmpty {
+          return
+        }
+        resume(with: .success(true))
+      }
+      browser.start(queue: queue)
+      
+      if Task.isCancelled {
+        resume(with: .failure(CancellationError()))
+        return
+      }
+    }
+  } onCancel: {
+    listener.cancel()
+    browser.cancel()
+  }
+}

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -2158,8 +2158,6 @@
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C8D8QTF339;
 				EX_BUNDLE_NAME = Expo;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -1283,7 +1283,9 @@
 				TargetAttributes = {
 					78CEE2BF1ACD07D70095B124 = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = C8D8QTF339;
 						LastSwiftMigration = 1150;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplePay = {
 								enabled = 0;
@@ -2154,6 +2156,8 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C8D8QTF339;
@@ -2199,7 +2203,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap\" -D RELEASE -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent;
 				PRODUCT_NAME = "Expo Go";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore host.exp.Exponent";
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		31E6D48020B845830082B09F /* EXSensorsManagerBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E6D47F20B845830082B09F /* EXSensorsManagerBinding.m */; };
 		31E8B2FD23D090E200E6C2BF /* EXClientReleaseType.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E8B2FC23D090E200E6C2BF /* EXClientReleaseType.m */; };
 		31F8E27E255F05D5005AA063 /* EXDeviceInstallationUUIDService.m in Sources */ = {isa = PBXBuildFile; fileRef = 31F8E27D255F05D5005AA063 /* EXDeviceInstallationUUIDService.m */; };
+		402B73292CC90F7100FA17BC /* RequestLocalNetworkAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */; };
 		4089335A2CAAF7A20095810E /* ExpoAppInstance.mm in Sources */ = {isa = PBXBuildFile; fileRef = 408933592CAAF7A20095810E /* ExpoAppInstance.mm */; };
 		40F867AB2CA04F0B009A7E2C /* JKBigInteger.podspec.json in Resources */ = {isa = PBXBuildFile; fileRef = 40F867A02CA04F0B009A7E2C /* JKBigInteger.podspec.json */; };
 		78CEE2D11ACD07D70095B124 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 78CEE2D01ACD07D70095B124 /* Images.xcassets */; };
@@ -243,6 +244,7 @@
 		3451876A2368FE9E008C4171 /* cp-bundle-resources-conditionally.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "cp-bundle-resources-conditionally.sh"; sourceTree = "<group>"; };
 		34656423B7AD3C99D408EF4F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Expo Go-Tests/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		39E8C61B17879D7B4A44D983 /* Pods-ExponentIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExponentIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-ExponentIntegrationTests/Pods-ExponentIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocalNetworkAccess.swift; sourceTree = "<group>"; };
 		408933582CAAF7870095810E /* ExpoAppInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpoAppInstance.h; sourceTree = "<group>"; };
 		408933592CAAF7A20095810E /* ExpoAppInstance.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExpoAppInstance.mm; sourceTree = "<group>"; };
 		40F867A02CA04F0B009A7E2C /* JKBigInteger.podspec.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = JKBigInteger.podspec.json; sourceTree = "<group>"; };
@@ -790,6 +792,7 @@
 				B2E2CCC62AA7D33E00E2260C /* HomeAppLoader.swift */,
 				B2E2CCC92AA7DAD400E2260C /* ManifestAndAssetRequestHeaders.swift */,
 				B2E2CCCF2AA7DF9C00E2260C /* HomeAppLoaderTask.swift */,
+				402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1280,9 +1283,7 @@
 				TargetAttributes = {
 					78CEE2BF1ACD07D70095B124 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = C8D8QTF339;
 						LastSwiftMigration = 1150;
-						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplePay = {
 								enabled = 0;
@@ -1829,6 +1830,7 @@
 				B5576085204A423B0041D9C8 /* EXHomeModuleManager.m in Sources */,
 				B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */,
 				31361A5A2260B2F600662769 /* EXScopedSecureStore.m in Sources */,
+				402B73292CC90F7100FA17BC /* RequestLocalNetworkAccess.swift in Sources */,
 				B5FB74F01FF6DADC001C764B /* EXScopedBridgeModule.m in Sources */,
 				31361A612261C65A00662769 /* EXPermissionsManager.m in Sources */,
 				B248B8842AD8888C003C9C10 /* UpdatesBinding.swift in Sources */,
@@ -2001,10 +2003,7 @@
 				LDPLUSPLUS = "";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -2067,10 +2066,7 @@
 				LD = "";
 				LDPLUSPLUS = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -2158,8 +2154,8 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C8D8QTF339;
 				EX_BUNDLE_NAME = Expo;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -2203,7 +2199,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap\" -D RELEASE -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent;
 				PRODUCT_NAME = "Expo Go";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore host.exp.Exponent";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/expo-go/ios/Exponent/Supporting/Info.plist
+++ b/apps/expo-go/ios/Exponent/Supporting/Info.plist
@@ -56,6 +56,10 @@
 			</array>
 		</dict>
 	</array>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_preflight_check._tcp</string>
+  </array>
 	<key>CFBundleVersion</key>
 	<string>2.32.1</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4,71 +4,71 @@ PODS:
     - CocoaLumberjack/Core (= 3.5.3)
   - CocoaLumberjack/Core (3.5.3)
   - DoubleConversion (1.1.6)
-  - EASClient (0.13.0):
+  - EASClient (0.13.1):
     - ExpoModulesCore
-  - EASClient/Tests (0.13.0):
+  - EASClient/Tests (0.13.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXApplication (6.0.0):
+  - EXApplication (6.0.1):
     - ExpoModulesCore
   - EXAV (15.0.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
-  - EXBarCodeScanner (14.0.0):
+  - EXBarCodeScanner (14.0.1):
     - EXImageLoader
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - EXConstants (17.0.0):
+  - EXConstants (17.0.1):
     - ExpoModulesCore
   - EXImageLoader (5.0.0):
     - ExpoModulesCore
     - React-Core
   - EXJSONUtils (0.14.0)
   - EXJSONUtils/Tests (0.14.0)
-  - EXManifests (0.15.0):
+  - EXManifests (0.15.1):
     - ExpoModulesCore
-  - EXManifests/Tests (0.15.0):
+  - EXManifests/Tests (0.15.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - EXNotifications (0.29.0):
     - ExpoModulesCore
-  - Expo (52.0.0-preview.0):
+  - Expo (52.0.0-preview.1):
     - ExpoModulesCore
-  - ExpoAppleAuthentication (7.0.0):
+  - ExpoAppleAuthentication (7.0.1):
     - ExpoModulesCore
   - ExpoAsset (11.0.0):
     - ExpoModulesCore
   - ExpoAudio (0.2.0):
     - ExpoModulesCore
-  - ExpoBackgroundFetch (13.0.0):
+  - ExpoBackgroundFetch (13.0.1):
     - ExpoModulesCore
-  - ExpoBattery (9.0.0):
+  - ExpoBattery (9.0.1):
     - ExpoModulesCore
-  - ExpoBlur (14.0.0):
+  - ExpoBlur (14.0.1):
     - ExpoModulesCore
-  - ExpoBrightness (13.0.0):
+  - ExpoBrightness (13.0.1):
     - ExpoModulesCore
-  - ExpoCalendar (14.0.0):
+  - ExpoCalendar (14.0.1):
     - ExpoModulesCore
   - ExpoCamera (16.0.0):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - ExpoCellular (7.0.0):
+  - ExpoCellular (7.0.1):
     - ExpoModulesCore
   - ExpoClipboard (7.0.0):
     - ExpoModulesCore
   - ExpoClipboard/Tests (7.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoContacts (14.0.0):
+  - ExpoContacts (14.0.1):
     - ExpoModulesCore
-  - ExpoCrypto (14.0.0):
+  - ExpoCrypto (14.0.1):
     - ExpoModulesCore
-  - ExpoDevice (7.0.0):
+  - ExpoDevice (7.0.1):
     - ExpoModulesCore
-  - ExpoDocumentPicker (13.0.0):
+  - ExpoDocumentPicker (13.0.1):
     - ExpoModulesCore
   - ExpoDomWebView (0.0.1):
     - ExpoModulesCore
@@ -99,13 +99,13 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-  - ExpoImageManipulator (13.0.0):
+  - ExpoImageManipulator (13.0.1):
     - EXImageLoader
     - ExpoModulesCore
     - SDWebImageWebPCoder
   - ExpoImagePicker (16.0.0):
     - ExpoModulesCore
-  - ExpoKeepAwake (14.0.0):
+  - ExpoKeepAwake (14.0.1):
     - ExpoModulesCore
   - ExpoLinearGradient (14.0.0):
     - ExpoModulesCore
@@ -113,13 +113,13 @@ PODS:
     - ExpoModulesCore
   - ExpoLivePhoto (0.0.1):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (15.0.0):
+  - ExpoLocalAuthentication (15.0.1):
     - ExpoModulesCore
   - ExpoLocalization (16.0.0):
     - ExpoModulesCore
-  - ExpoLocation (18.0.0):
+  - ExpoLocation (18.0.1):
     - ExpoModulesCore
-  - ExpoMailComposer (14.0.0):
+  - ExpoMailComposer (14.0.1):
     - ExpoModulesCore
   - ExpoMediaLibrary (17.0.0):
     - ExpoModulesCore
@@ -128,7 +128,7 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (2.0.0-preview.0):
+  - ExpoModulesCore (2.0.0-preview.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -151,7 +151,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesCore/Tests (2.0.0-preview.0):
+  - ExpoModulesCore/Tests (2.0.0-preview.1):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -261,7 +261,7 @@ PODS:
   - EXTaskManager (12.0.0):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.26.0):
+  - EXUpdates (0.26.1):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -288,7 +288,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXUpdates/Tests (0.26.0):
+  - EXUpdates/Tests (0.26.1):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -2998,31 +2998,31 @@ SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  EASClient: 7159c5f83e018efc818f460766c9a5940fbe5b80
-  EXApplication: dba7d1b232c10712c9443f07fa8d29e6d14c2939
+  EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
+  EXApplication: e1ad9c950c98b2b134578092c948b10b403f3ea7
   EXAV: 8996468e7e113e59d13c6530a0f5f54ee542439e
-  EXBarCodeScanner: 841325ad77586098203338a5af859932539ae2bc
-  EXConstants: c411a7e78e660d63445e55d0df589c0c4b07c02a
+  EXBarCodeScanner: 98bfb848dc71d57a51b8d9ab8e2cd98b95cc2ae7
+  EXConstants: c74958e9232c8c2a8d27537fc555253297ff7a3c
   EXImageLoader: 759063a65ab016b836f73972d3bb25404888713d
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
-  EXManifests: 18b49c1bf3298592516c37b7b00c36a13d6ce1d6
+  EXManifests: d2859eb09b260b4e819299782fb5e43da36e248b
   EXNotifications: cf4e8acb21fa1101bcf39433a1179eb8005413c6
-  Expo: eb3865ce59dc01d663134882a383111c0b97f570
-  ExpoAppleAuthentication: ab000e376f6821488b11cdbecca3ca04c49474d8
+  Expo: c2884243735806707b488e97bd39be1d41ae6861
+  ExpoAppleAuthentication: 59b0f5cf600284dd03b0d595c112acd067e0eb69
   ExpoAsset: 9de2f325e8c97a4c6c2bc85e507ae7f0809c91aa
   ExpoAudio: 8926a8ffff9d48460d31e177937e41348ec5f271
-  ExpoBackgroundFetch: 7508057586bcc86155d86e9c697f2af499bcf20a
-  ExpoBattery: 73368a54caf210a589638a6fb9438120f23195f9
-  ExpoBlur: 66591f1f9aec3aeb20ffaa33851d2e9a9b7f07f1
-  ExpoBrightness: b52d15f22efd59c10991ecaa2a5636a56cecc602
-  ExpoCalendar: d709c5f4e834a668ce86a782eb772b98eaf2be12
+  ExpoBackgroundFetch: 66626717d7d9266cb858b5d872b67c993975cc31
+  ExpoBattery: 71bb388c37c3bcd0e87077e06e95780ea34fa6c8
+  ExpoBlur: 562b3da84d3cd79016c411671eaf71a404266415
+  ExpoBrightness: 2afff5bb0637535d648544679fbcc222a852ddc2
+  ExpoCalendar: f43595a52437a6e1b71d1c2b1ad046d75fd9c777
   ExpoCamera: e7f3fba9e3f59d04a77f999019376b2d56d48dba
-  ExpoCellular: a6c10b82141ae95074f16231f1ca77dc2674c058
+  ExpoCellular: c7ae03fd9480e6a4296a5632c35ab00ddaea4783
   ExpoClipboard: 166ca8c13ca1041f5ba619a211f59427ab5da8a7
-  ExpoContacts: 603aa80879971c147053dac6c3771a577e39aea7
-  ExpoCrypto: 67dbd6958be9df1e6077ee1e6c7014cdee34b9ed
-  ExpoDevice: f4bff8c5150358b7f8f4e914de60977ad3e3ac21
-  ExpoDocumentPicker: a292e2cd0be7825316e7508f3770045cec8cd991
+  ExpoContacts: cd2db2a7d5b0f249785903e031f595c231b91b51
+  ExpoCrypto: 8465f71eb3798c194c0a509d4a76e5c429656d83
+  ExpoDevice: e24dd19a43065182eb246bc0e7f84186862f1e83
+  ExpoDocumentPicker: 4a89fd8a0cb90010214a416c858d7dece1c1eb10
   ExpoDomWebView: 71d9f0808dce43b9f36b45a8c091c242dfa7b372
   ExpoFileSystem: d8b51caca86749a132c8ffde46be9a175e46b819
   ExpoFont: 2fb6d98e0a5352bebcaa568d6bfbba0e0f2e0097
@@ -3030,18 +3030,18 @@ SPEC CHECKSUMS:
   ExpoHaptics: e636188d1d5f7ccb79f3c1bfab47aaf5a1768c73
   ExpoHead: 1a4ec158feefb5ea66c022ac1d612a67b680cc6f
   ExpoImage: bd04fd6e5f97d2a29284bd7113cc51d7c206d17d
-  ExpoImageManipulator: e88e86d4ff8548ef1b54054cdfb7c7b3bc5a6ee5
+  ExpoImageManipulator: bd71d33c53ec0d1bef814b3efb28b88c054a87a5
   ExpoImagePicker: 6977a8aa31e7fc21d209e9a5f0772f360f5f5f50
-  ExpoKeepAwake: 0f50926d48b0f24419892b1563a1c6eeb49208cc
+  ExpoKeepAwake: 783e68647b969b210a786047c3daa7b753dcac1f
   ExpoLinearGradient: 9bc3195e1aecea3e5ee91d0d739cdb47b20ba014
-  ExpoLinking: e5dce4ddb623560b00753edc4ba2ec980302af2f
+  ExpoLinking: 61a395847864e89b29786eaa11ecebd10799ed4e
   ExpoLivePhoto: e50e26d529b71b998c948db4d2d4e9f7b7b088f3
-  ExpoLocalAuthentication: 102413438d936ac1f2b9f72643f1ab60928a37b5
+  ExpoLocalAuthentication: fb519b5d39df0cc216e43fef3cc8e2db1930a01e
   ExpoLocalization: 8e37268a715b82b36fbb5e361efd5fe65a39c208
-  ExpoLocation: 3aa81e9f7efc0fda4900a9e216db812dcc7cc11f
-  ExpoMailComposer: 30fc9c04216fef55c5d5a9c622c01b8f357030fb
+  ExpoLocation: ac6a2c6605acfb9b70f765ea32d561dab51d481b
+  ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMediaLibrary: a85e3fcc6a85ede0ae2dae2577b8cf02d1051bbb
-  ExpoModulesCore: 19cc64a73f9a617413e700e3f3632f8dff86f555
+  ExpoModulesCore: db0f28809c964dd0cc17cd9c16cb6af681439332
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: 786e4a0f27543c9c70d595d24f59759167da854b
   ExpoPrint: a4fa04b75b2ed341916b80ec28a226c81571bcf0
@@ -3063,7 +3063,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: d4ec68b42681be3036ead40fe90689cc659ebdd8
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: 429965d990a8102f57f21a1f2c61a5ebc86f52d2
-  EXUpdates: b233f7f9b7695de860546da0749879fa637a5435
+  EXUpdates: 306820493aab4bd1bb5e7edb7512f66bb1ebbf21
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   FBLazyVector: 319d66555ce769137a84559a19fb8197733a68e1
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e


### PR DESCRIPTION
# Why
We need a way to trigger the local network permission dialog on iOS before a user attempts to load an app. It is requested when we attempt to connect to the dev server socket but this is too late as RN does not wait for the result and will hard crash when it can't connect. 

# How
I found a reliable method [here](https://gist.github.com/mac-cain13/fa684f54a7ae1bba8669e78d28611784) that will also give us the result of the request. We need to update the plist to add bonjour but I don't believe this requires any explanation to apple. We can make further enhancements where we do this before attempting to load any app and can provide appropriate messaging if the permission is denied. For now, we trigger the dialog once the app becomes active. 

# Test Plan
Expo go. A fresh install will request the permission on launch. Subsequent launches do nothing. 
