### PR TITLE
[docs] add docs for new Xcode 16.1 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -295,7 +295,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.6-xcode-16.0` (`latest`)
+#### `macos-sonoma-14.6-xcode-16.0`
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -67,7 +67,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-51`)
+#### `ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-51`, `sdk-52`)
 
 <Collapsible summary="Details">
 
@@ -276,6 +276,24 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
   ```
 
 ### iOS server images
+
+#### `macos-sonoma-14.6-xcode-16.1` (`latest`, `sdk-52`)
+
+<Collapsible summary="Details">
+
+- macOS Sonoma 14.6
+- Xcode 16.1 (16B40)
+- Node.js 18.18.0
+- Bun 1.1.33
+- Yarn 1.22.21
+- pnpm 9.12.3
+- npm 9.8.1
+- fastlane 2.225.0
+- CocoaPods 1.16.0
+- Ruby 3.2
+- node-gyp 10.2.0
+
+</Collapsible>
 
 #### `macos-sonoma-14.6-xcode-16.0` (`latest`)
 


### PR DESCRIPTION
# Why

Add docs for new image

# How

Add docs for new image

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
