### PR TITLE
[cli][ngrok] Fix invalid project randomness

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix invalid project randomness when using Ngrok ([#32359](https://github.com/expo/expo/pull/32359) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.19.3 — 2024-10-25

--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -224,14 +224,18 @@ export class AsyncNgrok {
 
   private async getProjectRandomnessAsync() {
     const { urlRandomness: randomness } = await ProjectSettings.readAsync(this.projectRoot);
-    if (randomness) {
+    if (randomness && /^[A-Za-z0-9]/.test(randomness)) {
       return randomness;
     }
     return await this._resetProjectRandomnessAsync();
   }
 
   async _resetProjectRandomnessAsync() {
-    const randomness = crypto.randomBytes(5).toString('base64url');
+    let randomness: string;
+    do {
+      randomness = crypto.randomBytes(5).toString('base64url');
+    } while (randomness.startsWith('_')); // _ is an invalid character for a hostname
+
     await ProjectSettings.setAsync(this.projectRoot, { urlRandomness: randomness });
     debug('Resetting project randomness:', randomness);
     return randomness;

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
@@ -164,4 +164,23 @@ describe('_getProjectHostnameAsync', () => {
     // randomness is persisted
     expect(JSON.parse(vol.toJSON()['/.expo/settings.json']).urlRandomness).toBeDefined();
   });
+
+  it(`ignore invalid urlRandomness values`, async () => {
+    const { projectRoot, ngrok } = createNgrokInstance();
+    const invalidRandomness = '_abcdef';
+    vol.fromJSON(
+      { '/.expo/settings.json': `{"urlRandomness": "${invalidRandomness}"}` },
+      projectRoot
+    );
+
+    const hostname = await ngrok._getProjectHostnameAsync();
+
+    // The invalid randomness should be ignored
+    expect(hostname).not.toEqual('_abcd-anonymous-3000.exp.direct');
+
+    // New randomness should be generated
+    expect(JSON.parse(vol.toJSON()['/.expo/settings.json']).urlRandomness).not.toEqual(
+      invalidRandomness
+    );
+  });
 });


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/32154

# How

Filter out invalid hostname characters when generating project randomness

# Test Plan

Run `yarn start --tunnel` and update tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
