### PR TITLE
[docs] add "new" and "deprecated" packages doc pages indication

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -691,6 +691,8 @@ function makePage(file) {
     name: data.title,
     // TODO(cedric): refactor href into url
     href: url,
+    isNew: data.isNew ?? undefined,
+    isDeprecated: data.isDeprecated ?? undefined,
   };
   // TODO(cedric): refactor sidebarTitle into metadata
   if (data.sidebar_title) {

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-av'
 packageName: 'expo-audio'
 iconUrl: '/static/images/packages/expo-av.png'
 platforms: ['android', 'ios', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo'
 packageName: 'expo'
 iconUrl: '/static/images/packages/expo.png'
 platforms: ['android', 'ios', 'tvos', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -4,6 +4,7 @@ description: A library that uses Google Mobile Vision to detect faces on images.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-face-detector'
 packageName: 'expo-face-detector'
 platforms: ['android*', 'ios*']
+isDeprecated: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-file-system
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/live-photo.mdx
+++ b/docs/pages/versions/unversioned/sdk/live-photo.mdx
@@ -4,6 +4,7 @@ description: A library that allows displaying Live Photos on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-live-photo'
 packageName: 'expo-live-photo'
 platforms: ['ios']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video'
 packageName: 'expo-video'
 iconUrl: '/static/images/packages/expo-video.png'
 platforms: ['android', 'ios', 'web', 'tvos']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-av'
 packageName: 'expo-audio'
 iconUrl: '/static/images/packages/expo-av.png'
 platforms: ['android', 'ios', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/expo.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo'
 packageName: 'expo'
 iconUrl: '/static/images/packages/expo.png'
 platforms: ['android', 'ios', 'tvos', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/facedetector.mdx
@@ -4,6 +4,7 @@ description: A library that uses Google Mobile Vision to detect faces on images.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-face-detector'
 packageName: 'expo-face-detector'
 platforms: ['android*', 'ios*']
+isDeprecated: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-file-syst
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/live-photo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/live-photo.mdx
@@ -4,6 +4,7 @@ description: A library that allows displaying Live Photos on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-live-photo'
 packageName: 'expo-live-photo'
 platforms: ['ios']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-video'
 packageName: 'expo-video'
 iconUrl: '/static/images/packages/expo-video.png'
 platforms: ['android', 'ios', 'web', 'tvos']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -42,6 +42,8 @@ export type NavigationRoute = {
   expanded?: boolean;
   sidebarTitle?: string;
   weight?: number;
+  isNew?: boolean;
+  isDeprecated?: boolean;
   children?: NavigationRoute[];
 };
 

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -44,14 +44,15 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
   const isExternal = info.href.startsWith('http');
 
   return (
-    <div className="flex min-h-8 items-center p-1 pr-2">
+    <div className="flex min-h-8 items-center p-1 pr-0">
       <LinkBase
         href={info.href as string}
         ref={ref}
         className={mergeClasses(
-          'text-xs flex decoration-0 text-secondary items-center scroll-m-[60px] w-full -ml-2.5',
+          'group text-xs flex decoration-0 text-secondary items-center scroll-m-[60px] w-full -ml-2.5',
           'hocus:text-link hocus:[&_svg]:text-icon-tertiary',
-          isSelected && 'text-link'
+          isSelected && 'text-link',
+          info.isDeprecated && 'line-through'
         )}
         {...customDataAttributes}>
         <div
@@ -61,7 +62,20 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
           )}
         />
         {children}
-        {isExternal && <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto" />}
+        {info.isNew && (
+          <div
+            className={mergeClasses(
+              'inline-flex ml-2 -mt-px border border-palette-blue10 text-palette-white text-[11px] font-semibold rounded-full px-[5px] leading-none items-center h-[17px]',
+              isSelected
+                ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
+                : 'bg-none border-palette-blue10 text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
+            )}>
+            NEW
+          </div>
+        )}
+        {isExternal && (
+          <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto group-hover:text-icon-info" />
+        )}
       </LinkBase>
     </div>
   );


### PR DESCRIPTION
# Why

It would be nice if we can highlight or denounce some of the API reference pages based on the package status.

# How

This PR adds two new flags for API reference pages: `isNew` and `isDeprecated` which will add a decoration to the sidebar entry of a given page. The flags have been added to the `unversioned` and SDK 52 doc files.

Let me know if I have missed or miss marked any of the entries!

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

https://github.com/user-attachments/assets/e5aae2ae-d272-4875-9651-c03d10ff094d


