### PR TITLE
[iOS][image] Fix displaying a placeholder when `useImage` hook is used

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed displaying a placeholder when `useImage` hook is used. ([#32430](https://github.com/expo/expo/pull/32430) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 2.0.0-preview.0 — 2024-10-22

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -27,10 +27,13 @@ public final class ImageModule: Module {
 
       Prop("source") { (view: ImageView, sources: Either<[ImageSource], SharedRef<UIImage>>?) in
         if let imageRef: SharedRef<UIImage> = sources?.get() {
+          // Unset an array of traditional sources and just render the image ref right away.
           view.sources = nil
-          view.renderImage(imageRef.ref)
+          view.renderSourceImage(imageRef.ref)
         } else {
+          // Update an array of sources. Image will start loading once the all props are updated.
           view.sources = sources?.get()
+          view.sourceImage = nil
         }
       }
 


### PR DESCRIPTION
# Why

Fixes #32372

# How

When an image ref is passed as a prop, we should prevent the placeholder from showing up. This required some changes in conditions (introduced `canDisplayPlaceholder` property) and saving an image from the shared ref as `sourceImage`.

# Test Plan

I tested it against examples in native-component-list and provided repro https://github.com/ludwig-pro/expo-image-2.0.0-preview.0