### PR TITLE
[expo][apps] align React and types version

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.2.79",
+    "@types/react": "~18.3.12",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-expo": "~12.0.0-preview.0",
     "expo-module-scripts": "^4.0.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -65,7 +65,7 @@
     "path-to-regexp": "^1.8.0",
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
-    "react": "18.2.0",
+    "react": "18.3.1",
     "react-native": "0.76.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.20.2",
@@ -94,7 +94,7 @@
     "@types/dedent": "^0.7.0",
     "@types/jest": "^29.2.1",
     "@types/lodash": "^4.14.161",
-    "@types/react": "~18.2.79",
+    "@types/react": "~18.3.12",
     "@types/semver": "^7.5.8",
     "expo-module-scripts": "^4.0.0"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -157,7 +157,7 @@
     "@types/fbemitter": "^2.0.32",
     "@types/i18n-js": "^3.0.1",
     "@types/pixi.js": "^4.8.6",
-    "@types/react": "~18.2.79",
+    "@types/react": "~18.3.12",
     "@types/three": "^0.137.0",
     "babel-jest": "^29.2.1",
     "expo-module-scripts": "^4.0.0",

--- a/packages/expo-dev-client-components/src/create-primitive.tsx
+++ b/packages/expo-dev-client-components/src/create-primitive.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { StyleSheet, type ViewStyle, type ImageStyle, type TextStyle } from 'react-native';
+import { ComponentType, PropsWithChildren, createElement, forwardRef } from 'react';
+import { type ImageStyle, StyleSheet, type TextStyle, type ViewStyle } from 'react-native';
 
 import { useTheme } from './useExpoTheme';
 
@@ -33,34 +33,33 @@ type SelectorProps = {
 };
 
 export function create<T extends object, O extends Options>(
-  component: React.ComponentType<T>,
+  component: ComponentType<T>,
   config: O & { selectors?: Selectors<O['variants']>; props?: T }
 ) {
   config.selectors = config.selectors ?? {};
   config.variants = config.variants ?? {};
 
-  const Component = React.forwardRef<
+  return forwardRef<
     T,
-    React.PropsWithChildren<T> & Nested<(typeof config)['variants']> & { selectors?: SelectorProps }
+    PropsWithChildren<T> & Nested<(typeof config)['variants']> & { selectors?: SelectorProps }
   >((props, ref) => {
     const theme = useTheme();
 
+    const variantFreeProps: any = { ...props };
+
     const variantStyles = stylesForVariants(props, config.variants);
     const selectorStyles = stylesForSelectors(props, config.selectors, { theme });
-    const selectorPropsStyles = stylesForSelectorProps(props.selectors, { theme });
-
-    const variantFreeProps: any = { ...props };
+    const selectorPropsStyles = stylesForSelectorProps(variantFreeProps.selectors, { theme });
 
     // @ts-ignore
     // there could be a conflict between the primitive prop and the variant name
     // for example - variant name "width" and prop "width"
     // in these cases, favor the variant because it is under the users control (e.g they can update the conflicting name)
-
     Object.keys(config.variants).forEach((variant) => {
       delete variantFreeProps[variant];
     });
 
-    return React.createElement(component, {
+    return createElement(component, {
       ...config.props,
       ...variantFreeProps,
       style: StyleSheet.flatten([
@@ -68,14 +67,11 @@ export function create<T extends object, O extends Options>(
         variantStyles,
         selectorStyles,
         selectorPropsStyles,
-        // @ts-ignore
-        props.style || {},
+        variantFreeProps.style ?? {},
       ]),
       ref,
     });
   });
-
-  return Component;
 }
 
 function stylesForVariants(props: any, variants: any = {}) {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -83,8 +83,8 @@
     "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
-    "@types/react": "~18.2.79",
-    "@types/react-test-renderer": "^18.0.0",
+    "@types/react": "~18.3.12",
+    "@types/react-test-renderer": "^18.3.0",
     "expo-module-scripts": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,17 +4228,17 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-test-renderer@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
-  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+"@types/react-test-renderer@^18.3.0":
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.3.0.tgz#839502eae70058a4ae161f63385a8e7929cef4c0"
+  integrity sha512-HW4MuEYxfDbOHQsVlY/XtOvNHftCVEPhJF2pQXXwcUiUF+Oyb0usgp48HSgpK5rt8m9KZb22yqOeZm+rrVG8gw==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@~18.2.79":
-  version "18.2.79"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
-  integrity sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==
+"@types/react@*", "@types/react@~18.3.12":
+  version "18.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
+  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -13743,7 +13743,7 @@ react-timer-mixin@^0.13.3:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
-react@18.2.0, react@18.3.1:
+react@18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
# Why

Spotted few React and types version mismatches in the `expo` package and apps.

# How

Align React and React types version, make sure that there is only one version of React in monorepo.

# Test Plan

Few basic test run locally passed successfully, let's run the CI for more comprehensive coverage.