### PR TITLE
[iOS][core] Make a dedicated dynamic type for Either types

### DIFF
--- a/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
+++ b/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
@@ -235,24 +235,28 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoMediaLibrary/ExpoMediaLibrary_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoMediaLibrary_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -13,10 +13,10 @@ PODS:
   - EXManifests/Tests (0.15.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - expo-dev-launcher (5.0.1):
+  - expo-dev-launcher (5.0.2):
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 5.0.1)
+    - expo-dev-launcher/Main (= 5.0.2)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -42,7 +42,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Main (5.0.1):
+  - expo-dev-launcher/Main (5.0.2):
     - DoubleConversion
     - EXManifests
     - expo-dev-launcher/Unsafe
@@ -71,7 +71,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Tests (5.0.1):
+  - expo-dev-launcher/Tests (5.0.2):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -104,7 +104,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Unsafe (5.0.1):
+  - expo-dev-launcher/Unsafe (5.0.2):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -132,10 +132,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu (6.0.1):
+  - expo-dev-menu (6.0.2):
     - DoubleConversion
-    - expo-dev-menu/Main (= 6.0.1)
-    - expo-dev-menu/ReactNativeCompatibles (= 6.0.1)
+    - expo-dev-menu/Main (= 6.0.2)
+    - expo-dev-menu/ReactNativeCompatibles (= 6.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -156,7 +156,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - expo-dev-menu-interface (1.9.0)
-  - expo-dev-menu/Main (6.0.1):
+  - expo-dev-menu/Main (6.0.2):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu-interface
@@ -182,7 +182,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (6.0.1):
+  - expo-dev-menu/ReactNativeCompatibles (6.0.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -203,7 +203,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/SafeAreaView (6.0.1):
+  - expo-dev-menu/SafeAreaView (6.0.2):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -225,7 +225,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Tests (6.0.1):
+  - expo-dev-menu/Tests (6.0.2):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -250,7 +250,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/UITests (6.0.1):
+  - expo-dev-menu/UITests (6.0.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -273,7 +273,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Vendored (6.0.1):
+  - expo-dev-menu/Vendored (6.0.2):
     - DoubleConversion
     - expo-dev-menu/SafeAreaView
     - glog
@@ -325,7 +325,7 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (2.0.0-preview.1):
+  - ExpoModulesCore (2.0.0-preview.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -348,7 +348,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesCore/Tests (2.0.0-preview.1):
+  - ExpoModulesCore/Tests (2.0.0-preview.2):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -379,7 +379,7 @@ PODS:
     - React-hermes
   - EXStructuredHeaders (4.0.0)
   - EXStructuredHeaders/Tests (4.0.0)
-  - EXUpdates (0.26.1):
+  - EXUpdates (0.26.2):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -406,7 +406,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXUpdates/Tests (0.26.1):
+  - EXUpdates/Tests (0.26.2):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -2256,33 +2256,33 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
-  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
   EXManifests: d2859eb09b260b4e819299782fb5e43da36e248b
-  expo-dev-launcher: befd0323d4ae270f4147689638f7f3f8e7910dec
-  expo-dev-menu: 1df2a0e4c990bcd360b4c7266bbdfcd0624ef074
+  expo-dev-launcher: 0d937968ae1fd97d82dc39d2acde2284d2e0d914
+  expo-dev-menu: 7f39524249d75726d3ce25f5f93d483159ed24bf
   expo-dev-menu-interface: 6f83f3119a91557e1d04cf43d6320ef545082fd4
   ExpoClipboard: 166ca8c13ca1041f5ba619a211f59427ab5da8a7
   ExpoFileSystem: d8b51caca86749a132c8ffde46be9a175e46b819
   ExpoImage: bd04fd6e5f97d2a29284bd7113cc51d7c206d17d
   ExpoMediaLibrary: a85e3fcc6a85ede0ae2dae2577b8cf02d1051bbb
-  ExpoModulesCore: db0f28809c964dd0cc17cd9c16cb6af681439332
+  ExpoModulesCore: dccd9f646be266b4cfdf992ac617061d0e62f344
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
-  EXUpdates: 8657eb1c34691a4298b1c1004f03bb9c2d6a385f
+  EXUpdates: 78ac3dbeb2eb72cc14f49a3e59c01e63fe81c7ae
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   FBLazyVector: aa59bef5c46e93168bffcf3dc37ee1e176de799a
-  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9de51d2f67336348a6cd5b686330e436d1dbd522
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
+  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: 4c2c4a088b6f0ccfcbd53c9d5614b0238ad57909
   RCTRequired: 2d8a683a7848bc0baf5883f0792c1ac43f6267b5
   RCTTypeSafety: 23df4344c69c602e1c5a8053a93c633af1bee825
@@ -2343,7 +2343,7 @@ SPEC CHECKSUMS:
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 1d66db49f38fd9e576a1d7c3b081e46ab4c28b9e
+  Yoga: f8ec45ce98bba1bc93dd28f2ee37215180e6d2b6
 
 PODFILE CHECKSUM: ccd8b50eabcb4ae3ee16e1484faf98baa32b0b75
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added a new dynamic type dedicated for Either types. ([#32328](https://github.com/expo/expo/pull/32328) by [@tsapeta](https://github.com/tsapeta))
+
 ## 2.0.0-preview.3 — 2024-10-24
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
@@ -1,0 +1,47 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+internal struct DynamicEitherType<EitherType: AnyEither>: AnyDynamicType {
+  let eitherType: EitherType.Type
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return eitherType.dynamicTypes().contains { eitherType in
+      return eitherType.wraps(type)
+    }
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    return type is Self
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    let types = eitherType.dynamicTypes()
+
+    for type in types {
+      if let preliminaryValue = try? type.cast(jsValue: jsValue, appContext: appContext),
+        let value = try? type.cast(preliminaryValue, appContext: appContext) {
+        return EitherType(value)
+      }
+    }
+    throw NeitherTypeException(types)
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if let value = value as? EitherType {
+      return value
+    }
+    let types = eitherType.dynamicTypes()
+
+    for type in types {
+      // Initialize the "either" when the current type can cast given value.
+      if let value = try? type.cast(value, appContext: appContext) {
+        return EitherType(value)
+      }
+    }
+    throw NeitherTypeException(types)
+  }
+
+  var description: String {
+    let types = eitherType.dynamicTypes()
+    return "Either<\(types.map(\.description).joined(separator: ", "))>"
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/DynamicEitherTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicEitherTypeSpec.swift
@@ -1,0 +1,93 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class DynamicEitherTypeSpec: ExpoSpec {
+  override class func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    it("is created") {
+      expect(~Either<Int, String>.self).to(beAKindOf(DynamicEitherType<Either<Int, String>>.self))
+    }
+
+    it("converts from raw values") {
+      let either1 = try (~Either<Int, String>.self).cast(123, appContext: appContext) as! Either<Int, String>
+      expect(try either1.as(Int.self)) == 123
+
+      let either2 = try (~Either<Int, String>.self).cast("expo", appContext: appContext) as! Either<Int, String>
+      expect(try either2.as(String.self)) == "expo"
+    }
+
+    it("converts from JS values") {
+      let either1 = try (~Either<Int, String>.self).cast(jsValue: .number(123), appContext: appContext) as! Either<Int, String>
+      expect(try either1.as(Int.self)) == 123
+
+      let either2 = try (~Either<Int, String>.self).cast(jsValue: .string("expo", runtime: runtime), appContext: appContext) as! Either<Int, String>
+      expect(try either2.as(String.self)) == "expo"
+    }
+
+    it("throws when converting from neither type") {
+      expect({ try (~Either<String, Int>.self).cast(true, appContext: appContext) })
+        .to(throwError(errorType: NeitherTypeException.self))
+
+      expect({ try (~Either<String, Bool>.self).cast(jsValue: .number(100), appContext: appContext) })
+        .to(throwError(errorType: NeitherTypeException.self))
+
+      expect({ try (~EitherOfThree<String, Int, Double>.self).cast(false, appContext: appContext) })
+        .to(throwError(errorType: NeitherTypeException.self))
+
+      expect({ try (~EitherOfFour<String, Int, Double, Bool>.self).cast([1, 2], appContext: appContext) })
+        .to(throwError(errorType: NeitherTypeException.self))
+    }
+
+    it("supports arrays") {
+      let either = try (~Either<String, [String]>.self).cast(["foo"], appContext: appContext) as! Either<String, [String]>
+      let value: [String]? = either.get()
+
+      expect(either.is([String].self)) == true
+      expect(value) == ["foo"]
+    }
+
+    it("supports convertibles (UIColor)") {
+      let either = try (~Either<Int, UIColor>.self).cast("blue", appContext: appContext) as! Either<Int, UIColor>
+      let color: UIColor? = either.get()
+
+      expect(either.is(Int.self)) == false
+      expect(either.is(UIColor.self)) == true
+      expect(color?.cgColor.components) == CGColor(red: 0, green: 0, blue: 1, alpha: 1).components
+    }
+
+    it("supports records") {
+      struct TestRecord: Record {
+        @Field
+        var foo: String
+      }
+      let either = try (~Either<String, TestRecord>.self).cast(["foo": "bar"], appContext: appContext) as! Either<String, TestRecord>
+      let record: TestRecord? = either.get()
+
+      expect(either.is(String.self)) == false
+      expect(either.is(TestRecord.self)) == true
+      expect(record?.foo) == "bar"
+    }
+
+    it("supports shared objects") {
+      class TestSharedObject: SharedObject {}
+
+      let nativeObject = TestSharedObject()
+
+      // Register a pair of objects
+      _ = appContext.sharedObjectRegistry.createSharedJavaScriptObject(runtime: runtime, nativeObject: nativeObject)
+
+      // TODO: We should test with JS value, but currently we have no way to convert JavaScriptObject to JavaScriptValue
+      let either = try (~Either<TestSharedObject, String>.self).cast(nativeObject.sharedObjectId, appContext: appContext) as! Either<TestSharedObject, String>
+
+      expect(either.is(TestSharedObject.self)) == true
+      expect(either.is(String.self)) == false
+      expect(try either.as(TestSharedObject.self).sharedObjectId) == nativeObject.sharedObjectId
+    }
+  }
+}
+

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -382,5 +382,23 @@ final class DynamicTypeSpec: ExpoSpec {
         }
       }
     }
+
+    // MARK: - DynamicEitherType
+
+    describe("DynamicEitherType") {
+      it("is created") {
+        expect(~Either<Int, String>.self).to(beAKindOf(DynamicEitherType<Either<Int, String>>.self))
+      }
+
+      describe("casts") {
+        it("succeeds") {
+          let either1 = try (~Either<Int, String>.self).cast(123, appContext: appContext) as! Either<Int, String>
+          expect(try either1.as(Int.self)) == 123
+
+          let either2 = try (~Either<Int, String>.self).cast("expo", appContext: appContext) as! Either<Int, String>
+          expect(try either2.as(String.self)) == "expo"
+        }
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/EitherSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EitherSpec.swift
@@ -6,8 +6,6 @@ import ExpoModulesTestCore
 
 final class EitherSpec: ExpoSpec {
   override class func spec() {
-    let appContext = AppContext.create()
-
     describe("Either") {
       it("is the first type") {
         let either = Either<String, Int>("string")
@@ -34,42 +32,6 @@ final class EitherSpec: ExpoSpec {
         let value: Int? = either.get()
         expect(value).notTo(beNil())
       }
-      it("converts as convertible") {
-        let either = try Either<String, Int>.convert(from: 123, appContext: appContext)
-        expect(either.is(String.self)) == false
-        expect(either.is(Int.self)) == true
-      }
-      it("throws when converting from neither type") {
-        expect({ try Either<String, Int>.convert(from: true, appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
-      }
-
-      it("supports arrays") {
-        let either = try Either<String, [String]>.convert(from: ["foo"], appContext: appContext)
-        let value: [String]? = either.get()
-
-        expect(either.is([String].self)) == true
-        expect(value) == ["foo"]
-      }
-
-      it("supports convertibles (UIColor)") {
-        let either = try Either<Int, UIColor>.convert(from: "blue", appContext: appContext)
-        let color: UIColor? = either.get()
-
-        expect(either.is(UIColor.self)) == true
-        expect(color?.cgColor.components) == CGColor(red: 0, green: 0, blue: 1, alpha: 1).components
-      }
-
-      it("supports records") {
-        struct TestRecord: Record {
-          @Field
-          var foo: String
-        }
-        let either = try Either<String, TestRecord>.convert(from: ["foo": "bar"], appContext: appContext)
-        let record: TestRecord? = either.get()
-
-        expect(either.is(TestRecord.self)) == true
-        expect(record?.foo) == "bar"
-      }
     }
     describe("EitherOfThree") {
       it("is the third type") {
@@ -88,9 +50,6 @@ final class EitherSpec: ExpoSpec {
         let either = EitherOfThree<String, Int, Bool>(false)
         let value: Bool? = either.get()
         expect(value).notTo(beNil())
-      }
-      it("throws when converting from neither type") {
-        expect({ try EitherOfThree<String, Int, Double>.convert(from: false, appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
       }
     }
     describe("EitherOfFour") {
@@ -112,9 +71,6 @@ final class EitherSpec: ExpoSpec {
         let either = EitherOfFour<String, Int, Bool, Double>(12.34)
         let value: Double? = either.get()
         expect(value).notTo(beNil())
-      }
-      it("throws when converting from neither type") {
-        expect({ try EitherOfFour<String, Int, Double, Bool>.convert(from: [1, 2], appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
       }
     }
   }


### PR DESCRIPTION
# Why

I want to use `Either<String, SharedRef<UIImage>>` in `expo-image-manipulator` but I noticed that Either types are not properly supporting shared objects when passed as JS objects. We didn't notice this before because it worked when the shared object ID is passed, so `expo-image` worked just fine.

# How

It makes `Either` types no longer conform to `Convertible` protocol. It turned out they need special handling during arguments conversion, so a separate dynamic type for them is needed.

I also reorganized tests – created a new test spec just for `DynamicEitherType` and moved there some of the tests from `EitherSpec`.

# Test Plan

Places where Either types are used in `expo-file-system/next`, `expo-image` and DOM components are working as expected.