### PR TITLE
[docs] Add SDK 52 related info for React Native, Android and iOS versions

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -85,9 +85,9 @@ Approximately every four months there is a new Expo SDK release that typically u
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
+| 52.0.0           | 0.76                 | 0.19.13                  |
 | 51.0.0           | 0.74                 | 0.19.10                  |
 | 50.0.0           | 0.73                 | 0.19.6                   |
-| 49.0.0           | 0.72                 | 0.19.6                   |
 
 ### Support for other React Native versions
 
@@ -99,6 +99,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 53.0.0           | 6+              | 35                  | 15.1+       |
 | 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |
-| 49.0.0           | 5+              | 33                  | 13+         |

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -99,6 +99,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
-| 53.0.0           | 6+              | 35                  | 15.1+       |
+| 52.0.0           | 6+              | 35                  | 15.1+       |
 | 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -85,9 +85,9 @@ Approximately every four months there is a new Expo SDK release that typically u
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
+| 52.0.0           | 0.76                 | 0.19.13                  |
 | 51.0.0           | 0.74                 | 0.19.10                  |
 | 50.0.0           | 0.73                 | 0.19.6                   |
-| 49.0.0           | 0.72                 | 0.19.6                   |
 
 ### Support for other React Native versions
 
@@ -99,6 +99,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 53.0.0           | 6+              | 35                  | 15.1+       |
 | 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |
-| 49.0.0           | 5+              | 33                  | 13+         |

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -99,6 +99,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
-| 53.0.0           | 6+              | 35                  | 15.1+       |
+| 52.0.0           | 6+              | 35                  | 15.1+       |
 | 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

SDK 52 beta reference docs are up. Updating React Native, Android and iOS versions are part of the [beta docs release process](https://www.notion.so/expo/New-SDK-release-Checklist-for-docs-343b26e1171a45198763438e91c666bb).

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding Expo SDK 52 version information in Reference index in `unversioned` and SDK 52 reference index. Also, removed SDK 49 info from both of these pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-24 at 16 19 58@2x](https://github.com/user-attachments/assets/f31e49eb-f604-449b-b921-52132c8f5ddf)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
