### PR TITLE
fix(cli): Add fallback method for determining internal IP

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add fallback method for determining internal IP address.
+
 ### 💡 Others
 
 ## 0.19.0 — 2024-10-22

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add fallback method for determining internal IP address.
+- Add fallback method for determining internal IP address. ([#32273](https://github.com/expo/expo/pull/32273) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,6 +1,7 @@
 import { isIPv4 } from 'node:net';
 import { spawnSync } from 'node:child_process';
 import { networkInterfaces } from 'node:os';
+import { dirname, basename } from 'node:path';
 import internalIp from 'internal-ip';
 
 /** Gets a route address by opening a UDP socket to a publicly routed address.
@@ -10,7 +11,8 @@ import internalIp from 'internal-ip';
   * ports don't send a message when opened.
   */
 function getRouteAddress(): string | null {
-  const { error, status, stdout } = spawnSync(process.execPath, ['-'], {
+  const command = basename(process.execPath);
+  const { error, status, stdout } = spawnSync(command, ['-'], {
     // This should be the cheapest method to determine the default route
     // By opening a socket to a publicly routed IP address, we let the default
     // gateway handle this socket, which means the socket's address will be
@@ -30,6 +32,8 @@ function getRouteAddress(): string | null {
         }
       });
     `,
+    cwd: dirname(process.execPath),
+    shell: false,
     timeout: 500,
     encoding: 'utf8',
     windowsVerbatimArguments: true,

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -52,7 +52,7 @@ function getRouteAddress(): string | null {
 /** Determines the internal IP address by opening a socket, then checking the socket address against non-internal network interface assignments
   * @throws If no address can be determined.
   */
-function getIPAddress(): string | null {
+function getRouteIPAddress(): string | null {
   // We check the IP address we get against the available network interfaces
   // It's only an internal IP address if we have a matching address on an interface's IP assignment
   const routeAddress = getRouteAddress();
@@ -73,5 +73,5 @@ function getIPAddress(): string | null {
 }
 
 export function getIpAddress(): string {
-  return internalIp.v4.sync() || getIPAddress() || '127.0.0.1';
+  return internalIp.v4.sync() || getRouteIPAddress() || '127.0.0.1';
 }

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -11,7 +11,7 @@ import internalIp from 'internal-ip';
   * ports don't send a message when opened.
   */
 function getRouteAddress(): string | null {
-  const command = basename(process.execPath);
+  const command = process.platform === 'win32' ? basename(process.execPath) : process.execPath;
   const { error, status, stdout } = spawnSync(command, ['-'], {
     // This should be the cheapest method to determine the default route
     // By opening a socket to a publicly routed IP address, we let the default

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -9,6 +9,7 @@ import { dirname, basename } from 'node:path';
  * This is wrapped in `spawnSync` since the original `getIpAddress` utility exported
  * in this module is used synchronosly. An appropriate timeout has been set and UDP
  * ports don't send a message when opened.
+ * @throws if `spawnSync` fails
  */
 function getRouteAddress(): string | null {
   const command = process.platform === 'win32' ? basename(process.execPath) : process.execPath;
@@ -55,7 +56,10 @@ function getRouteAddress(): string | null {
 function getRouteIPAddress(): string | null {
   // We check the IP address we get against the available network interfaces
   // It's only an internal IP address if we have a matching address on an interface's IP assignment
-  const routeAddress = getRouteAddress();
+  let routeAddress: string | null = null;
+  try {
+    routeAddress = getRouteAddress();
+  } catch {}
   if (!routeAddress) {
     return null;
   }

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -2,7 +2,6 @@ import internalIp from 'internal-ip';
 import { spawnSync } from 'node:child_process';
 import { isIPv4 } from 'node:net';
 import { networkInterfaces } from 'node:os';
-import { dirname, basename } from 'node:path';
 
 /** Gets a route address by opening a UDP socket to a publicly routed address.
  * @privateRemarks
@@ -12,8 +11,7 @@ import { dirname, basename } from 'node:path';
  * @throws if `spawnSync` fails
  */
 function getRouteAddress(): string | null {
-  const command = process.platform === 'win32' ? basename(process.execPath) : process.execPath;
-  const { error, status, stdout } = spawnSync(command, ['-'], {
+  const { error, status, stdout } = spawnSync(process.execPath, ['-'], {
     // This should be the cheapest method to determine the default route
     // By opening a socket to a publicly routed IP address, we let the default
     // gateway handle this socket, which means the socket's address will be
@@ -33,11 +31,10 @@ function getRouteAddress(): string | null {
         }
       });
     `,
-    cwd: dirname(process.execPath),
     shell: false,
     timeout: 500,
     encoding: 'utf8',
-    windowsVerbatimArguments: true,
+    windowsVerbatimArguments: false,
     windowsHide: true,
   });
   // We only use the stdout as an IP, if it validates as an IP and we got a zero exit code

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,5 +1,77 @@
+import { isIPv4 } from 'node:net';
+import { spawnSync } from 'node:child_process';
+import { networkInterfaces } from 'node:os';
 import internalIp from 'internal-ip';
 
+/** Gets a route address by opening a UDP socket to a publicly routed address.
+  * @privateRemarks
+  * This is wrapped in `spawnSync` since the original `getIpAddress` utility exported
+  * in this module is used synchronosly. An appropriate timeout has been set and UDP
+  * ports don't send a message when opened.
+  * @throws If no address can be determined.
+  */
+function getRouteAddress(): string {
+  const { status, stdout, stderr } = spawnSync(process.execPath, ['-'], {
+    // This should be the cheapest method to determine the default route
+    // By opening a socket to a publicly routed IP address, we let the default
+    // gateway handle this socket, which means the socket's address will be
+    // the prioritised route for public IP addresses.
+    // It might fall back to `"0.0.0.0"` when no network connection is established
+    input: `
+      var socket = require('dgram').createSocket({ type: 'udp4', reuseAddr: true });
+      socket.unref();
+      socket.connect(53, '1.1.1.1', function() {
+        var address = socket.address();
+        socket.close();
+        if (address && 'address' in address) {
+          process.stdout.write(address.address);
+          process.exit(0);
+        } else {
+          process.exit(1);
+        }
+      });
+    `,
+    timeout: 500,
+    encoding: 'utf8',
+    windowsVerbatimArguments: true,
+    windowsHide: true,
+  });
+  // We only use the stdout as an IP, if it validates as an IP and we got a zero exit code
+  if (status && stderr) {
+    throw new Error(stderr);
+  } else if (!status && typeof stdout === 'string' && isIPv4(stdout.trim())) {
+    return stdout.trim();
+  } else {
+    throw new Error('No route address could be determined');
+  }
+}
+
+/** Determines the internal IP address by opening a socket, then checking the socket address against non-internal network interface assignments
+  * @throws If no address can be determined.
+  */
+function getIPAddress(): string | null {
+  // We check the IP address we get against the available network interfaces
+  // It's only an internal IP address if we have a matching address on an interface's IP assignment
+  const routeAddress = getRouteAddress();
+  const ifaces = networkInterfaces();
+  for (const iface in ifaces) {
+    const assignments = ifaces[iface];
+    for (let i = 0; assignments && i < assignments.length; i++) {
+      const assignment = assignments[i];
+      // Only use IPv4 assigments that aren't internal
+      if (assignment.family === 'IPv4' && !assignment.internal && assignment.address === routeAddress)
+        return routeAddress;
+    }
+  }
+  return null;
+}
+
+const FALLBACK_INTERNAL_IP = '127.0.0.1';
+
 export function getIpAddress(): string {
-  return internalIp.v4.sync() || '127.0.0.1';
+  try {
+    return internalIp.v4.sync() || getIPAddress() || FALLBACK_INTERNAL_IP;
+  } catch (_error) {
+    return FALLBACK_INTERNAL_IP;
+  }
 }

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,15 +1,15 @@
-import { isIPv4 } from 'node:net';
+import internalIp from 'internal-ip';
 import { spawnSync } from 'node:child_process';
+import { isIPv4 } from 'node:net';
 import { networkInterfaces } from 'node:os';
 import { dirname, basename } from 'node:path';
-import internalIp from 'internal-ip';
 
 /** Gets a route address by opening a UDP socket to a publicly routed address.
-  * @privateRemarks
-  * This is wrapped in `spawnSync` since the original `getIpAddress` utility exported
-  * in this module is used synchronosly. An appropriate timeout has been set and UDP
-  * ports don't send a message when opened.
-  */
+ * @privateRemarks
+ * This is wrapped in `spawnSync` since the original `getIpAddress` utility exported
+ * in this module is used synchronosly. An appropriate timeout has been set and UDP
+ * ports don't send a message when opened.
+ */
 function getRouteAddress(): string | null {
   const command = process.platform === 'win32' ? basename(process.execPath) : process.execPath;
   const { error, status, stdout } = spawnSync(command, ['-'], {
@@ -50,8 +50,8 @@ function getRouteAddress(): string | null {
 }
 
 /** Determines the internal IP address by opening a socket, then checking the socket address against non-internal network interface assignments
-  * @throws If no address can be determined.
-  */
+ * @throws If no address can be determined.
+ */
 function getRouteIPAddress(): string | null {
   // We check the IP address we get against the available network interfaces
   // It's only an internal IP address if we have a matching address on an interface's IP assignment
@@ -65,7 +65,11 @@ function getRouteIPAddress(): string | null {
     for (let i = 0; assignments && i < assignments.length; i++) {
       const assignment = assignments[i];
       // Only use IPv4 assigments that aren't internal
-      if (assignment.family === 'IPv4' && !assignment.internal && assignment.address === routeAddress)
+      if (
+        assignment.family === 'IPv4' &&
+        !assignment.internal &&
+        assignment.address === routeAddress
+      )
         return routeAddress;
     }
   }


### PR DESCRIPTION
# Why

The `default-gateway` package that `internal-ip` relies on is going out of maintenance and has rejected an issue to fix getting the gateway on Windows, which it usually does using the `wmic` command. The `default-gateway` package basically maintains a large set of commands it relies on to get the default gateway per platform.
However, Windows won't always come with the `wmic` command since Windows 10, and this method of determining the IP via the default gateway will hence fail.

Instead of relying only on `internal-ip` & `default-gateway`, we can implement an alternative approach to resolve the default IP.

Resolves #24759

# How

By opening a socket to a publicly routed IP address (i.e. WAN), we can determine the local IP address that's bound to that socket. (Basically, `getsockname` on Unix systems). This is guaranteed to use the system's default gateway.

To workaround the issue that opening a TCP socket incurs a potential delay while a connection is established, we may instead use a UDP socket, which shouldn't send any packets to open the socket.

Lastly, we're wrapping this in a Node child process via `spawnSync` to maintain the current synchronous behaviour that we're relying on.

To avoid any issues:
- the timeout of the child process is set to `500ms`
- we check the output with `net.isIPv4` and carefully reject any abnormal results and process exits
- we check the socket's IP address against non-internal assignments in `os.networkInterfaces()`

**This method will currently only be used as a fallback method**

# Test Plan

Tested in isolation by running `getRouteIPAddress` with Node directly (this was tested both online and offline):
- Manually tested on Windows (Node.js 20, on Windows 11)
- Manually tested on macOS (Node.js 22, aarch64)
- Manually tested on Linux (Node.js 20 & 22, x86)

Tested with full `@expo/cli` by copying the new `build/src/utils/ip.js` build file into a local installation of `@expo/cli`, commenting out `internalIp.v4.sync()`, and running `expo start`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
