### PR TITLE
[ios][expo-go] Add legacy splashscreen

### DIFF
--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		31F8E27E255F05D5005AA063 /* EXDeviceInstallationUUIDService.m in Sources */ = {isa = PBXBuildFile; fileRef = 31F8E27D255F05D5005AA063 /* EXDeviceInstallationUUIDService.m */; };
 		402B73292CC90F7100FA17BC /* RequestLocalNetworkAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */; };
 		4089335A2CAAF7A20095810E /* ExpoAppInstance.mm in Sources */ = {isa = PBXBuildFile; fileRef = 408933592CAAF7A20095810E /* ExpoAppInstance.mm */; };
+		40CB1D752CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D722CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m */; };
+		40CB1D762CD2A0C200CB3717 /* EXSplashScreenModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D6C2CD2A0C200CB3717 /* EXSplashScreenModule.m */; };
+		40CB1D772CD2A0C200CB3717 /* EXSplashScreenService.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D6E2CD2A0C200CB3717 /* EXSplashScreenService.m */; };
+		40CB1D782CD2A0C200CB3717 /* EXSplashScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D702CD2A0C200CB3717 /* EXSplashScreenViewController.m */; };
 		40F867AB2CA04F0B009A7E2C /* JKBigInteger.podspec.json in Resources */ = {isa = PBXBuildFile; fileRef = 40F867A02CA04F0B009A7E2C /* JKBigInteger.podspec.json */; };
 		78CEE2D11ACD07D70095B124 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 78CEE2D01ACD07D70095B124 /* Images.xcassets */; };
 		78D82527204E8F9C00CBD9D9 /* EXApiV2Client.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D82526204E8F9C00CBD9D9 /* EXApiV2Client.m */; };
@@ -248,6 +252,15 @@
 		402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocalNetworkAccess.swift; sourceTree = "<group>"; };
 		408933582CAAF7870095810E /* ExpoAppInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpoAppInstance.h; sourceTree = "<group>"; };
 		408933592CAAF7A20095810E /* ExpoAppInstance.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExpoAppInstance.mm; sourceTree = "<group>"; };
+		40CB1D6B2CD2A0C200CB3717 /* EXSplashScreenModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenModule.h; sourceTree = "<group>"; };
+		40CB1D6C2CD2A0C200CB3717 /* EXSplashScreenModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXSplashScreenModule.m; sourceTree = "<group>"; };
+		40CB1D6D2CD2A0C200CB3717 /* EXSplashScreenService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenService.h; sourceTree = "<group>"; };
+		40CB1D6E2CD2A0C200CB3717 /* EXSplashScreenService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXSplashScreenService.m; sourceTree = "<group>"; };
+		40CB1D6F2CD2A0C200CB3717 /* EXSplashScreenViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenViewController.h; sourceTree = "<group>"; };
+		40CB1D702CD2A0C200CB3717 /* EXSplashScreenViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXSplashScreenViewController.m; sourceTree = "<group>"; };
+		40CB1D712CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenViewNativeProvider.h; sourceTree = "<group>"; };
+		40CB1D722CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXSplashScreenViewNativeProvider.m; sourceTree = "<group>"; };
+		40CB1D732CD2A0C200CB3717 /* EXSplashScreenViewProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenViewProvider.h; sourceTree = "<group>"; };
 		40F867A02CA04F0B009A7E2C /* JKBigInteger.podspec.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = JKBigInteger.podspec.json; sourceTree = "<group>"; };
 		45675DFC5DFCA8A77C135D1D /* Pods-Expo Go (main)-Expo Go.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Expo Go (main)-Expo Go.release.xcconfig"; path = "Target Support Files/Pods-Expo Go (main)-Expo Go/Pods-Expo Go (main)-Expo Go.release.xcconfig"; sourceTree = "<group>"; };
 		70D1A518C4DFB7D94147AC4B /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Expo Go/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
@@ -579,6 +592,22 @@
 				B5FB73A31FF6DADB001C764B /* RNViewShot.m */,
 			);
 			path = ViewShot;
+			sourceTree = "<group>";
+		};
+		40CB1D742CD2A0C200CB3717 /* EXSplashScreen */ = {
+			isa = PBXGroup;
+			children = (
+				40CB1D6B2CD2A0C200CB3717 /* EXSplashScreenModule.h */,
+				40CB1D6C2CD2A0C200CB3717 /* EXSplashScreenModule.m */,
+				40CB1D6D2CD2A0C200CB3717 /* EXSplashScreenService.h */,
+				40CB1D6E2CD2A0C200CB3717 /* EXSplashScreenService.m */,
+				40CB1D6F2CD2A0C200CB3717 /* EXSplashScreenViewController.h */,
+				40CB1D702CD2A0C200CB3717 /* EXSplashScreenViewController.m */,
+				40CB1D712CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.h */,
+				40CB1D722CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m */,
+				40CB1D732CD2A0C200CB3717 /* EXSplashScreenViewProvider.h */,
+			);
+			path = EXSplashScreen;
 			sourceTree = "<group>";
 		};
 		40F842852C9CB39F00E1AC82 /* AppInstance */ = {
@@ -978,6 +1007,7 @@
 		B5AC39A21E95A90B00540AA7 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				40CB1D742CD2A0C200CB3717 /* EXSplashScreen */,
 				19B2EF731FB25A1A003F2E1B /* EXCachedResourceManager.h */,
 				19B2EF741FB25A1A003F2E1B /* EXCachedResourceManager.m */,
 				31F8E27C255F05D5005AA063 /* EXDeviceInstallationUUIDService.h */,
@@ -1874,6 +1904,10 @@
 				B216039C2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */,
 				8764788D270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift in Sources */,
 				B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */,
+				40CB1D752CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m in Sources */,
+				40CB1D762CD2A0C200CB3717 /* EXSplashScreenModule.m in Sources */,
+				40CB1D772CD2A0C200CB3717 /* EXSplashScreenService.m in Sources */,
+				40CB1D782CD2A0C200CB3717 /* EXSplashScreenViewController.m in Sources */,
 				B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */,
 				28F885A428FEC26000CFD75C /* EXTextDirectionController.swift in Sources */,
 				ABE005EBFA92123617D22216 /* ExpoModulesProvider.swift in Sources */,

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenModule.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenModule.h
@@ -1,0 +1,9 @@
+//  Copyright © 2018 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXExportedModule.h>
+#import <ExpoModulesCore/EXAppLifecycleListener.h>
+#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
+
+@interface EXSplashScreenModule : EXExportedModule <EXModuleRegistryConsumer, EXAppLifecycleListener>
+
+@end

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenModule.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenModule.m
@@ -1,0 +1,185 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXSplashScreenModule.h"
+#import "EXSplashScreenService.h"
+#import <React/RCTRootView.h>
+#import <React/RCTSurfaceHostingView.h>
+#import <ExpoModulesCore/EXAppLifecycleService.h>
+#import <ExpoModulesCore/EXUtilities.h>
+
+@protocol EXSplashScreenUtilService
+
+- (UIViewController *)currentViewController;
+
+@end
+
+@interface EXSplashScreenModule ()
+
+@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) id<EXUtilitiesInterface> utilities;
+
+@end
+
+@implementation EXSplashScreenModule
+
+EX_EXPORT_MODULE(ExpoSplashScreen);
+
+- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
+{
+  _moduleRegistry = moduleRegistry;
+  _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
+  [[moduleRegistry getModuleImplementingProtocol:@protocol(EXAppLifecycleService)] registerAppLifecycleListener:self];
+}
+
+EX_EXPORT_METHOD_AS(hide,
+                    resolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
+{
+  [self hideWithResolve:resolve reject:reject];
+}
+
+EX_EXPORT_METHOD_AS(hideAsync,
+                    hideWithResolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
+{
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    UIViewController *currentViewController = [self reactViewController];
+    [[self splashScreenService] hideSplashScreenFor:currentViewController
+                                            options:EXSplashScreenDefault
+                                    successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
+                                    failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_HIDE", message, nil); }];
+  });
+}
+
+EX_EXPORT_METHOD_AS(preventAutoHideAsync,
+                    preventAutoHideWithResolve:(EXPromiseResolveBlock)resolve
+                    reject:(EXPromiseRejectBlock)reject)
+{
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    UIViewController *currentViewController = [self reactViewController];
+    [[self splashScreenService] preventSplashScreenAutoHideFor:currentViewController
+                                                       options:EXSplashScreenDefault
+                                               successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
+                                               failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_PREVENT_AUTOHIDE", message, nil); }];
+  });
+}
+
+# pragma mark - EXAppLifecycleListener
+
+- (void)onAppBackgrounded {}
+
+- (void)onAppForegrounded {}
+
+- (void)onAppContentDidAppear
+{
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    UIViewController* currentViewController = [self reactViewController];
+    [[self splashScreenService] onAppContentDidAppear:currentViewController];
+  });
+}
+
+- (void)onAppContentWillReload
+{
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    UIViewController* currentViewController = [self reactViewController];
+    [[self splashScreenService] onAppContentWillReload:currentViewController];
+  });
+}
+
+# pragma mark - internals
+
+/**
+ * Tries to obtain singleton module that is registered as "SplashScreen".
+ * Silent agreement is that registered module conforms to "EXSplashScreenService" protocol.
+ */
+- (id<EXSplashScreenService>)splashScreenService
+{
+  return [self.moduleRegistry getSingletonModuleForName:@"SplashScreen"];
+}
+
+/**
+ * Tries to obtain a reference to the UIViewController for the main RCTRootView
+ * by iterating through all of the application's windows and their viewControllers
+ * until it finds one with a RCTRootView.
+ */
+- (UIViewController *)reactViewController
+{
+  dispatch_assert_queue(dispatch_get_main_queue());
+
+  // first check to see if the host application has a module that provides the reference we want
+  // (this is the case in Expo Go and in the ExpoKit pod used in `expo build` apps)
+  id<EXSplashScreenUtilService> utilService = [_moduleRegistry getSingletonModuleForName:@"Util"];
+  if (utilService != nil) {
+    return [utilService currentViewController];
+  }
+
+  UIViewController *controller = [self viewControllerContainingRCTRootView];
+  if (!controller) {
+    // no RCTRootView was found, so just fall back to the key window's root view controller
+    controller = self.utilities.currentViewController;
+    while ([controller isKindOfClass:[UIAlertController class]] &&
+           controller.presentingViewController != nil) {
+      controller = controller.presentingViewController;
+    }
+    return controller;
+  }
+
+  UIViewController *presentedController = controller.presentedViewController;
+  while (presentedController &&
+         ![presentedController isBeingDismissed] &&
+         ![presentedController isKindOfClass:[UIAlertController class]]) {
+    controller = presentedController;
+    presentedController = controller.presentedViewController;
+  }
+  return controller;
+}
+
+- (nullable UIViewController *)viewControllerContainingRCTRootView
+{
+  NSArray<UIWindow *> *allWindows;
+  if (@available(iOS 13, *)) {
+    NSSet<UIScene *> *allWindowScenes = UIApplication.sharedApplication.connectedScenes;
+    NSMutableArray<UIWindow *> *allForegroundWindows = [NSMutableArray new];
+    for (UIScene *scene in allWindowScenes.allObjects) {
+      if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+        [allForegroundWindows addObjectsFromArray:((UIWindowScene *)scene).windows];
+      }
+    }
+    allWindows = allForegroundWindows;
+  } else {
+    allWindows = UIApplication.sharedApplication.windows;
+  }
+
+  for (UIWindow *window in allWindows) {
+    UIViewController *controller = window.rootViewController;
+    if ([self isReactRootView:controller.view]) {
+      return controller;
+    }
+    UIViewController *presentedController = controller.presentedViewController;
+    while (presentedController && ![presentedController isBeingDismissed]) {
+      if ([self isReactRootView:presentedController.view]) {
+        return presentedController;
+      }
+      controller = presentedController;
+      presentedController = controller.presentedViewController;
+    }
+  }
+
+  // no RCTRootView was found
+  return nil;
+}
+
+- (BOOL)isReactRootView:(UIView*)view
+{
+  return [view isKindOfClass:RCTRootView.class] || [view isKindOfClass:RCTSurfaceHostingView.class];
+}
+
+@end

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenService.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenService.h
@@ -1,0 +1,84 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
+#import "EXSplashScreenViewController.h"
+#import "EXSplashScreenViewProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_OPTIONS(NSUInteger, EXSplashScreenOptions) {
+  EXSplashScreenDefault = 0,
+
+  // Show splash screen even it was already shown before.
+  // e.g. show splash screen again when reloading apps,
+  EXSplashScreenForceShow = 1 << 0,
+};
+
+/**
+* Entry point for handling SplashScreen associated mechanism.
+* This class has state based on the following relation { ViewController -> ApplicationSplashScreenState }.
+* Each method call has to be made using ViewController that holds Application's view hierachy.
+*/
+@protocol EXSplashScreenService <NSObject>
+
+/**
+ * Overloaded method. See main method below.
+ */
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options;
+
+/**
+ * Entry point for SplashScreen unimodule.
+ * Registers SplashScreen for given viewController and presents it in that viewController.
+ */
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+   splashScreenViewProvider:(id<EXSplashScreenViewProvider>)splashScreenViewProvider
+            successCallback:(void (^)(void))successCallback
+            failureCallback:(void (^)(NSString *message))failureCallback;
+
+/**
+ * Entry point for SplashScreen unimodule.
+ * Registers SplashScreen for given viewController and EXSplashController and presents it in that viewController.
+ */
+-(void)showSplashScreenFor:(UIViewController *)viewController
+                   options:(EXSplashScreenOptions)options
+    splashScreenController:(EXSplashScreenViewController *)splashScreenController
+           successCallback:(void (^)(void))successCallback
+           failureCallback:(void (^)(NSString *message))failureCallback;
+
+/**
+ * Hides SplashScreen for given viewController.
+ */
+- (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+            successCallback:(void (^)(BOOL hasEffect))successCallback
+            failureCallback:(void (^)(NSString *message))failureCallback;
+
+/**
+ * Prevents SplashScreen from default autohiding.
+ */
+- (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(EXSplashScreenOptions)options
+                       successCallback:(void (^)(BOOL hasEffect))successCallback
+                       failureCallback:(void (^)(NSString *message))failureCallback;
+
+/**
+ * Signaling method that has to be called upon Content is rendered in view hierarchy.
+ * Autohide functionality depends on this call.
+ */
+- (void)onAppContentDidAppear:(UIViewController *)viewController;
+
+/**
+ * Signaling method that is responsible for reshowing SplashScreen upon full content reload.
+ */
+- (void)onAppContentWillReload:(UIViewController *)viewController;
+
+@end
+
+@interface EXSplashScreenService : EXSingletonModule <EXSplashScreenService, UIApplicationDelegate>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenService.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenService.m
@@ -1,0 +1,210 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import "EXSplashScreenService.h"
+#import "EXSplashScreenViewNativeProvider.h"
+#import <ExpoModulesCore/EXDefines.h>
+
+static NSString * const kRootViewController = @"rootViewController";
+static NSString * const kView = @"view";
+
+@interface EXSplashScreenService ()
+
+@property (nonatomic, strong) NSMapTable<UIViewController *, EXSplashScreenViewController *> *splashScreenControllers;
+/**
+ * This module holds a reference to rootViewController acting as a flag to indicate KVO is enabled.
+ * When KVO is enabled, actually we are observing two targets and re-show splash screen if targets changed:
+ *   - `keyWindow.rootViewController`: it is for expo-dev-client which replaced it in startup.
+ *   - `rootViewController.rootView`: it is for expo-updates which replaced it in startup.
+ *
+ * If `rootViewController` is changed, we also need the old `rootViewController` to unregister rootView KVO.
+ * That's why we keep a weak reference here but not a boolean flag.
+ */
+@property (nonatomic, weak) UIViewController *observingRootViewController;
+
+@end
+
+@implementation EXSplashScreenService
+
+EX_REGISTER_SINGLETON_MODULE(SplashScreen);
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _splashScreenControllers = [NSMapTable weakToStrongObjectsMapTable];
+  }
+  return self;
+}
+
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+{
+  id<EXSplashScreenViewProvider> splashScreenViewProvider = [EXSplashScreenViewNativeProvider new];
+  return [self showSplashScreenFor:viewController
+                           options:options
+          splashScreenViewProvider:splashScreenViewProvider
+                   successCallback:^{}
+                   failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];
+}
+
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+   splashScreenViewProvider:(id<EXSplashScreenViewProvider>)splashScreenViewProvider
+            successCallback:(void (^)(void))successCallback
+            failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if ((options & EXSplashScreenForceShow) == 0 && [self.splashScreenControllers objectForKey:viewController]) {
+    return failureCallback(@"'SplashScreen.show' has already been called for given view controller.");
+  }
+  
+  
+  UIView *rootView = viewController.view;
+  UIView *splashScreenView = [splashScreenViewProvider createSplashScreenView];
+  EXSplashScreenViewController *splashScreenController = [[EXSplashScreenViewController alloc] initWithRootView:rootView
+                                                                                               splashScreenView:splashScreenView];
+  
+  [self showSplashScreenFor:viewController
+                    options:options
+     splashScreenController:splashScreenController
+            successCallback:successCallback
+            failureCallback:failureCallback];
+}
+
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+     splashScreenController:(EXSplashScreenViewController *)splashScreenController
+            successCallback:(void (^)(void))successCallback
+            failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if ((options & EXSplashScreenForceShow) == 0 && [self.splashScreenControllers objectForKey:viewController]) {
+    return failureCallback(@"'SplashScreen.show' has already been called for given view controller.");
+  }
+  
+  [self.splashScreenControllers setObject:splashScreenController forKey:viewController];
+  [[self.splashScreenControllers objectForKey:viewController] showWithCallback:successCallback
+                                                               failureCallback:failureCallback];
+}
+
+- (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(EXSplashScreenOptions)options
+                       successCallback:(void (^)(BOOL hasEffect))successCallback
+                       failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if (![self.splashScreenControllers objectForKey:viewController]) {
+    return failureCallback(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
+  }
+  
+  return [[self.splashScreenControllers objectForKey:viewController] preventAutoHideWithCallback:successCallback
+                                                                                 failureCallback:failureCallback];
+}
+
+- (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
+            successCallback:(void (^)(BOOL hasEffect))successCallback
+            failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if (![self.splashScreenControllers objectForKey:viewController]) {
+    return failureCallback(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
+  }
+  [self removeRootViewControllerListener];
+
+  return [[self.splashScreenControllers objectForKey:viewController] hideWithCallback:successCallback
+                                                                      failureCallback:failureCallback];
+}
+
+- (void)onAppContentDidAppear:(UIViewController *)viewController
+{
+  BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
+  if (needsHide) {
+    [self hideSplashScreenFor:viewController
+                      options:EXSplashScreenDefault
+              successCallback:^(BOOL hasEffect){}
+              failureCallback:^(NSString *message){}];
+  }
+}
+
+- (void)onAppContentWillReload:(UIViewController *)viewController
+{
+  BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
+  if (needsShow) {
+    // For reloading apps, specify `EXSplashScreenForceShow` to show splash screen again
+    [self showSplashScreenFor:viewController
+                      options:EXSplashScreenForceShow
+       splashScreenController:[self.splashScreenControllers objectForKey:viewController]
+              successCallback:^{}
+              failureCallback:^(NSString *message){}];
+  }
+}
+
+- (BOOL)isAppActive {
+    return UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
+}
+
+# pragma mark - UIApplicationDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  UIViewController *rootViewController = [[application keyWindow] rootViewController];
+  if (rootViewController) {
+    [self showSplashScreenFor:rootViewController options:EXSplashScreenDefault];
+  }
+
+  [self addRootViewControllerListener];
+  return YES;
+}
+
+# pragma mark - RootViewController KVO
+
+- (void)addRootViewControllerListener
+{
+  NSAssert([NSThread isMainThread], @"Method must be called on main thread");
+  if (self.observingRootViewController == nil) {
+    UIViewController *rootViewController = UIApplication.sharedApplication.keyWindow.rootViewController;
+
+    [UIApplication.sharedApplication.keyWindow addObserver:self
+                                                forKeyPath:kRootViewController
+                                                   options:NSKeyValueObservingOptionNew
+                                                   context:nil];
+
+    [rootViewController addObserver:self forKeyPath:kView options:NSKeyValueObservingOptionNew context:nil];
+    self.observingRootViewController = rootViewController;
+  }
+}
+
+- (void)removeRootViewControllerListener
+{
+  NSAssert([NSThread isMainThread], @"Method must be called on main thread");
+  if (self.observingRootViewController != nil) {
+    UIWindow *window = self.observingRootViewController.view.window;
+    [window removeObserver:self forKeyPath:kRootViewController context:nil];
+    [self.observingRootViewController removeObserver:self forKeyPath:kView context:nil];
+    self.observingRootViewController = nil;
+  }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+  if (object == UIApplication.sharedApplication.keyWindow && [keyPath isEqualToString:kRootViewController]) {
+    UIViewController *newRootViewController = change[@"new"];
+    // For unknown reasons, this function may be sometimes called twice with the same changes.
+    // What leads to warnings like this one: `'SplashScreen.show' has already been called for given view controller`.
+    // To prevent this weird behaviour, we check if the value was really changed.
+    if (newRootViewController != nil && newRootViewController != self.observingRootViewController) {
+      [self removeRootViewControllerListener];
+      [self showSplashScreenFor:newRootViewController options:EXSplashScreenDefault];
+      [self addRootViewControllerListener];
+    }
+  }
+  if (object == UIApplication.sharedApplication.keyWindow.rootViewController && [keyPath isEqualToString:kView]) {
+    UIView *newView = change[@"new"];
+    if (newView != nil && [newView.nextResponder isKindOfClass:[UIViewController class]]) {
+      UIViewController *viewController = (UIViewController *)newView.nextResponder;
+      // To show splash screen as soon as possible, we do not wait for hiding callback and call showSplashScreen immediately.
+      // GCD main queue should keep the calls in sequence.
+      [self hideSplashScreenFor:viewController options:EXSplashScreenDefault successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
+      [self.splashScreenControllers removeObjectForKey:viewController];
+      [self showSplashScreenFor:viewController options:EXSplashScreenDefault];
+    }
+  }
+}
+
+@end

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewController.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewController.h
@@ -1,0 +1,24 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXSplashScreenViewController : NSObject
+
+@property (nonatomic, strong) UIView *splashScreenView;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithRootView:(UIView *)rootView
+                splashScreenView:(UIView *)splashScreenView;
+
+- (void)showWithCallback:(void (^)(void))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
+- (void)preventAutoHideWithCallback:(void (^)(BOOL hasEffect))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
+- (void)hideWithCallback:(void (^)(BOOL hasEffect))successCallback failureCallback:(void (^)(NSString *message))failureCallback;
+- (BOOL)needsHideOnAppContentDidAppear;
+- (BOOL)needsShowOnAppContentWillReload;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewController.m
@@ -1,0 +1,104 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import "EXSplashScreenViewController.h"
+#import <ExpoModulesCore/EXDefines.h>
+#import <ExpoModulesCore/EXUtilities.h>
+
+@interface EXSplashScreenViewController ()
+
+@property (nonatomic, weak) UIView *rootView;
+
+@property (nonatomic, assign) BOOL autoHideEnabled;
+@property (nonatomic, assign) BOOL splashScreenShown;
+@property (nonatomic, assign) BOOL appContentAppeared;
+
+@end
+
+@implementation EXSplashScreenViewController
+
+- (instancetype)initWithRootView:(UIView *)rootView splashScreenView:(nonnull UIView *)splashScreenView
+{
+  if (self = [super init]) {
+    _rootView = rootView;
+    _autoHideEnabled = YES;
+    _splashScreenShown = NO;
+    _appContentAppeared = NO;
+    _splashScreenView = splashScreenView;
+  }
+  return self;
+}
+
+# pragma mark public methods
+
+- (void)showWithCallback:(void (^)(void))successCallback failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  [self showWithCallback:successCallback];
+}
+
+- (void)showWithCallback:(nullable void(^)(void))successCallback
+{
+  [EXUtilities performSynchronouslyOnMainThread:^{
+    UIView *rootView = self.rootView;
+    self.splashScreenView.frame = rootView.bounds;
+    self.splashScreenView.layer.zPosition = MAXFLOAT;
+    [rootView addSubview:self.splashScreenView];
+    self.splashScreenShown = YES;
+    if (successCallback) {
+      successCallback();
+    }
+  }];
+}
+
+- (void)preventAutoHideWithCallback:(void (^)(BOOL))successCallback failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if (!_autoHideEnabled) {
+    return successCallback(NO);
+  }
+
+  _autoHideEnabled = NO;
+  successCallback(YES);
+}
+
+- (void)hideWithCallback:(void (^)(BOOL))successCallback failureCallback:(void (^)(NSString * _Nonnull))failureCallback
+{
+  if (!_splashScreenShown) {
+    return successCallback(NO);
+  }
+  
+  [self hideWithCallback:successCallback];
+}
+
+- (void)hideWithCallback:(nullable void(^)(BOOL))successCallback
+{
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    [self.splashScreenView removeFromSuperview];
+    self.splashScreenShown = NO;
+    self.autoHideEnabled = YES;
+    if (successCallback) {
+      successCallback(YES);
+    }
+  });
+}
+
+- (BOOL)needsHideOnAppContentDidAppear
+{
+  if (!_appContentAppeared && _autoHideEnabled) {
+    _appContentAppeared = YES;
+    return YES;
+  }
+  return NO;
+}
+
+- (BOOL)needsShowOnAppContentWillReload
+{
+  if (!_appContentAppeared) {
+    _autoHideEnabled = YES;
+    _appContentAppeared = NO;
+    return YES;
+  }
+  return NO;
+}
+
+@end

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewNativeProvider.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewNativeProvider.h
@@ -1,0 +1,12 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import "EXSplashScreenViewProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXSplashScreenViewNativeProvider : NSObject<EXSplashScreenViewProvider>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewNativeProvider.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewNativeProvider.m
@@ -1,0 +1,51 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import "EXSplashScreenViewNativeProvider.h"
+#import <ExpoModulesCore/EXLogManager.h>
+
+@implementation EXSplashScreenViewNativeProvider
+
+- (nonnull UIView *)createSplashScreenView
+{
+  NSString *splashScreenFilename = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"SplashScreen";
+  UIStoryboard *storyboard;
+  @try {
+    storyboard = [UIStoryboard storyboardWithName:splashScreenFilename bundle:[NSBundle mainBundle]];
+  } @catch (NSException *_) {
+    EXLogWarn([NSString stringWithFormat:@"'%@.storyboard' file is missing. Fallbacking to '%@.xib' file.", splashScreenFilename, splashScreenFilename]);
+  }
+  if (storyboard) {
+    @try {
+      UIViewController *splashScreenViewController = [storyboard instantiateInitialViewController];
+      UIView *splashScreenView = splashScreenViewController.view;
+      return splashScreenView;
+    } @catch (NSException *_) {
+      @throw [NSException exceptionWithName:@"ERR_INVALID_SPLASH_SCREEN"
+                                     reason:[NSString stringWithFormat:@"'%@.storyboard'does not contain proper ViewController. Add correct ViewController to your '%@.storyboard' file (https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-configure-ios).", splashScreenFilename, splashScreenFilename]
+                                   userInfo:nil];
+    }
+  }
+  
+  NSArray *views;
+  @try {
+    views = [[NSBundle mainBundle] loadNibNamed:splashScreenFilename owner:self options:nil];
+  } @catch (NSException *_) {
+    EXLogWarn([NSString stringWithFormat:@"'%@.xib' file is missing - 'expo-splash-screen' will not work as expected.", splashScreenFilename]);
+  }
+  if (views) {
+    if (!views.firstObject) {
+      @throw [NSException exceptionWithName:@"ERR_INVALID_SPLASH_SCREEN"
+                                     reason:[NSString stringWithFormat:@"'%@.xib' does not contain any views. Add a view to the '%@.xib' or create '%@.storyboard' (https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-configure-ios).", splashScreenFilename, splashScreenFilename, splashScreenFilename]
+                                   userInfo:nil];
+    }
+    UIView *view = views.firstObject;
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    return view;
+  }
+  
+  @throw [NSException exceptionWithName:@"ERR_NO_SPLASH_SCREEN"
+                                 reason:[NSString stringWithFormat:@"Couln't locate neither '%@.storyboard' file nor '%@.xib' file. Create one of these in the project to make 'expo-splash-screen' work (https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-configure-ios).", splashScreenFilename, splashScreenFilename]
+                               userInfo:nil];
+}
+
+@end

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewProvider.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSplashScreen/EXSplashScreenViewProvider.h
@@ -1,0 +1,14 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol EXSplashScreenViewProvider
+
+- (UIView *)createSplashScreenView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
@@ -22,7 +22,7 @@
 #import "EXUpdatesManager.h"
 #import "EXUtil.h"
 
-#import <EXSplashScreen/EXSplashScreenService.h>
+#import "EXSplashScreenService.h"
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 
 #import <React/RCTUtils.h>

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXHomeAppSplashScreenViewProvider.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXHomeAppSplashScreenViewProvider.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <EXSplashScreen/EXSplashScreenViewNativeProvider.h>
+#import "EXSplashScreenViewNativeProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewController.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <EXSplashScreen/EXSplashScreenViewController.h>
+#import "EXSplashScreenViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.h
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenViewProvider.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-#import <EXSplashScreen/EXSplashScreenViewProvider.h>
+#import "EXSplashScreenViewProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -47,7 +47,8 @@ target 'Expo Go' do
       'expo-maps',
       'expo-network-addons',
       'expo-insights',
-      'expo-face-detector'
+      'expo-face-detector',
+      'expo-splash-screen',
     ],
     includeTests: true,
     flags: {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -26,9 +26,9 @@ PODS:
   - EXManifests/Tests (0.15.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXNotifications (0.29.3):
+  - EXNotifications (0.29.4):
     - ExpoModulesCore
-  - Expo (52.0.0-preview.7):
+  - Expo (52.0.0-preview.10):
     - ExpoModulesCore
   - ExpoAppleAuthentication (7.0.1):
     - ExpoModulesCore
@@ -79,7 +79,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - ExpoHaptics (14.0.0):
     - ExpoModulesCore
-  - ExpoHead (4.0.0-preview.4):
+  - ExpoHead (4.0.0-preview.6):
     - ExpoModulesCore
   - ExpoImage (2.0.0-preview.0):
     - ExpoModulesCore
@@ -94,7 +94,7 @@ PODS:
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
-  - ExpoImageManipulator (13.0.4):
+  - ExpoImageManipulator (13.0.5):
     - EXImageLoader
     - ExpoModulesCore
     - SDWebImageWebPCoder
@@ -123,7 +123,7 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (2.0.0-preview.5):
+  - ExpoModulesCore (2.0.0-preview.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -146,7 +146,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesCore/Tests (2.0.0-preview.5):
+  - ExpoModulesCore/Tests (2.0.0-preview.7):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -229,28 +229,6 @@ PODS:
     - ExpoModulesCore
   - ExpoWebBrowser (14.0.0):
     - ExpoModulesCore
-  - EXSplashScreen (0.28.4):
-    - DoubleConversion
-    - ExpoModulesCore
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - EXStructuredHeaders (4.0.0)
   - EXStructuredHeaders/Tests (4.0.0)
   - EXTaskManager (12.0.0):
@@ -2545,7 +2523,6 @@ DEPENDENCIES:
   - ExpoVideo (from `../../../packages/expo-video/ios`)
   - ExpoVideoThumbnails (from `../../../packages/expo-video-thumbnails/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
-  - EXSplashScreen (from `../../../packages/expo-splash-screen/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
   - EXStructuredHeaders/Tests (from `../../../packages/expo-structured-headers/ios`)
   - EXTaskManager (from `../../../packages/expo-task-manager/ios`)
@@ -2801,8 +2778,6 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-video-thumbnails/ios"
   ExpoWebBrowser:
     :path: "../../../packages/expo-web-browser/ios"
-  EXSplashScreen:
-    :path: "../../../packages/expo-splash-screen/ios"
   EXStructuredHeaders:
     :path: "../../../packages/expo-structured-headers/ios"
   EXTaskManager:
@@ -2997,8 +2972,8 @@ SPEC CHECKSUMS:
   EXImageLoader: 759063a65ab016b836f73972d3bb25404888713d
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
   EXManifests: d2859eb09b260b4e819299782fb5e43da36e248b
-  EXNotifications: 33607da6df349ba02bb7fba99c853a8db650fc50
-  Expo: fb9ed49d3130b7091ee223798b5090864deb7fa8
+  EXNotifications: 3aa75b51d57b5331001befad0a0e073eaaef0203
+  Expo: 58f7ac68c4cee818e08035bea0f397f2d6498494
   ExpoAppleAuthentication: 59b0f5cf600284dd03b0d595c112acd067e0eb69
   ExpoAsset: 9de2f325e8c97a4c6c2bc85e507ae7f0809c91aa
   ExpoAudio: 1312651a35d00c1b728be169d5a1e5d1e8f10f9a
@@ -3019,9 +2994,9 @@ SPEC CHECKSUMS:
   ExpoFont: 2fb6d98e0a5352bebcaa568d6bfbba0e0f2e0097
   ExpoGL: 25f19d2db3ad0e48ee43b16e0272c0e526968c1d
   ExpoHaptics: e636188d1d5f7ccb79f3c1bfab47aaf5a1768c73
-  ExpoHead: d049cd3ba9728d22a9a9a6deabe94d5cce70eda1
+  ExpoHead: 4cd4ad55acfea534331bbb447b53ec7e609ab2b3
   ExpoImage: bd04fd6e5f97d2a29284bd7113cc51d7c206d17d
-  ExpoImageManipulator: 56d6b262157be2cde9648f727396e4e7b83415da
+  ExpoImageManipulator: 774eb1a17c5db07944d6f9000650d422ebb3ce47
   ExpoImagePicker: 6977a8aa31e7fc21d209e9a5f0772f360f5f5f50
   ExpoKeepAwake: 783e68647b969b210a786047c3daa7b753dcac1f
   ExpoLinearGradient: 7ca3b1d1625a1ab85c129abce4a3cdc78a9500a3
@@ -3032,7 +3007,7 @@ SPEC CHECKSUMS:
   ExpoLocation: ac6a2c6605acfb9b70f765ea32d561dab51d481b
   ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMediaLibrary: a85e3fcc6a85ede0ae2dae2577b8cf02d1051bbb
-  ExpoModulesCore: c8f57f80aff1195c74e78e69e7d6902d91807783
+  ExpoModulesCore: 00a820930efd4a62ba41eb2bdc8015a2134255d0
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: 786e4a0f27543c9c70d595d24f59759167da854b
   ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
@@ -3051,7 +3026,6 @@ SPEC CHECKSUMS:
   ExpoVideo: 29fbd66d8466666e35de3729b5852d8c21684017
   ExpoVideoThumbnails: 97eea3f5b0d9cc54728126d5875d6d7d391e6f8f
   ExpoWebBrowser: ea83cc6f03bec1938c3b8fb4dcb9df71960fba36
-  EXSplashScreen: 461da413241fdf16b41576f45ef34bb9ca208702
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: 429965d990a8102f57f21a1f2c61a5ebc86f52d2
   EXUpdates: 7ea0e706a990a9ce890f1adc328f3b0f4468a6e4
@@ -3167,6 +3141,6 @@ SPEC CHECKSUMS:
   Yoga: 157bed1c62656587df4639d4dc29714898f8fb10
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: a55dff50a80accf78a8db0aa86be957c63fdfc01
+PODFILE CHECKSUM: 0203a21856355bd5b026299b1a6306354278cfe3
 
 COCOAPODS: 1.15.2

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -8,7 +8,7 @@ import loadAssetsAsync from './src/utilities/loadAssetsAsync';
 
 SplashScreen.preventAutoHideAsync();
 
-function useSplashScreen(loadingFunction: () => void) {
+function useSplashScreen(loadingFunction: () => Promise<void>) {
   const [isLoadingCompleted, setLoadingComplete] = React.useState(false);
 
   // Load any resources or data that we need prior to rendering the app
@@ -21,7 +21,7 @@ function useSplashScreen(loadingFunction: () => void) {
         console.warn(e);
       } finally {
         setLoadingComplete(true);
-        await SplashScreen.hideAsync();
+        await SplashScreen.hide();
       }
     }
 


### PR DESCRIPTION
# Why
Follow up of  #32475. 

# How
Adds the legacy splashscreen impl for expo go on iOS

# Test Plan
Expo go. Splashscreen works as expected

