### PR TITLE
fix(cli): avoid broadcasting binary events in messages websocket

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - fix async routes in web ssr ([#32331](https://github.com/expo/expo/pull/32331) by [@EvanBacon](https://github.com/EvanBacon))
+- Avoid broadcasting binary data over messages websocket.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - fix async routes in web ssr ([#32331](https://github.com/expo/expo/pull/32331) by [@EvanBacon](https://github.com/EvanBacon))
-- Avoid broadcasting binary data over messages websocket.
+- Avoid broadcasting binary data over messages websocket. ([#32400](https://github.com/expo/expo/pull/32400) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -85,7 +85,7 @@ function createClientMessageHandler(
 
     // Handle broadcast messages
     if (messageIsBroadcast(message)) {
-      return broadcast(null, data);
+      return broadcast(null, data.toString());
     }
 
     // Handle incoming requests from clients

--- a/packages/@expo/cli/src/start/server/metro/dev-server/utils/createSocketBroadcaster.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/utils/createSocketBroadcaster.ts
@@ -1,11 +1,9 @@
-import type { RawData as WebSocketRawData } from 'ws';
-
 import type { SocketId, SocketMap } from './createSocketMap';
 
 const debug = require('debug')('expo:metro:dev-server:broadcaster') as typeof console.log;
 
 export function createBroadcaster(sockets: SocketMap) {
-  return function broadcast(senderSocketId: SocketId | null, message: string | WebSocketRawData) {
+  return function broadcast(senderSocketId: SocketId | null, message: string) {
     // Ignore if there are no connected sockets
     if (!sockets.size) return;
 


### PR DESCRIPTION
# Why

Fixes #32399

The messages websocket is the standard way to interface with the development version of the app -- since we now have our own CLI server API.

Unfortunately, testing `ws` in Jest doesn't give us the full picture -- especially if the receiving end is implemented in another language (like Swift of ObjC). There are subtle differences between sending string messages and sending the string-equivalent in binary format.

# How

- Forced string formatted messages in `/message` websocket's broadcast method
- Forced re-broadcast messages to string before re-broadcasting them

# Test Plan

- `bun create ./test-message --template default@next`
- `cd ./test-message`
- `bun expo run ios`
- Wait until its ready
- Connect a websocket to `ws://localhost:8081/message` (e.g. [with this](https://ws-playground.netlify.app/))
- Send `{"method":"devMenu","version":2}` to open the dev menu
- App should not crash

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
