### PR TITLE
[go][dev-launcher] fix crash from network interceptor

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
@@ -3,9 +3,11 @@
 package versioned.host.exp.exponent
 
 import android.net.Uri
+import android.util.Log
 import com.facebook.react.packagerconnection.ReconnectingWebSocket
 import expo.modules.kotlin.devtools.ExpoRequestCdpInterceptor
 import java.io.Closeable
+import java.io.IOException
 
 class ExpoNetworkInterceptor(private val appUrl: Uri) : Closeable, ExpoRequestCdpInterceptor.Delegate {
   private var metroConnection: ReconnectingWebSocket? = null
@@ -33,9 +35,17 @@ class ExpoNetworkInterceptor(private val appUrl: Uri) : Closeable, ExpoRequestCd
 
   //region ExpoRequestCdpInterceptor.Delegate implementations
   override fun dispatch(event: String) {
-    metroConnection?.sendMessage(event)
+    try {
+      metroConnection?.sendMessage(event)
+    } catch (_: IOException) {
+      Log.w(TAG, "Failed to send CDP network event")
+    }
   }
   //endregion ExpoRequestCdpInterceptor.Delegate implementations
+
+  companion object {
+    private val TAG = ExpoNetworkInterceptor::class.java.simpleName
+  }
 }
 
 private fun createMetroConnection(appUrl: Uri): ReconnectingWebSocket {

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `java.nio.channels.ClosedChannelException` crash from network inspector. ([#32352](https://github.com/expo/expo/pull/32352) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Skipped internal bundles from debugging targets. ([#32322](https://github.com/expo/expo/pull/32322) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherNetworkInterceptor.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherNetworkInterceptor.kt
@@ -3,9 +3,11 @@
 package expo.modules.devlauncher.launcher
 
 import android.net.Uri
+import android.util.Log
 import com.facebook.react.packagerconnection.ReconnectingWebSocket
 import expo.modules.kotlin.devtools.ExpoRequestCdpInterceptor
 import java.io.Closeable
+import java.io.IOException
 
 internal class DevLauncherNetworkInterceptor(appUrl: Uri) : Closeable, ExpoRequestCdpInterceptor.Delegate {
   private val metroConnection = ReconnectingWebSocket(
@@ -30,9 +32,17 @@ internal class DevLauncherNetworkInterceptor(appUrl: Uri) : Closeable, ExpoReque
 
   //region ExpoRequestCdpInterceptor.Delegate implementations
   override fun dispatch(event: String) {
-    metroConnection.sendMessage(event)
+    try {
+      metroConnection.sendMessage(event)
+    } catch (_: IOException) {
+      Log.w(TAG, "Failed to send CDP network event")
+    }
   }
   //endregion ExpoRequestCdpInterceptor.Delegate implementations
+
+  companion object {
+    private val TAG = DevLauncherNetworkInterceptor::class.java.simpleName
+  }
 }
 
 private fun createNetworkInspectorUrl(appUrl: Uri): String {


### PR DESCRIPTION
# Why

fix crash when dev-server is stopped
```
            DevLauncher  E  DevLauncher tries to handle uncaught exception.
                         E  java.nio.channels.ClosedChannelException
                         E      at com.facebook.react.packagerconnection.ReconnectingWebSocket.sendMessage(ReconnectingWebSocket.java:182)
                         E      at expo.modules.devlauncher.launcher.DevLauncherNetworkInterceptor.dispatch(DevLauncherNetworkInterceptor.kt:33)
                         E      at expo.modules.kotlin.devtools.ExpoRequestCdpInterceptor$dispatchEvent$1.invokeSuspend(ExpoRequestCdpInterceptor.kt:37)
                         E      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                         E      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
                         E      Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3c81434, Dispatchers.Default]
```

# How

try-catch the sender

# Test Plan

stop the dev server and do `fetch` in js

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
