### PR TITLE
fix(expo): Fix react-native-webview Android `decelerationRate` prop issue.

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix react-native-webview Android `decelerationRate` prop issue.
+
 ### 💡 Others
 
 ## 52.0.0-preview.7 — 2024-10-28

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix react-native-webview Android `decelerationRate` prop issue.
+- Fix react-native-webview Android `decelerationRate` prop issue. ([#32420](https://github.com/expo/expo/pull/32420) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -77,7 +77,7 @@ const RawWebView = React.forwardRef<object, Props>(({ dom, source, ...marshalPro
   return React.createElement(webView, {
     webviewDebuggingEnabled: __DEV__,
     // Make iOS scrolling feel native.
-    decelerationRate: 'normal',
+    decelerationRate: process.env.EXPO_OS === 'ios' ? 'normal' : undefined,
     originWhitelist: ['*'],
     allowFileAccess: true,
     allowFileAccessFromFileURLs: true,


### PR DESCRIPTION
# Why

- The prop handling on native Android webview appears to have changed, we now need to pass in undefined manually.
