### PR TITLE
[docs] Fix a link to group routes in "native-intent.mdx"

### DIFF
--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -84,7 +84,7 @@ Choose the pattern that aligns with your deployment strategy and technical requi
 While your app is open, you can react to URL changes within your `_layout` files using the `usePathname()` hook. The location of the `_layout` dictates the scope of the subscription.
 
 - **global**: Add the logic to your root `_layout` file
-- **localized**: Add a `_layout` file to an existing directory (or create a new (group directory)[/router/layouts/#groups])
+- **localized**: Add a `_layout` file to an existing directory (or create a new [group directory](/router/layouts/#groups))
 
 ```tsx app/_layout.tsx
 import { Slot, Redirect } from 'expo-router';


### PR DESCRIPTION
# Why
Link is not clickable.

# How
Fix the Markdown syntax for link

# Test Plan
Build and click the link.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
