### PR TITLE
[audio] Add audio config plugin

### DIFF
--- a/packages/expo-audio/app.plugin.js
+++ b/packages/expo-audio/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withAudio');

--- a/packages/expo-audio/plugin/build/withAudio.d.ts
+++ b/packages/expo-audio/plugin/build/withAudio.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+declare const _default: ConfigPlugin<void | {
+    microphonePermission?: string | false | undefined;
+}>;
+export default _default;

--- a/packages/expo-audio/plugin/build/withAudio.js
+++ b/packages/expo-audio/plugin/build/withAudio.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const pkg = require('expo-audio/package.json');
+const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
+const withAudio = (config, { microphonePermission } = {}) => {
+    config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
+        NSMicrophoneUsageDescription: MICROPHONE_USAGE,
+    })(config, {
+        NSMicrophoneUsageDescription: microphonePermission,
+    });
+    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        microphonePermission !== false && 'android.permission.RECORD_AUDIO',
+        'android.permission.MODIFY_AUDIO_SETTINGS',
+    ].filter(Boolean));
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withAudio, pkg.name, pkg.version);

--- a/packages/expo-audio/plugin/src/withAudio.ts
+++ b/packages/expo-audio/plugin/src/withAudio.ts
@@ -1,0 +1,26 @@
+import { AndroidConfig, ConfigPlugin, IOSConfig, createRunOncePlugin } from 'expo/config-plugins';
+
+const pkg = require('expo-audio/package.json');
+
+const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
+
+const withAudio: ConfigPlugin<{ microphonePermission?: string | false } | void> = (
+  config,
+  { microphonePermission } = {}
+) => {
+  IOSConfig.Permissions.createPermissionsPlugin({
+    NSMicrophoneUsageDescription: MICROPHONE_USAGE,
+  })(config, {
+    NSMicrophoneUsageDescription: microphonePermission,
+  });
+
+  return AndroidConfig.Permissions.withPermissions(
+    config,
+    [
+      microphonePermission !== false && 'android.permission.RECORD_AUDIO',
+      'android.permission.MODIFY_AUDIO_SETTINGS',
+    ].filter(Boolean) as string[]
+  );
+};
+
+export default createRunOncePlugin(withAudio, pkg.name, pkg.version);

--- a/packages/expo-audio/plugin/tsconfig.json
+++ b/packages/expo-audio/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why
Audio needs a plugin to add microphone permissions to the app

# How
It's the same plugin as the one used in AV. Just renamed

# Test Plan
Sandbox app