### PR TITLE
[docs] API: render return value for function types

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -8997,6 +8997,51 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </table>
       </div>
     </div>
+    <div
+      class="flex flex-row gap-2 items-start mt-4"
+    >
+      <div
+        class="flex flex-row gap-2 items-center"
+      >
+        <svg
+          class="inline-block icon-sm text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            id="corner-down-right-outline-icon"
+          >
+            <path
+              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+        <span
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+        data-text="true"
+      >
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
+        >
+          void
+        </code>
+      </p>
+    </div>
   </div>
   <div
     class="emotion-0"
@@ -11446,6 +11491,51 @@ in order to enable/disable the permission.
           </tbody>
         </table>
       </div>
+    </div>
+    <div
+      class="flex flex-row gap-2 items-start mt-4"
+    >
+      <div
+        class="flex flex-row gap-2 items-center"
+      >
+        <svg
+          class="inline-block icon-sm text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            id="corner-down-right-outline-icon"
+          >
+            <path
+              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+        <span
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+        data-text="true"
+      >
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
+        >
+          void
+        </code>
+      </p>
     </div>
   </div>
   <div

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -1,3 +1,4 @@
+import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 import { Fragment, ReactNode } from 'react';
 
 import { APIBox } from '~/components/plugins/APIBox';
@@ -156,6 +157,22 @@ const renderType = (
               </div>
             ))
           : null}
+        {type.declaration.signatures && type.declaration.signatures[0].type && (
+          <div className="flex flex-row gap-2 items-start mt-4">
+            <div className="flex flex-row gap-2 items-center">
+              <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+              <CALLOUT tag="span" theme="secondary" weight="medium">
+                Returns:
+              </CALLOUT>
+            </div>
+            <CALLOUT>
+              <APIDataType
+                typeDefinition={type.declaration.signatures[0].type}
+                sdkVersion={sdkVersion}
+              />
+            </CALLOUT>
+          </div>
+        )}
       </div>
     );
   } else if (type.elements) {


### PR DESCRIPTION
# Why

Spotted that we are not rendering return values for types which are function definitions.

# How

Add missing return type, when type is a function definition.

# Test Plan

The changes have been reviewed by running docs app locally. Test snapshots reflects the change correctly.

# Preview

![Screenshot 2024-10-28 at 14 56 23](https://github.com/user-attachments/assets/53f49f5c-958f-4871-b287-2cbe72757ecc)
