### PR TITLE
[docs] Fix ordered list bullet style

### DIFF
--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -242,7 +242,7 @@ export const UL = createTextComponent(
 );
 export const OL = createTextComponent(
   TextElement.OL,
-  'list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4'
+  'list-decimal ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4'
 );
 export const KBD = createTextComponent(
   TextElement.KBD,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In a [recent migration to Tailwind from Emotion](https://github.com/expo/expo/pull/32191/files#diff-8f81f33c310a10c5aeffb42e8dab120ba1b685468cd80079d466be3e7dde6120), it seems that the ordered list bullet style was set to disc. We use ordered list in sections to specify the order of steps.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change the style of the `TextElement.OL` element to `list-decimal`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes are reflected correctly when there's a ordered list used in a document.

![CleanShot 2024-10-31 at 17 41 01](https://github.com/user-attachments/assets/a716a8b8-f59d-4991-870d-63d643f12b3e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
