### PR TITLE
[router] Fix for push not pushing screens to the stack and working with history

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixes [#25001](https://github.com/expo/expo/issues/25001) [#32338](https://github.com/expo/expo/issues/29928) issue with pushing screens to the stack that use the same route with different params. router.push() now always pushes a screen to the stack that appropriately navigates backwards through the history. ([#32338](https://github.com/expo/expo/pull/32338) by [@KennethStarkRL](https://github.com/KennethStarkRL))
+
 ### 💡 Others
 
 ## 4.0.0-preview.3 — 2024-10-26

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixes [#25001](https://github.com/expo/expo/issues/25001) [#32338](https://github.com/expo/expo/issues/29928) issue with pushing screens to the stack that use the same route with different params. router.push() now always pushes a screen to the stack that appropriately navigates backwards through the history. ([#32338](https://github.com/expo/expo/pull/32338) by [@KennethStarkRL](https://github.com/KennethStarkRL))
+- Fixes [#25001](https://github.com/expo/expo/issues/25001) [#32338](https://github.com/expo/expo/issues/29928) issue with pushing screens to the stack that use the same route with different params. router.push() now always pushes a screen to the stack that appropriately navigates backwards through the history. ([#32386](https://github.com/expo/expo/pull/32386) by [@KennethStarkRL](https://github.com/KennethStarkRL))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/global-state/routing.ts
+++ b/packages/expo-router/src/global-state/routing.ts
@@ -173,7 +173,12 @@ export function linkTo(
     return;
   }
 
-  return navigationRef.dispatch(getNavigateAction(state, rootState, event, withAnchor));
+  const navigateAction = getNavigateAction(state, rootState, event);
+
+  if(event === 'PUSH'){
+    return navigationRef.dispatch(native_1.StackActions.push(rootState.routes[0].name,{screen:navigateAction.payload.name,params:navigateAction.payload.params}));
+  }
+  return navigationRef.dispatch(navigateAction);
 }
 
 function getNavigateAction(
@@ -247,30 +252,6 @@ function getNavigateAction(
     params = payload;
 
     actionStateRoute = actionStateRoute.state?.routes[actionStateRoute.state?.routes.length - 1];
-  }
-
-  // Expo Router uses only three actions, but these don't directly translate to all navigator actions
-  if (type === 'PUSH') {
-    // Only stack navigators have a push action, and even then we want to use NAVIGATE (see below)
-    type = 'NAVIGATE';
-
-    /*
-     * The StackAction.PUSH does not work correctly with Expo Router.
-     *
-     * Expo Router provides a getId() function for every route, altering how React Navigation handles stack routing.
-     * Ordinarily, PUSH always adds a new screen to the stack. However, with getId() present, it navigates to the screen with the matching ID instead (by moving the screen to the top of the stack)
-     * When you try and push to a screen with the same ID, no navigation will occur
-     * Refer to: https://github.com/react-navigation/react-navigation/blob/13d4aa270b301faf07960b4cd861ffc91e9b2c46/packages/routers/src/StackRouter.tsx#L279-L290
-     *
-     * Expo Router needs to retain the default behavior of PUSH, consistently adding new screens to the stack, even if their IDs are identical.
-     *
-     * To resolve this issue, we switch to using a NAVIGATE action with a new key. In the navigate action, screens are matched by either key or getId() function.
-     * By generating a unique new key, we ensure that the screen is always pushed onto the stack.
-     *
-     */
-    if (navigationState.type === 'stack') {
-      rootPayload.params.__EXPO_ROUTER_key = `${rootPayload.name}-${nanoid()}`; // @see https://github.com/react-navigation/react-navigation/blob/13d4aa270b301faf07960b4cd861ffc91e9b2c46/packages/routers/src/StackRouter.tsx#L406-L407
-    }
   }
 
   if (navigationState.type === 'expo-tab') {

--- a/packages/expo-router/src/global-state/routing.ts
+++ b/packages/expo-router/src/global-state/routing.ts
@@ -173,7 +173,7 @@ export function linkTo(
     return;
   }
 
-  const navigateAction = getNavigateAction(state, rootState, event);
+  const navigateAction = getNavigateAction(state, rootState, event, withAnchor);
 
   if(event === 'PUSH'){
     return navigationRef.dispatch(native_1.StackActions.push(rootState.routes[0].name,{screen:navigateAction.payload.name,params:navigateAction.payload.params}));


### PR DESCRIPTION
# Why

It's long been an issue that pushing routes to the stack that use the same base route but different params doesn't push a new screen on the stack. [#25001](https://github.com/expo/expo/issues/25001) [#32338](https://github.com/expo/expo/issues/29928) 

# How

<!--
How did you build this feature or fix this bug and why?
-->

We use React Navigations StackAction.push() directly which allows the new route to push. The previous fix was to create a new key for getId(), however, I found that the key is undefined at that point and adding a key didn't fix the issue. It seems expo-router just lets react navigation generate the keys as it's always passing undefined.

# Test Plan

Tested in a dev build of my prod app. Clicking through pages that using push but have the same path with changing params now pushes a new screen onto the stack properly and works with history.

The setup is to have a page that uses params and pushes when the params change.

(entry)
-test
--[param]
---index.jsx

Navigating to pages /test/1 then /test/2, /test/3 ..etc then navigating back down should now navigate backwards through the stack appropriately.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
