### PR TITLE
[autolinking] fix aar build error

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build error from `gradleAarProjects`. ([#32349](https://github.com/expo/expo/pull/32349) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.0.0-preview.0 — 2024-10-22

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -245,7 +245,11 @@ if (rootProject instanceof ProjectDescriptor) {
       }
       for (moduleAarProject in module.aarProjects) {
         include(":${moduleAarProject.name}")
-        project(":${moduleAarProject.name}").projectDir = new File(moduleAarProject.projectDir)
+        def projectDir = new File(moduleAarProject.projectDir)
+        if (!projectDir.exists()) {
+          projectDir.mkdirs()
+        }
+        project(":${moduleAarProject.name}").projectDir = projectDir
       }
     }
 


### PR DESCRIPTION
# Why

fixes build error from `gradleAarProjects`

# How

apply fix from https://github.com/expo/expo/pull/30707#issuecomment-2437350834

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
