### PR TITLE
[docs] focus related fixes, Collapsible mobile tweak

### DIFF
--- a/docs/global-styles/global.css
+++ b/docs/global-styles/global.css
@@ -31,7 +31,7 @@ input {
 }
 
 *:focus-visible {
-  outline: 3px solid var(--expo-theme-icon-tertiary);
+  outline: 3px solid var(--expo-theme-icon-info);
   outline-offset: 1px;
   border-radius: 3px;
 }

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -70,11 +70,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Name of your app.
       </p>
       <details
-        class="overflow-hidden bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
         id="bare-workflow"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
         >
           <div
             class="mt-[5px] ml-1.5 mr-2 self-baseline"
@@ -98,17 +98,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
+            class="inline ml-auto"
             href="#bare-workflow"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -131,6 +132,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               />
             </svg>
           </a>
+          <div />
         </summary>
         <div
           class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
@@ -211,11 +213,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="overflow-hidden bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
         id="expokit"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
         >
           <div
             class="mt-[5px] ml-1.5 mr-2 self-baseline"
@@ -239,17 +241,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             ExpoKit
           </span>
           <a
+            class="inline ml-auto"
             href="#expokit"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -272,6 +275,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               />
             </svg>
           </a>
+          <div />
         </summary>
         <div
           class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
@@ -285,11 +289,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <details
-        class="overflow-hidden bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
         id="bare-workflow-1"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
         >
           <div
             class="mt-[5px] ml-1.5 mr-2 self-baseline"
@@ -313,17 +317,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
+            class="inline ml-auto"
             href="#bare-workflow-1"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -346,6 +351,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               />
             </svg>
           </a>
+          <div />
         </summary>
         <div
           class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
@@ -434,11 +440,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="overflow-hidden bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+          class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
           id="expokit-1"
         >
           <summary
-            class="group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+            class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
           >
             <div
               class="mt-[5px] ml-1.5 mr-2 self-baseline"
@@ -462,17 +468,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="text-default leading-[1.6154] font-medium inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
               data-text="true"
             >
               ExpoKit
             </span>
             <a
+              class="inline ml-auto"
               href="#expokit-1"
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
+                class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -495,6 +502,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 />
               </svg>
             </a>
+            <div />
           </summary>
           <div
             class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
@@ -742,11 +750,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="overflow-hidden bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
         id="bare-workflow-2"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
         >
           <div
             class="mt-[5px] ml-1.5 mr-2 self-baseline"
@@ -770,17 +778,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
+            class="inline ml-auto"
             href="#bare-workflow-2"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -803,6 +812,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               />
             </svg>
           </a>
+          <div />
         </summary>
         <div
           class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -76,7 +76,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
       <details
         id={heading.current.slug}
         className={mergeClasses(
-          'overflow-hidden bg-default border border-default rounded-md p-0 mb-3',
+          'bg-default border border-default rounded-md p-0 mb-3',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3',
           className
@@ -85,7 +85,8 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
         data-testid={testID}>
         <summary
           className={mergeClasses(
-            'group grid grid-cols-[min-content_auto_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 cursor-pointer',
+            'group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer',
+            isOpen && 'rounded-b-none',
             '[&_h4]:my-0',
             '[&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px'
           )}
@@ -101,14 +102,18 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           </div>
           <DEMI
             className={mergeClasses(
-              'inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative',
+              'inline gap-1.5 items-center scroll-m-5 mr-2 relative',
               'group-hover:text-secondary group-hover:[&_code]:text-secondary'
             )}>
             {summary}
           </DEMI>
-          <LinkBase href={'#' + heading.current.slug} ref={heading.current.ref}>
-            <PermalinkIcon className="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible" />
+          <LinkBase
+            href={'#' + heading.current.slug}
+            ref={heading.current.ref}
+            className="inline ml-auto">
+            <PermalinkIcon className="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible" />
           </LinkBase>
+          <div />
         </summary>
         <div className={mergeClasses('py-4 px-5', '[&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1')}>
           {children}


### PR DESCRIPTION
# Why

Follow up to the latest changes related to Emotion styling refactors.

# How

Correct the focus state color, improve focus handling in Collapsibles, fix Collapsibles layout breaking on mobile.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-10-23 at 19 17 24](https://github.com/user-attachments/assets/b158afc6-40db-4b93-bcf5-db0e726c1796)

![Screenshot 2024-10-23 at 19 19 55](https://github.com/user-attachments/assets/4f3a3c43-aa07-4d8e-8185-f0fe5811d9a8)

![Screenshot 2024-10-23 at 19 22 35](https://github.com/user-attachments/assets/8c4c3f0a-6ea8-439f-9eab-af6470e753ff)


