### PR TITLE
[chore] Add lfs.fetchexclude config

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	fetchexclude = ios/Pods*


### PR DESCRIPTION
# Why

We've exceeded out bandwidth for git lfs for our github account. Looking at the usage (linked in task), this is due to lfs objects on this repo.

Closes ENG-13981.

# How

```
$ git lfs ls-files --all
27afab4e5f - ios/Pods/FBAudienceNetwork/Static/FBAudienceNetwork.framework/FBAudienceNetwork
749e31e2dc - ios/Pods/FirebaseMLVisionFaceModel/Frameworks/FirebaseMLVisionFaceModel.framework/FirebaseMLVisionFaceModel
4f59030997 - ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.framework/GoogleMobileAds
f560450309 - ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMapsCore.framework/GoogleMapsCore
43de50a242 - ios/Pods/FBAudienceNetwork/Static/FBAudienceNetwork.framework/FBAudienceNetwork
33dcab5837 - ios/Pods/FBAudienceNetwork/Static/FBAudienceNetwork.framework/FBAudienceNetwork
3c8f90328e - ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.framework/GoogleMobileAds
9b841baf59 - ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.framework/GoogleMobileAds
38ae52ae32 - ios/Pods/GoogleMobileVision/Detector/Frameworks/GoogleMobileVision.framework/GoogleMobileVision
d5b09bb2de - ios/Pods/GoogleMobileVision/FaceDetector/Frameworks/FaceDetector.framework/FaceDetector
5af4c50d9c - ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.framework/GoogleMobileAds
18a5526d06 - ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMapsCore.framework/GoogleMapsCore
e6cbf52b38 - ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMapsCore.framework/GoogleMapsCore
15a7d5d7a7 - ios/Pods/FBAudienceNetwork/Static/FBAudienceNetwork.framework/FBAudienceNetwork
6ad0169c83 - ios/Pods/GoogleInterchangeUtilities/Frameworks/frameworks/GoogleInterchangeUtilities.framework/GoogleInterchangeUtilities
01501581b7 - ios/Pods/GoogleMobileVision/Detector/Frameworks/frameworks/GoogleMobileVision.framework/GoogleMobileVision
e4cea14bb2 - ios/Pods/GoogleMobileVision/FaceDetector/Frameworks/frameworks/FaceDetector.framework/FaceDetector
```

It looks like we still have some objects in lfs from long ago. We can't remove these without rewriting history (which is impossible for this repo), but we can do our best to limit the bandwidth they use by instructing full clone operations not to download the files. That is at least theoretically what this config does: https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-fetch.adoc

# Test Plan

Push this and then do a full clone and see what shows up.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
