### PR TITLE
[dev-launcher] support network inspector from react-native 0.76

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed network inspector support for react-native 0.76. ([#32290](https://github.com/expo/expo/pull/32290) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 5.0.2 — 2024-10-24

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -107,8 +107,7 @@ class DevLauncherController private constructor() :
 
   private var appIsLoading = false
 
-  @Suppress("unused")
-  private val networkInterceptor = DevLauncherNetworkInterceptor(this)
+  private var networkInterceptor: DevLauncherNetworkInterceptor? = null
 
   private fun isEASUpdateURL(url: Uri): Boolean {
     return url.host.equals("u.expo.dev") || url.host.equals("staging-u.expo.dev")
@@ -191,6 +190,11 @@ class DevLauncherController private constructor() :
   override fun onAppLoaded(context: ReactContext) {
     synchronized(this) {
       appIsLoading = false
+    }
+    manifestURL?.let {
+      runBlockingOnMainThread {
+        networkInterceptor = DevLauncherNetworkInterceptor(it)
+      }
     }
   }
 
@@ -287,6 +291,8 @@ class DevLauncherController private constructor() :
   private fun ensureHostWasCleared(host: ReactHostWrapper, activityToBeInvalidated: ReactActivity? = null) {
     if (host.hasInstance) {
       runBlockingOnMainThread {
+        networkInterceptor?.close()
+        networkInterceptor = null
         clearHost(host, activityToBeInvalidated)
       }
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherNetworkInterceptor.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherNetworkInterceptor.kt
@@ -2,113 +2,42 @@
 
 package expo.modules.devlauncher.launcher
 
-import com.facebook.react.bridge.Inspector
-import com.facebook.react.common.LifecycleState
-import com.facebook.react.devsupport.DevServerHelper
-import com.facebook.react.devsupport.DevSupportManagerBase
-import com.facebook.react.devsupport.InspectorPackagerConnection
-import expo.modules.devlauncher.DevLauncherController
-import expo.interfaces.devmenu.ReactHostWrapper
+import android.net.Uri
+import com.facebook.react.packagerconnection.ReconnectingWebSocket
 import expo.modules.kotlin.devtools.ExpoRequestCdpInterceptor
 import java.io.Closeable
-import java.lang.ref.WeakReference
-import java.lang.reflect.Field
-import java.lang.reflect.Method
 
-internal class DevLauncherNetworkInterceptor(controller: DevLauncherController) : Closeable, ExpoRequestCdpInterceptor.Delegate {
-  private val weakController = WeakReference(controller)
-  private var reactHostHashCode: Int = 0
-  private var _inspectorPackagerConnection: InspectorPackagerConnectionWrapper? = null
-
-  private val inspectorPackagerConnection: InspectorPackagerConnectionWrapper
-    get() {
-      val reactHost = requireNotNull(weakController.get()?.appHost)
-      if (reactHostHashCode != reactHost.hashCode()) {
-        _inspectorPackagerConnection?.clear()
-        _inspectorPackagerConnection = null
-        reactHostHashCode = 0
-      }
-      if (_inspectorPackagerConnection == null) {
-        _inspectorPackagerConnection = InspectorPackagerConnectionWrapper(reactHost)
-        reactHostHashCode = reactHost.hashCode()
-      }
-      return requireNotNull(_inspectorPackagerConnection)
+internal class DevLauncherNetworkInterceptor(appUrl: Uri) : Closeable, ExpoRequestCdpInterceptor.Delegate {
+  private val metroConnection = ReconnectingWebSocket(
+    createNetworkInspectorUrl(appUrl),
+    null,
+    null
+  )
+    .apply {
+      connect()
     }
 
   init {
     ExpoRequestCdpInterceptor.setDelegate(this)
   }
 
-  /**
-   * Returns true when it is allowed to send CDP events
-   */
-  private fun shouldEmitEvents(): Boolean {
-    return DevLauncherController.wasInitialized() && weakController.get()?.appHost?.lifecycleState == LifecycleState.RESUMED
-  }
-
   //region Closeable implementations
   override fun close() {
     ExpoRequestCdpInterceptor.setDelegate(null)
+    metroConnection.closeQuietly()
   }
   //endregion Closeable implementations
 
   //region ExpoRequestCdpInterceptor.Delegate implementations
   override fun dispatch(event: String) {
-    if (shouldEmitEvents()) {
-      inspectorPackagerConnection.sendWrappedEventToAllPages(event)
-    }
+    metroConnection.sendMessage(event)
   }
   //endregion ExpoRequestCdpInterceptor.Delegate implementations
 }
 
-/**
- * A `InspectorPackagerConnection` wrapper to expose private members with reflection
- */
-internal class InspectorPackagerConnectionWrapper constructor(reactHost: ReactHostWrapper) {
-  private var inspectorPackagerConnectionWeak: WeakReference<InspectorPackagerConnection> = WeakReference(null)
-  private val devServerHelperWeak: WeakReference<DevServerHelper>
-  private val inspectorPackagerConnectionField: Field
-  private val sendWrappedEventMethod: Method
-
-  private val inspectorPackagerConnection: InspectorPackagerConnection?
-    get() {
-      var inspectorPackagerConnection = inspectorPackagerConnectionWeak.get()
-      if (inspectorPackagerConnection == null) {
-        val devServerHelper = devServerHelperWeak.get() ?: return null
-        inspectorPackagerConnection = inspectorPackagerConnectionField[devServerHelper] as? InspectorPackagerConnection
-
-        if (inspectorPackagerConnection != null) {
-          inspectorPackagerConnectionWeak = WeakReference(inspectorPackagerConnection)
-        }
-      }
-      return inspectorPackagerConnection
-    }
-
-  init {
-    val devSupportManager = requireNotNull(reactHost.devSupportManager)
-    val devSupportManagerBaseClass = DevSupportManagerBase::class.java
-    val mDevServerHelperField = devSupportManagerBaseClass.getDeclaredField("mDevServerHelper")
-    mDevServerHelperField.isAccessible = true
-    val devServerHelper = mDevServerHelperField[devSupportManager]
-    devServerHelperWeak = WeakReference(devServerHelper as DevServerHelper)
-
-    inspectorPackagerConnectionField = DevServerHelper::class.java.getDeclaredField("mInspectorPackagerConnection")
-    inspectorPackagerConnectionField.isAccessible = true
-
-    sendWrappedEventMethod = InspectorPackagerConnection::class.java.getDeclaredMethod("sendWrappedEvent", String::class.java, String::class.java)
-    sendWrappedEventMethod.isAccessible = true
-  }
-
-  fun clear() {
-    inspectorPackagerConnectionWeak.clear()
-  }
-
-  fun sendWrappedEventToAllPages(event: String) {
-    val inspectorPackagerConnection = this.inspectorPackagerConnection ?: return
-    for (page in Inspector.getPages()) {
-      if (!page.title.contains("Reanimated")) {
-        sendWrappedEventMethod.invoke(inspectorPackagerConnection, page.id.toString(), event)
-      }
-    }
-  }
+private fun createNetworkInspectorUrl(appUrl: Uri): String {
+  val host = appUrl.host ?: "localhost"
+  val port = if (appUrl.port > 0) appUrl.port else 8081
+  val scheme = if (appUrl.scheme == "https") "wss" else "ws"
+  return "$scheme://$host:$port/inspector/network"
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -56,7 +56,7 @@
 @property (nonatomic, strong) NSURL *possibleManifestURL;
 @property (nonatomic, strong) EXDevLauncherErrorManager *errorManager;
 @property (nonatomic, strong) EXDevLauncherInstallationIDHelper *installationIDHelper;
-@property (nonatomic, strong) EXDevLauncherNetworkInterceptor *networkInterceptor;
+@property (nonatomic, strong, nullable) EXDevLauncherNetworkInterceptor *networkInterceptor;
 @property (nonatomic, assign) BOOL isStarted;
 @property (nonatomic, strong) EXDevLauncherAppDelegate *appDelegate;
 @property (nonatomic, strong) NSURL *lastOpenedAppUrl;
@@ -84,7 +84,6 @@
     self.pendingDeepLinkRegistry = [EXDevLauncherPendingDeepLinkRegistry new];
     self.errorManager = [[EXDevLauncherErrorManager alloc] initWithController:self];
     self.installationIDHelper = [EXDevLauncherInstallationIDHelper new];
-    self.networkInterceptor = [EXDevLauncherNetworkInterceptor new];
     self.shouldPreferUpdatesInterfaceSourceUrl = NO;
 
     __weak __typeof(self) weakSelf = self;
@@ -323,6 +322,7 @@
 
   self.manifest = nil;
   self.manifestURL = nil;
+  self.networkInterceptor = nil;
 
   [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
 
@@ -576,6 +576,7 @@
     if (![bundleUrl.scheme isEqualToString:@"file"]) {
       [[RCTPackagerConnection sharedPackagerConnection] setSocketConnectionURL:bundleUrl];
     }
+    self.networkInterceptor = [[EXDevLauncherNetworkInterceptor alloc] initWithBundleUrl:bundleUrl];
 #endif
 
     UIUserInterfaceStyle userInterfaceStyle = [EXDevLauncherManifestHelper exportManifestUserInterfaceStyle:manifest.userInterfaceStyle];


### PR DESCRIPTION
# Why

network inspector is broken from react-native 0.76 because of fusebox rewrite InspectorPackagerConnection in c++. we cannot intercept it anymore.

# How

send CDP events to our own websocket endpoint.

# Test Plan

bare-expo network inspector

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
