### PR TITLE
[go][Android] Synchronize `reloadExpoApp`

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -39,7 +39,7 @@ object VersionedUtils {
     }
   }
 
-  private fun reloadExpoApp() {
+  private fun reloadExpoApp() = synchronized(this) {
     val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,


### PR DESCRIPTION
# Why

Fixes ENG-13989

# How

When launching a clear project on Android emulator with Expo Go on SDK 52, and try reloading from CLI several times, sometimes it works ok, while other times it takes very long to reload or displays a blank screen with spinner that never goes away, and on some occasions reload crashes the app process. This PR aims to fix that. The problem is caused by several memory leaks on Android, which we're still investigating. However, by synchronizing the `reloadExpoApp` method, we at least eliminate the problem of app being stuck. 

# Test Plan

- Expo Go ✅ 