### PR TITLE
chore(@expo/config): Bump `sucrase@3.34.0` to `sucrase@3.35.0`

### DIFF
--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `sucrase@3.34.0` to `sucrase@0.35.0` to to remove transitive dependency on `glob@7`
+
 ## 10.0.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Bump `sucrase@3.34.0` to `sucrase@0.35.0` to to remove transitive dependency on `glob@7` ([#32274](https://github.com/expo/expo/pull/32274) by [@kitten](https://github.com/kitten))
+- Bump `sucrase@3.34.0` to `sucrase@3.35.0` to to remove transitive dependency on `glob@7` ([#32274](https://github.com/expo/expo/pull/32274) by [@kitten](https://github.com/kitten))
 
 ## 10.0.0 — 2024-10-22
 

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Bump `sucrase@3.34.0` to `sucrase@0.35.0` to to remove transitive dependency on `glob@7`
+- Bump `sucrase@3.34.0` to `sucrase@0.35.0` to to remove transitive dependency on `glob@7` ([#32274](https://github.com/expo/expo/pull/32274) by [@kitten](https://github.com/kitten))
 
 ## 10.0.0 — 2024-10-22
 

--- a/packages/@expo/config/package.json
+++ b/packages/@expo/config/package.json
@@ -45,7 +45,7 @@
     "resolve-workspace-root": "^2.0.0",
     "semver": "^7.6.0",
     "slugify": "^1.3.4",
-    "sucrase": "3.34.0"
+    "sucrase": "3.35.0"
   },
   "devDependencies": {
     "@types/require-from-string": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15270,14 +15270,14 @@ styleq@^0.1.3:
   resolved "https://registry.yarnpkg.com/styleq/-/styleq-0.1.3.tgz#8efb2892debd51ce7b31dc09c227ad920decab71"
   integrity sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==
 
-sucrase@3.34.0, sucrase@^3.32.0:
-  version "3.34.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.34.0.tgz#1e0e2d8fcf07f8b9c3569067d92fbd8690fb576f"
-  integrity sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==
+sucrase@3.35.0, sucrase@^3.32.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.35.0.tgz#57f17a3d7e19b36d8995f06679d121be914ae263"
+  integrity sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"
     commander "^4.0.0"
-    glob "7.1.6"
+    glob "^10.3.10"
     lines-and-columns "^1.1.6"
     mz "^2.7.0"
     pirates "^4.0.1"


### PR DESCRIPTION
# Why

`sucrase@3.35.0` is a security upgrade with the only change bumping from `glob@^7` to `glob@^10`. This was causing a remaining dependency warning for us.

# How

The impact of this change should be minimal, see: https://github.com/alangpierce/sucrase/blob/61c05e1e6f29c906c432da57c91ab44660196c8d/CHANGELOG.md#3350-2023-12-21

# Test Plan

- Manually verified that upgrading `sucrase` in a local installation still works as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
