### PR TITLE
[docs] always display platform tags in SDK 52 API reference

### DIFF
--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -23,7 +23,7 @@ export const APISectionPlatformTags = ({
   const { platforms: defaultPlatforms } = usePageMetadata();
   const { version } = usePageApiVersion();
 
-  const isUnversionedVersion = version === 'unversioned';
+  const isCompatibleVersion = ['unversioned', 'v52.0.0'].includes(version);
   const platformsData = platforms || getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 
@@ -31,7 +31,7 @@ export const APISectionPlatformTags = ({
     ? userProvidedPlatforms
     : platformsData.length > 0
       ? platformsData?.map(platformData => getCommentContent(platformData.content))
-      : isUnversionedVersion && !disableFallback
+      : isCompatibleVersion && !disableFallback
         ? defaultPlatforms?.map(platform => platform.replace('*', ''))
         : [];
 
@@ -48,7 +48,7 @@ export const APISectionPlatformTags = ({
         </CALLOUT>
       )}
       <PlatformTags
-        prefix={isUnversionedVersion ? prefix : prefix ?? 'Only for:'}
+        prefix={isCompatibleVersion ? prefix : prefix ?? 'Only for:'}
         platforms={platformNames}
       />
     </div>


### PR DESCRIPTION
# Why

Aman spotted that we do not display platform tags in SDK 52 docs as expected.

# How

Add SDK 52 to compatible versions with new platforms tag approach. After the stable version release we would need to add `latest` to this array.

# Test Plan

The changes has been tested locally.

# Preview

![Screenshot 2024-10-29 at 11 44 25](https://github.com/user-attachments/assets/fcaf9af0-e431-4a06-8fea-29b1363d7fe9)
