### PR TITLE
[expo] Bump `react-native-gesture-handler` to `2.20.2`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2465,7 +2465,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNGestureHandler (2.20.1):
+  - RNGestureHandler (2.20.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3413,7 +3413,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6ad936eee086dbe2aeb658994021770b46897d62
   RNDateTimePicker: 6008d74df8122d6af6d9d08096bff19a8c6ba647
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
-  RNGestureHandler: 364e6862a112045bb5c5d35601f0bdb0304af979
+  RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
   RNReanimated: 95e2f00605658327d2563d097495c0f4a347f337
   RNScreens: 4e3efc2486e31429d0b1fb20a75be5aa85d71945
   RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.0",
-    "react-native-gesture-handler": "~2.20.1",
+    "react-native-gesture-handler": "~2.20.2",
     "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2225,7 +2225,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNGestureHandler (2.20.1):
+  - RNGestureHandler (2.20.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3154,7 +3154,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6ad936eee086dbe2aeb658994021770b46897d62
   RNDateTimePicker: 6008d74df8122d6af6d9d08096bff19a8c6ba647
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
-  RNGestureHandler: 364e6862a112045bb5c5d35601f0bdb0304af979
+  RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
   RNReanimated: 95e2f00605658327d2563d097495c0f4a347f337
   RNScreens: 4e3efc2486e31429d0b1fb20a75be5aa85d71945
   RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "react": "18.2.0",
     "react-native": "0.76.0",
     "react-native-fade-in-image": "^1.6.1",
-    "react-native-gesture-handler": "~2.20.1",
+    "react-native-gesture-handler": "~2.20.2",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.18.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -136,7 +136,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.0",
     "react-native-dropdown-picker": "^5.3.0",
-    "react-native-gesture-handler": "~2.20.1",
+    "react-native-gesture-handler": "~2.20.2",
     "react-native-maps": "1.18.0",
     "react-native-pager-view": "6.4.1",
     "react-native-paper": "^5.12.5",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.19",
     "react": "18.3.1",
     "react-native": "0.76.0",
-    "react-native-gesture-handler": "~2.20.1",
+    "react-native-gesture-handler": "~2.20.2",
     "sinon": "^7.1.1"
   },
   "browserslist": [

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -89,7 +89,7 @@
   "react-dom": "18.3.1",
   "react-native": "0.76.0",
   "react-native-web": "~0.19.13",
-  "react-native-gesture-handler": "~2.20.1",
+  "react-native-gesture-handler": "~2.20.2",
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.18.0",
   "react-native-pager-view": "6.4.1",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.0",
-    "react-native-gesture-handler": "~2.20.1",
+    "react-native-gesture-handler": "~2.20.2",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
     "react-native-screens": "4.0.0-beta.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13505,10 +13505,10 @@ react-native-fade-in-image@^1.6.1:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~2.20.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.20.1.tgz#04743f7064d6ad7d0f66ec0d71c35eeee8c89a97"
-  integrity sha512-Oqq5A606F6iV1eQ3FExEH6V4zE2uatNdrwQU1qMy7szHgm0SewQexeyLY3Zaaeo7luOknVq2xvZjNN/LvULGPw==
+react-native-gesture-handler@~2.20.2:
+  version "2.20.2"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.20.2.tgz#73844c8e9c417459c2f2981bc4d8f66ba8a5ee66"
+  integrity sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
# Why

Bumps `react-native-gesture-handler` to `2.20.2`

# Test Plan

- bare-expo ✅ 
- Expo Go ✅ 