### PR TITLE
[docs] Update Expo Tutorial code snippets

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#25292e',
-     /* @tutinfo Modify container styles to remove <CODE>justifyContent</CODE> property. */
+    /* @tutinfo Modify container styles to remove <CODE>justifyContent</CODE> property. */
     alignItems: 'center',
     /* @end */
   },
@@ -137,10 +137,10 @@ Let's divide the code into multiple files as we add more components to this scre
 {/* prettier-ignore */}
 ```tsx components/ImageViewer.tsx|collapseHeight=280
 import { StyleSheet } from "react-native";
-import { Image } from "expo-image";
+import { Image, type ImageSource } from "expo-image";
 
 type Props = {
-  imgSource: string;
+  imgSource: ImageSource;
 };
 
 export default function ImageViewer({ imgSource }: Props) {
@@ -204,9 +204,9 @@ The `@` symbol is a custom [path alias](/guides/typescript/#path-aliases-optiona
 
 ## Create buttons using Pressable
 
-React Native includes a few different components for handling touch events, but[`<Pressable>`](https://reactnative.dev/docs/pressable) is recommended for its flexibility. It can detect single taps, long presses, trigger separate events when the button is pushed in and released, and more.
+React Native includes a few different components for handling touch events, but [`<Pressable>`](https://reactnative.dev/docs/pressable) is recommended for its flexibility. It can detect single taps, long presses, trigger separate events when the button is pushed in and released, and more.
 
-In the design, there are two buttons we need to create. Each has a different style and label. Let's start by creating a reusable component for these buttons. Create a **Button.tsx** file inside the components directory with the following code:
+In the design, there are two buttons we need to create. Each has a different style and label. Let's start by creating a reusable component for these buttons. Create a **Button.tsx** file inside the **components** directory with the following code:
 
 {/* prettier-ignore */}
 ```tsx components/Button.tsx|collapseHeight=280

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -624,6 +624,9 @@ Now, update the **app/(tabs)/index.tsx** to import the `<EmojiList>` component a
 import { View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
+/* @tutinfo Import the type <CODE>ImageSource</CODE> from <CODE>expo-image</CODE>. */
+import { type ImageSource } from 'expo-image';
+/* @end */
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
@@ -632,9 +635,6 @@ import CircleButton from '@/components/CircleButton';
 import EmojiPicker from '@/components/EmojiPicker';
 /* @tutinfo Import the <CODE>EmojiList</CODE> component. */
 import EmojiList from '@/components/EmojiList';
-/* @end */
-/* @tutinfo Import the type <CODE>ImageSource</CODE>. */
-import { type ImageSource } from 'expo-image';
 /* @end */
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
@@ -750,8 +750,7 @@ Now, we'll put the emoji sticker on the image. Create a new file in the **compon
 
 ```tsx components/EmojiSticker.tsx|collapseHeight=300
 import { View } from 'react-native';
-import { Image } from 'expo-image';
-import { type ImageSource } from 'expo-image';
+import { Image, type ImageSource } from 'expo-image';
 
 type Props = {
   imageSize: number;
@@ -779,6 +778,8 @@ Import this component in the **app/(tabs)/index.tsx** file and update the `Index
 import { View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
+import { type ImageSource } from 'expo-image';
+
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
@@ -796,7 +797,8 @@ export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(undefined);
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
+   const [pickedEmoji, setPickedEmoji] = useState<ImageSource | undefined>(undefined);
+
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -28,7 +28,7 @@ To get gesture interactions to work in the app, we'll render `<GestureHandlerRoo
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx
 // ... rest of the import statements remain same
-/* @tutinfo Import GestureHandlerRootView from react-native-gesture-handler-library. */import { GestureHandlerRootView } from "react-native-gesture-handler";/* @end */
+/* @tutinfo Import <CODE>GestureHandlerRootView</CODE> from <CODE>react-native-gesture-handler-library</CODE>. */import { GestureHandlerRootView } from "react-native-gesture-handler";/* @end */
 
 export default function Index() {
   return (
@@ -58,10 +58,11 @@ An `Animated` component looks at the `style` prop of the component and determine
 ```tsx components/EmojiSticker.tsx
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { type ImageSource } from "expo-image";
 
 type Props = {
   imageSize: number;
-  stickerSource: string;
+  stickerSource: ImageSource;
 };
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
@@ -147,10 +148,11 @@ Next, wrap the `<Animated.Image>` component with the `<GestureDetector>` and mod
 import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { type ImageSource } from "expo-image";
 
 type Props = {
   imageSize: number;
-  stickerSource: string;
+  stickerSource: ImageSource;
 };
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
@@ -175,7 +177,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
 
   return (
     <View style={{ top: -350 }}>
-      /* @tutinfo Wrap the Animated.Image component with GestureDetector. */<GestureDetector gesture={doubleTap}>/* @end */
+      /* @tutinfo Wrap the <CODE>Animated.Image</CODE> component with <CODE>GestureDetector</CODE>.*/ <GestureDetector gesture={doubleTap}>/* @end */
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
@@ -218,7 +220,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   // ...rest of the code remains same
 
   return (
-    /* @tutinfo Replace the View component with Animated.View. */<Animated.View style={{ top: -350 }}>/* @end */
+    /* @tutinfo Replace the <CODE>View</CODE> component with <CODE>Animated.View</CODE>. */<Animated.View style={{ top: -350 }}>/* @end */
       <GestureDetector gesture={doubleTap}>
         {/* ...rest of the code remains same */}
       </GestureDetector>
@@ -264,13 +266,13 @@ Next, inside the JSX code:
 
 {/* prettier-ignore */}
 ```tsx components/EmojiSticker.tsx
-import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { type ImageSource } from "expo-image";
 
 type Props = {
   imageSize: number;
-  stickerSource: string;
+  stickerSource: ImageSource;
 };
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
@@ -314,8 +316,8 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   });
 
   return (
-    /* @tutinfo Wrap all components inside GestureDetector. */<GestureDetector gesture={drag}>/* @end */
-      <Animated.View style={/* @tutinfo Add containerStyle to the AnimatedView style prop. */[containerStyle, { top: -350 }]/* @end */}>
+    /* @tutinfo Wrap all components inside <CODE>GestureDetector</CODE>. */<GestureDetector gesture={drag}>/* @end */
+      <Animated.View style={/* @tutinfo Add <CODE>containerStyle</CODE> to the <CODE>Animated.View</CODE> style prop. */[containerStyle, { top: -350 }]/* @end */}>
         <GestureDetector gesture={doubleTap}>
           <Animated.Image
             source={stickerSource}

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -301,7 +301,9 @@ Modify the **app/(tabs)/index.tsx** file:
 ```tsx app/(tabs)/index.tsx
 import { View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-/* @tutinfo Import useState hook from React. */ import { useState } from 'react';/* @end */
+/* @tutinfo Import <CODE>useState</CODE> hook from React.*/
+import { useState } from 'react';
+/* @end */
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
@@ -369,16 +371,16 @@ Pass the `selectedImage` prop to the `ImageViewer` component to display the sele
 {/* prettier-ignore */}
 ```tsx components/ImageViewer.tsx
 import { StyleSheet } from 'react-native';
-import { Image } from 'expo-image';
+import { Image, type ImageSource } from "expo-image";
 
 type Props = {
-  imgSource: string;
+  imgSource: ImageSource;
   /* @tutinfo */
   selectedImage?: string;
   /* @end */
 };
 
-export default function ImageViewer({ imgSource, /* @tutinfo Pass the selectedImage prop.*/selectedImage/* @end */ }: Props) {
+export default function ImageViewer({ imgSource, /* @tutinfo Pass the <CODE>selectedImage</CODE> prop.*/selectedImage/* @end */ }: Props) {
   /* @tutinfo If the selected image is not null, show the image from the device, otherwise, show the placeholder image. */
   const imageSource = selectedImage ? { uri: selectedImage } : imgSource;
   /* @end */

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -53,6 +53,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { useState, useRef } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import * as MediaLibrary from 'expo-media-library';
+import { type ImageSource } from "expo-image";
 import { captureRef } from 'react-native-view-shot';
 /* @tutinfo Import <CODE>domtoimage</CODE> library. */import domtoimage from 'dom-to-image';/* @end */
 
@@ -70,7 +71,7 @@ export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(undefined);
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
+  const [pickedEmoji, setPickedEmoji] = useState<ImageSource | undefined>(undefined);
   const [status, requestPermission] = MediaLibrary.usePermissions();
   const imageRef = useRef<View>(null);
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -116,6 +116,7 @@ import { useState, useRef } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import * as MediaLibrary from 'expo-media-library';
 import { captureRef } from 'react-native-view-shot';
+import { type ImageSource } from "expo-image";
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
@@ -131,7 +132,7 @@ export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(undefined);
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-  const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
+  const [pickedEmoji, setPickedEmoji] = useState<ImageSource | undefined>(undefined);
   const [status, requestPermission] = MediaLibrary.usePermissions();
   const imageRef = useRef<View>(null);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Follow up https://github.com/expo/expo/pull/32115 to add `ImageSource` type whenever Expo Image is used.
- Fix typo in Build a screen chapter
- Fix code annotations that were missing code syntax highlights

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating code snippets.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
