### PR TITLE
fix(cli): fix async routes in web ssr

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix async routes in web ssr ([#32331](https://github.com/expo/expo/pull/32331) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 💡 Others
 
 ## 0.19.2 — 2024-10-24

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -296,10 +296,7 @@ function pruneCustomTransformOptions(
   if (
     transformOptions.customTransformOptions?.asyncRoutes &&
     // The async routes settings are also used in `expo-router/_ctx.ios.js` (and other platform variants) via `process.env.EXPO_ROUTER_IMPORT_MODE`
-    !(
-      filePath.match(/\/expo-router\/_ctx\.(ios|android|web)\.js$/) ||
-      filePath.match(/\/expo-router\/build\/import-mode\/index\.js$/)
-    )
+    !(filePath.match(/\/expo-router\/_ctx/) || filePath.match(/\/expo-router\/build\//))
   ) {
     delete transformOptions.customTransformOptions.asyncRoutes;
   }


### PR DESCRIPTION
# Why

The async routes prop was being removed before it got to the async routes transform.
