### PR TITLE
Update using-sentry.mdx

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -196,7 +196,7 @@ function RootLayout() {
   const ref = useNavigationContainerRef();
 
   useEffect(() => {
-    if (ref) {
+    if (ref && ref.current) {
       routingInstrumentation.registerNavigationContainer(ref);
     }
   }, [ref]);

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -196,7 +196,7 @@ function RootLayout() {
   const ref = useNavigationContainerRef();
 
   useEffect(() => {
-    if (ref && ref.current) {
+    if (ref?.current) {
       routingInstrumentation.registerNavigationContainer(ref);
     }
   }, [ref]);


### PR DESCRIPTION
# Why

When implementing Sentry by following Expo's Sentry guide. A warning is shown (`debug` needs to be `true` in `Sentry.init()`):
```shell
WARN  Sentry Logger [warn]: [ReactNavigationInstrumentation] Received invalid navigation container ref! 
    at Suspense
    at Route (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:180827:24)
    at Route() (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:181202:24)
    at RNCSafeAreaProvider
    at SafeAreaProvider (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:174123:24)
    at wrapper (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:201142:27)
    at EnsureSingleNavigator (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:168133:24)
    at BaseNavigationContainer (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:166629:28)
    at ThemeProvider (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:172393:21)
    at NavigationContainerInner (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:201599:26)
    at ContextNavigator (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:201177:24)
    at ExpoRoot (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:201133:28)
    at App
    at ErrorToastContainer (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:351420:24)
    at ErrorOverlay
    at withDevTools(ErrorOverlay) (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:268579:27)
    at RCTView
    at View (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:41520:43)
    at RCTView
    at View (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:41520:43)
    at AppContainer (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:41363:25)
    at main(RootComponent) (http://192.168.178.20:8081/node_modules/expo-router/entry.bundle//&platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=true&transform.routerRoot=app:119719:28)
```

Since it is not an error, I don't know if this breaks functionality or not. When following source code into `/node_modules/@sentry/react-native/dist/js/tracing/reactnavigation.js` on `"@sentry/react-native": "~5.24.3",` there is a check for `ref.current`: 
```js
if ('current' in navigationContainerRef) {
    ...
}
...
else {
    logger.warn('[ReactNavigationInstrumentation] Received invalid navigation container ref!');
}
```

When logging the NavigationContainer ref that is passed to this function it prints:
```js
ref:  {"addListener": [Function anonymous], "canGoBack": [Function anonymous], "current": null, "dispatch": [Function anonymous], "getCurrentOptions": [Function anonymous], "getCurrentRoute": [Function anonymous], "getParent": [Function anonymous], "getRootState": [Function anonymous], "getState": [Function anonymous], "goBack": [Function anonymous], "isFocused": [Function anonymous], "isReady": [Function isReady], "navigate": [Function anonymous], "removeListener": [Function anonymous], "reset": [Function anonymous], "resetRoot": [Function anonymous], "setParams": [Function anonymous]}
```

We can see `ref` is not null but `ref.current` is, causing this warning. This warning is also displayed a rather distracting popup inside the app. To prevent this warning from polluting the console log as well as the app, I propose to add an extra check on ref.current since the only alternate way is to disable `debug` on `Sentry.init()` entirely.



# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
