### PR TITLE
[expo-go] Fix build error

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/singletons/SplashScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/singletons/SplashScreen.kt
@@ -3,7 +3,6 @@ package host.exp.exponent.experience.splashscreen.legacy.singletons
 import android.app.Activity
 import android.util.Log
 import android.view.ViewGroup
-import expo.modules.splashscreen.*
 import expo.modules.core.interfaces.SingletonModule
 import host.exp.exponent.experience.splashscreen.legacy.NativeResourcesBasedSplashScreenViewProvider
 import host.exp.exponent.experience.splashscreen.legacy.SplashScreenImageResizeMode


### PR DESCRIPTION
# Why
Fixes the error when building expo go

# How
I added `expo-splash-screen` to the autolinking exclusion list and this broke one of the left over imports in the legacy module.

# Test Plan
expo-go can build and run

