### PR TITLE
[ios][camera] Fix build issue with after switch to Swift concurrency

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix build issue with after switch to Swift concurrency. ([#TBC](https://github.com/expo/expo/pull/) by [@eingin](https://github.com/Eingin))
+
 ### 💡 Others
 
 ## 16.0.2 — 2024-10-25

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix build issue with after switch to Swift concurrency. ([#TBC](https://github.com/expo/expo/pull/) by [@eingin](https://github.com/Eingin))
+- [iOS] Fix build issue with after switch to Swift concurrency. ([#32379](https://github.com/expo/expo/pull/32379) by [@Eingin](https://github.com/Eingin))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -76,6 +76,10 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     }
   }
 
+  func setOnBarcodeScanned(_ onBarcodeScanned: @escaping ([String: Any]?) -> Void) {
+    self.onBarcodeScanned = onBarcodeScanned
+  }
+
   func maybeStartBarcodeScanning() async {
     guard isScanningBarcodes else {
       return

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -4,7 +4,7 @@ import AVFoundation
 let BARCODE_TYPES_KEY = "barcodeTypes"
 
 actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
-  var onBarcodeScanned: (([String: Any]?) -> Void)?
+  private var onBarcodeScanned: (([String: Any]?) -> Void)?
   var isScanningBarcodes = false
 
   // MARK: - Properties

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -801,10 +801,10 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
           )
           await scanner.setOnBarcodeScanned { [weak self] body in
               guard let self else {
-                  return
+                return
               }
               if let body {
-                  self.onBarcodeScanned(body)
+                self.onBarcodeScanned(body)
               }
           }
       }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -791,14 +791,10 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   private func createBarcodeScanner() -> BarcodeScanner {
-    let scanner = BarcodeScanner(
-      session: session,
-      sessionQueue: sessionQueue
-    )
+    let scanner = BarcodeScanner(session: session, sessionQueue: sessionQueue)
+
     Task {
-      await scanner.setPreviewLayer(
-        layer: previewLayer
-      )
+      await scanner.setPreviewLayer(layer: previewLayer)
       await scanner.setOnBarcodeScanned { [weak self] body in
         guard let self else {
           return

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -791,23 +791,23 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   private func createBarcodeScanner() -> BarcodeScanner {
-      let scanner = BarcodeScanner(
-        session: session,
-        sessionQueue: sessionQueue
+    let scanner = BarcodeScanner(
+      session: session,
+      sessionQueue: sessionQueue
+    )
+    Task {
+      await scanner.setPreviewLayer(
+        layer: previewLayer
       )
-      Task {
-          await scanner.setPreviewLayer(
-            layer: previewLayer
-          )
-          await scanner.setOnBarcodeScanned { [weak self] body in
-              guard let self else {
-                return
-              }
-              if let body {
-                self.onBarcodeScanned(body)
-              }
-          }
+      await scanner.setOnBarcodeScanned { [weak self] body in
+        guard let self else {
+          return
+        }
+        if let body {
+          self.onBarcodeScanned(body)
+        }
       }
+    }
 
     return scanner
   }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -791,16 +791,23 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   private func createBarcodeScanner() -> BarcodeScanner {
-    let scanner = BarcodeScanner(session: session, sessionQueue: sessionQueue)
-    scanner.setPreviewLayer(layer: previewLayer)
-    scanner.onBarcodeScanned = { [weak self] body in
-      guard let self else {
-        return
+      let scanner = BarcodeScanner(
+        session: session,
+        sessionQueue: sessionQueue
+      )
+      Task {
+          await scanner.setPreviewLayer(
+            layer: previewLayer
+          )
+          await scanner.setOnBarcodeScanned { [weak self] body in
+              guard let self else {
+                  return
+              }
+              if let body {
+                  self.onBarcodeScanned(body)
+              }
+          }
       }
-      if let body {
-        self.onBarcodeScanned(body)
-      }
-    }
 
     return scanner
   }


### PR DESCRIPTION
# Why
`expo-camera` does not currently compile for iOS because of a bug that was missed after the change to use Swift concurrency.

Closes #32378

# How
Wrapped the code within the `createBarcodeScanner` where the invalid code is in a `Task`. Also an created a setter for `onBarcodeScanned` to satisfy the Swift compiler.

# Test Plan
Was able to build the `bare-expo` app after applying theses changes.
