### PR TITLE
[ios][camera] Bring back `removeFromSuperview`

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed issue regarding using the "back"-facing on mobile web browswer. ([#30811](https://github.com/expo/expo/pull/30811) by [@entiendoNull](https://github.com/entiendoNull))
 - Fix `takePictureAsync` `quality` option when set to 0. ([#31587](https://github.com/expo/expo/pull/31587) by [@davidavz](https://github.com/davidavz))
 - [iOS] Fix crash related to `sublayers` on 0.75 and above on the new architecture. ([#32194](https://github.com/expo/expo/pull/32194) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix regression in running the cameras cleanup function. ([#32333](https://github.com/expo/expo/pull/32333) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -155,7 +155,6 @@ public final class CameraViewModule: Module, ScannerResultHandler {
           view.active = active
           return
         }
-        view.active = true
       }
 
       OnViewDidUpdateProps { view in

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -648,7 +648,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     previewLayer.frame = self.bounds
     self.layer.insertSublayer(previewLayer, at: 0)
   }
-  
+
   public override func removeFromSuperview() {
     super.removeFromSuperview()
     Task {
@@ -745,8 +745,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     #if targetEnvironment(simulator)
     return
     #endif
-//    self.previewLayer.removeFromSuperlayer()
-
     session.beginConfiguration()
     for input in self.session.inputs {
       session.removeInput(input)

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -592,12 +592,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     }
   }
 
-  public override func didMoveToWindow() {
-    if window == nil {
-      cleanupCamera()
-    }
-  }
-
   func updateSessionAudioIsMuted() async {
     session.beginConfiguration()
     defer { session.commitConfiguration() }
@@ -654,13 +648,13 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     previewLayer.frame = self.bounds
     self.layer.insertSublayer(previewLayer, at: 0)
   }
-
-  private func cleanupCamera() {
-    cameraShouldInit = true
-    lifecycleManager?.unregisterAppLifecycleListener(self)
+  
+  public override func removeFromSuperview() {
+    super.removeFromSuperview()
     Task {
       await stopSession()
     }
+    lifecycleManager?.unregisterAppLifecycleListener(self)
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
   }
@@ -751,7 +745,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     #if targetEnvironment(simulator)
     return
     #endif
-//    self.previewLayer.layer.removeFromSuperlayer()
+//    self.previewLayer.removeFromSuperlayer()
 
     session.beginConfiguration()
     for input in self.session.inputs {


### PR DESCRIPTION
# Why
Fixes a regression introduced in #31900 by moving the cleanup to `didMoveToWindow `. It was an attempt to solve the layer issues we were having on the new arch. This solution does not work well when the camera is presented in a modal like it is in expo go. The only way to ensure cleanup is to move to `removeFromSuperview`. This now works as before as the layer problems were resolved in #32194. 

# How
Moved the implementation of `cleanupCamera` to `removeFromSuperview`.

# Test Plan
@aleqsio told me about these problems in expo go and I could reproduce. With this change I can no longer reproduce the issues we were seeing and the camera works as expected.
