### PR TITLE
[expo] Bump `react-native-screens` to `4.0.0-beta.14`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2573,7 +2573,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.0.0-beta.13):
+  - RNScreens (4.0.0-beta.14):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2594,9 +2594,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.0.0-beta.13)
+    - RNScreens/common (= 4.0.0-beta.14)
     - Yoga
-  - RNScreens/common (4.0.0-beta.13):
+  - RNScreens/common (4.0.0-beta.14):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3415,7 +3415,7 @@ SPEC CHECKSUMS:
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
   RNReanimated: 95e2f00605658327d2563d097495c0f4a347f337
-  RNScreens: 4e3efc2486e31429d0b1fb20a75be5aa85d71945
+  RNScreens: c1e151cab51643c0cf42b88d275592a4aee220f1
   RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",
     "react-native-webview": "13.12.2",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2333,7 +2333,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.0.0-beta.13):
+  - RNScreens (4.0.0-beta.14):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2354,9 +2354,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.0.0-beta.13)
+    - RNScreens/common (= 4.0.0-beta.14)
     - Yoga
-  - RNScreens/common (4.0.0-beta.13):
+  - RNScreens/common (4.0.0-beta.14):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3156,7 +3156,7 @@ SPEC CHECKSUMS:
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
   RNReanimated: 95e2f00605658327d2563d097495c0f4a347f337
-  RNScreens: 4e3efc2486e31429d0b1fb20a75be5aa85d71945
+  RNScreens: c1e151cab51643c0cf42b88d275592a4aee220f1
   RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -76,7 +76,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-webview": "13.12.2",
     "react-redux": "^7.2.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -142,7 +142,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",
     "react-native-web": "~0.19.13",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -26,7 +26,7 @@
     "react": "18.3.1",
     "react-native": "0.76.0",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-webview": "13.8.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@react-navigation/native-stack": "7.0.0-rc.28",
     "@react-navigation/routers": "7.0.0-rc.8",
     "@react-navigation/stack": "7.0.0-rc.27",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "**/util": "~0.12.4"
   },
   "dependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
@@ -13,7 +13,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.74.2",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.74.2",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
@@ -12,7 +12,7 @@
     "expo-splash-screen": "~0.27.0",
     "expo-status-bar": "^1.12.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.13"
+    "react-native-screens": "4.0.0-beta.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -12,7 +12,7 @@
     "expo-splash-screen": "~0.27.0",
     "expo-status-bar": "^1.12.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13"
+    "react-native-screens": "4.0.0-beta.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-native-maps": "1.18.0",
   "react-native-pager-view": "6.4.1",
   "react-native-reanimated": "~3.16.1",
-  "react-native-screens": "4.0.0-beta.13",
+  "react-native-screens": "4.0.0-beta.14",
   "react-native-safe-area-context": "4.11.0",
   "react-native-svg": "15.8.0",
   "react-native-view-shot": "3.8.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -36,7 +36,7 @@
     "react-native-gesture-handler": "~2.20.2",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -30,7 +30,7 @@
     "react-native": "0.76.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.11.0",
-    "react-native-screens": "4.0.0-beta.13",
+    "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13589,10 +13589,10 @@ react-native-safe-area-context@4.11.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.11.0.tgz#d45271363672dc1923ddb0ce5a6ad588e210c85d"
   integrity sha512-Bg7bozxEB+ZS+H3tVYs5yY1cvxNXgR6nRQwpSMkYR9IN5CbxohLnSprrOPG/ostTCd4F6iCk0c51pExEhifSKQ==
 
-react-native-screens@4.0.0-beta.13:
-  version "4.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.0.0-beta.13.tgz#e37796fb616206ff68c3318d904b6839fae641ab"
-  integrity sha512-vKddzR+oNYX3SSGbHeCEBFSEcM40E28SAZdapuY0NAVI7pRCW/wJhdbgumAumek9uFlpPLdenows5CIRB0KN4w==
+react-native-screens@4.0.0-beta.14:
+  version "4.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.0.0-beta.14.tgz#67702d0785df8746220a9d7314bdd31ebedc459c"
+  integrity sha512-O81GMV/ptGiOie+jpI2qdXZP4tktR0vdIw05m8eaAWJshMTC1cRxhmyF4puVKRFh8USN2b/awfA0ikLaTkeipQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Bumps `react-native-screens` to `4.0.0-beta.14`

# Test Plan

- bare-expo ✅ 