### PR TITLE
[ios][sdk-52] Add Mac minimum system requirement to template-bare-minimum

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
@@ -24,6 +24,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
# Why

When uploading iOS Apps to the AppStore using SDK-52 users are getting this report:

![image](https://github.com/user-attachments/assets/c0076c0c-ca0e-4dbb-8c05-f328cced73fb)

To avoid getting the ITMS-90899 error when uploading an app to the App Store, we need to set the minimum MacOS version to 12 when submitting an app built using Expo SDK-52.

# How

This commit adds the LSMimiumSystemVersion=12 to the default bare-minimum template.

Fixes ENG-13885

# Test Plan

Verify that submitted apps is submitted without the ITMS-90899 warning.

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
