### PR TITLE
fix(babel-preset-expo): fix support for non-obvious client-only usage

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Don't assert `client-only` in SSR bundles.
 - Fix invalid project randomness when using Ngrok ([#32359](https://github.com/expo/expo/pull/32359) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Don't assert `client-only` in SSR bundles.
+- Don't assert `client-only` in SSR bundles. ([#32479](https://github.com/expo/expo/pull/32479) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix invalid project randomness when using Ngrok ([#32359](https://github.com/expo/expo/pull/32359) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -187,7 +187,7 @@ function isTransformError(
 function logFromError({ error, projectRoot }: { error: Error; projectRoot: string }) {
   // Remap direct Metro Node.js errors to a format that will appear more client-friendly in the logbox UI.
   let stack: MetroStackFrame[] | undefined;
-  if (isTransformError(error)) {
+  if (isTransformError(error) && error.filename) {
     // Syntax errors in static rendering.
     stack = [
       {

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Don't assert `client-only` in SSR bundles.
+
 ### 💡 Others
 
 ## 12.0.0-preview.3 — 2024-10-30

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Don't assert `client-only` in SSR bundles.
+- Don't assert `client-only` in SSR bundles. ([#32479](https://github.com/expo/expo/pull/32479) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/environment-restricted-imports.js
+++ b/packages/babel-preset-expo/build/environment-restricted-imports.js
@@ -7,14 +7,14 @@ const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
 /** Prevent importing certain known imports in given environments. This is for sanity to ensure a module never accidentally gets imported unexpectedly. */
 function environmentRestrictedImportsPlugin(api) {
     const { types: t } = api;
-    const isAnyServerEnvironment = api.caller(common_1.getIsReactServer) || api.caller(common_1.getIsServer);
-    const forbiddenPackages = isAnyServerEnvironment
+    const isReactServer = api.caller(common_1.getIsReactServer);
+    const forbiddenPackages = isReactServer
         ? FORBIDDEN_REACT_SERVER_IMPORTS
         : FORBIDDEN_CLIENT_IMPORTS;
     function checkSource(source, path) {
         forbiddenPackages.forEach((forbiddenImport) => {
             if (source === forbiddenImport) {
-                if (isAnyServerEnvironment) {
+                if (isReactServer) {
                     throw path.buildCodeFrameError(`Importing '${forbiddenImport}' module is not allowed in a React server bundle. Add the "use client" directive to this file or one of the parent modules to allow importing this module.`);
                 }
                 else {

--- a/packages/babel-preset-expo/src/environment-restricted-imports.ts
+++ b/packages/babel-preset-expo/src/environment-restricted-imports.ts
@@ -3,7 +3,7 @@
  */
 import { ConfigAPI, NodePath, types } from '@babel/core';
 
-import { getIsReactServer, getIsServer } from './common';
+import { getIsReactServer } from './common';
 
 const FORBIDDEN_CLIENT_IMPORTS = ['server-only'];
 const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
@@ -14,16 +14,16 @@ export function environmentRestrictedImportsPlugin(
 ): babel.PluginObj {
   const { types: t } = api;
 
-  const isAnyServerEnvironment = api.caller(getIsReactServer) || api.caller(getIsServer);
+  const isReactServer = api.caller(getIsReactServer);
 
-  const forbiddenPackages = isAnyServerEnvironment
+  const forbiddenPackages = isReactServer
     ? FORBIDDEN_REACT_SERVER_IMPORTS
     : FORBIDDEN_CLIENT_IMPORTS;
 
   function checkSource(source: string, path: NodePath<any>) {
     forbiddenPackages.forEach((forbiddenImport) => {
       if (source === forbiddenImport) {
-        if (isAnyServerEnvironment) {
+        if (isReactServer) {
           throw path.buildCodeFrameError(
             `Importing '${forbiddenImport}' module is not allowed in a React server bundle. Add the "use client" directive to this file or one of the parent modules to allow importing this module.`
           );


### PR DESCRIPTION
# Why

- apparently `client-only` can be used on the server 🙃 
