### PR TITLE
[expo-modules-core][android] Fix enum implementation of OnStartObserving/OnStopObserving

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [android] Add enum event support to OnStartObserving and OnStopObserving ([#32251](https://github.com/expo/expo/pull/32251) by [@wschurman](https://github.com/wschurman))
+- [android] Add enum event support to OnStartObserving and OnStopObserving. ([#32251](https://github.com/expo/expo/pull/32251), [#32287](https://github.com/expo/expo/pull/32287) by [@wschurman](https://github.com/wschurman))
 
 ## 2.0.0-preview.1 — 2024-10-22
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -511,7 +511,7 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after all event listeners are removed for given event.
    */
   fun <T> OnStopObserving(enum: T, body: () -> Unit) where T : Enumerable, T : Enum<T> {
-    OnStartObserving(convertEnumToString(enum), body)
+    OnStopObserving(convertEnumToString(enum), body)
   }
 
   /**


### PR DESCRIPTION
# Why

The flakiness of the updates e2e tests gave me false confidence that https://app.graphite.dev/github/pr/expo/expo/32251/core-android-Add-enum-event-support-to-OnStartObserving-and-OnStopObserving was working, but in reality there was a typo.

# How

Fix typo.

# Test Plan

Run the updates e2e locally (the only library that currently uses this feature) and ensure events are successfully working.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
