### PR TITLE
[ios][camera] Fix Barcode scanner concurrency issues

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -34,7 +34,7 @@ _This version does not introduce any user-facing changes._
 - Fix `takePictureAsync` `quality` option when set to 0. ([#31587](https://github.com/expo/expo/pull/31587) by [@davidavz](https://github.com/davidavz))
 - [iOS] Fix crash related to `sublayers` on 0.75 and above on the new architecture. ([#32194](https://github.com/expo/expo/pull/32194) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix regression in running the cameras cleanup function. ([#32333](https://github.com/expo/expo/pull/32333) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Use an `Actor` to ensure correct order of changes to the barcode scanners outputs.
+- [iOS] Use an `Actor` to ensure correct order of changes to the barcode scanners outputs. ([#32353](https://github.com/expo/expo/pull/32353) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -34,6 +34,7 @@ _This version does not introduce any user-facing changes._
 - Fix `takePictureAsync` `quality` option when set to 0. ([#31587](https://github.com/expo/expo/pull/31587) by [@davidavz](https://github.com/davidavz))
 - [iOS] Fix crash related to `sublayers` on 0.75 and above on the new architecture. ([#32194](https://github.com/expo/expo/pull/32194) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix regression in running the cameras cleanup function. ([#32333](https://github.com/expo/expo/pull/32333) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Use an `Actor` to ensure correct order of changes to the barcode scanners outputs.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -3,7 +3,7 @@ import AVFoundation
 
 let BARCODE_TYPES_KEY = "barcodeTypes"
 
-class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
+actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   var onBarcodeScanned: (([String: Any]?) -> Void)?
   var isScanningBarcodes = false
 
@@ -21,8 +21,8 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     AVMetadataObject.ObjectType.code39: ZXCode39Reader()
   ]
   private var previewLayer: AVCaptureVideoPreviewLayer?
-  private var zxingFPSProcessed = 6.0
   private var zxingEnabled = true
+  private var delegate: MetatDataDelegate?
 
   init(session: AVCaptureSession, sessionQueue: DispatchQueue) {
     self.session = session
@@ -42,7 +42,7 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
         let zxingCoveredTypes = Set(zxingBarcodeReaders.keys)
         zxingEnabled = !zxingCoveredTypes.isDisjoint(with: newTypes)
         Task {
-          await self.maybeStartBarcodeScanning()
+          await maybeStartBarcodeScanning()
         }
       }
     }
@@ -52,23 +52,21 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     self.previewLayer = layer
   }
 
-  func setIsEnabled(_ enabled: Bool) {
+  func setIsEnabled(_ enabled: Bool) async {
     guard isScanningBarcodes != enabled else {
       return
     }
 
     isScanningBarcodes = enabled
-    Task {
-      if isScanningBarcodes {
-        if metadataOutput != nil {
-          setConnection(enabled: true)
-        } else {
-          await maybeStartBarcodeScanning()
-        }
+    if isScanningBarcodes {
+      if metadataOutput != nil {
+        setConnection(enabled: true)
       } else {
-        setConnection(enabled: false)
-        await stopBarcodeScanning()
+        await maybeStartBarcodeScanning()
       }
+    } else {
+      setConnection(enabled: false)
+      await stopBarcodeScanning()
     }
   }
 
@@ -105,43 +103,20 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     }
   }
 
-  func scanBarcodes(from image: CGImage, completion: @escaping (ZXResult) -> Void) {
-    let source = ZXCGImageLuminanceSource(cgImage: image)
-    let binarizer = ZXHybridBinarizer(source: source)
-    let bitmap = ZXBinaryBitmap(binarizer: binarizer)
-
-    var result: ZXResult?
-
-    for reader in zxingBarcodeReaders.values {
-      result = try? reader.decode(bitmap, hints: nil)
-      if result != nil {
-        break
-      }
-    }
-
-    if result == nil && bitmap?.rotateSupported == true {
-      if let rotatedBitmap = bitmap?.rotateCounterClockwise() {
-        for reader in zxingBarcodeReaders.values {
-          result = try? reader.decode(rotatedBitmap, hints: nil)
-          if result != nil {
-            break
-          }
-        }
-      }
-    }
-
-    if let result {
-      completion(result)
-    }
-  }
-
   private func addOutputs() async {
     session.beginConfiguration()
     defer { session.commitConfiguration() }
 
+    delegate = MetatDataDelegate(
+      settings: settings,
+      previewLayer: previewLayer,
+      zxingBarcodeReaders: zxingBarcodeReaders,
+      zxingEnabled: zxingEnabled,
+      metadataResultHandler: self)
+
     if metadataOutput == nil {
       let output = AVCaptureMetadataOutput()
-      output.setMetadataObjectsDelegate(self, queue: sessionQueue)
+      output.setMetadataObjectsDelegate(delegate, queue: sessionQueue)
       if session.canAddOutput(output) {
         session.addOutput(output)
         metadataOutput = output
@@ -152,7 +127,7 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
       let output = AVCaptureVideoDataOutput()
       output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
       output.alwaysDiscardsLateVideoFrames = true
-      output.setSampleBufferDelegate(self, queue: zxingCaptureQueue)
+      output.setSampleBufferDelegate(delegate, queue: zxingCaptureQueue)
       if session.canAddOutput(output) {
         session.addOutput(output)
         videoDataOutput = output
@@ -179,55 +154,7 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     }
   }
 
-  func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
-    guard let settings = settings[BARCODE_TYPES_KEY], let metadataOutput else {
-      return
-    }
-
-    for metadata in metadataObjects {
-      var codeMetadata = metadata as? AVMetadataMachineReadableCodeObject
-      if let previewLayer {
-        codeMetadata = previewLayer.transformedMetadataObject(for: metadata) as? AVMetadataMachineReadableCodeObject
-      }
-
-      for barcodeType in settings {
-        if zxingBarcodeReaders[barcodeType] != nil {
-          continue
-        }
-
-        if let codeMetadata {
-          if codeMetadata.stringValue != nil && codeMetadata.type == barcodeType {
-            onBarcodeScanned?(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
-          }
-        }
-      }
-    }
-  }
-
-  func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-    guard let barcodeTypes = settings[BARCODE_TYPES_KEY],
-      let metadataOutput,
-      zxingEnabled else {
-      return
-    }
-
-    let kMinMargin = 1.0 / zxingFPSProcessed
-    let presentTimeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-
-    var curFrameTimeStamp = 0.0
-    var lastFrameTimeStamp = 0.0
-
-    curFrameTimeStamp = Double(presentTimeStamp.value) / Double(presentTimeStamp.timescale)
-
-    if curFrameTimeStamp - lastFrameTimeStamp > Double(kMinMargin) {
-      lastFrameTimeStamp = curFrameTimeStamp
-
-      if let videoFrame = CMSampleBufferGetImageBuffer(sampleBuffer),
-      let videoFrameImage = ZXCGImageLuminanceSource.createImage(from: videoFrame) {
-        self.scanBarcodes(from: videoFrameImage) { barcodeScannerResult in
-          self.onBarcodeScanned?(BarcodeScannerUtils.zxResultToDictionary(barcodeScannerResult))
-        }
-      }
-    }
+  func onScanningResult(_ result: [String: Any]) {
+    self.onBarcodeScanned?(result)
   }
 }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -49,7 +49,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var isScanningBarcodes = false {
     didSet {
-      barcodeScanner.setIsEnabled(isScanningBarcodes)
+      Task {
+       await barcodeScanner.setIsEnabled(isScanningBarcodes)
+      }
     }
   }
 
@@ -145,7 +147,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     UIDevice.current.beginGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(orientationChanged(notification:)),
+      selector: #selector(orientationChanged),
       name: UIDevice.orientationDidChangeNotification,
       object: nil)
     lifecycleManager?.register(self)
@@ -303,7 +305,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   func setBarcodeScannerSettings(settings: BarcodeSettings) {
-    barcodeScanner.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
+    Task {
+     await barcodeScanner.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
+    }
   }
 
   func updateResponsiveOrientation() {
@@ -770,8 +774,10 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     previewLayer.connection?.isEnabled = false
   }
 
-  @objc func orientationChanged(notification: Notification) async {
-    await changePreviewOrientation()
+  @objc func orientationChanged() {
+    Task {
+      await changePreviewOrientation()
+    }
   }
 
   @MainActor

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -50,7 +50,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   var isScanningBarcodes = false {
     didSet {
       Task {
-       await barcodeScanner.setIsEnabled(isScanningBarcodes)
+        await barcodeScanner.setIsEnabled(isScanningBarcodes)
       }
     }
   }
@@ -306,7 +306,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   func setBarcodeScannerSettings(settings: BarcodeSettings) {
     Task {
-     await barcodeScanner.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
+      await barcodeScanner.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
     }
   }
 

--- a/packages/expo-camera/ios/Current/MetatDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetatDataDelegate.swift
@@ -12,11 +12,13 @@ class MetatDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCap
   private var zxingFPSProcessed = 6.0
   private let responseHandler: BarcodeScanningResponseHandler
 
-  init(settings: [String: [AVMetadataObject.ObjectType]],
-       previewLayer: AVCaptureVideoPreviewLayer?,
-       zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader],
-       zxingEnabled: Bool,
-       metadataResultHandler: BarcodeScanningResponseHandler) {
+  init(
+    settings: [String: [AVMetadataObject.ObjectType]],
+    previewLayer: AVCaptureVideoPreviewLayer?,
+    zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader],
+    zxingEnabled: Bool,
+    metadataResultHandler: BarcodeScanningResponseHandler
+  ) {
     self.settings = settings
     self.previewLayer = previewLayer
     self.zxingEnabled = zxingEnabled

--- a/packages/expo-camera/ios/Current/MetatDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetatDataDelegate.swift
@@ -1,0 +1,110 @@
+import ZXingObjC
+
+protocol BarcodeScanningResponseHandler {
+  func onScanningResult(_ result: [String: Any]) async
+}
+
+class MetatDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
+  private var settings: [String: [AVMetadataObject.ObjectType]]
+  private var previewLayer: AVCaptureVideoPreviewLayer?
+  private var zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader]
+  private var zxingEnabled = true
+  private var zxingFPSProcessed = 6.0
+  private let responseHandler: BarcodeScanningResponseHandler
+
+  init(settings: [String: [AVMetadataObject.ObjectType]],
+       previewLayer: AVCaptureVideoPreviewLayer?,
+       zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader],
+       zxingEnabled: Bool,
+       metadataResultHandler: BarcodeScanningResponseHandler) {
+    self.settings = settings
+    self.previewLayer = previewLayer
+    self.zxingEnabled = zxingEnabled
+    self.responseHandler = metadataResultHandler
+    self.zxingBarcodeReaders = zxingBarcodeReaders
+  }
+
+  func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+    guard let settings = settings[BARCODE_TYPES_KEY] else {
+      return
+    }
+
+    for metadata in metadataObjects {
+      var codeMetadata = metadata as? AVMetadataMachineReadableCodeObject
+      if let previewLayer {
+        codeMetadata = previewLayer.transformedMetadataObject(for: metadata) as? AVMetadataMachineReadableCodeObject
+      }
+
+      for barcodeType in settings {
+        if zxingBarcodeReaders[barcodeType] != nil {
+          continue
+        }
+
+        if let codeMetadata {
+          if codeMetadata.stringValue != nil && codeMetadata.type == barcodeType {
+            Task {
+              await responseHandler.onScanningResult(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+    guard zxingEnabled else {
+      return
+    }
+
+    let kMinMargin = 1.0 / zxingFPSProcessed
+    let presentTimeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+
+    var curFrameTimeStamp = 0.0
+    var lastFrameTimeStamp = 0.0
+
+    curFrameTimeStamp = Double(presentTimeStamp.value) / Double(presentTimeStamp.timescale)
+
+    if curFrameTimeStamp - lastFrameTimeStamp > Double(kMinMargin) {
+      lastFrameTimeStamp = curFrameTimeStamp
+
+      if let videoFrame = CMSampleBufferGetImageBuffer(sampleBuffer),
+      let videoFrameImage = ZXCGImageLuminanceSource.createImage(from: videoFrame) {
+        self.scanBarcodes(from: videoFrameImage) { barcodeScannerResult in
+          Task {
+            await self.responseHandler.onScanningResult(BarcodeScannerUtils.zxResultToDictionary(barcodeScannerResult))
+          }
+        }
+      }
+    }
+  }
+
+  func scanBarcodes(from image: CGImage, completion: @escaping (ZXResult) -> Void) {
+    let source = ZXCGImageLuminanceSource(cgImage: image)
+    let binarizer = ZXHybridBinarizer(source: source)
+    let bitmap = ZXBinaryBitmap(binarizer: binarizer)
+
+    var result: ZXResult?
+
+    for reader in zxingBarcodeReaders.values {
+      result = try? reader.decode(bitmap, hints: nil)
+      if result != nil {
+        break
+      }
+    }
+
+    if result == nil && bitmap?.rotateSupported == true {
+      if let rotatedBitmap = bitmap?.rotateCounterClockwise() {
+        for reader in zxingBarcodeReaders.values {
+          result = try? reader.decode(rotatedBitmap, hints: nil)
+          if result != nil {
+            break
+          }
+        }
+      }
+    }
+
+    if let result {
+      completion(result)
+    }
+  }
+}


### PR DESCRIPTION
# Why
I found another issue with the migration to swift concurrency. Opening and closing the QR scanner quickly would sometimes cause a crash because adding and removing outputs on the scanner could run in the incorrect order. Previously, we used a serial queue to manage calls that needed to run on a background thread. This ensured that calling `addOutputs` and `removeOutputs` would happen in a predictable order. With the migration to swift concurrency we lost this guarantee which led to issues like the barcode scanners `addOutputs` function being called again before `removeOutputs` had finished

# How
The solution is to make the `BarcodeScanner` class an `Actor`. This guarantees that the calls to `addOutputs` and `removeOutputs` will run in a predictable order. I created a separate delegate class to handle the metadata and video output callbacks because actors do not support obj-c methods. 

# Test Plan
expo-go with NCL

