### PR TITLE
[jest-expo] Update SplashScreen

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update SplashScreen api to add `hide` method.
+
 ## 52.0.0-preview.2 — 2024-10-29
 
 ### 🐛 Bug fixes

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update SplashScreen api to add `hide` method.
+- Update SplashScreen api to add `hide` method. ([#32484](https://github.com/expo/expo/pull/32484) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 52.0.0-preview.2 — 2024-10-29
 

--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -637,6 +637,7 @@ module.exports = {
         ],
         ExpoSplashScreen: [
           { name: 'hideAsync', argumentsCount: 0, key: 0 },
+          { name: 'hide', argumentsCount: 0, key: 0 },
           { name: 'preventAutoHideAsync', argumentsCount: 0, key: 1 },
         ],
         ExpoSQLite: [


### PR DESCRIPTION
# Why
#23882 added a new function to the Spalshscreen api. We need to add it to the mocks for expo-router tests.

# How
Update api

# Test Plan
`et cp expo-router`
