### PR TITLE
[cli] add dom components support to export command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added DOM Components support to the `export` command. ([#32504](https://github.com/expo/expo/pull/32504) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 - Add fallback method for determining internal IP address. ([#32273](https://github.com/expo/expo/pull/32273) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
@@ -67,4 +67,55 @@ describe(createMetadataJson, () => {
       version: expect.any(Number),
     });
   });
+  it(`writes metadata manifest with dom components asset`, async () => {
+    const metadata = await createMetadataJson({
+      fileNames: { ios: ['_expo/static/js/ios/ios-xxfooxxbarxx.js', 'other'] },
+
+      bundles: {
+        ios: {
+          assets: [{ type: 'image', fileHashes: ['foobar', 'other'] } as any],
+        },
+      },
+      domComponentAssetsMetadata: {
+        ios: [
+          {
+            path: 'www.bundle/6f3d5250b031acb593b17db64fef2375a3763a5e.html',
+            ext: 'html',
+          },
+          {
+            path: 'www.bundle/_expo/static/js/web/entry-f6b050d6eb8cc8aa0515b4914358ee47.js',
+            ext: 'js',
+          },
+        ],
+      },
+    });
+
+    expect(metadata).toStrictEqual({
+      bundler: expect.any(String),
+      fileMetadata: {
+        ios: {
+          assets: [
+            {
+              ext: 'image',
+              path: 'assets/foobar',
+            },
+            {
+              ext: 'image',
+              path: 'assets/other',
+            },
+            {
+              ext: 'html',
+              path: 'www.bundle/6f3d5250b031acb593b17db64fef2375a3763a5e.html',
+            },
+            {
+              ext: 'js',
+              path: 'www.bundle/_expo/static/js/web/entry-f6b050d6eb8cc8aa0515b4914358ee47.js',
+            },
+          ],
+          bundle: '_expo/static/js/ios/ios-xxfooxxbarxx.js',
+        },
+      },
+      version: expect.any(Number),
+    });
+  });
 });

--- a/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
@@ -1,0 +1,207 @@
+import crypto from 'crypto';
+
+import { updateDomComponentAssetsForMD5Naming } from '../exportDomComponents';
+import { type BundleOutput, type ExportAssetMap } from '../saveAssets';
+
+jest.mock('crypto');
+describe(updateDomComponentAssetsForMD5Naming, () => {
+  const mockMd5 = jest.fn().mockReturnValue('MOCK_MD5_HASH');
+  const mockSha1 = jest.fn().mockReturnValue('MOCK_SHA1_HASH');
+
+  (crypto.createHash as jest.Mock).mockImplementation((algorithm: string) => {
+    if (algorithm === 'md5') {
+      return {
+        update: jest.fn().mockReturnThis(),
+        digest: mockMd5,
+      };
+    } else if (algorithm === 'sha1') {
+      return {
+        update: jest.fn().mockReturnThis(),
+        digest: mockSha1,
+      };
+    }
+    return jest.fn();
+  });
+
+  it('should update asset paths and remove leading slashes from filenames', () => {
+    const domComponentReference = 'file:///app/components/DomView.tsx';
+    const nativeBundle1Chunk = `
+__d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
+  var _interopRequireDefault = require(_dependencyMap[0]);
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+  exports.default = undefined;
+  var _react = _interopRequireDefault(require(_dependencyMap[1]));
+  var _internal = require(_dependencyMap[2]);
+  var source = {
+    uri: process.env.EXPO_DOM_BASE_URL + "/${mockSha1()}.html"
+  };
+  var _default = exports.default = _react.default.forwardRef((props, ref) => {
+    return _react.default.createElement(_internal.WebView, {
+      ref,
+      ...props,
+      source
+    });
+  });
+},896,[4,157,897]);
+`;
+
+    const domHtml1 = `
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+        <style id="expo-dom-component-style">
+        /* These styles make the body full-height */
+        html,
+        body {
+          -webkit-overflow-scrolling: touch; /* Enables smooth momentum scrolling */
+        }
+        /* These styles make the root element full-height */
+        #root {
+          display: flex;
+          flex: 1;
+        }
+        </style>
+    </head>
+    <body>
+    <noscript>DOM Components require <code>javaScriptEnabled</code></noscript>
+        <!-- Root element for the DOM component. -->
+        <div id="root"></div>
+
+    <script src="./_expo/static/js/web/entry-dom1.js" defer></script>
+</body>
+</html>
+`;
+    const domBundle1Chunk = `
+__d((function(g,r,i,a,m,e,d){m.exports={uri:"assets/assets/images/react-logo.d883906de993aa65bf0ef0d1bc2ff6ad.png",width:100,height:100}}),1168,[]);
+`;
+    const nativeBundle: BundleOutput = {
+      artifacts: [
+        {
+          filename: '_expo/static/js/ios/entry-native1.js',
+          originFilename: 'node_modules/expo-router/entry.js',
+          type: 'js',
+          metadata: {},
+          source: nativeBundle1Chunk,
+        },
+      ],
+      assets: [
+        {
+          __packager_asset: true,
+          fileSystemLocation: '/app/node_modules/@react-navigation/elements/lib/commonjs/assets',
+          httpServerLocation:
+            './assets/node_modules/@react-navigation/elements/lib/commonjs/assets',
+          width: 96,
+          height: 96,
+          scales: [1, 2, 3],
+          files: [
+            '/app/node_modules/@react-navigation/elements/lib/commonjs/assets/close-icon.png',
+            '/app/node_modules/@react-navigation/elements/lib/commonjs/assets/close-icon@2x.png',
+            '/app/node_modules/@react-navigation/elements/lib/commonjs/assets/close-icon@3x.png',
+          ],
+          hash: '3162e8a244d8f6fbd259e79043e23ce4',
+          name: 'close-icon',
+          type: 'png',
+          fileHashes: [
+            'd84e297c3b3e49a614248143d53e40ca',
+            '1190ab078c57159f4245a328118fcd9a',
+            '0747a1317bbe9c6fc340b889ef8ab3ae',
+          ],
+        },
+      ],
+    };
+
+    const domComponentBundle: BundleOutput = {
+      artifacts: [
+        {
+          filename: '_expo/static/js/web/entry-dom1.js',
+          originFilename: 'node_modules/expo/dom/entry.js',
+          type: 'js',
+          metadata: {},
+          source: domBundle1Chunk,
+        },
+      ],
+      assets: [
+        {
+          __packager_asset: true,
+          fileSystemLocation: '/Users/kudo/sdk52domota/assets/images',
+          httpServerLocation: './assets/assets/images',
+          width: 100,
+          height: 100,
+          scales: [1, 2, 3],
+          files: [
+            '/Users/kudo/sdk52domota/assets/images/react-logo.png',
+            '/Users/kudo/sdk52domota/assets/images/react-logo@2x.png',
+            '/Users/kudo/sdk52domota/assets/images/react-logo@3x.png',
+          ],
+          hash: '633435dcb418833920a16771610ca404',
+          name: 'react-logo.d883906de993aa65bf0ef0d1bc2ff6ad',
+          type: 'png',
+          fileHashes: [
+            '695d5a1c6f29a689130f3aaa573aec6e',
+            'b507e7f2c91ebc8fe24dee79ccb3b600',
+            '8a4d0e5b845044e56e3b2df627d01cfd',
+          ],
+        },
+      ],
+    };
+    const files: ExportAssetMap = new Map([
+      [
+        '_expo/static/js/ios/entry-native1.js',
+        {
+          contents: nativeBundle1Chunk,
+        },
+      ],
+      [
+        '/www.bundle/_expo/static/js/web/entry-dom1.js',
+        {
+          contents: domBundle1Chunk,
+        },
+      ],
+      [
+        'www.bundle/dom1.html',
+        {
+          contents: domHtml1,
+        },
+      ],
+    ]);
+    const htmlOutputName = 'www.bundle/dom1.html';
+
+    const assetsMetadata = updateDomComponentAssetsForMD5Naming({
+      domComponentReference,
+      nativeBundle,
+      domComponentBundle,
+      files,
+      htmlOutputName,
+    });
+
+    // Expects to add js and html to assets metadata
+    expect(assetsMetadata).toEqual([
+      {
+        ext: 'js',
+        path: 'www.bundle/_expo/static/js/web/entry-dom1.js',
+      },
+      {
+        ext: 'html',
+        path: 'www.bundle/dom1.html',
+      },
+    ]);
+
+    const domJsContents = files.get('/www.bundle/_expo/static/js/web/entry-dom1.js').contents;
+    expect(domJsContents).not.toEqual(domBundle1Chunk);
+    expect(domJsContents).toContain(domComponentBundle.assets[0].fileHashes[0]);
+
+    const domHtmlContents = files.get('www.bundle/dom1.html').contents;
+    expect(domHtmlContents).not.toEqual(domHtml1);
+    expect(domHtmlContents).toContain('MOCK_MD5_HASH');
+
+    const nativeJsContents = files.get('_expo/static/js/ios/entry-native1.js').contents;
+    expect(nativeJsContents).not.toEqual(nativeBundle1Chunk);
+    expect(nativeJsContents).toContain('MOCK_MD5_HASH');
+  });
+});

--- a/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
@@ -34,14 +34,12 @@ __d(function (global, require, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, expor
   exports.default = undefined;
   var _react = _interopRequireDefault(require(_dependencyMap[1]));
   var _internal = require(_dependencyMap[2]);
-  var source = {
-    uri: process.env.EXPO_DOM_BASE_URL + "/${mockSha1()}.html"
-  };
+  var filePath = "${mockSha1()}.html";
   var _default = exports.default = _react.default.forwardRef((props, ref) => {
     return _react.default.createElement(_internal.WebView, {
       ref,
       ...props,
-      source
+      filePath,
     });
   });
 },896,[4,157,897]);

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -6,7 +6,7 @@ export type BundlePlatform = 'android' | 'ios';
 
 type PlatformMetadataAsset = { path: string; ext: string };
 
-type PlatformMetadata = { bundle: string; assets: PlatformMetadataAsset[] };
+export type PlatformMetadata = { bundle: string; assets: PlatformMetadataAsset[] };
 
 type FileMetadata = {
   [key in BundlePlatform]: PlatformMetadata;
@@ -16,10 +16,12 @@ export function createMetadataJson({
   bundles,
   fileNames,
   embeddedHashSet,
+  domComponentAssetsMetadata,
 }: {
   bundles: Partial<Record<BundlePlatform, Pick<BundleOutput, 'assets'>>>;
   fileNames: Record<string, string[]>;
   embeddedHashSet?: Set<string>;
+  domComponentAssetsMetadata?: Record<string, PlatformMetadataAsset[]>;
 }): {
   version: 0;
   bundler: 'metro';
@@ -33,24 +35,30 @@ export function createMetadataJson({
       (metadata, [platform, bundle]) => {
         if (platform === 'web') return metadata;
 
+        // Collect all of the assets and convert them to the serial format.
+        const assets = bundle.assets
+          .filter((asset) => !embeddedHashSet || !embeddedHashSet.has(asset.hash))
+          .map((asset) =>
+            // Each asset has multiple hashes which we convert and then flatten.
+            asset.fileHashes?.map((hash) => ({
+              path: path.join('assets', hash),
+              ext: asset.type,
+            }))
+          )
+          .filter(Boolean)
+          .flat();
+
+        if (domComponentAssetsMetadata?.[platform] != null) {
+          assets.push(...domComponentAssetsMetadata?.[platform]);
+        }
+
         return {
           ...metadata,
           [platform]: {
             // Get the filename for each platform's bundle.
             // TODO: Add multi-bundle support to EAS Update!!
             bundle: fileNames[platform][0],
-            // Collect all of the assets and convert them to the serial format.
-            assets: bundle.assets
-              .filter((asset) => !embeddedHashSet || !embeddedHashSet.has(asset.hash))
-              .map((asset) =>
-                // Each asset has multiple hashes which we convert and then flatten.
-                asset.fileHashes?.map((hash) => ({
-                  path: path.join('assets', hash),
-                  ext: asset.type,
-                }))
-              )
-              .filter(Boolean)
-              .flat(),
+            assets,
           },
         };
       },

--- a/packages/@expo/cli/src/export/exportDomComponents.ts
+++ b/packages/@expo/cli/src/export/exportDomComponents.ts
@@ -1,0 +1,175 @@
+import type { ExpoConfig } from '@expo/config';
+import assert from 'assert';
+import crypto from 'crypto';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { type PlatformMetadata } from './createMetadataJson';
+import { type BundleOutput, type ExportAssetMap, getFilesFromSerialAssets } from './saveAssets';
+import { type MetroBundlerDevServer } from '../start/server/metro/MetroBundlerDevServer';
+import { serializeHtmlWithAssets } from '../start/server/metro/serializeHtml';
+import {
+  getDomComponentHtml,
+  DOM_COMPONENTS_BUNDLE_DIR,
+} from '../start/server/middleware/DomComponentsMiddleware';
+import { env } from '../utils/env';
+import { resolveRealEntryFilePath } from '../utils/filePath';
+
+const debug = require('debug')('expo:export:exportDomComponents') as typeof console.log;
+
+// TODO(EvanBacon): determine how to support DOM Components with hosting.
+export async function exportDomComponentAsync({
+  filePath,
+  projectRoot,
+  dev,
+  devServer,
+  isHermes,
+  includeSourceMaps,
+  exp,
+  files,
+}: {
+  filePath: string;
+  projectRoot: string;
+  dev: boolean;
+  devServer: MetroBundlerDevServer;
+  isHermes: boolean;
+  includeSourceMaps: boolean;
+  exp: ExpoConfig;
+  files: ExportAssetMap;
+}): Promise<{
+  bundle: BundleOutput;
+  htmlOutputName: string;
+}> {
+  const virtualEntry = resolveFrom(projectRoot, 'expo/dom/entry.js');
+  debug('Bundle DOM Component:', filePath);
+  // MUST MATCH THE BABEL PLUGIN!
+  const hash = crypto.createHash('sha1').update(filePath).digest('hex');
+  const outputName = `${DOM_COMPONENTS_BUNDLE_DIR}/${hash}.html`;
+  const generatedEntryPath = filePath.startsWith('file://') ? filePath.slice(7) : filePath;
+  const baseUrl = `/${DOM_COMPONENTS_BUNDLE_DIR}`;
+  const relativeImport = './' + path.relative(path.dirname(virtualEntry), generatedEntryPath);
+  // Run metro bundler and create the JS bundles/source maps.
+  const bundle = await devServer.legacySinglePageExportBundleAsync({
+    platform: 'web',
+    domRoot: encodeURI(relativeImport),
+    splitChunks: !env.EXPO_NO_BUNDLE_SPLITTING,
+    mainModuleName: resolveRealEntryFilePath(projectRoot, virtualEntry),
+    mode: dev ? 'development' : 'production',
+    engine: isHermes ? 'hermes' : undefined,
+    serializerIncludeMaps: includeSourceMaps,
+    bytecode: false,
+    reactCompiler: !!exp.experiments?.reactCompiler,
+    baseUrl: './',
+    // Minify may be false because it's skipped on native when Hermes is enabled, default to true.
+    minify: true,
+  });
+
+  const html = await serializeHtmlWithAssets({
+    isExporting: true,
+    resources: bundle.artifacts,
+    template: getDomComponentHtml(),
+    baseUrl: './',
+  });
+
+  const serialAssets = bundle.artifacts.map((a) => {
+    return {
+      ...a,
+      filename: path.join(baseUrl, a.filename),
+    };
+  });
+
+  getFilesFromSerialAssets(serialAssets, {
+    includeSourceMaps,
+    files,
+    platform: 'web',
+  });
+
+  files.set(outputName, {
+    contents: html,
+  });
+
+  return {
+    bundle,
+    htmlOutputName: outputName,
+  };
+}
+
+/**
+ * For EAS Updates exports,
+ * post-processes the DOM component bundle and updates the asset paths to use flattened MD5 naming.
+ */
+export function updateDomComponentAssetsForMD5Naming({
+  domComponentReference,
+  nativeBundle,
+  domComponentBundle,
+  files,
+  htmlOutputName,
+}: {
+  domComponentReference: string;
+  nativeBundle: BundleOutput;
+  domComponentBundle: BundleOutput;
+  files: ExportAssetMap;
+  htmlOutputName: string;
+}): PlatformMetadata['assets'] {
+  const assetsMetadata: PlatformMetadata['assets'] = [];
+
+  for (const artifact of domComponentBundle.artifacts) {
+    if (artifact.type !== 'js') {
+      continue;
+    }
+    const artifactAssetName = `/${DOM_COMPONENTS_BUNDLE_DIR}/${artifact.filename}`;
+    let source = artifact.source;
+
+    // [0] Updates asset paths in the DOM component JS bundle (which is a web bundle)
+    for (const asset of domComponentBundle.assets) {
+      const prefix = asset.httpServerLocation.startsWith('./')
+        ? asset.httpServerLocation.slice(2)
+        : asset.httpServerLocation;
+      const uri = `${prefix}/${asset.name}.${asset.type}`;
+      const regexp = new RegExp(`(uri:")(${uri})(")`, 'g');
+      const index = asset.scales.findIndex((s) => s === 1) ?? 0; // DOM components (web) uses 1x assets
+      const md5 = asset.fileHashes[index];
+      source = source.replace(regexp, `$1${md5}.${asset.type}$3`);
+
+      const domJsAssetEntity = files.get(artifactAssetName);
+      assert(domJsAssetEntity);
+      domJsAssetEntity.contents = source;
+    }
+
+    // [1] Updates JS artifacts in HTML
+    const md5 = crypto.createHash('md5').update(source).digest('hex');
+    const htmlAssetEntity = files.get(htmlOutputName);
+    assert(htmlAssetEntity);
+    const regexp = new RegExp(`(<script src=")(.*${artifact.filename})(" defer></script>)`, 'g');
+    htmlAssetEntity.contents = htmlAssetEntity.contents.toString().replace(regexp, `$1${md5}.js$3`);
+
+    assetsMetadata.push({
+      path: artifactAssetName.slice(1),
+      ext: 'js',
+    });
+  }
+
+  // [2] Updates HTML names from native bundle
+  const htmlContent = files.get(htmlOutputName);
+  assert(htmlContent);
+  const htmlMd5 = crypto.createHash('md5').update(htmlContent.contents.toString()).digest('hex');
+  const hash = crypto.createHash('sha1').update(domComponentReference).digest('hex');
+  for (const artifact of nativeBundle.artifacts) {
+    if (artifact.type !== 'js') {
+      continue;
+    }
+    const assetEntity = files.get(artifact.filename);
+    assert(assetEntity);
+    const regexp = new RegExp(
+      `(\\buri:.*process\\.env\\.EXPO_DOM_BASE_URL.*"/)(${hash}\\.html)(")`,
+      'g'
+    );
+    assetEntity.contents = assetEntity.contents.toString().replace(regexp, `$1${htmlMd5}.html$3`);
+  }
+  assetsMetadata.push({
+    path: htmlOutputName,
+    ext: 'html',
+  });
+
+  return assetsMetadata;
+}

--- a/packages/@expo/cli/src/export/exportDomComponents.ts
+++ b/packages/@expo/cli/src/export/exportDomComponents.ts
@@ -160,11 +160,8 @@ export function updateDomComponentAssetsForMD5Naming({
     }
     const assetEntity = files.get(artifact.filename);
     assert(assetEntity);
-    const regexp = new RegExp(
-      `(\\buri:.*process\\.env\\.EXPO_DOM_BASE_URL.*"/)(${hash}\\.html)(")`,
-      'g'
-    );
-    assetEntity.contents = assetEntity.contents.toString().replace(regexp, `$1${htmlMd5}.html$3`);
+    const regexp = new RegExp(`(['"])${hash}\\.html(['"])`, 'g');
+    assetEntity.contents = assetEntity.contents.toString().replace(regexp, `$1${htmlMd5}.html$2`);
   }
   assetsMetadata.push({
     path: htmlOutputName,

--- a/packages/@expo/cli/src/utils/filePath.ts
+++ b/packages/@expo/cli/src/utils/filePath.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+/**
+ * This is a workaround for Metro not resolving entry file paths to their real location.
+ * When running exports through `eas build --local` on macOS, the `/var/folders` path is used instead of `/private/var/folders`.
+ *
+ * See: https://github.com/expo/expo/issues/28890
+ */
+export function resolveRealEntryFilePath(projectRoot: string, entryFile: string): string {
+  if (projectRoot.startsWith('/private/var') && entryFile.startsWith('/var')) {
+    return fs.realpathSync(entryFile);
+  }
+
+  return entryFile;
+}

--- a/packages/expo/build/dom/base.d.ts.map
+++ b/packages/expo/build/dom/base.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"base.d.ts","sourceRoot":"","sources":["../../src/dom/base.ts"],"names":[],"mappings":"AAEA;;GAEG;AACH,wBAAgB,UAAU,IAAI,MAAM,CA6BnC"}
+{"version":3,"file":"base.d.ts","sourceRoot":"","sources":["../../src/dom/base.ts"],"names":[],"mappings":"AAEA;;GAEG;AACH,wBAAgB,UAAU,IAAI,MAAM,CAkCnC"}

--- a/packages/expo/build/dom/base.d.ts.map
+++ b/packages/expo/build/dom/base.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"base.d.ts","sourceRoot":"","sources":["../../src/dom/base.ts"],"names":[],"mappings":"AAEA;;GAEG;AACH,wBAAgB,UAAU,IAAI,MAAM,CA6CnC"}
+{"version":3,"file":"base.d.ts","sourceRoot":"","sources":["../../src/dom/base.ts"],"names":[],"mappings":"AAEA;;GAEG;AACH,wBAAgB,UAAU,IAAI,MAAM,CA6BnC"}

--- a/packages/expo/src/dom/base.ts
+++ b/packages/expo/src/dom/base.ts
@@ -9,6 +9,11 @@ export function getBaseURL(): string {
   }
 
   // Serving from updates
+  const updatesBaseUrl = getUpdatesBaseURL();
+  if (updatesBaseUrl != null) {
+    cachedBaseUrl = updatesBaseUrl;
+    return cachedBaseUrl;
+  }
 
   if (process.env.EXPO_OS === 'web') {
     cachedBaseUrl = process.env.EXPO_BASE_URL ?? '';

--- a/packages/expo/src/dom/base.ts
+++ b/packages/expo/src/dom/base.ts
@@ -9,22 +9,6 @@ export function getBaseURL(): string {
   }
 
   // Serving from updates
-  const ExpoUpdates = globalThis.expo?.modules?.['ExpoUpdates'] as
-    | import('expo-updates').ExpoUpdatesModule
-    | undefined;
-  const updatesIsInstalledAndEnabled = ExpoUpdates?.isEnabled ?? false;
-  const updatesIsEmbeddedLaunch = ExpoUpdates?.isEmbeddedLaunch ?? false;
-  const shouldServeDomFromUpdates = updatesIsInstalledAndEnabled && !updatesIsEmbeddedLaunch;
-  // If updates is installed and enabled, and we're not running from an embedded launch, we should serve the DOM Components from the `.expo-internal` directory
-  if (shouldServeDomFromUpdates) {
-    const localAssets = ExpoUpdates?.localAssets ?? {};
-    const anyLocalAsset = Object.values(localAssets)[0];
-    if (anyLocalAsset) {
-      // Try to get the `.expo-internal` directory from the first local asset
-      cachedBaseUrl = anyLocalAsset.slice(0, anyLocalAsset.lastIndexOf('/'));
-      return cachedBaseUrl;
-    }
-  }
 
   if (process.env.EXPO_OS === 'web') {
     cachedBaseUrl = process.env.EXPO_BASE_URL ?? '';
@@ -48,4 +32,26 @@ export function getBaseURL(): string {
   const devServer = getDevServer();
   cachedBaseUrl = new URL('/_expo/@dom', devServer.url).toString();
   return cachedBaseUrl;
+}
+
+/**
+ * Get the base URL for the DOM Components when serving from updates
+ */
+function getUpdatesBaseURL(): string | null {
+  const ExpoUpdates = globalThis.expo?.modules?.['ExpoUpdates'] as
+    | import('expo-updates').ExpoUpdatesModule
+    | undefined;
+  const updatesIsInstalledAndEnabled = ExpoUpdates?.isEnabled ?? false;
+  const updatesIsEmbeddedLaunch = ExpoUpdates?.isEmbeddedLaunch ?? false;
+  const shouldServeDomFromUpdates = updatesIsInstalledAndEnabled && !updatesIsEmbeddedLaunch;
+  // If updates is installed and enabled, and we're not running from an embedded launch, we should serve the DOM Components from the `.expo-internal` directory
+  if (shouldServeDomFromUpdates) {
+    const localAssets = ExpoUpdates?.localAssets ?? {};
+    const anyLocalAsset = Object.values(localAssets)[0];
+    if (anyLocalAsset) {
+      // Try to get the `.expo-internal` directory from the first local asset
+      return anyLocalAsset.slice(0, anyLocalAsset.lastIndexOf('/'));
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
# Why

added eas updates support to dom components
close ENG-12926

# How

- refactor common code for `export` and `export:embed`  to `exportDomComponents.ts`
- since updates serve assets in flattened MD5 based names, we cannot export web files like `export:embed`. this pr tries to post-transform bundles to have flattened MD5 based names.
- ❌ since updates serves in flattened files, we cannot support [public assets](https://docs.expo.dev/guides/dom-components/#public-assets) for updates. will have a pr to document that later.

# Test Plan

- add an unit test for `updateDomComponentAssetsForMD5Naming`
- router-e2e dom components debug build
- router-e2e dom components release build
- test eas updates in a default template project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
