### PR TITLE
fix(cli): work around React Native DevTools not responding to open requests

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix unresponsive terminal after opening React Native DevTools.
+
 ### 💡 Others
 
 ## 0.19.4 — 2024-10-28

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix unresponsive terminal after opening React Native DevTools.
+- Fix unresponsive terminal after opening React Native DevTools. ([#32451](https://github.com/expo/expo/pull/32451) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes ENG-13977

Originally, there was an issue where the middleware responding to the "open React Native DevTools" requests never responded with a proper response. This would cause the terminal become unresponsive as it waited for the response, or the default timeout was hit.

We've fixed this in https://github.com/facebook/react-native/pull/46814

Unfortunately, that same middleware has another issue. The [`browserLauncher.launchDebuggerAppWindow`](https://github.com/facebook/react-native/blob/7090b790c6febed048203ea5f5a4f7116d1206cf/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js#L133-L140) async method never completes. Meaning, we still have that endpoint not responding to the request properly.

# How

- Added a timeout of 1s to the open debugger request

# Test Plan

- `bun create expo ./test-rndt --template default@next`
- `cd ./test-rndt`
- `bun expo start --ios`
- Press `j` in terminal once the app is started
- Terminal should become responsive again after maximum of 1s

Also added debug logging to check if users run into this timeout state. You can see this logging with:

- `DEBUG="expo:start:server:middleware:inspector:jsInspector" bun expo start`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
