### PR TITLE
[sqlite] sync outdate changes from #32181

### DIFF
--- a/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
@@ -4,7 +4,7 @@ description: A library that provides access to a database that can be queried th
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-sqlite'
 packageName: 'expo-sqlite'
 iconUrl: '/static/images/packages/expo-sqlite.png'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'macos']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added macOS support in expo-sqlite. ([#32181](https://github.com/expo/expo/pull/32181) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others
@@ -23,7 +25,6 @@
 - Added SQLCipher support. ([#30824](https://github.com/expo/expo/pull/30824), [#30825](https://github.com/expo/expo/pull/30825) by [@kudo](https://github.com/kudo))
 - Added a way to specify custom directory for the database. ([#31278](https://github.com/expo/expo/pull/31278)) by [@IgorKhramtsov](https://github.com/IgorKhramtsov)
 - Added key-value storage and compatible API with `@react-native-async-storage/async-storage`. ([#31596](https://github.com/expo/expo/pull/31596), [#31676](https://github.com/expo/expo/pull/31676) by [@kudo](https://github.com/kudo))
-- Added macOS support in expo-sqlite. ([#32181](https://github.com/expo/expo/pull/32181) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

fix outdated changes from #32181

# How

- move changelog to right place
- add macos to sdk 52 doc