### PR TITLE
feat(create-expo): Add hint for `--template` and `--example` args when those are omitted

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add log hint for `--template` and `--example` arguments.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add log hint for `--template` and `--example` arguments.
+- Add log hint for `--template` and `--example` arguments. ([#32519](https://github.com/expo/expo/pull/32519) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { CLI_NAME } from './cmd';
 import { ExitError } from './error';
 import { Log } from './log';
+import { formatSelfCommand } from './resolvePackageManager';
 import { assertWithOptionsArgs, printHelp, resolveStringOrBooleanArgsAsync } from './utils/args';
 
 const debug = require('debug')('expo:init:cli') as typeof console.log;
@@ -47,12 +48,12 @@ async function run() {
       chalk`
     {gray To choose a template pass in the {bold --template} arg:}
 
-    {gray $} npx ${CLI_NAME} {cyan --template}
+    {gray $} ${formatSelfCommand()} {cyan --template}
 
     {gray To choose an Expo example pass in the {bold --example} arg:}
 
-    {gray $} npx ${CLI_NAME} {cyan --example}
-    {gray $} npx ${CLI_NAME} {cyan --example with-router}
+    {gray $} ${formatSelfCommand()} {cyan --example}
+    {gray $} ${formatSelfCommand()} {cyan --example with-router}
 
     {gray The package manager used for installing}
     {gray node modules is based on how you invoke the CLI:}

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -96,16 +96,15 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     resolvedTemplate = await promptTemplateAsync();
   } else {
     resolvedTemplate = props.template ?? null;
-  }
-
-  console.log(
-    chalk`Creating an Expo project using the {cyan ${resolvedTemplate ?? 'default'}} template.\n`
-  );
-  if (!resolvedTemplate) {
-    console.log(chalk`{gray To choose from all available templates pass in the --template arg:}`);
-    console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --template}\n`);
-    console.log(chalk`{gray To choose from all available examples pass in the --example arg:}`);
-    console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --example}\n`);
+    console.log(
+      chalk`Creating an Expo project using the {cyan ${resolvedTemplate ?? 'default'}} template.\n`
+    );
+    if (!resolvedTemplate) {
+      console.log(chalk`{gray To choose from all available templates pass in the --template arg:}`);
+      console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --template}\n`);
+      console.log(chalk`{gray To choose from all available examples pass in the --example arg:}`);
+      console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --example}\n`);
+    }
   }
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
@@ -153,11 +152,10 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
     resolvedExample = await promptExamplesAsync();
   } else if (props.example) {
     resolvedExample = props.example;
+    console.log(chalk`Creating an Expo project using the {cyan ${resolvedExample}} example.\n`);
   }
 
   await ensureExampleExists(resolvedExample);
-
-  console.log(chalk`Creating an Expo project using the {cyan ${resolvedExample}} example.\n`);
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -9,7 +9,6 @@ import {
   promptExamplesAsync,
 } from './Examples';
 import * as Template from './Template';
-import { CLI_NAME } from './cmd';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
 import {
@@ -17,6 +16,7 @@ import {
   installDependenciesAsync,
   PackageManagerName,
   resolvePackageManager,
+  formatSelfCommand,
 } from './resolvePackageManager';
 import { assertFolderEmpty, assertValidName, resolveProjectRootAsync } from './resolveProjectRoot';
 import {
@@ -101,9 +101,9 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     );
     if (!resolvedTemplate) {
       console.log(chalk`{gray To choose from all available templates pass in the --template arg:}`);
-      console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --template}\n`);
+      console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --template}\n`);
       console.log(chalk`{gray To choose from all available examples pass in the --example arg:}`);
-      console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --example}\n`);
+      console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --example}\n`);
     }
   }
 

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -9,6 +9,7 @@ import {
   promptExamplesAsync,
 } from './Examples';
 import * as Template from './Template';
+import { CLI_NAME } from './cmd';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
 import {
@@ -97,6 +98,16 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     resolvedTemplate = props.template ?? null;
   }
 
+  console.log(
+    chalk`Creating an Expo project using the {cyan ${resolvedTemplate ?? 'default'}} template.\n`
+  );
+  if (!resolvedTemplate) {
+    console.log(chalk`{gray To choose from all available templates pass in the --template arg:}`);
+    console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --template}\n`);
+    console.log(chalk`{gray To choose from all available examples pass in the --example arg:}`);
+    console.log(chalk`  {gray $} npx ${CLI_NAME} {cyan --example}\n`);
+  }
+
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });
 
@@ -145,6 +156,8 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
   }
 
   await ensureExampleExists(resolvedExample);
+
+  console.log(chalk`Creating an Expo project using the {cyan ${resolvedExample}} example.\n`);
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });


### PR DESCRIPTION
> [!NOTE]
> This is a **proposal**, so there's no ticket/task associated to it.
> I've created this, since I've seen the same question pop up on Discord several times

# Why

On Discord, I've repeatedly seen messages that show that some beginners are unaware that `--template` and `--example` are options they can pass to get to different templates or examples. Running `npx create-expo-app` doesn't give them any indication that there's way more templates and examples they could be choosing from.
(e.g.: https://discord.com/channels/695411232856997968/695411232856997971/1301607696667119626)

This comes up often enough that I think we could add a helpful log message letting users know that how to get to other templates and examples to make this more obvious.

# How

When no `--template [arg]`, `--example [arg]`, `--template`, or `--example` argument is passed (i.e. we'll choose the default template), when applying this change, we now print out a message saying that the "default" template will be used and show people the full commands to list out all available templates and examples:

<img width="506" alt="Screenshot 2024-10-31 at 22 30 51" src="https://github.com/user-attachments/assets/d9e6a1ea-85d6-43d2-b34c-6423acdafce1">

When an explicit `--template [arg]` or `--example [arg]` is passed, we acknowledge their input, to mirror the above:

<img width="420" alt="Screenshot 2024-10-31 at 22 31 00" src="https://github.com/user-attachments/assets/efc92915-b025-4239-a675-ff2842006350">
<img width="423" alt="Screenshot 2024-10-31 at 22 31 51" src="https://github.com/user-attachments/assets/37c46582-3d1b-4574-8431-fa63c9e12faa">

# Test Plan

- Built locally, and tested using `./build/index.js`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
