### PR TITLE
[expo-modules-core][ios] Fix build failure on 0.76

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- [ios] Fix build failure on 0.76 ([#32330](https://github.com/expo/expo/pull/32330) by [@matinzd](https://github.com/matinzd))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -7,7 +7,7 @@
 #import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 #import <React/RCTComponentViewFactory.h> // Allows non-umbrella since it's coming from React-RCTFabric
-#import <ReactCommon/RCTHost.h> // Allows non-umbrella because the header is not inside a clang module
+#import <React_RuntimeApple/ReactCommon/RCTHost.h> // Allows non-umbrella because the header is not inside a clang module
 
 
 @interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider, RCTHostDelegate>


### PR DESCRIPTION
# Why

Build on iOS is failing with:

```
/node_modules/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm:10:9: 'ReactCommon/RCTHost.h' file not found
```

RCT host is not under ReactCommon anymore in RN 76.

# How



# Test Plan

CI should not fail

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
