### PR TITLE
update react-native-safe-area-context to 4.12.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1978,7 +1978,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.11.0):
+  - react-native-safe-area-context (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1991,8 +1991,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 4.11.0)
-    - react-native-safe-area-context/fabric (= 4.11.0)
+    - react-native-safe-area-context/common (= 4.12.0)
+    - react-native-safe-area-context/fabric (= 4.12.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2001,7 +2001,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (4.11.0):
+  - react-native-safe-area-context/common (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2022,7 +2022,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (4.11.0):
+  - react-native-safe-area-context/fabric (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3376,7 +3376,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 0b7db04c18f6bb01ef5b1f9007c3229abecc35dd
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
-  react-native-safe-area-context: f1fda705dfe14355f41933debb5932887e234cc5
+  react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-slider: 124ce99f9cd2d04c79f020da6dee9f8d38a6b8c7
   react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -65,7 +65,7 @@
     "react-native-gesture-handler": "~2.20.2",
     "react-native-pager-view": "6.4.1",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1717,7 +1717,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.11.0):
+  - react-native-safe-area-context (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1730,8 +1730,8 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-safe-area-context/common (= 4.11.0)
-    - react-native-safe-area-context/fabric (= 4.11.0)
+    - react-native-safe-area-context/common (= 4.12.0)
+    - react-native-safe-area-context/fabric (= 4.12.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1740,7 +1740,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/common (4.11.0):
+  - react-native-safe-area-context/common (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1761,7 +1761,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context/fabric (4.11.0):
+  - react-native-safe-area-context/fabric (4.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3073,7 +3073,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: cebbfd12e298f9345fe866d4e028f360bdb13f9f
+  hermes-engine: 038839cdcee75bf907ee1f6208694635bbbd916f
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3117,7 +3117,7 @@ SPEC CHECKSUMS:
   react-native-maps: 2e6e9896195781327ee15b33e3e84bf73c08207a
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 94195f1bf32e7f78359fa20057c97e632364a08b
-  react-native-safe-area-context: f1fda705dfe14355f41933debb5932887e234cc5
+  react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-skia: 425a5610939828363e0681b8b3e994dd4f18b711
   react-native-slider: 124ce99f9cd2d04c79f020da6dee9f8d38a6b8c7

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -75,7 +75,7 @@
     "react-native-pager-view": "^6.4.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-webview": "13.12.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -141,7 +141,7 @@
     "react-native-pager-view": "6.4.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "3.8.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -25,7 +25,7 @@
     "expo-sqlite": "~15.0.0",
     "react": "18.3.1",
     "react-native": "0.76.0",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-webview": "13.12.2"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -11,7 +11,7 @@
     "expo-router": "^3.5.15",
     "expo-splash-screen": "~0.27.0",
     "expo-status-bar": "^1.12.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -95,7 +95,7 @@
   "react-native-pager-view": "6.4.1",
   "react-native-reanimated": "~3.16.1",
   "react-native-screens": "4.0.0-beta.14",
-  "react-native-safe-area-context": "4.11.0",
+  "react-native-safe-area-context": "4.12.0",
   "react-native-svg": "15.8.0",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.12.2",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -35,7 +35,7 @@
     "react-native": "0.76.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -29,7 +29,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.0",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.11.0",
+    "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.14",
     "react-native-web": "~0.19.13"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13577,10 +13577,10 @@ react-native-reanimated@~3.16.1:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.11.0.tgz#d45271363672dc1923ddb0ce5a6ad588e210c85d"
-  integrity sha512-Bg7bozxEB+ZS+H3tVYs5yY1cvxNXgR6nRQwpSMkYR9IN5CbxohLnSprrOPG/ostTCd4F6iCk0c51pExEhifSKQ==
+react-native-safe-area-context@4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz#17868522a55bbc6757418c94a1b4abdda6b045d9"
+  integrity sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==
 
 react-native-screens@4.0.0-beta.14:
   version "4.0.0-beta.14"


### PR DESCRIPTION
# Why

after https://github.com/th3rdwave/react-native-safe-area-context/pull/535 and https://github.com/th3rdwave/react-native-safe-area-context/pull/537

safe area context should now properly support RN 0.76 and autolinking in core

# How

bump the package

# Test Plan

tested in bare expo, expo go wip

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
