### PR TITLE
[docs] Rename and fix the order of Video APIs in the sidebar

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -711,7 +711,8 @@ function pagesFromDir(dir) {
   return fs
     .readdirSync(path.resolve(PAGES_DIR, dir), { withFileTypes: true })
     .filter(entity => entity.isFile())
-    .map(file => makePage(path.join(dir, file.name)));
+    .map(file => makePage(path.join(dir, file.name)))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Video
+title: Video (expo-video)
 description: A library that provides an API to implement video playback in apps.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video'
 packageName: 'expo-video'

--- a/docs/pages/versions/v51.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Video
+title: Video (expo-video)
 description: A library that provides an API to implement video playback in apps.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-video'
 packageName: 'expo-video'


### PR DESCRIPTION
# Why

It's been a bit confusing that we have two pages for `Video` component and:
- only one has `(expo-av)` suffix
- there is `VideoThumbnails` in between them
🤔 

# How

- Added `(expo-video)` to the new docs page for `expo-video`
- Sorted pages in the sidebar by their name instead of the file name

# Test Plan

Before:
<img width="192" alt="Screenshot 2024-10-23 at 20 38 59" src="https://github.com/user-attachments/assets/0fb5bd74-ac61-450a-bd0c-0efc4ea731d0">

After:
<img width="192" alt="Screenshot 2024-10-23 at 20 38 07" src="https://github.com/user-attachments/assets/a0d422c3-5bf0-45e3-8420-0c66fd712079">
