### PR TITLE
[docs] API: tweaks and fixes for note/callouts display

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -225,7 +225,7 @@ button.
 not appear on the screen.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
@@ -288,7 +288,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 text-secondary flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-tertiary flex flex-row gap-2 items-center font-medium"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -1055,11 +1055,11 @@ This should come from the user field of an
     
 
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -1081,7 +1081,7 @@ This should come from the user field of an
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
       >
         
 
@@ -2472,7 +2472,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
@@ -3347,7 +3347,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
@@ -3658,7 +3658,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
@@ -3986,7 +3986,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
@@ -4406,7 +4406,7 @@ After calling this function, the listener will no longer receive any events from
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationButtonStyle Values
@@ -4671,7 +4671,7 @@ After calling this function, the listener will no longer receive any events from
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationButtonType Values
@@ -4975,7 +4975,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
@@ -5033,7 +5033,7 @@ for more details.
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationCredentialState Values
@@ -5317,7 +5317,7 @@ for more details.
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationOperation Values
@@ -5623,11 +5623,11 @@ for more details.
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5649,7 +5649,7 @@ for more details.
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
         >
           
 
@@ -5665,7 +5665,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
@@ -5723,7 +5723,7 @@ for more details.
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationScope Values
@@ -5899,7 +5899,7 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
@@ -5957,7 +5957,7 @@ for more details.
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           AppleAuthenticationUserDetectionStatus Values
@@ -6197,14 +6197,14 @@ exports[`APISection expo-barcode-scanner 1`] = `
     class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !shadow-none"
   >
     <div
-      class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
+      class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-lg-gutters:mx-[-17px]"
     >
       <blockquote
-        class="border flex gap-2 rounded-md py-3 px-4 mb-4 bg-warning border-warning [&_code]:bg-palette-yellow4 [&_code]:border-palette-yellow6 dark:[&_code]:bg-palette-yellow5 dark:[&_code]:border-palette-yellow7 [&_p]:!mb-0 [table_&]:last-of-type:mb-2.5 pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4"
+        class="border flex gap-2 rounded-md py-3 px-4 mb-4 [table_&]:last:mb-0 bg-warning border-warning [&_code]:bg-palette-yellow4 [&_code]:border-palette-yellow6 dark:[&_code]:bg-palette-yellow5 dark:[&_code]:border-palette-yellow7 [&_p]:!mb-0 [table_&]:last-of-type:mb-2.5 pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
             class="icon-sm text-warning"
@@ -6226,7 +6226,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -6373,7 +6373,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 text-secondary flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-tertiary flex flex-row gap-2 items-center font-medium"
             href="#barcodescannerprops"
             id="barcodescannerprops"
           >
@@ -6621,11 +6621,11 @@ provided with an
         
 
         <blockquote
-          class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+          class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
           data-testid="callout-container"
         >
           <div
-            class="select-none mt-1 [table_&]:mt-0.5"
+            class="select-none [table_&]:mt-0.5 mt-0.5"
           >
             <svg
               class="icon-sm text-icon-default"
@@ -6647,7 +6647,7 @@ provided with an
             </svg>
           </div>
           <div
-            class="text-default w-full leading-normal last:mb-0"
+            class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
           >
             
 
@@ -7204,7 +7204,7 @@ This uses both
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           <svg
@@ -7808,11 +7808,11 @@ the platform.
               
 
               <blockquote
-                class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+                class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
                 data-testid="callout-container"
               >
                 <div
-                  class="select-none mt-1 [table_&]:mt-0.5"
+                  class="select-none [table_&]:mt-0.5 mt-0.5"
                 >
                   <svg
                     class="icon-sm text-icon-default"
@@ -7834,7 +7834,7 @@ the platform.
                   </svg>
                 </div>
                 <div
-                  class="text-default w-full leading-normal last:mb-0"
+                  class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
                 >
                   
 
@@ -8056,7 +8056,7 @@ code.
       data-text="true"
     >
       <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
         data-text="true"
       >
         PermissionResponse Properties
@@ -9661,7 +9661,7 @@ you don't get this value.
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           PermissionStatus Values
@@ -10346,11 +10346,11 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -10372,7 +10372,7 @@ exports[`APISection expo-pedometer 1`] = `
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
         >
           
 
@@ -10869,11 +10869,11 @@ provided with a single argument that is
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -10895,7 +10895,7 @@ provided with a single argument that is
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
         >
           
 
@@ -11033,7 +11033,7 @@ On iOS, the
       data-text="true"
     >
       <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
         data-text="true"
       >
         PermissionResponse Properties
@@ -11870,7 +11870,7 @@ After calling this function, the listener will no longer receive any events from
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
           data-text="true"
         >
           PermissionStatus Values

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -25,9 +25,10 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
     <div
       className={mergeClasses(
         `[table_&]:mt-0 [table_&]:${ELEMENT_SPACING} [table_&]:last:mb-0`,
-        sticky && 'mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]'
+        sticky && 'mx-[-21px] mt-[-21px] max-lg-gutters:mx-[-17px]'
       )}>
       <Callout
+        size="sm"
         type="warning"
         key="deprecation-note"
         className={mergeClasses(

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -76,7 +76,7 @@ const getInvalidLinkMessage = (href: string) =>
   `Using "../" when linking other packages in doc comments produce a broken link! Please use "./" instead. Problematic link:\n\t${href}`;
 
 export const mdComponents: MDComponents = {
-  blockquote: ({ children }) => <Callout>{children}</Callout>,
+  blockquote: ({ children }) => <Callout size="sm">{children}</Callout>,
   code: ({ className, children, node }: CodeComponentProps) => {
     return className ? (
       <PrismCodeBlock className={className} title={node?.data?.meta}>
@@ -640,7 +640,7 @@ export const BoxSectionHeader = ({
         'max-lg-gutters:-mx-4',
         className
       )}>
-      <TextWrapper weight="medium" className="text-secondary flex flex-row gap-2 items-center">
+      <TextWrapper className="text-tertiary flex flex-row gap-2 items-center font-medium">
         {Icon && <Icon className="icon-sm text-icon-secondary" />}
         {text}
       </TextWrapper>
@@ -862,7 +862,7 @@ export const CommentTextBlock = ({
   const exampleText = examples?.map((example, index) => (
     <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:mb-0')}>
       {inlineHeaders ? (
-        <DEMI theme="secondary" className="flex flex-row gap-1.5 items-center mb-1.5">
+        <DEMI className="flex flex-row gap-1.5 items-center mb-1.5 text-secondary">
           <CodeSquare01Icon className="icon-sm" />
           Example
         </DEMI>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -85,7 +85,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       data-text="true"
     >
       <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary flex flex-row gap-2 items-center"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
         data-text="true"
       >
         <svg

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -53,12 +53,11 @@ export const Callout = ({
     <blockquote
       className={mergeClasses(
         'bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4',
-        '[table_&]:last-of-type:mb-0',
+        '[table_&]:last:mb-0',
         '[&_code]:bg-element',
         getCalloutColor(finalType),
         // TODO(simek): remove after migration to new components is completed
         '[&_p]:!mb-0',
-        size === 'sm' && '!text-xs',
         className
       )}
       data-testid="callout-container">
@@ -70,7 +69,12 @@ export const Callout = ({
           <Icon className={mergeClasses('icon-sm', getCalloutIconColor(finalType))} />
         )}
       </div>
-      <div className={mergeClasses('text-default w-full leading-normal', 'last:mb-0')}>
+      <div
+        className={mergeClasses(
+          'text-default w-full leading-normal',
+          'last:mb-0',
+          size === 'sm' && 'text-xs [&_p]:text-xs [&_code]:text-[90%]'
+        )}>
         {type === finalType ? children : contentChildren.filter((_, i) => i !== 0)}
       </div>
     </blockquote>


### PR DESCRIPTION
# Why

Stacked on #32404

Spotted few thing when finishing Emotion refactor, this is a follow up.

# How

Few tweaks and fixes, mostly for notes/callouts used on API reference pages. Correctly apply text size in all circumstances for `size=sm` callouts.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-10-28 at 18 01 26](https://github.com/user-attachments/assets/83c16a5d-aa53-480c-9ac1-ec1e1c7d6304)
![Screenshot 2024-10-28 at 17 57 23](https://github.com/user-attachments/assets/ebbda537-3162-4f92-bd76-4c9e70bd92c6)

