### PR TITLE
[docs] Update APIInstallSection to display different instructions for third-party libraries

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -23,20 +23,28 @@ export default function InstallSection({
   href = getPackageLink(packageName),
 }: InstallSectionProps) {
   const { sourceCodeUrl } = usePageMetadata();
+  const isExpoLibrary = sourceCodeUrl?.includes('expo');
 
   return (
     <>
       <Terminal cmd={cmd} />
       {hideBareInstructions ? null : (
         <P>
-          If you are installing this in an{' '}
-          <A href="/bare/overview/">existing React Native app (bare workflow)</A>, start by{' '}
+          If you are installing this in an <A href="/bare/overview/">existing React Native app</A>,
+          start by{' '}
           <A href="/bare/installing-expo-modules/">
             installing <CODE>expo</CODE>
           </A>{' '}
           in your project. Then, follow the{' '}
-          <A href={sourceCodeUrl ?? href}>additional instructions</A> as mentioned by library's
-          README under <DEMI>"Installation in bare React Native projects"</DEMI> section.
+          <A href={sourceCodeUrl ?? href}>additional instructions</A>{' '}
+          {isExpoLibrary ? (
+            <>
+              as mentioned by library's README under{' '}
+              <DEMI>"Installation in bare React Native projects"</DEMI> section.
+            </>
+          ) : (
+            <>provided by the library's README or documentation.</>
+          )}
         </P>
       )}
     </>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -39,7 +39,7 @@ export default function InstallSection({
           <A href={sourceCodeUrl ?? href}>additional instructions</A>{' '}
           {isExpoLibrary ? (
             <>
-              as mentioned by library's README under{' '}
+              as mentioned by the library's README under{' '}
               <DEMI>"Installation in bare React Native projects"</DEMI> section.
             </>
           ) : (

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -23,7 +23,7 @@ export default function InstallSection({
   href = getPackageLink(packageName),
 }: InstallSectionProps) {
   const { sourceCodeUrl } = usePageMetadata();
-  const isExpoLibrary = sourceCodeUrl?.includes('expo');
+  const isExpoLibrary = sourceCodeUrl?.startsWith('https://github.com/expo/expo');
 
   return (
     <>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -36,7 +36,7 @@ export default function InstallSection({
             installing <CODE>expo</CODE>
           </A>{' '}
           in your project. Then, follow the{' '}
-          <A href={sourceCodeUrl ?? href}>additional instructions</A>{' '}
+          <A href={href ? href : sourceCodeUrl}>additional instructions</A>{' '}
           {isExpoLibrary ? (
             <>
               as mentioned by the library's README under{' '}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based [user feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1729251214463209)
- Sometimes, the link to a third party library is referring either their GitHub repo or documentation
  - This PR improves the verbiage to cover both cases
- `href` value for Reanimated is passed correctly but it is still picking up the `sourceCodeUrl` value.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the `APIInstallSection` component to conditionally display different verbiage for Expo and third-party libraries (in the context of existing React Native apps).
- Also dropped "bare workflow" deprecated terminology from Expo library instructions.
- Use ternary operator to check if `href` (passed as a prop to `APIInstallSection` component) is present on `A` and use it otherwise use `sourceCodeUrl` (which is passed from a doc's metadata)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

### See the comparison of an Expo vs third-party library.

![CleanShot 2024-10-24 at 17 17 54](https://github.com/user-attachments/assets/8b47475b-bdba-4929-8450-b3071ae7dc81)

![CleanShot 2024-10-24 at 17 18 02](https://github.com/user-attachments/assets/cfc53d9c-1e69-4dd9-a393-31071dfe2118)

### Issue about navigating to the correct link when `href` is present as a prop to `APIInstallSection` component


https://github.com/user-attachments/assets/d2d455c1-0246-4a0c-b283-04b36f5200d1

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
