### PR TITLE
feat(babel-preset-expo): Assert that layout routes and API routes cannot be DOM components.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Assert that layout routes and API routes cannot be DOM components.
+- Assert that layout routes and API routes cannot be DOM components. ([#32422](https://github.com/expo/expo/pull/32422) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Assert that layout routes and API routes cannot be DOM components.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.js
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.js
@@ -17,6 +17,7 @@ function expoUseDomDirectivePlugin(api) {
     // TODO: Is exporting
     const isProduction = api.caller(common_1.getIsProd);
     const platform = api.caller((caller) => caller?.platform);
+    const projectRoot = api.caller(common_1.getPossibleProjectRoot);
     return {
         name: 'expo-use-dom-directive',
         visitor: {
@@ -59,6 +60,23 @@ function expoUseDomDirectivePlugin(api) {
                 if (!hasDefaultExport) {
                     throw path.buildCodeFrameError('The "use dom" directive requires a default export to be present in the file.');
                 }
+                // Assert that _layout routes cannot be used in DOM components.
+                const fileBasename = (0, path_1.basename)(filePath);
+                if (projectRoot &&
+                    // Detecting if the file is in the router root would be extensive as it would cause a more complex
+                    // cache key for each file. Instead, let's just check if the file is in the project root and is not a node_module,
+                    // then we can assert that users should not use `_layout` or `+api` with "use dom".
+                    filePath.includes(projectRoot) &&
+                    !filePath.match(/node_modules/)) {
+                    if (fileBasename.match(/^_layout\.[jt]sx?$/)) {
+                        throw path.buildCodeFrameError('Layout routes cannot be marked as DOM components because they cannot render native views.');
+                    }
+                    else if (
+                    // No API routes
+                    fileBasename.match(/\+api\.[jt]sx?$/)) {
+                        throw path.buildCodeFrameError('API routes cannot be marked as DOM components.');
+                    }
+                }
                 const outputKey = url_1.default.pathToFileURL(filePath).href;
                 const proxyModule = [
                     `import React from 'react';`,
@@ -81,7 +99,7 @@ function expoUseDomDirectivePlugin(api) {
                 else {
                     proxyModule.push(
                     // Add the basename to improve the Safari debug preview option.
-                    `const source = { uri: new URL("/_expo/@dom/${(0, path_1.basename)(filePath)}?file=" + ${JSON.stringify(outputKey)}, require("react-native/Libraries/Core/Devtools/getDevServer")().url).toString() };`);
+                    `const source = { uri: new URL("/_expo/@dom/${fileBasename}?file=" + ${JSON.stringify(outputKey)}, require("react-native/Libraries/Core/Devtools/getDevServer")().url).toString() };`);
                 }
                 proxyModule.push(`
 export default React.forwardRef((props, ref) => {

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -134,16 +134,18 @@ const LANGUAGE_SAMPLES: {
     },
     hermesError: /error: 'export' statement requires module mode/,
   },
-  {
-    // https://babeljs.io/docs/babel-plugin-proposal-export-default-from
-    // Web preset doesn't transform this
-    name: `export-default-from`,
-    code: `export v from "mod";`,
-    getCompiledCode() {
-      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"v",{enumerable:true,get:function(){return _mod.default;}});var _mod=_interopRequireDefault(require("mod"));`;
-    },
-    hermesError: /error: expected declaration in export/,
-  },
+  // This is broken as of RN 76 / SDK 52 due to this upstream change:
+  // https://github.com/facebook/react-native/commit/1387f521fdd8f187eab7a4a6a05d4d75a96b4f88#diff-23432c49a1b0fbaa32ac0db0694a712f12f58619619948137f2cccf282fa61ceL28
+  // {
+  //   // https://babeljs.io/docs/babel-plugin-proposal-export-default-from
+  //   // Web preset doesn't transform this
+  //   name: `export-default-from`,
+  //   code: `export v from "mod";`,
+  //   getCompiledCode() {
+  //     return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"v",{enumerable:true,get:function(){return _mod.default;}});var _mod=_interopRequireDefault(require("mod"));`;
+  //   },
+  //   hermesError: /error: expected declaration in export/,
+  // },
   {
     // https://babeljs.io/docs/babel-plugin-syntax-dynamic-import
     name: `dynamic-import`,

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -83,7 +83,6 @@ it(`compiles samples with Metro targeting Hermes`, () => {
 
   // All of this code should remain intact.
   const sourceCode = `
-// @babel/plugin-transform-computed-properties
 var obj = {
   ["x" + foo]: "heh",
   ["y" + bar]: "noo",
@@ -91,46 +90,37 @@ var obj = {
   bar: "bar"
 };
 
-// @babel/plugin-transform-shorthand-properties
 var a1 = 0;
 var c = { a1 };
 
-// @babel/plugin-proposal-optional-catch-binding
 try {
   throw 0;
 } catch {
 }
 
-// @babel/plugin-transform-literals
-var d = 0b11; // binary integer literal
-var e = 0o7; // octal integer literal
-var f = "Hello\\u{000A}\\u{0009}!"; // unicode string literals, newline and tab
+var d = 0b11;
+var e = 0o7;
+var f = "Hello\\u{000A}\\u{0009}!";
 
-// @babel/plugin-proposal-numeric-separator
 var budget = 1_000_000_000_000;
 var nibbles = 0b1010_0001_1000_0101;
 var message = 0xa0_b0_c0;
 
-// @babel/plugin-transform-sticky-regex
 var g = /o+/y;
 
-// @babel/plugin-transform-spread
 var h = ["a", "b", "c"];
 
 var i = [...h, "foo"];
 
 var j = foo(...h);
 
-// @babel/plugin-transform-object-rest-spread
 var y = {};
 var x = 1;
 var k = { x, ...y };
 
 
-// @babel/plugin-proposal-optional-chaining
 var m = {}?.x;
 
-// @babel/plugin-proposal-nullish-coalescing-operator
 var obj2 = {};
 var foo = obj2.foo ?? "default";`;
   const withHermes = babel.transform(sourceCode, options)!;

--- a/packages/babel-preset-expo/src/__tests__/use-dom-directive-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/use-dom-directive-plugin.test.ts
@@ -196,6 +196,34 @@ it('allows type exports', () => {
   expect(res.code).toMatch('expo/dom/internal');
 });
 
+it('asserts that Layout Routes cannot be DOM components', () => {
+  const sourceCode = `
+    'use dom';
+
+    export default function App() {
+      return <div />;
+    }
+`;
+
+  expect(() => transformClient({ sourceCode, filename: '_layout.tsx' })).toThrow(
+    /Layout routes cannot be marked as DOM components/
+  );
+});
+
+it('asserts that API Routes cannot be DOM components', () => {
+  const sourceCode = `
+    'use dom';
+
+    export default function App() {
+      return <div />;
+    }
+`;
+
+  expect(() => transformClient({ sourceCode, filename: 'foo+api.js' })).toThrow(
+    /API routes cannot be marked as DOM components/
+  );
+});
+
 describe('errors', () => {
   it(`throws when there are non-default exports`, () => {
     const sourceCode = `


### PR DESCRIPTION
# Why

Improve the DX by making this unsupported functionality feel more intentional.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- Added Babel tests