### PR TITLE
[doctor] Update to use latest @expo/config to stop config plugin resolution error

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash when using config plugins with an entry point other than app.plugin.js ([#32130](https://github.com/expo/expo/pull/32443) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.12.0 — 2024-10-25

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -33,7 +33,7 @@
     "prepublishOnly": "expo-module prepublishOnly"
   },
   "devDependencies": {
-    "@expo/config": "~10.0.0",
+    "@expo/config": "~10.0.2",
     "@expo/json-file": "~9.0.0",
     "@expo/schemer": "1.5.3",
     "@expo/spawn-async": "^1.7.2",


### PR DESCRIPTION
# Why
`@expo/config` 10.0.2 by way of fixes to `@expo/config-plugins` fixes https://github.com/expo/expo/issues/32185 by allowing whatever is in **package.json** `main` to be the entry point to a config plugin.

# How
Bumped the version

# Test Plan
Tested with `@bugsnag/plugin-expo-eas-sourcemaps`, worked

