### PR TITLE
[docs] Fix `<DiffBlock>` missing monospace font

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -79,7 +79,8 @@ export default function App({ Component, pageProps }: AppProps) {
                     font-family: ${regularFont.style.fontFamily}, sans-serif;
                   }
                   code,
-                  pre {
+                  pre,
+                  table.diff {
                     font-family: ${monospaceFont.style.fontFamily}, monospace;
                   }
                 `}</style>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Font missing from `<DiffBlock>`:

![CleanShot 2024-10-24 at 21 12 46](https://github.com/user-attachments/assets/65c45c09-5e5e-444e-960c-dcedb1fc30aa)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `table.diff` class so that `monospaceFont` styles are applied to `<DiffBlock>`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-10-24 at 21 15 00](https://github.com/user-attachments/assets/2a61a1ee-7b82-40be-a1d4-af2d54a0f6a8)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
