### PR TITLE
[docs] AppConfigSchema: add client-side search ability

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -144,14 +144,10 @@ export const CodeBlock = ({ children, theme, className, inline = false }: CodeBl
   const Element = inline ? 'span' : 'pre';
   return (
     <Element
-      className={mergeClasses('whitespace-pre m-0 px-1 py-1.5', inline && 'inline-flex !p-0')}
+      className={mergeClasses('whitespace-pre m-0 px-2 py-1.5', inline && 'inline-flex !p-0')}
       {...attributes}>
       <CODE
-        className={mergeClasses(
-          '!text-3xs text-default',
-          inline && 'block w-full !p-1.5',
-          className
-        )}
+        className={mergeClasses('!text-3xs text-default', inline && 'block w-full !p-2', className)}
         theme={theme}>
         {children}
       </CODE>

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -20,7 +20,7 @@ export const APIBox = ({ header, platforms, children, className }: APIBoxProps) 
         STYLES_APIBOX,
         STYLES_APIBOX_WRAPPER,
         className,
-        '!pb-4 last:[&>*]:!mb-1'
+        '!pb-4 last:[&>*]:!mb-0'
       )}>
       {platforms && <APISectionPlatformTags prefix="Only for:" userProvidedPlatforms={platforms} />}
       {header && (

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -2,370 +2,41 @@
 
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
-  <div>
+  <div
+    class="flex flex-col gap-3.5"
+  >
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="relative"
     >
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-        data-text="true"
+      <svg
+        class="icon-md text-icon-tertiary absolute pointer-events-none left-3 top-3.5"
+        fill="none"
+        role="img"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-          href="#name"
-          id="name"
+        <g
+          id="search-sm-outline-icon"
         >
-          <span
-            class="inline"
-          >
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-              data-text="true"
-            >
-              name
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-        data-text="true"
-      >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-          data-text="true"
-        >
-          string
-        </code>
-      </p>
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-        data-text="true"
-      >
-        Name of your app.
-      </p>
-      <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
-        id="bare-workflow"
-      >
-        <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
-        >
-          <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
-          >
-            <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                id="triangle-down-custom-icon"
-              >
-                <path
-                  d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
-                  fill="currentColor"
-                  id="Vector 250"
-                />
-              </g>
-            </svg>
-          </div>
-          <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
-            data-text="true"
-          >
-            Bare Workflow
-          </span>
-          <a
-            class="inline ml-auto"
-            href="#bare-workflow"
-          >
-            <svg
-              aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-          <div />
-        </summary>
-        <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
-        >
-          <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-            data-text="true"
-          >
-            Edit the 'Display Name' field in Xcode
-          </p>
-        </div>
-      </details>
+          <path
+            d="M21 21L15.0001 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z"
+            id="Icon"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </g>
+      </svg>
+      <input
+        class="block shadow-xs border border-default rounded-md text-default bg-default h-12 w-full px-4 placeholder:text-icon-quaternary pl-10 my-0"
+        placeholder="search properties..."
+        value=""
+      />
     </div>
-    <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
-    >
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-        data-text="true"
-      >
-        <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-          href="#androidnavigationbar"
-          id="androidnavigationbar"
-        >
-          <span
-            class="inline"
-          >
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-              data-text="true"
-            >
-              androidNavigationBar
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-        data-text="true"
-      >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-          data-text="true"
-        >
-          object
-        </code>
-      </p>
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-        data-text="true"
-      >
-        Configuration for the bottom navigation bar on Android.
-      </p>
-      <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
-        id="expokit"
-      >
-        <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
-        >
-          <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
-          >
-            <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                id="triangle-down-custom-icon"
-              >
-                <path
-                  d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
-                  fill="currentColor"
-                  id="Vector 250"
-                />
-              </g>
-            </svg>
-          </div>
-          <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
-            data-text="true"
-          >
-            ExpoKit
-          </span>
-          <a
-            class="inline ml-auto"
-            href="#expokit"
-          >
-            <svg
-              aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-          <div />
-        </summary>
-        <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
-        >
-          <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-            data-text="true"
-          >
-            Set this property using AppConstants.java.
-          </p>
-        </div>
-      </details>
-      <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
-        id="bare-workflow-1"
-      >
-        <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
-        >
-          <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
-          >
-            <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                id="triangle-down-custom-icon"
-              >
-                <path
-                  d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
-                  fill="currentColor"
-                  id="Vector 250"
-                />
-              </g>
-            </svg>
-          </div>
-          <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
-            data-text="true"
-          >
-            Bare Workflow
-          </span>
-          <a
-            class="inline ml-auto"
-            href="#bare-workflow-1"
-          >
-            <svg
-              aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-          <div />
-        </summary>
-        <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
-        >
-          <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-            data-text="true"
-          >
-            Set this property using just Xcode
-          </p>
-        </div>
-      </details>
+    <div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -373,22 +44,22 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           <a
             class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-            href="#visible"
-            id="visible"
+            href="#name"
+            id="name"
           >
             <span
               class="inline"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
+                class="text-default leading-[1.6154] !text-sm"
                 data-text="true"
               >
-                visible
+                name
               </code>
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -421,27 +92,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
             data-text="true"
           >
-            enum
-          </code>
-           • Path:
-           
-          <code
-            class="text-secondary px-1 break-words"
-          >
-            androidNavigationBar
-            .
-            visible
+            string
           </code>
         </p>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
         >
-          Determines how and when the navigation bar is shown.
+          Name of your app.
         </p>
         <details
           class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
-          id="expokit-1"
+          id="bare-workflow"
         >
           <summary
             class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
@@ -471,11 +133,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
               data-text="true"
             >
-              ExpoKit
+              Bare Workflow
             </span>
             <a
               class="inline ml-auto"
-              href="#expokit-1"
+              href="#bare-workflow"
             >
               <svg
                 aria-label="permalink"
@@ -511,12 +173,231 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
               data-text="true"
             >
-              Set this property using Xcode.
+              Edit the 'Display Name' field in Xcode
+            </p>
+          </div>
+        </details>
+      </div>
+      <div
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
+      >
+        <p
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
+          data-text="true"
+        >
+          <a
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            href="#androidnavigationbar"
+            id="androidnavigationbar"
+          >
+            <span
+              class="inline"
+            >
+              <code
+                class="text-default leading-[1.6154] !text-sm"
+                data-text="true"
+              >
+                androidNavigationBar
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </p>
+        <p
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+          data-text="true"
+        >
+          Type: 
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            data-text="true"
+          >
+            object
+          </code>
+        </p>
+        <p
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+          data-text="true"
+        >
+          Configuration for the bottom navigation bar on Android.
+        </p>
+        <details
+          class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+          id="expokit"
+        >
+          <summary
+            class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          >
+            <div
+              class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            >
+              <svg
+                class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  id="triangle-down-custom-icon"
+                >
+                  <path
+                    d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
+                    fill="currentColor"
+                    id="Vector 250"
+                  />
+                </g>
+              </svg>
+            </div>
+            <span
+              class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              data-text="true"
+            >
+              ExpoKit
+            </span>
+            <a
+              class="inline ml-auto"
+              href="#expokit"
+            >
+              <svg
+                aria-label="permalink"
+                class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+            <div />
+          </summary>
+          <div
+            class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          >
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+              data-text="true"
+            >
+              Set this property using AppConstants.java.
+            </p>
+          </div>
+        </details>
+        <details
+          class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+          id="bare-workflow-1"
+        >
+          <summary
+            class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          >
+            <div
+              class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            >
+              <svg
+                class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  id="triangle-down-custom-icon"
+                >
+                  <path
+                    d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
+                    fill="currentColor"
+                    id="Vector 250"
+                  />
+                </g>
+              </svg>
+            </div>
+            <span
+              class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              data-text="true"
+            >
+              Bare Workflow
+            </span>
+            <a
+              class="inline ml-auto"
+              href="#bare-workflow-1"
+            >
+              <svg
+                aria-label="permalink"
+                class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+            <div />
+          </summary>
+          <div
+            class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          >
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+              data-text="true"
+            >
+              Set this property using just Xcode
             </p>
           </div>
         </details>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -524,17 +405,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             <a
               class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-              href="#always"
-              id="always"
+              href="#visible"
+              id="visible"
             >
               <span
                 class="inline"
               >
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
+                  class="text-default leading-[1.6154] !text-sm"
                   data-text="true"
                 >
-                  always
+                  visible
                 </code>
               </span>
               <svg
@@ -572,7 +453,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
               data-text="true"
             >
-              boolean
+              enum
             </code>
              • Path:
              
@@ -580,426 +461,167 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="text-secondary px-1 break-words"
             >
               androidNavigationBar.visible
-              .
-              always
             </code>
           </p>
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
           >
-            Test sub-sub-property
+            Determines how and when the navigation bar is shown.
           </p>
-        </div>
-      </div>
-      <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
-      >
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-          data-text="true"
-        >
-          <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-            href="#backgroundcolor"
-            id="backgroundcolor"
+          <details
+            class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+            id="expokit-1"
           >
-            <span
-              class="inline"
+            <summary
+              class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
             >
-              <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
+              <div
+                class="mt-[5px] ml-1.5 mr-2 self-baseline"
+              >
+                <svg
+                  class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+                  fill="none"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    id="triangle-down-custom-icon"
+                  >
+                    <path
+                      d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
+                      fill="currentColor"
+                      id="Vector 250"
+                    />
+                  </g>
+                </svg>
+              </div>
+              <span
+                class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
                 data-text="true"
               >
-                backgroundColor
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+                ExpoKit
+              </span>
+              <a
+                class="inline ml-auto"
+                href="#expokit-1"
+              >
+                <svg
+                  aria-label="permalink"
+                  class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </a>
+              <div />
+            </summary>
+            <div
+              class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-          data-text="true"
-        >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-            data-text="true"
+              <p
+                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+                data-text="true"
+              >
+                Set this property using Xcode.
+              </p>
+            </div>
+          </details>
+          <div
+            class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
           >
-            string
-          </code>
-           • Path:
-           
-          <code
-            class="text-secondary px-1 break-words"
-          >
-            androidNavigationBar
-            .
-            backgroundColor
-          </code>
-        </p>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
-        >
-          Specifies the background color of the navigation bar.
-        </p>
-        
-
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
-        >
-          6 character long hex color string, eg: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
-            data-text="true"
-          >
-            '#000000'
-          </code>
-        </p>
-      </div>
-    </div>
-    <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
-    >
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-        data-text="true"
-      >
-        <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-          href="#intentfilters"
-          id="intentfilters"
-        >
-          <span
-            class="inline"
-          >
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
               data-text="true"
             >
-              intentFilters
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-        data-text="true"
-      >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-          data-text="true"
-        >
-          array
-        </code>
-      </p>
-      <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-        data-text="true"
-      >
-        Configuration for setting an array of custom intent filters in Android manifest.
-      </p>
-      <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
-        id="bare-workflow-2"
-      >
-        <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
-        >
-          <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
-          >
-            <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                id="triangle-down-custom-icon"
+              <a
+                class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+                href="#always"
+                id="always"
               >
-                <path
-                  d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
-                  fill="currentColor"
-                  id="Vector 250"
-                />
-              </g>
-            </svg>
+                <span
+                  class="inline"
+                >
+                  <code
+                    class="text-default leading-[1.6154] !text-sm"
+                    data-text="true"
+                  >
+                    always
+                  </code>
+                </span>
+                <svg
+                  aria-label="permalink"
+                  class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </a>
+            </p>
+            <p
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+              data-text="true"
+            >
+              Type: 
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                data-text="true"
+              >
+                boolean
+              </code>
+               • Path:
+               
+              <code
+                class="text-secondary px-1 break-words"
+              >
+                androidNavigationBar.visible.always
+              </code>
+            </p>
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+              data-text="true"
+            >
+              Test sub-sub-property
+            </p>
           </div>
-          <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
-            data-text="true"
-          >
-            Bare Workflow
-          </span>
-          <a
-            class="inline ml-auto"
-            href="#bare-workflow-2"
-          >
-            <svg
-              aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-          <div />
-        </summary>
-        <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
-        >
-          <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-            data-text="true"
-          >
-            This is set in AndroidManifest.xml directly.
-          </p>
         </div>
-      </details>
-      <span
-        class="grid grid-cols-1 gap-2 mb-6"
-      >
-        <p
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary font-bold"
-          data-text="true"
-        >
-          Example
-        </p>
-        <span
-          class="whitespace-pre m-0 px-1 py-1.5 inline-flex !p-0"
-          data-text="true"
-        >
-          <code
-            class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] rounded-md border border-secondary bg-subtle px-1 py-0.5 !text-3xs text-default block w-full !p-1.5"
-            data-text="true"
-          >
-            [
-  {
-    "autoVerify": true,
-    "data": {
-      "host": "*.example.com"
-    }
-  }
-]
-          </code>
-        </span>
-      </span>
-      <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
-      >
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-          data-text="true"
-        >
-          <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-            href="#autoverify"
-            id="autoverify"
-          >
-            <span
-              class="inline"
-            >
-              <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
-              >
-                autoVerify
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-          data-text="true"
-        >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-            data-text="true"
-          >
-            boolean
-          </code>
-           • Path:
-           
-          <code
-            class="text-secondary px-1 break-words"
-          >
-            intentFilters
-            .
-            autoVerify
-          </code>
-        </p>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
-        >
-          You may also use an intent filter to set your app as the default handler for links
-        </p>
-      </div>
-      <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
-      >
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
-          data-text="true"
-        >
-          <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-            href="#data"
-            id="data"
-          >
-            <span
-              class="inline"
-            >
-              <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
-              >
-                data
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
-          data-text="true"
-        >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-            data-text="true"
-          >
-            array || object
-          </code>
-           • Path:
-           
-          <code
-            class="text-secondary px-1 break-words"
-          >
-            intentFilters
-            .
-            data
-          </code>
-        </p>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -1007,17 +629,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             <a
               class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
-              href="#host"
-              id="host"
+              href="#backgroundcolor"
+              id="backgroundcolor"
             >
               <span
                 class="inline"
               >
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
+                  class="text-default leading-[1.6154] !text-sm"
                   data-text="true"
                 >
-                  host
+                  backgroundColor
                 </code>
               </span>
               <svg
@@ -1062,11 +684,430 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             <code
               class="text-secondary px-1 break-words"
             >
-              intentFilters.data
-              .
-              host
+              androidNavigationBar.backgroundColor
             </code>
           </p>
+          <p
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+            data-text="true"
+          >
+            Specifies the background color of the navigation bar.
+          </p>
+          
+
+          <p
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+            data-text="true"
+          >
+            6 character long hex color string, eg: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+              data-text="true"
+            >
+              '#000000'
+            </code>
+          </p>
+        </div>
+      </div>
+      <div
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
+      >
+        <p
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
+          data-text="true"
+        >
+          <a
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            href="#intentfilters"
+            id="intentfilters"
+          >
+            <span
+              class="inline"
+            >
+              <code
+                class="text-default leading-[1.6154] !text-sm"
+                data-text="true"
+              >
+                intentFilters
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </p>
+        <p
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+          data-text="true"
+        >
+          Type: 
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            data-text="true"
+          >
+            array
+          </code>
+        </p>
+        <p
+          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+          data-text="true"
+        >
+          Configuration for setting an array of custom intent filters in Android manifest.
+        </p>
+        <details
+          class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+          id="bare-workflow-2"
+        >
+          <summary
+            class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          >
+            <div
+              class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            >
+              <svg
+                class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  id="triangle-down-custom-icon"
+                >
+                  <path
+                    d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
+                    fill="currentColor"
+                    id="Vector 250"
+                  />
+                </g>
+              </svg>
+            </div>
+            <span
+              class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              data-text="true"
+            >
+              Bare Workflow
+            </span>
+            <a
+              class="inline ml-auto"
+              href="#bare-workflow-2"
+            >
+              <svg
+                aria-label="permalink"
+                class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+            <div />
+          </summary>
+          <div
+            class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          >
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+              data-text="true"
+            >
+              This is set in AndroidManifest.xml directly.
+            </p>
+          </div>
+        </details>
+        <span
+          class="grid grid-cols-1 gap-2 mb-6"
+        >
+          <p
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row gap-1.5 items-center text-secondary"
+            data-text="true"
+          >
+            <svg
+              class="text-icon-default icon-sm"
+              fill="none"
+              role="img"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                id="code-square-01-outline-icon"
+              >
+                <path
+                  d="M14.5 15L17.5 12L14.5 9M9.5 9L6.5 12L9.5 15M7.8 21H16.2C17.8802 21 18.7202 21 19.362 20.673C19.9265 20.3854 20.3854 19.9265 20.673 19.362C21 18.7202 21 17.8802 21 16.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V16.2C3 17.8802 3 18.7202 3.32698 19.362C3.6146 19.9265 4.07354 20.3854 4.63803 20.673C5.27976 21 6.11984 21 7.8 21Z"
+                  id="Icon"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </g>
+            </svg>
+            Example
+          </p>
+          <span
+            class="whitespace-pre m-0 px-2 py-1.5 inline-flex !p-0"
+            data-text="true"
+          >
+            <code
+              class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] rounded-md border border-secondary bg-subtle px-1 py-0.5 !text-3xs text-default block w-full !p-2"
+              data-text="true"
+            >
+              [
+  {
+    "autoVerify": true,
+    "data": {
+      "host": "*.example.com"
+    }
+  }
+]
+            </code>
+          </span>
+        </span>
+        <div
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
+        >
+          <p
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
+            data-text="true"
+          >
+            <a
+              class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+              href="#autoverify"
+              id="autoverify"
+            >
+              <span
+                class="inline"
+              >
+                <code
+                  class="text-default leading-[1.6154] !text-sm"
+                  data-text="true"
+                >
+                  autoVerify
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </p>
+          <p
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+            data-text="true"
+          >
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              boolean
+            </code>
+             • Path:
+             
+            <code
+              class="text-secondary px-1 break-words"
+            >
+              intentFilters.autoVerify
+            </code>
+          </p>
+          <p
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
+            data-text="true"
+          >
+            You may also use an intent filter to set your app as the default handler for links
+          </p>
+        </div>
+        <div
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
+        >
+          <p
+            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
+            data-text="true"
+          >
+            <a
+              class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+              href="#data"
+              id="data"
+            >
+              <span
+                class="inline"
+              >
+                <code
+                  class="text-default leading-[1.6154] !text-sm"
+                  data-text="true"
+                >
+                  data
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </p>
+          <p
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+            data-text="true"
+          >
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              array || object
+            </code>
+             • Path:
+             
+            <code
+              class="text-secondary px-1 break-words"
+            >
+              intentFilters.data
+            </code>
+          </p>
+          <div
+            class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-0"
+          >
+            <p
+              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
+              data-text="true"
+            >
+              <a
+                class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+                href="#host"
+                id="host"
+              >
+                <span
+                  class="inline"
+                >
+                  <code
+                    class="text-default leading-[1.6154] !text-sm"
+                    data-text="true"
+                  >
+                    host
+                  </code>
+                </span>
+                <svg
+                  aria-label="permalink"
+                  class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </a>
+            </p>
+            <p
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+              data-text="true"
+            >
+              Type: 
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                data-text="true"
+              >
+                string
+              </code>
+               • Path:
+               
+              <code
+                class="text-secondary px-1 break-words"
+              >
+                intentFilters.data.host
+              </code>
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/ui/components/AppConfigSchemaTable/helpers.ts
+++ b/docs/ui/components/AppConfigSchemaTable/helpers.ts
@@ -78,3 +78,35 @@ export function createDescription(propertyEntry: [string, Property]) {
 
   return propertyDescription;
 }
+
+export function filterSchemaEntries(entry: FormattedProperty, searchTerm?: string) {
+  if (!searchTerm) {
+    return true;
+  }
+
+  return (
+    entry.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    entry.description.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+}
+
+export function flattenProperties(properties: FormattedProperty[]): FormattedProperty[] {
+  const flattened: FormattedProperty[] = [];
+
+  function flatten(property: FormattedProperty, parentPath?: string) {
+    flattened.push({
+      ...property,
+      parent: parentPath,
+    });
+
+    if (property.subproperties && property.subproperties.length > 0) {
+      property.subproperties.forEach(subProp => flatten(subProp, parentPath));
+    }
+  }
+
+  properties.forEach(property =>
+    flatten(property, property.parent ? `${property.parent}.${property.name}` : property.name)
+  );
+
+  return flattened;
+}

--- a/docs/ui/components/AppConfigSchemaTable/index.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/index.tsx
@@ -1,7 +1,12 @@
-import { mergeClasses } from '@expo/styleguide';
+import { Button, mergeClasses } from '@expo/styleguide';
+import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
+import { SearchSmIcon } from '@expo/styleguide-icons/outline/SearchSmIcon';
+import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
+import debounce from 'lodash/debounce';
+import { useCallback, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
-import { formatSchema } from './helpers';
+import { filterSchemaEntries, flattenProperties, formatSchema } from './helpers';
 import { FormattedProperty, Property } from './types';
 
 import { HeadingType } from '~/common/headingManager';
@@ -9,24 +14,76 @@ import { CodeBlock } from '~/components/base/code';
 import { APIBox } from '~/components/plugins/APIBox';
 import { mdComponents } from '~/components/plugins/api/APISectionUtils';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { P, CALLOUT, CODE, createPermalinkedComponent } from '~/ui/components/Text';
+import { Input } from '~/ui/components/Form';
+import { P, CALLOUT, CODE, createPermalinkedComponent, MONOSPACE } from '~/ui/components/Text';
 
 export type AppConfigSchemaProps = {
   schema: Record<string, Property>;
 };
 
 export default function AppConfigSchemaTable({ schema }: AppConfigSchemaProps) {
-  const formattedSchema = formatSchema(Object.entries(schema));
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState<string>('');
+
+  const debouncedSearch = useCallback(
+    debounce((input: string) => {
+      setDebouncedSearchTerm(input);
+    }, 200),
+    [setDebouncedSearchTerm]
+  );
+
+  const formattedSchema =
+    debouncedSearchTerm.length > 0
+      ? flattenProperties(formatSchema(Object.entries(schema))).filter(entry =>
+          filterSchemaEntries(entry, searchTerm)
+        )
+      : formatSchema(Object.entries(schema));
 
   return (
-    <div>
-      {formattedSchema.map((formattedProperty, index) => (
-        <AppConfigProperty
-          {...formattedProperty}
-          key={`${formattedProperty.name}-${index}`}
-          nestingLevel={0}
+    <div className="flex flex-col gap-3.5">
+      <div className="relative">
+        <SearchSmIcon className="text-icon-tertiary absolute pointer-events-none left-3 top-3.5" />
+        <Input
+          placeholder="search properties..."
+          className="pl-10 my-0"
+          value={searchTerm}
+          onChange={event => {
+            const input = event.target.value;
+            setSearchTerm(input);
+            debouncedSearch(input);
+          }}
+          onBlur={() => debouncedSearch.cancel()}
         />
-      ))}
+        {debouncedSearchTerm && (
+          <Button
+            theme="quaternary"
+            className="absolute right-2 top-1.5"
+            leftSlot={<XIcon className="icon-md" />}
+            onClick={() => {
+              setSearchTerm('');
+              setDebouncedSearchTerm('');
+            }}
+          />
+        )}
+      </div>
+      <div>
+        {formattedSchema.length > 0 ? (
+          formattedSchema.map((formattedProperty, index) => (
+            <AppConfigProperty
+              {...formattedProperty}
+              key={`${formattedProperty.name}-${index}`}
+              nestingLevel={0}
+              searchTerm={debouncedSearchTerm}
+            />
+          ))
+        ) : (
+          <div className="rounded-md border border-secondary px-6 py-8 bg-subtle">
+            <P className="text-tertiary text-center">
+              There are no properties matching given search query.
+            </P>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -41,7 +98,7 @@ const Anchor = createPermalinkedComponent(P, {
 function PropertyName({ name, nestingLevel }: PropertyNameProps) {
   return (
     <Anchor level={nestingLevel} data-testid={name} data-heading="true">
-      <CODE className="!px-1.5 !text-sm">{name}</CODE>
+      <MONOSPACE className="!text-sm">{name}</MONOSPACE>
     </Anchor>
   );
 }
@@ -54,9 +111,10 @@ function AppConfigProperty({
   bareWorkflow,
   type,
   nestingLevel,
+  searchTerm,
   subproperties,
   parent,
-}: FormattedProperty & { nestingLevel: number }) {
+}: FormattedProperty & { nestingLevel: number; searchTerm?: string }) {
   return (
     <APIBox
       className={mergeClasses(
@@ -80,11 +138,11 @@ function AppConfigProperty({
             Type: <CODE>{type ?? 'undefined'}</CODE>
           </>
         )}
-        {nestingLevel > 0 && (
+        {(searchTerm || nestingLevel > 0) && (
           <>
             &emsp;&bull;&emsp;Path:{' '}
             <code className="text-secondary px-1 break-words">
-              {parent}.{name}
+              {parent === name ? name : `${parent}.${name}`}
             </code>
           </>
         )}
@@ -102,7 +160,8 @@ function AppConfigProperty({
       )}
       {example && (
         <span className="grid grid-cols-1 gap-2 mb-6">
-          <CALLOUT theme="secondary" className="font-bold">
+          <CALLOUT className="flex flex-row gap-1.5 items-center text-secondary">
+            <CodeSquare01Icon className="icon-sm" />
             Example
           </CALLOUT>
           <CodeBlock inline>{JSON.stringify(example, null, 2)}</CodeBlock>
@@ -114,6 +173,7 @@ function AppConfigProperty({
             {...formattedProperty}
             key={`${name}-${index}`}
             nestingLevel={nestingLevel + 1}
+            searchTerm={searchTerm}
           />
         ))}
     </APIBox>


### PR DESCRIPTION
# Why

Was tinkering with that page a bit based on. the recent feedback. Decided to give a go the search ability.

# How

Implement simple client-side search ability for `AppConfigSchema` reference page, which should help users to find out more quickly the fields they are interested in.

In the process I have also made few small visual tweaks, to align the presentation more with up-to-date API reference sections.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

https://github.com/user-attachments/assets/4d769035-7206-443f-8144-d2f0a8b07033


