### PR TITLE
[expo-go][android] Remove mainModuleName from KernelData

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
@@ -6,7 +6,6 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.shell.MainReactPackage
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.kernel.KernelConfig
-import host.exp.exponent.kernel.KernelConstants
 import host.exp.expoview.Exponent
 import versioned.host.exp.exponent.ExpoReanimatedPackage
 import versioned.host.exp.exponent.ExpoTurboPackage
@@ -55,9 +54,8 @@ class ExpoGoReactNativeHost(
 }
 
 data class KernelData(
-  val initialURL: String? = null,
-  val localBundlePath: String? = null,
-  val mainModuleName: String? = null
+  val initialURL: String?,
+  val localBundlePath: String
 )
 
 class KernelReactNativeHost(
@@ -84,7 +82,7 @@ class KernelReactNativeHost(
 
   override fun getJSMainModuleName(): String {
     return if (devSupportEnabled) {
-      data?.mainModuleName ?: KernelConstants.DEFAULT_APPLICATION_KEY
+      exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
     } else {
       super.getJSMainModuleName()
     }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -225,19 +225,15 @@ class Kernel : KernelInterface() {
           val nativeHost = KernelReactNativeHost(
             applicationContext,
             exponentManifest,
-            KernelData(
-              kernelInitialURL,
-              localBundlePath,
-              kernelMainModuleName
-            )
+            KernelData(kernelInitialURL, localBundlePath)
           )
           val hostWrapper = ReactNativeHostWrapper(applicationContext, nativeHost)
           reactHost = ReactHostFactory.createFromReactNativeHost(applicationContext, hostWrapper)
 
           if (nativeHost.devSupportEnabled) {
             Exponent.enableDeveloperSupport(
-              kernelDebuggerHost,
-              kernelMainModuleName
+              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost(),
+              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
             )
           }
 
@@ -267,10 +263,6 @@ class Kernel : KernelInterface() {
     }
   }
 
-  private val kernelDebuggerHost: String
-    get() = exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost()
-  private val kernelMainModuleName: String
-    get() = exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
   private val bundleUrl: String?
     get() {
       return try {


### PR DESCRIPTION
# Why

Proposed extension of https://app.graphite.dev/github/pr/expo/expo/32293/expo-go-android-Fix-launch-crash-in-release

# How

1. Remove data class member to better signal that it is not usable.
2. At callsite, substitute it with what it used to be: `exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()`
3. Since it's only constructed in one place, make args required and narrow their types.
4. Remove helper properties from Kernel to simplify.

# Test Plan

Build expo go for android, see it launches.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
