### PR TITLE
[docs] Fix collapsible component safari issue

### DIFF
--- a/docs/global-styles/global.css
+++ b/docs/global-styles/global.css
@@ -65,6 +65,10 @@ div[class*='Terminal'] > div ::-webkit-scrollbar-thumb:hover {
   background: var(--expo-theme-icon-tertiary);
 }
 
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
 /* Misc */
 
 .code-annotation {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As shared by [user feedback on X](https://x.com/ridwansameer/status/1849346540563013990):

![CleanShot 2024-10-24 at 13 29 05@2x](https://github.com/user-attachments/assets/20906cca-40b8-45bd-94b4-463e5e52e968)


# How

<!--
How did you build this feature or fix this bug and why?
-->

By hiding Safari’s default marker so that the component can use its own marker.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-24 at 13 29 09@2x](https://github.com/user-attachments/assets/a52fd9c5-1610-4465-ab39-8768f1cae027)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
