### PR TITLE
[docs] Fix build-a-screen.mdx

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -243,9 +243,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flexDirection: 'row',
   },
-  buttonIcon: {
-    paddingRight: 8,
-  },
   buttonLabel: {
     color: '#fff',
     fontSize: 16,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I think `styles.buttonIcon` is not used [here](https://docs.expo.dev/tutorial/build-a-screen/#create-buttons-using-pressable), so we can remove it.

It is used in the [next section](https://docs.expo.dev/tutorial/build-a-screen/#enhance-the-reusable-button-component).

# How

<!--
How did you build this feature or fix this bug and why?
-->

This is just an update for a tutorial document.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
