### PR TITLE
[docs] Add e2e test video

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -7,12 +7,15 @@ description: Learn how to set up and run E2E tests on EAS Build with Maestro.
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **info** This guide will evolve over time as support for E2E testing in EAS Build improves. If you are looking for an archived guide on how to run E2E tests on EAS Build using Detox, you can see it in the [archive section](/archive/e2e-tests/).
 
 In this guide, you will learn how to create and run E2E tests on EAS Build using [Maestro](https://maestro.mobile.dev/), which is one of the most popular tools for running E2E tests in mobile apps.
 
 The example demonstrates how to configure your EAS Build Maestro E2E tests workflow using the [default Expo template](/more/create-expo/#--template). For your own app, you will need to adjust the flows to match your app's UI.
+
+<VideoBoxLink videoId="-o-bfIRrg9U" title="Watch: How to run E2E tests on EAS Build" />
 
 <Step label="1">
 ## Initialize a new project


### PR DESCRIPTION
# Why

[ENG-13900 Get video embedded in docs](https://linear.app/expo/issue/ENG-13900/get-video-embedded-in-docs)

# How

Embed video using `VideoBoxLink`

# Test Plan

Ran locally and verify video shows correctly

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/0d7fe350-4e03-4fa5-9215-7fda836b426f">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
