### PR TITLE
[docs] remove duplicated note on Audio pages, change note theme

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/unversioned/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/unversioned/sdk/audio-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio-av.mdx
@@ -12,9 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **info** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
-
-> **info** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/v52.0.0/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/v52.0.0/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
@@ -12,9 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **info** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
-
-> **info** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/unversioned/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](https://docs.expo.dev/versions/v52.0.0/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 


### PR DESCRIPTION
# Why

Spotted that Audio page for legacy `expo-av` module have duplicated note:

![Screenshot 2024-10-28 at 14 28 22](https://github.com/user-attachments/assets/d4762f87-719d-4b9b-974b-3f9b4e62f6cb)

# How

Remove duplicated note, change note theme.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-10-28 at 14 26 41](https://github.com/user-attachments/assets/447c982a-d05b-49c5-b39b-85ea91e090e9)

