### PR TITLE
feat(docs): rework RSC docs to use server actions by default

### DIFF
--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -19,8 +19,6 @@ Expo Router enables support for [React Server Components](https://react.dev/refe
 
 Your project must use Expo Router and React Native new architecture (default in SDK 52).
 
-As of SDK 52, there is no strategy for migrating existing projects. We recommend starting with a new project.
-
 ## Usage
 
 To use React Server Components in your Expo app, you need to:
@@ -32,7 +30,6 @@ To use React Server Components in your Expo app, you need to:
 {
   "expo": {
     "experiments": {
-      "reactServerComponents": true,
       "reactServerActions": true
     }
   }
@@ -41,59 +38,50 @@ To use React Server Components in your Expo app, you need to:
 
 3. Create an initial route **app/index.tsx**:
 
-```tsx app/index.tsx
-// This is a server component.
+```tsx app/index.tsx (Client component)
+/// <reference types="react/canary" />
+
+import React from 'react';
+import { ActivityIndicator } from 'react-native';
+import renderInfo from '../actions/render-info';
+
+export default function Index() {
+  return (
+    <React.Suspense
+      fallback={
+        // The view that will render while the server action is awaiting data.
+        <ActivityIndicator />
+      }>
+      {renderInfo({ name: 'World' })}
+    </React.Suspense>
+  );
+}
+```
+
+4. Create a server action **actions/render-info.tsx**:
+
+```tsx actions/render-info.tsx (Server action)
+'use server';
+
 import { Text } from 'react-native';
 
-export default function Index() {
-  return <Text>Hello, world!</Text>;
+export default async function renderInfo({ name }) {
+  // Securely fetch data from an API, and read environment variables...
+  return <Text>Hello, {name}!</Text>;
 }
 ```
 
-## Navigating between routes
-
-You can navigate between routes by using the `<Link />` API from Expo Router (not all props are supported yet).
-
-```tsx app/index.tsx
-import { Link } from 'expo-router';
-
-export default function Index() {
-  return (
-    <Link href="/second">
-      <Text>Hello, world!</Text>
-    </Link>
-  );
-}
-```
-
-## Layout Routes
-
-> Complex built-in layouts such as Stack and Tabs are not yet supported. They will fallback to a `<Slot />`.
-
-Layout routes (**app/\_layout.tsx**) can wrap all routes in a common layout.
-
-```tsx app/_layout.tsx
-import { View } from 'react-native';
-import { Slot } from 'expo-router';
-
-export default function Layout() {
-  return (
-    <View>
-      <Slot />
-    </View>
-  );
-}
-```
-
-The `Slot` component is used to render the current route.
+The views return value of the server action is a React Server Component payload that will be streamed to the client.
 
 ## Server Components
 
-Server Components run in the server, meaning they can access Node.js built-ins and server APIs. They can also use async components.
+Server Components run in the server, meaning they can access server APIs and Node.js built-ins (when running locally). They can also use async components.
 
 Consider the following component which fetches data and renders it:
 
-```tsx app/index.tsx
+```tsx components/pokemon.tsx
+import 'server-only';
+
 import { Image, Text, View } from 'react-native';
 
 export async function Pokemon() {
@@ -111,6 +99,8 @@ export async function Pokemon() {
   );
 }
 ```
+
+In order to render this as a server component, you'll need to return it from a server action.
 
 ### Key points
 
@@ -132,34 +122,13 @@ export default function Button({ title }) {
 }
 ```
 
-This file can be imported and used in a Server Component:
-
-```tsx app/index.tsx
-import Button from '../components/button';
-
-export default function Index() {
-  return <Button title="Press me" />;
-}
-```
+This module can be imported and used in a Server Action or Server Component.
 
 ### Key point
 
 You cannot pass functions as props to Server Components. You can only pass serializable data.
 
 ## Server Actions
-
-Server Actions are gated behind an additional experimental flag.
-
-```json app.json
-{
-  "expo": {
-    "experiments": {
-      "reactServerActions": true,
-      "reactServerComponents": true
-    }
-  }
-}
-```
 
 Server Actions are functions that run on the server and can be called from client components. Think of them like fully-typed API routes that are easier to write.
 
@@ -296,7 +265,7 @@ export default function Profile() {
 
 ## Library compatibility
 
-Not all libraries are optimized for React Server Components yet. You can use the `"use client" directive to mark a file as a Client Component and use it in a Server Component. This can be used to temporarily workaround compatibility issues.
+Not all libraries are optimized for React Server Components yet. You can use the `"use client"` directive to mark a file as a Client Component and use it in a Server Component. This can be used to temporarily workaround compatibility issues.
 
 For example, consider a library `react-native-unoptimized` that does not ship with `"use client"` directives yet. You can workaround this by creating a module and re-exporting each module:
 
@@ -312,55 +281,25 @@ Avoid using `export * from '...'` as this breaks some of the internals of intero
 
 Modules marked with `"use client"` cannot be dot-accessed from Server Components. This means operations like `StyleSheet.create` or `Platform.OS` will not work on the server without further optimization in the `react-native` package.
 
-## CSS
-
-Expo Router supports importing global CSS and CSS modules in Server Components.
-
-```tsx app/index.tsx
-import './styles.css';
-import styles from './styles.module.css';
-
-export default function Index() {
-  return <div className={styles.container}>Hello, world!</div>;
-}
-```
-
-The CSS will be hoisted into the client bundle from the server.
-
-## Metadata
-
-React Server Components are a feature of React 19. To enable them, Expo CLI automatically uses a special canary build of React on all platforms. In the future, it will be removed when React 19 is enabled by default in React Native.
-
-As a result, you can use React 19 features such as placing `<meta>` tags anywhere in your app (web-only).
-
-```tsx app/index.tsx
-export default function Index() {
-  return (
-    <>
-      {process.env.EXPO_OS === 'web' && (
-        <>
-          <meta name="description" content="Hello, world!" />
-          <meta property="og:image" content="/og-image.png" />
-        </>
-      )}
-      <MyComponent />
-    </>
-  );
-}
-```
-
-You can use this instead of the `Head` component from `expo-router/head`.
-
 ## Suspense
 
 You can stream back partial UI from the server while waiting for data to load by using React Suspense.
 
 In the following example, a `Loading...` text is returned instantly on the client, and when the `<MediumTask>` finishes rendering one second later, it will replace the text with `Medium task done!`. The `<ExpensiveTask>` will take three seconds to load, and when it finishes, it will replace the text with `Expensive task done!`.
 
-```tsx app/index.tsx
+```tsx app/index.tsx (Client component)
 import { Suspense } from 'react';
+import { renderMediumTask, renderExpensiveTask } from '@/actions/tasks';
 
 export default function App() {
+  return <Suspense fallback={<Text>Loading...</Text>}>{renderTasks()}</Suspense>;
+}
+```
+
+```tsx actions/tasks.tsx (Server actions)
+'use server';
+
+export async function renderTasks() {
   return (
     <Suspense fallback={<Text>Loading...</Text>}>
       <>
@@ -388,7 +327,139 @@ async function ExpensiveTask() {
 
 If you remove the `Suspense` wrapper around `<ExpensiveTask>`, you'll see that the `Loading...` waits for both components to finish rendering before updating the UI. This enables you to control the loading state incrementally. Sometimes, it makes sense to wait for everything to load at once (most of the time), while other times, it is beneficial to stream back UI as soon as you have (like the text response in ChatGPT).
 
-## Build-time rendering
+## Secrets
+
+Server Components can access secrets and server-side APIs. You can use the `process.env` object to access environment variables. You can ensure a module never runs on the client by importing the `server-only` module in your project.
+
+```tsx actions/renderData.tsx
+// This will assert if the module runs on the client.
+import 'server-only';
+
+import { Text } from 'react-native';
+
+export async function renderData() {
+  // This code only runs on the server.
+  const data = await fetch('https://my-endpoint/', {
+    headers: {
+      Authorization: `Bearer ${process.env.SECRET}`,
+    },
+  });
+
+  // ...
+  return <div />;
+}
+```
+
+You can define the secret in your **.env** file:
+
+```text .env
+SECRET=123
+```
+
+> You do not need to restart the dev server to update environment variables. They are automatically reloaded on every request.
+
+## Platform detection
+
+To detect which platform your code is bundled for, use the `process.env.EXPO_OS` environment variable. For example, `process.env.EXPO_OS === 'ios'`. Prefer this to `Platform.OS` as `react-native` is not fully optimized for React Server Components yet and won't work as expected.
+
+You can detect if code is running in the server by performing a `typeof window === 'undefined'` check. This will always return `true` on client devices and `false` on the server.
+
+## Testing with jest
+
+Library authors can test their modules support Server Components by using `jest-expo`. Learn more in the [testing react server components guide](/guides/testing-rsc).
+
+## Metadata
+
+React Server Components are a feature of React 19. To enable them, Expo CLI automatically uses a special canary build of React on all platforms. In the future, it will be removed when React 19 is enabled by default in React Native.
+
+As a result, you can use React 19 features such as placing `<meta>` tags anywhere in your app (web-only).
+
+```tsx app/index.tsx
+export default function Index() {
+  return (
+    <>
+      {process.env.EXPO_OS === 'web' && (
+        <>
+          <meta name="description" content="Hello, world!" />
+          <meta property="og:image" content="/og-image.png" />
+        </>
+      )}
+      <MyComponent />
+    </>
+  );
+}
+```
+
+You can use this instead of the `Head` component from `expo-router/head`, but it only works on web for now.
+
+## Known limitations
+
+> This is a very early technical preview that we're actively developing.
+
+- Expo Snack does not support bundling Server Components.
+- EAS Update does not work with Server Components yet.
+- DOM components cannot use Server Actions yet.
+- Production deployment is very limited and not recommended yet.
+- Server Rendering RSC payloads to HTML is not supported yet.
+- `generateStaticParams` is not yet supported.
+- HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
+- `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
+- Server Actions that invoke other server actions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.
+
+## Full React Server Components mode
+
+> This mode is even more experimental!
+
+You can leverage even more features by enabling full React Server Components support, where the default rendering mode for routes is as server components instead of client components. This mode is still in development as the router and React Navigation need to be rewritten to support concurrency.
+
+To enable full Server Components mode, you need to enable the `reactServerComponents` flag in the app config:
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "reactServerActions": true,
+      "reactServerComponents": true
+    }
+  }
+}
+```
+
+With this enabled, all routes will render as Server Components by default. In the future this will reduce server/client waterfalls and enable build-time rendering to provide better offline support.
+
+- There is currently no stack routing. The custom layouts, `Stack`, `Tabs`, and `Drawer`, do not support Server Components yet.
+- Most `<Link />` props are not supported yet.
+
+### Reloading server components
+
+> This is limited to full React Server Components mode.
+
+Server Components are reloaded on every request in development. This means that you can make changes to your server components and see them reflected immediately in the client runtime. You may want to manually trigger a reload event programatically to refetch data or re-render the component. This can be done using the `router.reload()` function from the `useRouter` hook.
+
+```tsx components/button.tsx
+'use client';
+import { useRouter } from 'expo-router';
+import { Text } from 'react-native';
+
+export function Button() {
+  const router = useRouter();
+  return (
+    <Text
+      onPress={() => {
+        // Reload the current route.
+        router.reload();
+      }}>
+      Reload current route
+    </Text>
+  );
+}
+```
+
+If the route was rendered at build-time, it will not be re-rendered on the client. This is because the rendering code is not included in the production server.
+
+### Build-time rendering
+
+> This is limited to full React Server Components mode.
 
 Expo Router supports two different modes of rendering Server Components: build-time rendering and request-time rendering. These modes can be indicated on a per-route basis by using the `unstable_settings` export:
 
@@ -418,84 +489,22 @@ Routes marked with `static` output will be rendered at build-time and embeded in
 
 The current default is `dynamic` rendering. In the future, we'll change the caching and optimizations to be smarter and more automatic.
 
-## Reloading server components
+### CSS
 
-Server Components are reloaded on every request in development. This means that you can make changes to your server components and see them reflected immediately in the client runtime. You may want to manually trigger a reload event programatically to refetch data or re-render the component. This can be done using the `router.reload()` function from the `useRouter` hook.
+> This is limited to full React Server Components mode.
 
-```tsx components/button.tsx
-'use client';
-import { useRouter } from 'expo-router';
-import { Text } from 'react-native';
-
-export function Button() {
-  const router = useRouter();
-  return (
-    <Text
-      onPress={() => {
-        // Reload the current route.
-        router.reload();
-      }}>
-      Reload current route
-    </Text>
-  );
-}
-```
-
-If the route was rendered at build-time, it will not be re-rendered on the client. This is because the rendering code is not included in the production server.
-
-## Secrets
-
-Server Components can access secrets and server-side APIs. You can use the `process.env` object to access environment variables. You can ensure a module never runs on the client by importing the `server-only` module in your project.
+Expo Router supports importing global CSS and CSS modules in Server Components.
 
 ```tsx app/index.tsx
-// This will assert if the module runs on the client.
-import 'server-only';
+import './styles.css';
+import styles from './styles.module.css';
 
-import { Text } from 'react-native';
-
-export default async function Index() {
-  // This code only runs on the server.
-  const data = await fetch('https://my-endpoint/', {
-    headers: {
-      Authorization: `Bearer ${process.env.SECRET}`,
-    },
-  });
-
-  // ...
-  return <div />;
+export default function Index() {
+  return <div className={styles.container}>Hello, world!</div>;
 }
 ```
 
-You can define the secret in your **.env** file:
-
-```text .env
-SECRET=123
-```
-
-## Platform detection
-
-To detect which platform your code is bundled for, use the `process.env.EXPO_OS` environment variable. For example, `process.env.EXPO_OS === 'ios'`. Prefer this to `Platform.OS` as `react-native` is not fully optimized for React Server Components yet and won't work as expected.
-
-You can detect if code is running in the server by performing a `typeof window === 'undefined'` check. This will always return `true` on client devices and `false` on the server.
-
-## Testing with jest
-
-Library authors can test their modules support Server Components by using `jest-expo`. Learn more in the [testing react server components guide](/guides/testing-rsc).
-
-## Known limitations
-
-> This is a very early technical preview that we're actively developing.
-
-- There is currently no stack routing. The custom layouts, `Stack`, `Tabs`, and `Drawer`, do not support Server Components yet.
-- Expo Snack does not support bundling Server Components.
-- EAS Update does not work with Server Components yet.
-- DOM components cannot use Server Components yet.
-- Production deployment is very limited and not recommended yet.
-- Server Rendering RSC payloads to HTML is not supported yet.
-- `generateStaticParams` is not yet supported.
-- HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
-- `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
-- Server Actions that invoke other server actions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.
+The CSS will be hoisted into the client bundle from the server.
 
 ## Deployment
 

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -392,20 +392,6 @@ export default function Index() {
 
 You can use this instead of the `Head` component from `expo-router/head`, but it only works on web for now.
 
-## Known limitations
-
-> This is a very early technical preview that we're actively developing.
-
-- Expo Snack does not support bundling Server Components.
-- EAS Update does not work with Server Components yet.
-- DOM components cannot use Server Actions yet.
-- Production deployment is very limited and not recommended yet.
-- Server Rendering RSC payloads to HTML is not supported yet. This means static and server output doesn't fully work yet.
-- [`generateStaticParams`](/router/reference/static-rendering/#generatestaticparams) is not yet supported.
-- HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
-- `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
-- Server Actions that invoke other server actions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.
-
 ## Full React Server Components mode
 
 > This mode is even more experimental!
@@ -519,3 +505,17 @@ You can host the website locally with the [express server adapter](/router/refer
 ### Native
 
 Production exports for React Server Components on native are not yet supported. This is planned for Expo SDK 53.
+
+## Known limitations
+
+> This is a very early technical preview that we're actively developing.
+
+- Expo Snack does not support bundling Server Components.
+- EAS Update does not work with Server Components yet.
+- DOM components cannot use Server Actions yet.
+- Production deployment is very limited and not recommended yet.
+- Server Rendering RSC payloads to HTML is not supported yet. This means static and server output doesn't fully work yet.
+- [`generateStaticParams`](/router/reference/static-rendering/#generatestaticparams) is not yet supported.
+- HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
+- `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
+- Server Actions that invoke other server actions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -100,7 +100,7 @@ export async function Pokemon() {
 }
 ```
 
-In order to render this as a server component, you'll need to return it from a server action.
+To render this as a server component, you'll need to return it from a server action.
 
 ### Key points
 
@@ -362,11 +362,11 @@ SECRET=123
 
 To detect which platform your code is bundled for, use the `process.env.EXPO_OS` environment variable. For example, `process.env.EXPO_OS === 'ios'`. Prefer this to `Platform.OS` as `react-native` is not fully optimized for React Server Components yet and won't work as expected.
 
-You can detect if code is running in the server by performing a `typeof window === 'undefined'` check. This will always return `true` on client devices and `false` on the server.
+You can detect if code is running on the server by performing a `typeof window === 'undefined'` check. This will always return `true` on client devices and `false` on the server.
 
 ## Testing with jest
 
-Library authors can test their modules support Server Components by using `jest-expo`. Learn more in the [testing react server components guide](/guides/testing-rsc).
+Library authors can test their modules support Server Components by using `jest-expo`. Learn more in the [Testing React Server Components](/guides/testing-rsc) guide.
 
 ## Metadata
 
@@ -401,7 +401,7 @@ You can use this instead of the `Head` component from `expo-router/head`, but it
 - DOM components cannot use Server Actions yet.
 - Production deployment is very limited and not recommended yet.
 - Server Rendering RSC payloads to HTML is not supported yet. This means static and server output doesn't fully work yet.
-- `generateStaticParams` is not yet supported.
+- [`generateStaticParams`](/router/reference/static-rendering/#generatestaticparams) is not yet supported.
 - HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
 - `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
 - Server Actions that invoke other server actions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.
@@ -410,7 +410,7 @@ You can use this instead of the `Head` component from `expo-router/head`, but it
 
 > This mode is even more experimental!
 
-You can leverage even more features by enabling full React Server Components support, where the default rendering mode for routes is as server components instead of client components. This mode is still in development as the router and React Navigation need to be rewritten to support concurrency.
+Enabling full React Server Components support allows you to leverage even more features. In this mode, the default rendering mode for routes is server components instead of client components. It is still in development, as the Router and React Navigation need to be rewritten to support concurrency.
 
 To enable full Server Components mode, you need to enable the `reactServerComponents` flag in the app config:
 
@@ -428,7 +428,7 @@ To enable full Server Components mode, you need to enable the `reactServerCompon
 With this enabled, all routes will render as Server Components by default. In the future this will reduce server/client waterfalls and enable build-time rendering to provide better offline support.
 
 - There is currently no stack routing. The custom layouts, `Stack`, `Tabs`, and `Drawer`, do not support Server Components yet.
-- Most `<Link />` props are not supported yet.
+- Most `Link` component props are not supported yet.
 
 ### Reloading server components
 

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -400,7 +400,7 @@ You can use this instead of the `Head` component from `expo-router/head`, but it
 - EAS Update does not work with Server Components yet.
 - DOM components cannot use Server Actions yet.
 - Production deployment is very limited and not recommended yet.
-- Server Rendering RSC payloads to HTML is not supported yet.
+- Server Rendering RSC payloads to HTML is not supported yet. This means static and server output doesn't fully work yet.
 - `generateStaticParams` is not yet supported.
 - HTML `form` integration with Server Actions is not supported yet (this partially works automatically, but data is not encrypted).
 - `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.


### PR DESCRIPTION
# Why

- The new server actions-only mode makes it simpler to integrate and migrate to RSC. This PR reworks the docs to position SAO as the default and full RSC as an upcoming mode.
- All the classic Expo Router code works with SAO-mode so we can simplify the docs a bit.
