### PR TITLE
[docs] Fix debugging step 2 in iOS Universal Links guide

### DIFF
--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -135,7 +135,7 @@ Set the environment variable `EXPO_TUNNEL_SUBDOMAIN=my-custom-domain` where `my-
 
 <Step label="2">
 
-Add `intentFilters` to your app config as [described above](#add-intentfilters-to-app-config). Replace the `host` value with a Ngrok URL: `my-custom-domain.ngrok.io`.
+Add `intentFilters` to your app config as [described above](#add-intentfilters-to-the-app-config). Replace the `host` value with a Ngrok URL: `my-custom-domain.ngrok.io`.
 
 </Step>
 

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -206,7 +206,7 @@ Set the environment variable `EXPO_TUNNEL_SUBDOMAIN=my-custom-domain` where `my-
 
 <Step label="2">
 
-Add `intentFilters` to your app config as [described above](#add-intentfilters-to-app-config). Replace the `host` value with a Ngrok URL: `my-custom-domain.ngrok.io`.
+Add `associatedDomains` to your app config as [described above](#native-app-configuration). Replace the domain value with a Ngrok URL: `my-custom-domain.ngrok.io`.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix https://github.com/expo/expo/issues/32431

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fixes the step 2 instruction in iOS Universal Links > Debugging section to mention `associatedDomains`. Also, fix the internal link.
- Fixes the internal link under Debugging section for `intentFilters` in Android App Links.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Updated instruction in iOS Universal Links guide:

![CleanShot 2024-10-29 at 16 37 46@2x](https://github.com/user-attachments/assets/67033851-2d9f-4ca2-91fe-dc0b6973a6db)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
