### PR TITLE
[go] enable debugging on release build

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
@@ -4,7 +4,6 @@ package host.exp.exponent
 import android.app.Application
 import android.os.Debug
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import host.exp.exponent.analytics.EXL
@@ -74,8 +73,10 @@ abstract class ExpoApplication : Application() {
     }
 
     SoLoader.init(applicationContext, OpenSourceMergedSoMapping)
+    ExpoGoReactNativeFeatureFlags.setup()
     // For the New Architecture, we load the native entry point for this app.
-    load()
+    // We should keep the code in sync with `DefaultNewArchitectureEntryPoint.load()`
+    SoLoader.loadLibrary("react_newarchdefaults")
 
     // Add exception handler. This is used by the entire process, so only need to add it here.
     Thread.setDefaultUncaughtExceptionHandler(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoReactNativeFeatureFlags.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoReactNativeFeatureFlags.kt
@@ -1,0 +1,23 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package host.exp.exponent
+
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlagsDefaults
+
+internal object ExpoGoReactNativeFeatureFlags {
+  fun setup() {
+    ReactNativeFeatureFlags.override(
+      object : ReactNativeNewArchitectureFeatureFlagsDefaults(newArchitectureEnabled = true) {
+        override fun useFabricInterop(): Boolean = true
+
+        // We turn this feature flag to true for OSS to fix #44610 and #45126 and other
+        // similar bugs related to pressable.
+        override fun enableEventEmitterRetentionDuringGesturesOnAndroid(): Boolean =
+          true
+
+        override fun fuseboxEnabledRelease(): Boolean =
+          true
+      })
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoReactNativeFeatureFlags.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoGoReactNativeFeatureFlags.kt
@@ -18,6 +18,7 @@ internal object ExpoGoReactNativeFeatureFlags {
 
         override fun fuseboxEnabledRelease(): Boolean =
           true
-      })
+      }
+    )
   }
 }

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -8,6 +8,8 @@ class AppDelegate: ExpoAppDelegate {
   var rootViewController: EXRootViewController?
 
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    ExpoGoReactNativeFeatureFlags.setup()
+
     if application.applicationState != UIApplication.State.background {
       // App launched in foreground
       setUpUserInterfaceForApplication(application, withLaunchOptions: launchOptions)

--- a/apps/expo-go/ios/Client/EXGoReactNativeFeatureFlags.h
+++ b/apps/expo-go/ios/Client/EXGoReactNativeFeatureFlags.h
@@ -1,0 +1,14 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(ExpoGoReactNativeFeatureFlags)
+@interface EXGoReactNativeFeatureFlags : NSObject
+
++ (void)setup;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Client/EXGoReactNativeFeatureFlags.mm
+++ b/apps/expo-go/ios/Client/EXGoReactNativeFeatureFlags.mm
@@ -1,0 +1,31 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXGoReactNativeFeatureFlags.h"
+
+#import <react/featureflags/ReactNativeFeatureFlags.h>
+#import <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+
+@implementation EXGoReactNativeFeatureFlags
+
+class ExpoGoReactNativeFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
+ public:
+  bool useModernRuntimeScheduler() override {
+    return true;
+  }
+  bool enableMicrotasks() override {
+    return true;
+  }
+  bool batchRenderingUpdatesInEventLoop() override {
+    return true;
+  }
+  bool fuseboxEnabledRelease() override {
+    return true;
+  }
+};
+
++ (void)setup
+{
+  facebook::react::ReactNativeFeatureFlags::override(std::make_unique<ExpoGoReactNativeFeatureFlags>());
+}
+
+@end

--- a/apps/expo-go/ios/Exponent-Bridging-Header.h
+++ b/apps/expo-go/ios/Exponent-Bridging-Header.h
@@ -22,3 +22,4 @@
 #import "EXStatusBarManager.h"
 #import "EXKernelDevKeyCommands.h"
 #import "EXClientReleaseType.h"
+#import "EXGoReactNativeFeatureFlags.h"

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		78D82527204E8F9C00CBD9D9 /* EXApiV2Client.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D82526204E8F9C00CBD9D9 /* EXApiV2Client.m */; };
 		78D8252A204F826700CBD9D9 /* EXApiV2Result.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D82529204F826700CBD9D9 /* EXApiV2Result.m */; };
 		8397AA3E2CC969A5000A6349 /* EXVersionedNetworkInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8397AA3D2CC96997000A6349 /* EXVersionedNetworkInterceptor.swift */; };
+		83B4FA5F2CCA98E1007374E2 /* EXGoReactNativeFeatureFlags.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83B4FA5E2CCA98E1007374E2 /* EXGoReactNativeFeatureFlags.mm */; };
 		84713BFB28584A0100E86B56 /* EXErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84713BFA28584A0100E86B56 /* EXErrorView.xib */; };
 		8746D75E24D04B2300BFAD22 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8746D75C24D04B2300BFAD22 /* LaunchScreen.storyboard */; };
 		8764788D270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764788C270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift */; };
@@ -258,6 +259,8 @@
 		78D82528204F826700CBD9D9 /* EXApiV2Result.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXApiV2Result.h; sourceTree = "<group>"; };
 		78D82529204F826700CBD9D9 /* EXApiV2Result.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXApiV2Result.m; sourceTree = "<group>"; };
 		8397AA3D2CC96997000A6349 /* EXVersionedNetworkInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXVersionedNetworkInterceptor.swift; sourceTree = "<group>"; };
+		83B4FA5E2CCA98E1007374E2 /* EXGoReactNativeFeatureFlags.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EXGoReactNativeFeatureFlags.mm; sourceTree = "<group>"; };
+		83B4FA602CCA98FF007374E2 /* EXGoReactNativeFeatureFlags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXGoReactNativeFeatureFlags.h; sourceTree = "<group>"; };
 		83BF8C0E87795C6808128A31 /* Pods-Expo Go.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Expo Go.release.xcconfig"; path = "Target Support Files/Pods-Expo Go/Pods-Expo Go.release.xcconfig"; sourceTree = "<group>"; };
 		84713BFA28584A0100E86B56 /* EXErrorView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EXErrorView.xib; sourceTree = "<group>"; };
 		8746D75D24D04B2300BFAD22 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -785,6 +788,8 @@
 				F1F7433D24ABECD500EA5023 /* AppDelegate.swift */,
 				B56C65C5204768F2002B2424 /* EXHomeAppManager.h */,
 				B56C65C4204768F2002B2424 /* EXHomeAppManager.m */,
+				83B4FA602CCA98FF007374E2 /* EXGoReactNativeFeatureFlags.h */,
+				83B4FA5E2CCA98E1007374E2 /* EXGoReactNativeFeatureFlags.mm */,
 				B56C65C0204768F2002B2424 /* EXRootViewController.h */,
 				B56C65C1204768F2002B2424 /* EXRootViewController.m */,
 				B56C65C9204769B6002B2424 /* Menu */,
@@ -1824,6 +1829,7 @@
 				B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */,
 				0799CFDA21839B520039E97C /* EXSession.m in Sources */,
 				B54D2913205307380019411A /* EXAppLoadingCancelView.m in Sources */,
+				83B4FA5F2CCA98E1007374E2 /* EXGoReactNativeFeatureFlags.mm in Sources */,
 				317168FA213DA0E000766458 /* EXScopedReactNativeAdapter.m in Sources */,
 				31E6D47E20B8451B0082B09F /* EXSensorManager.m in Sources */,
 				B5FB74B51FF6DADC001C764B /* EXUtil.m in Sources */,


### PR DESCRIPTION
# Why

close ENG-13896

# How

- override ReactNativeFeatureFlags for `fuseboxEnabledRelease=true`
- [android] replace original `DefaultNewArchitectureEntryPoint.load()` with our implementation, because `ReactNativeFeatureFlags.override` cannot call more than once.
- [ios] just add `ExpoGoReactNativeFeatureFlags.setup()`. i noticed that we did not actually call  [`RCTAppDelegate.application:didFinishLaunchingWithOptions:options:`](https://github.com/facebook/react-native/blob/dc7e9e2d83f5af3d2a970521af4fcc7f86d2168d/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L50C50-L68) so we did not setup feature flags

# Test Plan

expo-go release build + ncl debugging

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
