### PR TITLE
[docs] Add role and aria-checked to checkbox tutorial

### DIFF
--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -25,6 +25,8 @@ function MyCheckbox() {
   const [checked, setChecked] = useState(false);
   return (
     <Pressable
+      /* @info Specifying a role of checkbox or switch lets screen readers understand the state set with aria-checked */role="checkbox"/* @end */
+      aria-checked={checked}
       style={[styles.checkboxBase, checked && styles.checkboxChecked]}
       onPress={() => setChecked(!checked)}>
       {checked && <Ionicons name="checkmark" size={24} color="white" />}
@@ -99,6 +101,8 @@ import { Ionicons } from '@expo/vector-icons';
 function MyCheckbox({ /* @info Define checked and onChange as props instead of state */onChange, checked/* @end */ }) {
   return (
     <Pressable
+      role="checkbox"
+      aria-checked={checked}
       style={[styles.checkboxBase, checked && styles.checkboxChecked]}
       onPress={onChange}>
       {checked && <Ionicons name="checkmark" size={24} color="white" />}
@@ -191,6 +195,8 @@ function MyCheckbox({
   /* @end */
   return (
     <Pressable
+      role="checkbox"
+      aria-checked={checked}
       style={[
         buttonStyle,
         /* @info Pass the active / inactive style props to the button based on the current checked value */ checked


### PR DESCRIPTION
Most people referencing this tutorial would not know that these fields (role and aria-checked) need to be added for screen readers to understand the semantic meaning of the Pressable component.

# Why
Most people referencing this tutorial would not know that these fields (role and aria-checked) need to be added for screen readers to understand the semantic meaning of the Pressable component.

# How
I added `role="checkbox"` and `aria-checked={checked}` to the examples, along with an info comment on the first one.

# Test Plan
Not applicable.

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
