### PR TITLE
[docs] API Reference: visual tweaks and DOM simplification for types rendering

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -280,7 +280,7 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !text-secondary !font-medium"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4"
         data-text="true"
       >
         <span
@@ -376,15 +376,10 @@ for more details.
             </svg>
           </a>
         </h3>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
+        <div
+          class="text-secondary font-medium text-[14px] mb-3.5"
         >
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Type:
-          </span>
+          Type:
            
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -397,7 +392,7 @@ for more details.
               AppleAuthenticationButtonStyle
             </a>
           </code>
-        </p>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -453,15 +448,10 @@ for more details.
             </svg>
           </a>
         </h3>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
+        <div
+          class="text-secondary font-medium text-[14px] mb-3.5"
         >
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Type:
-          </span>
+          Type:
            
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -474,7 +464,7 @@ for more details.
               AppleAuthenticationButtonType
             </a>
           </code>
-        </p>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -530,20 +520,11 @@ for more details.
             </svg>
           </a>
         </h3>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
+        <div
+          class="text-secondary font-medium text-[14px] mb-3.5"
         >
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Optional • 
-          </span>
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Type:
-          </span>
+          Optional • 
+          Type:
            
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -551,7 +532,7 @@ for more details.
           >
             number
           </code>
-        </p>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -615,15 +596,10 @@ for more details.
             </svg>
           </a>
         </h3>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
+        <div
+          class="text-secondary font-medium text-[14px] mb-3.5"
         >
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Type:
-          </span>
+          Type:
            
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -642,7 +618,7 @@ for more details.
              
             void
           </code>
-        </p>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -711,20 +687,11 @@ in here.
             </svg>
           </a>
         </h3>
-        <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
-          data-text="true"
+        <div
+          class="text-secondary font-medium text-[14px] mb-3.5"
         >
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Optional • 
-          </span>
-          <span
-            class="text-secondary font-medium text-[90%]"
-          >
-            Type:
-          </span>
+          Optional • 
+          Type:
            
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -790,7 +757,7 @@ in here.
               &gt;
             </span>
           </code>
-        </p>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -7902,38 +7869,24 @@ in order to enable/disable the permission.
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      class="tracking-[-0.006rem] text-secondary font-medium text-[14px]"
       data-text="true"
     >
-      <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium text-secondary"
+      Acceptable values are:
+       
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
         data-text="true"
       >
-        Acceptable values are:
-         
-      </span>
-      <span>
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-          data-text="true"
-        >
-          'never'
-        </code>
-        <span
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-quaternary"
-          data-text="true"
-        >
-           | 
-        </span>
-      </span>
-      <span>
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
-          data-text="true"
-        >
-          number
-        </code>
-      </span>
+        'never'
+      </code>
+       | 
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        data-text="true"
+      >
+        number
+      </code>
     </p>
   </div>
   <div

--- a/docs/components/plugins/api/APIDataType.tsx
+++ b/docs/components/plugins/api/APIDataType.tsx
@@ -5,7 +5,7 @@ import { CodeBlock } from '~/components/base/code';
 import { CODE } from '~/ui/components/Text';
 
 const typeDefinitionContainsObject = (typDef: TypeDefinitionData) =>
-  typDef.type === 'reflection' && typDef.declaration?.children;
+  typDef.type === 'reflection' && typDef.declaration;
 
 type APIDataTypeProps = {
   typeDefinition: TypeDefinitionData;
@@ -21,11 +21,11 @@ export const APIDataType = ({ typeDefinition, sdkVersion, inline = true }: APIDa
     type === 'intersection' && types?.filter(typeDefinitionContainsObject).length;
   const isUnionWithObject =
     (type === 'union' || (elementType && elementType.type === 'union')) &&
-    types?.filter(typeDefinitionContainsObject).length;
+    (types?.filter(typeDefinitionContainsObject)?.length ?? 0) > 0;
   const isObjectWrapped =
     type === 'reference' &&
     typeArguments &&
-    typeArguments?.filter(typeDefinitionContainsObject).length;
+    typeArguments?.filter(typeDefinitionContainsObject).length > 0;
 
   return isObjectDefinition || isIntersectionWithObject || isUnionWithObject || isObjectWrapped ? (
     <CodeBlock inline={inline} key={typeDefinition.name}>

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -158,7 +158,6 @@ const renderClass = (
         <>
           <BoxSectionHeader
             text={`${name} Properties`}
-            className="!text-secondary !font-medium"
             exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
@@ -181,7 +180,6 @@ const renderClass = (
         <>
           <BoxSectionHeader
             text={`${name} Methods`}
-            className="!text-secondary !font-medium !text-sm"
             exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -5,9 +5,9 @@ import { ConstantDefinitionData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import { APISectionPlatformTags } from './APISectionPlatformTags';
 import { CommentTextBlock, getTagNamesList, H3Code } from './APISectionUtils';
-import { STYLES_APIBOX } from './styles';
+import { STYLES_APIBOX, STYLES_SECONDARY } from './styles';
 
-import { H2, DEMI, P, MONOSPACE } from '~/ui/components/Text';
+import { H2, P, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
@@ -32,9 +32,8 @@ const renderConstant = (
       </MONOSPACE>
     </H3Code>
     {type && (
-      <P>
-        <DEMI theme="secondary">Type:</DEMI>{' '}
-        <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+      <P className={STYLES_SECONDARY}>
+        Type: <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </P>
     )}
     {comment && (

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -21,7 +21,7 @@ import {
 } from './APISectionUtils';
 import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
 
-import { CODE, H2, H3, H4, LI, MONOSPACE, P, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, MONOSPACE, UL } from '~/ui/components/Text';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -127,18 +127,17 @@ export const renderProp = (
           {name}
         </MONOSPACE>
       </HeaderComponent>
-      <P className={mergeClasses(extractedComment && ELEMENT_SPACING)}>
-        {flags?.isOptional && <span className={STYLES_SECONDARY}>Optional&emsp;&bull;&emsp;</span>}
-        {flags?.isReadonly && <span className={STYLES_SECONDARY}>Read Only&emsp;&bull;&emsp;</span>}
-        <span className={STYLES_SECONDARY}>Type:</span>{' '}
+      <div className={mergeClasses(STYLES_SECONDARY, extractedComment && ELEMENT_SPACING)}>
+        {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
+        {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}
+        <>Type:</>{' '}
         {renderTypeOrSignatureType({ type, signatures: extractedSignatures, sdkVersion })}
-        {defaultValue && defaultValue !== UNKNOWN_VALUE ? (
-          <span>
-            <span className={STYLES_SECONDARY}>&emsp;&bull;&emsp;Default:</span>{' '}
-            <CODE>{defaultValue}</CODE>
-          </span>
-        ) : null}
-      </P>
+        {defaultValue && defaultValue !== UNKNOWN_VALUE && (
+          <>
+            &emsp;&bull;&emsp;Default: <CODE>{defaultValue}</CODE>
+          </>
+        )}
+      </div>
       <CommentTextBlock comment={extractedComment} includePlatforms={false} />
     </div>
   );
@@ -163,12 +162,7 @@ const APISectionProps = ({
       ) : (
         <div>
           {baseProp && <APISectionDeprecationNote comment={baseProp.comment} />}
-          <BoxSectionHeader
-            text={header}
-            className="!text-secondary !font-medium"
-            exposeInSidebar
-            baseNestingLevel={99}
-          />
+          <BoxSectionHeader text={header} exposeInSidebar baseNestingLevel={99} />
           {baseProp && baseProp.comment && <CommentTextBlock comment={baseProp.comment} />}
         </div>
       )}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -29,7 +29,7 @@ import {
   getCommentContent,
   listParams,
 } from './APISectionUtils';
-import { STYLES_APIBOX } from './styles';
+import { STYLES_APIBOX, STYLES_SECONDARY } from './styles';
 
 import { APIBox } from '~/components/plugins/APIBox';
 import { Cell, Row, Table } from '~/ui/components/Table';
@@ -186,11 +186,8 @@ const renderType = (
           <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT>
-          <SPAN theme="secondary" weight="medium">
-            Tuple:{' '}
-          </SPAN>
-          <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
+        <CALLOUT className={STYLES_SECONDARY}>
+          Tuple: <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
         </CALLOUT>
       </div>
     );
@@ -217,10 +214,8 @@ const renderType = (
           <CommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
-              <CALLOUT>
-                <SPAN theme="secondary" weight="medium">
-                  Type:{' '}
-                </SPAN>
+              <CALLOUT className={STYLES_SECONDARY}>
+                Type:{' '}
                 {type.types
                   .filter(type =>
                     ['reference', 'union', 'intersection', 'intrinsic', 'literal'].includes(
@@ -233,14 +228,12 @@ const renderType = (
                       {type.type === 'union' ? ' or ' : ' '}
                     </Fragment>
                   ))}
-                <SPAN theme="secondary">
-                  {type.type === 'union'
-                    ? propMethodDefinitions.length > 2
-                      ? 'an anonymous method defined as described below'
-                      : 'object shaped as below'
-                    : 'extended by'}
-                  :
-                </SPAN>
+                {type.type === 'union'
+                  ? propMethodDefinitions.length > 2
+                    ? 'an anonymous method defined as described below'
+                    : 'object shaped as below'
+                  : 'extended by'}
+                :
               </CALLOUT>
               <br />
             </>
@@ -274,21 +267,13 @@ const renderType = (
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
           <CommentTextBlock comment={comment} includePlatforms={false} />
-          <CALLOUT>
-            <SPAN theme="secondary" weight="medium">
-              Acceptable values are:{' '}
-            </SPAN>
+          <CALLOUT className={STYLES_SECONDARY}>
+            Acceptable values are:{' '}
             {literalTypes.map((lt, index) => (
-              <span key={`${name}-literal-type-${index}`}>
+              <Fragment key={`${name}-literal-type-${index}`}>
                 <CODE>{resolveTypeName(lt, sdkVersion)}</CODE>
-                {index + 1 !== literalTypes.length ? (
-                  <CALLOUT tag="span" theme="quaternary">
-                    {' | '}
-                  </CALLOUT>
-                ) : (
-                  ''
-                )}
-              </span>
+                {index + 1 !== literalTypes.length ? ' | ' : ''}
+              </Fragment>
             ))}
           </CALLOUT>
         </div>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -466,7 +466,7 @@ export const resolveTypeName = (
           <span className="text-quaternary">(</span>
           {renderUnion(unionTypes, { sdkVersion })}
           <span className="text-quaternary">)</span>
-          {type === 'array' && '[]'}
+          {type === 'array' && <span className="text-quaternary">[]</span>}
         </>
       );
     } else if (declaration?.signatures) {
@@ -479,11 +479,12 @@ export const resolveTypeName = (
               <span key={`param-${index}-${param.name}`}>
                 {param.name}
                 <span className="text-quaternary">:</span> {resolveTypeName(param.type, sdkVersion)}
-                {index + 1 !== baseSignature.parameters?.length && ', '}
+                {index + 1 !== baseSignature.parameters?.length && (
+                  <span className="text-quaternary">, </span>
+                )}
               </span>
             ))}
-            <span className="text-quaternary">)</span>{' '}
-            <span className="text-quaternary">{'=>'}</span>{' '}
+            <span className="text-quaternary">{') =>'}</span>{' '}
             {baseSignature.type ? resolveTypeName(baseSignature.type, sdkVersion) : 'undefined'}
           </>
         );

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -435,13 +435,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   <span
     class="text-quaternary"
   >
-    )
-  </span>
-   
-  <span
-    class="text-quaternary"
-  >
-    =&gt;
+    ) =&gt;
   </span>
    
   <span>
@@ -490,13 +484,7 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
   <span
     class="text-quaternary"
   >
-    )
-  </span>
-   
-  <span
-    class="text-quaternary"
-  >
-    =&gt;
+    ) =&gt;
   </span>
    
   void
@@ -786,7 +774,11 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   >
     )
   </span>
-  []
+  <span
+    class="text-quaternary"
+  >
+    []
+  </span>
 </div>
 `;
 

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -2,7 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 
 export const ELEMENT_SPACING = mergeClasses('mb-3.5');
 
-export const STYLES_SECONDARY = mergeClasses('text-secondary font-medium text-[90%]');
+export const STYLES_SECONDARY = mergeClasses('text-secondary font-medium text-[14px]');
 
 export const STYLES_OPTIONAL = mergeClasses('text-secondary pt-5 !text-[13px]');
 


### PR DESCRIPTION
# Why

While reviewing few API references I have spotted few thing which can be corrected, or simplified after Emotion removal.

# How

Simplify DOM when rendering types, apply secondary styling to few more non-crucial characters, relay on block display also for unions with object as parameters.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-10-29 at 15 51 10](https://github.com/user-attachments/assets/019b07e9-f383-4450-9a60-e3378e93067d)
![Screenshot 2024-10-29 at 16 19 19](https://github.com/user-attachments/assets/e5d81ed2-a5ee-4f1e-840b-e589bed66f54)

