### PR TITLE
[expo-updates][e2e] Revert erroneous e2e jest focus

### DIFF
--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -540,7 +540,7 @@ describe('JS API tests', () => {
     Server.stop();
   });
 
-  fit('downloads and runs update with JS API', async () => {
+  it('downloads and runs update with JS API', async () => {
     const bundleFilename = 'bundle1.js';
     const newNotifyString = 'test-update-1';
     const hash = await Update.copyBundleToStaticFolder(


### PR DESCRIPTION
# Why

Accidentally committed this while trying to debug a particular test. In a follow-up, I'll add a lint to disallow committing this.

# How

Revert change on line.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
