### PR TITLE
[docs] Update code signing docs with source control recommendations

### DIFF
--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -32,11 +32,11 @@ In this step, we will generate a key pair and corresponding code signing certifi
 
 This command generated a key pair along with a code signing certificate to be included in the app:
 
-- `../keys/private-key.pem` - the private key of the key pair.
-- `../keys/public-key.pem` - the public key of the key pair.
-- `certs/certificate.pem` - the code signing certificate, configured to be valid for 10 years. This file should be added to source control (if applicable).
+- `../keys/private-key.pem`: the private key of the key pair.
+- `../keys/public-key.pem`: the public key of the key pair.
+- `certs/certificate.pem`: the code signing certificate configured to be valid for 10 years. This file should be added to source control (if applicable).
 
-- The generated private key must be kept private and secure. The command above suggests generating them into a directory outside of your project (`../keys`, for example) to store the keys to help ensure they are not accidentally checked into source control. We recommend storing the private key in the same way you would store other sensitive information (KMS, password manager, etc...), and how you store it will vary the steps needed to publish an update in step 3.
+- The generated private key must be kept private and secure. The command above suggests generating and storing these keys in a directory outside of your project (for example, **../keys**) to ensure they are not accidentally checked into source control. We recommend storing the private key in the same way you would store other sensitive information (KMS, password manager, and so on), and how you store it will vary the steps needed to publish an update in step (3).
 - The public key may be stored alongside the private key, but isn't sensitive.
 - The certificate should be included in the project (checked into source control). It contains the public key and a method for verifying code signatures. When a signed update is downloaded, the update's signature is verified using this certificate.
 - The certificate validity duration is a setting that may vary based on the security needs of your app.

--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -10,27 +10,35 @@ import { Step } from '~/ui/components/Step';
 
 > **info** EAS Update Code Signing is only available to accounts subscribed to the EAS Production or Enterprise plans. [Learn more](https://expo.dev/pricing).
 
-The `expo-updates` library supports end-to-end code signing. Code signing allows developers to cryptographically sign their updates with their own keys. The signatures are then verified on the client before the update is applied, which ensures ISPs, CDNs, cloud providers, and even EAS itself cannot tamper with updates run by apps.
+The `expo-updates` library supports end-to-end code signing using [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography). Code signing allows developers to cryptographically sign their updates with their own keys. The signatures are then verified on the client before the update is applied, which ensures ISPs, CDNs, cloud providers, and even EAS itself cannot tamper with updates run by apps.
 
 The following steps will guide you through the process of generating a private key and corresponding certificate, configuring your project to use code signing, and publishing a signed update for your app.
 
 <Step label="1">
 ## Generate a private key and corresponding certificate
 
-In this step, we will generate a private key and corresponding code signing certificate for your app:
+In this step, we will generate a key pair and corresponding code signing certificate for your app:
 
 <Terminal
   cmd={[
     '$ npx expo-updates codesigning:generate \\',
-    '  --key-output-directory keys \\',
+    '  --key-output-directory ../keys \\',
     '  --certificate-output-directory certs \\',
     '  --certificate-validity-duration-years 10 \\',
-    '  --certificate-common-name "Your App Name"',
+    '  --certificate-common-name "Your Organization Name"',
   ]}
-  cmdCopy='npx expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 10 --certificate-common-name "Your App Name"'
+  cmdCopy='npx expo-updates codesigning:generate --key-output-directory ../keys --certificate-output-directory certs --certificate-validity-duration-years 10 --certificate-common-name "Your Organization Name"'
 />
 
-- The generated private key must be kept private and secure.
+This command generated a key pair along with a code signing certificate to be included in the app:
+
+- `../keys/private-key.pem` - the private key of the key pair.
+- `../keys/public-key.pem` - the public key of the key pair.
+- `certs/certificate.pem` - the code signing certificate, configured to be valid for 10 years. This file should be added to source control (if applicable).
+
+- The generated private key must be kept private and secure. The command above suggests generating them into a directory outside of your project (`../keys`, for example) to store the keys to help ensure they are not accidentally checked into source control. We recommend storing the private key in the same way you would store other sensitive information (KMS, password manager, etc...), and how you store it will vary the steps needed to publish an update in step 3.
+- The public key may be stored alongside the private key, but isn't sensitive.
+- The certificate should be included in the project (checked into source control). It contains the public key and a method for verifying code signatures. When a signed update is downloaded, the update's signature is verified using this certificate.
 - The certificate validity duration is a setting that may vary based on the security needs of your app.
   - A shorter validity duration will require [key rotation](#key-rotation) more frequently but is considered better practice since a compromised private key will have a sooner expiration which limits exposure.
   - Shorter validity durations add overhead to your app's release process as the key must be rotated more frequently. Binaries with expired certificates won't apply new updates.
@@ -46,7 +54,7 @@ In this step, we will generate a private key and corresponding code signing cert
   cmd={[
     '$ npx expo-updates codesigning:configure \\',
     '  --certificate-input-directory certs \\',
-    '  --key-input-directory keys',
+    '  --key-input-directory ../keys',
   ]}
 />
 
@@ -76,7 +84,7 @@ After running the above command, your **app.json** will include additional confi
 
 <br />
 
-**If you are not using Continuous Native Generation (CNG) to generate your native projects**, then you will need to configure the code signing in your app **AndroidManifest.xml** and/or **Expo.plist** files.
+**If you are not using Continuous Native Generation (CNG) to generate your native projects**, then you will need to configure code signing in your app **AndroidManifest.xml** and/or **Expo.plist** files.
 
 <Collapsible summary="Configure code signing in an Android native project">
 
@@ -150,21 +158,16 @@ With code signing configured, create a new build with a new runtime version. The
 <Step label="3">
 ## Publish a signed update for your app
 
-<Terminal cmd={['$ eas update --private-key-path keys/private-key.pem']} />
+<Terminal cmd={['$ eas update --private-key-path ../keys/private-key.pem']} />
 
-During `eas update`, the EAS CLI automatically detects that code signing is configured for your app. It then verifies the integrity of the update and creates a digital signature using your private key. This process is performed locally so that your private key never leaves your machine. The generated signature is automatically sent to EAS to store alongside the update.
+During an EAS Update publish using `eas update`, the EAS CLI automatically detects that code signing is configured for your app. It then verifies the integrity of the update and creates a digital signature using your private key. This process is performed locally so that your private key never leaves your machine. The generated signature is automatically sent to EAS to store alongside the update.
 
 </Step>
 
 <Step label="4">
 ## Verify that the update is loaded
 
-Download the update on the client (this step is done automatically by the library). The build from
-step (2) that is configured for code signing checks if there is a new update available. The server
-responds with the update published in step (3) and its generated signature. After being downloaded
-but before being applied, the update is verified against the embedded certificate and included
-signature. The update is applied if the certificate and signature are valid, and rejected
-otherwise.
+Download the update on the client (this step is done automatically by the library). The build from step (2) that is configured for code signing checks if there is a new update available. The server responds with the update published in step (3) and its generated signature. After being downloaded but before being applied, the update is verified against the embedded certificate and included signature. The update is applied if the certificate and signature are valid, and rejected otherwise.
 
 </Step>
 
@@ -175,14 +178,14 @@ otherwise.
 Key rotation is the process by which the key pair used for signing updates is changed. This is most commonly done in a few cases:
 
 - Key expiration. In step (1) from the section above, we set `certificate-validity-duration-years` to 10 years (though it can be configured to any value). This means that after 10 years, updates signed with the private key corresponding to the certificate will no longer be applied after being downloaded by the app. Updates downloaded before the expiration of their signing certificate will continue to function normally. Rotating keys well before the certificate expires helps to preempt any potential key expiration issues and helps to guarantee all users are using the new certificate before the old certificate expires.
-- Private key compromise. If the private key used to sign updates is accidentally exposed to the public, it can no longer be considered secure and therefore can no longer guarantee integrity of updates it signed. For example, a malicious actor could craft a malicious update and sign it with the leaked private key.
+- Private key compromise. If the private key used to sign updates is accidentally exposed to the public, it can no longer be considered secure and therefore the integrity of updates signed with it can no longer be guaranteed. For example, a malicious actor could craft a malicious update and sign it with the leaked private key.
 - Key rotation for security best practices. It is best practice to rotate keys periodically to ensure that a system is resilient to manual key rotation in response to one of the other reasons above.
 
 In any of these cases, the procedure is similar:
 
-1. Backup the old key and certificate that were generated in step (1) above.
-2. Generate a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (**app.json**).
-3. The certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key run in the new build.
+1. Back up the old keys and certificate that were generated in step (1) above.
+2. Generate a new key by following the steps above starting from step (1). To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (**app.json**).
+3. The code signing certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key run in the new build.
 4. Publish signed updates using the new key by following step (3) above.
 
 ### Removing code signing


### PR DESCRIPTION
# Why

We received some questions regarding how to store keys and certs generated during code signing setup. This PR clarifies this and provides recommendations.

Closes ENG-13941.

# How

Update the doc, proofread.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
