### PR TITLE
[fingerprint] Add ability to diff two fingeprint files to CLI

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Show more information in fingerprint diff ([#32486](https://github.com/expo/expo/pull/32486) by [@wschurman](https://github.com/wschurman))
+- Add ability to diff two fingeprint files to CLI ([#32488](https://github.com/expo/expo/pull/32488) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/fingerprint/cli/build/cli.js
+++ b/packages/@expo/fingerprint/cli/build/cli.js
@@ -6,24 +6,30 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-(async () => {
-    const Fingerprint = await import('../../build/index.js');
-    if (process.argv.length !== 3 && process.argv.length !== 4) {
-        console.log(`Usage: ${path_1.default.basename(process.argv[1])} projectRoot [fingerprintFileToDiff]`);
+function readFingerprintFile(path) {
+    try {
+        return JSON.parse(fs_1.default.readFileSync(path, 'utf-8'));
+    }
+    catch (e) {
+        console.log(`Unable to read fingerprint file ${path}: ${e.message}`);
         process.exit(1);
     }
-    let comparatorFingerprint;
-    if (process.argv.length === 4) {
-        const comparator = process.argv[3];
-        try {
-            comparatorFingerprint = JSON.parse(fs_1.default.readFileSync(comparator, 'utf-8'));
-        }
-        catch (e) {
-            console.log(`Unable to diff with fingerprint file ${comparator}: ${e.message}`);
-            process.exit(1);
-        }
+}
+(async () => {
+    const Fingerprint = await import('../../build/index.js');
+    if (process.argv.length !== 3 && process.argv.length !== 4 && process.argv.length !== 5) {
+        console.log(`Usage: ${path_1.default.basename(process.argv[1])} projectRoot [fingerprintFile1ToDiff] [fingerprintFile2ToDiff]`);
+        process.exit(1);
     }
     const projectRoot = process.argv[2];
+    const fingerprintFile1ToDiff = process.argv[3];
+    const fingerprintFile2ToDiff = process.argv[4];
+    const fingeprint1ToDiff = fingerprintFile1ToDiff
+        ? readFingerprintFile(fingerprintFile1ToDiff)
+        : undefined;
+    const fingeprint2ToDiff = fingerprintFile2ToDiff
+        ? readFingerprintFile(fingerprintFile2ToDiff)
+        : undefined;
     const options = {
         debug: !!process.env.DEBUG,
         useRNCoreAutolinkingFromExpo: process.env.USE_RNCORE_AUTOLINKING_FROM_EXPO
@@ -31,8 +37,12 @@ const path_1 = __importDefault(require("path"));
             : undefined,
     };
     try {
-        if (comparatorFingerprint) {
-            const diff = await Fingerprint.diffFingerprintChangesAsync(comparatorFingerprint, projectRoot, options);
+        if (fingeprint1ToDiff && fingeprint2ToDiff) {
+            const diff = Fingerprint.diffFingerprints(fingeprint1ToDiff, fingeprint2ToDiff);
+            console.log(JSON.stringify(diff, null, 2));
+        }
+        else if (fingeprint1ToDiff) {
+            const diff = await Fingerprint.diffFingerprintChangesAsync(fingeprint1ToDiff, projectRoot, options);
             console.log(JSON.stringify(diff, null, 2));
         }
         else {

--- a/packages/@expo/fingerprint/cli/src/cli.ts
+++ b/packages/@expo/fingerprint/cli/src/cli.ts
@@ -2,26 +2,38 @@
 import fs from 'fs';
 import path from 'path';
 
+import { Fingerprint } from '../../build/Fingerprint.types.js';
+
+function readFingerprintFile(path: string): Fingerprint {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf-8'));
+  } catch (e: any) {
+    console.log(`Unable to read fingerprint file ${path}: ${e.message}`);
+    process.exit(1);
+  }
+}
+
 (async () => {
   const Fingerprint = await import('../../build/index.js');
 
-  if (process.argv.length !== 3 && process.argv.length !== 4) {
-    console.log(`Usage: ${path.basename(process.argv[1])} projectRoot [fingerprintFileToDiff]`);
+  if (process.argv.length !== 3 && process.argv.length !== 4 && process.argv.length !== 5) {
+    console.log(
+      `Usage: ${path.basename(process.argv[1])} projectRoot [fingerprintFile1ToDiff] [fingerprintFile2ToDiff]`
+    );
     process.exit(1);
   }
 
-  let comparatorFingerprint;
-  if (process.argv.length === 4) {
-    const comparator = process.argv[3];
-    try {
-      comparatorFingerprint = JSON.parse(fs.readFileSync(comparator, 'utf-8'));
-    } catch (e: any) {
-      console.log(`Unable to diff with fingerprint file ${comparator}: ${e.message}`);
-      process.exit(1);
-    }
-  }
-
   const projectRoot = process.argv[2];
+
+  const fingerprintFile1ToDiff = process.argv[3];
+  const fingerprintFile2ToDiff = process.argv[4];
+
+  const fingeprint1ToDiff = fingerprintFile1ToDiff
+    ? readFingerprintFile(fingerprintFile1ToDiff)
+    : undefined;
+  const fingeprint2ToDiff = fingerprintFile2ToDiff
+    ? readFingerprintFile(fingerprintFile2ToDiff)
+    : undefined;
 
   const options = {
     debug: !!process.env.DEBUG,
@@ -30,9 +42,12 @@ import path from 'path';
       : undefined,
   };
   try {
-    if (comparatorFingerprint) {
+    if (fingeprint1ToDiff && fingeprint2ToDiff) {
+      const diff = Fingerprint.diffFingerprints(fingeprint1ToDiff, fingeprint2ToDiff);
+      console.log(JSON.stringify(diff, null, 2));
+    } else if (fingeprint1ToDiff) {
       const diff = await Fingerprint.diffFingerprintChangesAsync(
-        comparatorFingerprint,
+        fingeprint1ToDiff,
         projectRoot,
         options
       );


### PR DESCRIPTION
# Why

This is an extension of https://github.com/expo/expo/pull/25565 that allows two fingerprint files to be diff'ed.

While I think it'd be cleaner to start fresh with the CLI and add new separate commands, that'd be a breaking change that could break something.

# How

Add another arg.

# Test Plan

```
$ yarn create expo-app lksadklasdjahdwut --template default@canary
$ cd lksadklasdjahdwut
$ yarn add file:./../../expo/expo/packages/@expo/fingerprint
$ npx @expo/fingerprint . > fp1
// change app.json
$ npx @expo/fingerprint . > fp2
$ npx @expo/fingerprint . fp1 fp2
[
  {
    "op": "changed",
    "beforeSource": {
      "type": "contents",
      "id": "expoConfig",
      "contents": "{\"android\":{\"adaptiveIcon\":{\"backgroundColor\":\"#ffffff\",\"foregroundImage\":\"./assets/images/adaptive-icon.png\"}},\"experiments\":{\"typedRoutes\":true},\"extra\":{\"router\":{\"origin\":false}},\"icon\":\"./assets/images/icon.png\",\"ios\":{\"supportsTablet\":true},\"name\":\"lksadklasdjahdwut\",\"newArchEnabled\":true,\"orientation\":\"portrait\",\"platforms\":[\"android\",\"ios\",\"web\"],\"plugins\":[\"expo-router\"],\"scheme\":\"myapp\",\"sdkVersion\":\"52.0.0\",\"slug\":\"lksadklasdjahdwut\",\"splash\":{\"backgroundColor\":\"#ffffff\",\"image\":\"./assets/images/splash.png\",\"resizeMode\":\"contain\"},\"userInterfaceStyle\":\"automatic\",\"version\":\"1.0.0\",\"web\":{\"bundler\":\"metro\",\"favicon\":\"./assets/images/favicon.png\",\"output\":\"static\"}}",
      "reasons": [
        "expoConfig"
      ],
      "hash": "0feec032f57a310e2b2605f0ec79e971043e0618"
    },
    "afterSource": {
      "type": "contents",
      "id": "expoConfig",
      "contents": "{\"android\":{\"adaptiveIcon\":{\"backgroundColor\":\"#ffffff\",\"foregroundImage\":\"./assets/images/adaptive-icon.png\"}},\"experiments\":{\"typedRoutes\":false},\"extra\":{\"router\":{\"origin\":false}},\"icon\":\"./assets/images/icon.png\",\"ios\":{\"supportsTablet\":true},\"name\":\"lksadklasdjahdwut\",\"newArchEnabled\":true,\"orientation\":\"portrait\",\"platforms\":[\"android\",\"ios\",\"web\"],\"plugins\":[\"expo-router\"],\"scheme\":\"myapp\",\"sdkVersion\":\"52.0.0\",\"slug\":\"lksadklasdjahdwut\",\"splash\":{\"backgroundColor\":\"#ffffff\",\"image\":\"./assets/images/splash.png\",\"resizeMode\":\"contain\"},\"userInterfaceStyle\":\"automatic\",\"version\":\"1.0.0\",\"web\":{\"bundler\":\"metro\",\"favicon\":\"./assets/images/favicon.png\",\"output\":\"static\"}}",
      "reasons": [
        "expoConfig"
      ],
      "hash": "d923ecb025cfcf8406e855251169a8ff62ef6750"
    }
  }
]
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
