### PR TITLE
[core] fix retain cycle for ExpoRequestCdpInterceptor

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix optionals conversion. ([#32239](https://github.com/expo/expo/pull/32239) by [@aleqsio](https://github.com/aleqsio))
+- Fixed retain cycle for `ExpoRequestCdpInterceptor`. ([#32289](https://github.com/expo/expo/pull/32289) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptor.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
+import java.lang.ref.WeakReference
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -22,18 +23,18 @@ import java.math.RoundingMode
  * dispatch CDP (Chrome DevTools Protocol: https://chromedevtools.github.io/devtools-protocol/) events.
  */
 object ExpoRequestCdpInterceptor : ExpoNetworkInspectOkHttpInterceptorsDelegate {
-  private var delegate: Delegate? = null
+  private var delegate: WeakReference<Delegate?> = WeakReference(null)
   internal var coroutineScope = CoroutineScope(Dispatchers.Default)
 
   fun setDelegate(delegate: Delegate?) {
     coroutineScope.launch {
-      this@ExpoRequestCdpInterceptor.delegate = delegate
+      this@ExpoRequestCdpInterceptor.delegate = WeakReference(delegate)
     }
   }
 
   private fun dispatchEvent(event: Event) {
     coroutineScope.launch {
-      this@ExpoRequestCdpInterceptor.delegate?.dispatch(event.toJson())
+      this@ExpoRequestCdpInterceptor.delegate.get()?.dispatch(event.toJson())
     }
   }
 

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestCdpInterceptor.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestCdpInterceptor.swift
@@ -8,7 +8,7 @@ import Foundation
  */
 @objc(EXRequestCdpInterceptor)
 public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorProtocolDelegate {
-  private var delegate: ExpoRequestCdpInterceptorDelegate?
+  private weak var delegate: ExpoRequestCdpInterceptorDelegate?
   public var dispatchQueue = DispatchQueue(label: "expo.requestCdpInterceptor")
 
   override private init() {}


### PR DESCRIPTION
# Why

fix retain cycle for `ExpoRequestCdpInterceptor`

# How

we should keep its delegate as weak, otherwise the network interceptor <-> delegate will have retain cycle

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
