### PR TITLE
[expo-go][android] Fix launch crash in release

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
@@ -6,7 +6,6 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.shell.MainReactPackage
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.kernel.KernelConfig
-import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.Exponent
 import versioned.host.exp.exponent.ExpoReanimatedPackage
 import versioned.host.exp.exponent.ExpoTurboPackage
@@ -57,7 +56,6 @@ class ExpoGoReactNativeHost(
 data class KernelData(
   val initialURL: String? = null,
   val localBundlePath: String? = null,
-  val mainModuleName: String? = null
 )
 
 class KernelReactNativeHost(
@@ -84,7 +82,7 @@ class KernelReactNativeHost(
 
   override fun getJSMainModuleName(): String {
     return if (devSupportEnabled) {
-      data?.mainModuleName ?: KernelConstants.DEFAULT_APPLICATION_KEY
+      exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
     } else {
       super.getJSMainModuleName()
     }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
@@ -55,7 +55,7 @@ class ExpoGoReactNativeHost(
 
 data class KernelData(
   val initialURL: String? = null,
-  val localBundlePath: String? = null,
+  val localBundlePath: String? = null
 )
 
 class KernelReactNativeHost(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -228,7 +228,7 @@ class Kernel : KernelInterface() {
             KernelData(
               kernelInitialURL,
               localBundlePath,
-              kernelMainModuleName
+              null
             )
           )
           val hostWrapper = ReactNativeHostWrapper(applicationContext, nativeHost)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -227,8 +227,7 @@ class Kernel : KernelInterface() {
             exponentManifest,
             KernelData(
               kernelInitialURL,
-              localBundlePath,
-              null
+              localBundlePath
             )
           )
           val hostWrapper = ReactNativeHostWrapper(applicationContext, nativeHost)
@@ -236,8 +235,8 @@ class Kernel : KernelInterface() {
 
           if (nativeHost.devSupportEnabled) {
             Exponent.enableDeveloperSupport(
-              kernelDebuggerHost,
-              kernelMainModuleName
+              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost(),
+              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
             )
           }
 
@@ -267,10 +266,6 @@ class Kernel : KernelInterface() {
     }
   }
 
-  private val kernelDebuggerHost: String
-    get() = exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost()
-  private val kernelMainModuleName: String
-    get() = exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
   private val bundleUrl: String?
     get() {
       return try {


### PR DESCRIPTION
# Why
`kernelMainModuleName` should only be accessed when running home from a local dev server. Accessing it without a server running causes a crash. 

# How
The `KernelReactNativeHost` takes care of returning the correct name for the main module depending on if it is running locally or not so we can pass null as the module name in this case. 

# Test Plan
expo-go running in release and in debug (with and without a local dev server)

