### PR TITLE
[expo-dev-menu][ios] Fix build failure on 0.76 with use frameworks

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unpublished
 
-[ios] Fix build failure on 0.76 with use frameworks ([#32341](https://github.com/expo/expo/pull/32341) by [@matinzd](https://github.com/matinzd))
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- [iOS] Fix build failure on 0.76 with use frameworks. ([#32341](https://github.com/expo/expo/pull/32341) by [@matinzd](https://github.com/matinzd))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+[ios] Fix build failure on 0.76 with use frameworks ([#32341](https://github.com/expo/expo/pull/32341) by [@matinzd](https://github.com/matinzd))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-jserrorhandler/React_jserrorhandler.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-nativeconfig/React_nativeconfig.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-performancetimeline/React_performancetimeline.framework/Headers"',
     ])
   end
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why

Build is failing with when using `USE_FRAMEWORKS=static`:

```
'react/performance/timeline/PerformanceEntryReporter.h' file not found
```

# How

Added React-performancetimeline to the header search paths.

# Test Plan

Here's an improved version with more clarity and actionable points:

---

# Test Plan

Ensure that the CI pipeline successfully runs with the `USE_FRAMEWORKS=static` configuration. 

If there is currently no CI coverage for this configuration, we need to consider adding a dedicated test to validate compatibility and catch potential issues early. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
