### PR TITLE
[router-e2e] migrate newArchEnabled

### DIFF
--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   // For testing the output bundle
   jsEngine: process.env.E2E_ROUTER_JS_ENGINE ?? (process.env.E2E_ROUTER_SRC ? 'jsc' : 'hermes'),
+  newArchEnabled: true,
   splash: {
     image: './assets/splash.png',
     resizeMode: 'contain',
@@ -41,11 +42,7 @@ module.exports = {
       'expo-build-properties',
       {
         ios: {
-          newArchEnabled: true,
           ccacheEnabled: true,
-        },
-        android: {
-          newArchEnabled: true,
         },
       },
     ],


### PR DESCRIPTION
# Why

when running prebuild in router-e2e, it shows `newArchEnabled` deprecated warning

![Screenshot 2024-10-31 at 7.12.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BhF1ySaozaWrX9KbwtqY/791b49ee-c954-48a4-84aa-88c15c609ba7.png)

# How

migrate to app.json direct upport `newArchEnabled`

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
