### PR TITLE
[docs] refactor code and appearance of Tabs component

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -7,9 +7,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
-
-<TabsGroup>
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 [ESLint](https://eslint.org/) is a JavaScript linter that helps you find and fix errors in your code. It's a great tool to help you write better code and catch mistakes before they make it to production. In conjunction, you can use [Prettier](https://prettier.io/docs/en/), a code formatter that ensures all the code files follow a consistent styling.
 
@@ -250,5 +248,3 @@ To use `npx expo lint` command to lint your code, update the `lint` script in yo
 Now you can run `npx expo lint` to lint your code.
 
 </Step>
-
-</TabsGroup>

--- a/docs/ui/components/Tabs/TabButton.tsx
+++ b/docs/ui/components/Tabs/TabButton.tsx
@@ -1,35 +1,78 @@
-import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
-import { Tab as ReachTab, TabProps } from '@reach/tabs';
+import { mergeClasses } from '@expo/styleguide';
+import { Tab as ReachTab } from '@reach/tabs';
+import { motion, useReducedMotion } from 'framer-motion';
+import * as React from 'react';
+import { ComponentType, ReactElement } from 'react';
 
-type Props = TabProps & {
-  selected?: boolean;
+import { P } from '../Text';
+
+import { TextComponentProps } from '~/ui/components/Text/types';
+
+export type TabProps = {
+  label: string;
+  active: boolean;
+  href?: string;
+  icon?: ReactElement;
+  disabled?: boolean;
+  className?: string;
+  layoutId?: string;
+  rightSlot?: ReactElement;
+  theme?: 'default' | 'secondary';
+  LabelElement?: ComponentType<TextComponentProps>;
 };
 
-export const TabButton = ({ selected, ...props }: Props) => (
-  <ReachTab
-    {...props}
-    css={tabButtonStyles}
-    style={{
-      borderBottomColor: selected ? theme.palette.blue9 : 'transparent',
-      color: selected ? theme.text.default : theme.text.secondary,
-    }}
-  />
-);
+export function TabButton({
+  label,
+  active,
+  disabled,
+  icon,
+  className,
+  rightSlot,
+  layoutId,
+  theme = 'secondary',
+  LabelElement = P,
+}: TabProps) {
+  const shouldReduceMotion = useReducedMotion();
 
-const tabButtonStyles = css({
-  ...typography.fontSizes[15],
-  fontWeight: 500,
-  transition: 'all 0.05s ease 0s',
-  padding: `${spacing[2.5]}px ${spacing[6]}px ${spacing[2] - 1}px`,
-  border: 0,
-  borderBottom: '0.2rem solid transparent',
-  borderRight: `1px solid ${theme.border.default}`,
-  backgroundColor: 'transparent',
-  cursor: 'pointer',
-
-  '&:hover': {
-    backgroundColor: theme.background.subtle,
-  },
-});
+  return (
+    <div className="relative">
+      {active && (
+        <motion.div
+          layoutId={`active-indicator-${layoutId}`}
+          transition={{
+            ease: 'linear',
+            duration: shouldReduceMotion ? 0 : 0.2,
+          }}
+          className={mergeClasses(
+            'absolute inset-0 rounded-md border',
+            theme === 'default' && 'border-secondary bg-screen dark:bg-hover dark:drop-shadow-none',
+            theme === 'secondary' && 'border-button-secondary bg-default shadow-xs dark:bg-subtle'
+          )}
+        />
+      )}
+      <ReachTab
+        disabled={disabled}
+        className={mergeClasses(
+          'relative z-10 rounded-md transition-colors',
+          !active && theme === 'default' && 'hocus:bg-selected dark:hocus:bg-element',
+          !active && theme === 'secondary' && 'hocus:bg-element dark:hocus:bg-subtle',
+          className
+        )}>
+        <div
+          className={mergeClasses(
+            'flex items-center gap-2 px-4 py-1.5',
+            rightSlot && 'w-full justify-between'
+          )}>
+          {icon}
+          <LabelElement
+            theme={active ? 'default' : 'tertiary'}
+            weight="medium"
+            className="transition-colors max-md-gutters:text-sm max-sm-gutters:text-xs">
+            {label}
+          </LabelElement>
+          {rightSlot}
+        </div>
+      </ReachTab>
+    </div>
+  );
+}

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -1,39 +1,31 @@
-import { css } from '@emotion/react';
-import { shadows, theme } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import { TabList, TabPanels, Tabs as ReachTabs, TabsProps } from '@reach/tabs';
-import * as React from 'react';
+import {
+  Children,
+  PropsWithChildren,
+  isValidElement,
+  useState,
+  useContext,
+  ReactNode,
+  useMemo,
+} from 'react';
 
 import { TabButton } from './TabButton';
+import { SharedTabsContext } from './TabsGroup';
 
-type Props = React.PropsWithChildren<TabsProps> & {
+type Props = PropsWithChildren<TabsProps> & {
   tabs: string[];
 };
 
-const generateTabLabels = (children: React.ReactNode) => {
-  return React.Children.map(children, child =>
-    React.isValidElement(child) ? child?.props?.label : child || '[untitled]'
+const generateTabLabels = (children: ReactNode) => {
+  return Children.map(children, child =>
+    isValidElement(child) ? child?.props?.label : child || '[untitled]'
   );
 };
 
-const SharedTabsContext = React.createContext<{
-  index: number;
-  setIndex: (index: number) => void;
-} | null>(null);
-
-/**
- * Wraps a group of tabs to share the same state. Useful for guides where one aspect of the guide is broken up into multiple tabs, e.g. Yarn vs NPM.
- */
-export function TabsGroup({ children }: { children: React.ReactNode }) {
-  const [index, setIndex] = React.useState(0);
-  return (
-    <SharedTabsContext.Provider value={{ index, setIndex }}>{children}</SharedTabsContext.Provider>
-  );
-}
-
 export const Tabs = (props: Props) => {
-  const context = React.useContext(SharedTabsContext);
-  const [tabIndex, setTabIndex] = React.useState(0);
+  const context = useContext(SharedTabsContext);
+  const [tabIndex, setTabIndex] = useState(0);
 
   if (context) {
     return <InnerTabs {...props} {...context} />;
@@ -48,43 +40,31 @@ const InnerTabs = ({
   index: tabIndex,
   setIndex,
 }: Props & { index: number; setIndex: (index: number) => void }) => {
-  const tabTitles = tabs || generateTabLabels(children);
+  const tabTitles = tabs ?? generateTabLabels(children);
+
+  const layoutId = useMemo(
+    () => tabTitles.reduce((acc, tab) => acc + tab, `${Math.random().toString(36).substring(5)}-`),
+    []
+  );
 
   return (
-    <ReachTabs index={tabIndex} onChange={setIndex} css={tabsWrapperStyle}>
-      <TabList css={tabsListStyle}>
+    <ReachTabs
+      index={tabIndex}
+      onChange={setIndex}
+      className="border border-default rounded-md shadow-xs my-4">
+      <TabList className="flex px-4 py-3 gap-1 flex-wrap border-b border-secondary">
         {tabTitles.map((title, index) => (
-          <TabButton key={index} selected={index === tabIndex}>
-            {title}
-          </TabButton>
+          <TabButton key={index} active={index === tabIndex} label={title} layoutId={layoutId} />
         ))}
       </TabList>
-      <TabPanels css={tabsPanelStyle} className="last:[&>div>*]:!mb-0">
+      <TabPanels
+        className={mergeClasses(
+          'py-4 px-5',
+          '[&_ul]:mb-3 [&_pre]:first-of-type:mt-1',
+          'last:[&>div>*]:!mb-0'
+        )}>
         {children}
       </TabPanels>
     </ReachTabs>
   );
 };
-
-const tabsWrapperStyle = css({
-  border: `1px solid ${theme.border.default}`,
-  borderRadius: borderRadius.sm,
-  boxShadow: shadows.xs,
-  margin: `${spacing[4]}px 0`,
-});
-
-const tabsPanelStyle = css({
-  padding: `${spacing[4]}px ${spacing[5]}px`,
-
-  'pre:first-of-type': {
-    marginTop: spacing[1],
-  },
-
-  ul: {
-    marginBottom: spacing[3],
-  },
-});
-
-const tabsListStyle = css({
-  borderBottom: `1px solid ${theme.border.default}`,
-});

--- a/docs/ui/components/Tabs/TabsGroup.tsx
+++ b/docs/ui/components/Tabs/TabsGroup.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren, createContext, useState } from 'react';
+
+export const SharedTabsContext = createContext<{
+  index: number;
+  setIndex: (index: number) => void;
+} | null>(null);
+
+/**
+ * Wraps a group of tabs to share the same state. Useful for guides where one aspect of the guide is broken up into multiple tabs, e.g. Yarn vs NPM.
+ */
+export function TabsGroup({ children }: PropsWithChildren) {
+  const [index, setIndex] = useState(0);
+  return (
+    <SharedTabsContext.Provider value={{ index, setIndex }}>{children}</SharedTabsContext.Provider>
+  );
+}

--- a/docs/ui/components/Tabs/index.ts
+++ b/docs/ui/components/Tabs/index.ts
@@ -1,2 +1,3 @@
 export * from './Tab';
 export * from './Tabs';
+export * from './TabsGroup';


### PR DESCRIPTION
# Why

Replace Emotion code in Tabs, align appearance with Expo dashboard component.

# How

Replace the Tabs appearance code based on the component used in the dashboard, apply tweaks related to docs use-case. 

Additionally I have rearranged the component code a bit, and fixed one usage.

> [!note]
> `default` theme is not used, but I have retained it in the code, so future extraction to the Styleguide packages should be easier, due to less difference of component variants.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

https://github.com/user-attachments/assets/8040c037-1515-4976-b590-c1652663d5a1

https://github.com/user-attachments/assets/1c1bfd62-b27c-4b38-9543-52b1212b6f70
