### PR TITLE
[@expo/cli] Get runtime version from expo-updates for local manifest serving

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Get runtime version from expo-updates for local manifest serving ([#32520](https://github.com/expo/expo/pull/32520) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.20.1 — 2024-11-06

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -19,6 +19,7 @@ import {
   ResponseContentType,
 } from '../ExpoGoManifestHandlerMiddleware';
 import { ManifestMiddlewareOptions } from '../ManifestMiddleware';
+import { resolveRuntimeVersionWithExpoUpdatesAsync } from '../resolveRuntimeVersionWithExpoUpdatesAsync';
 import { ServerHeaders, ServerRequest } from '../server.types';
 
 jest.mock('../../../../api/user/user');
@@ -74,6 +75,7 @@ jest.mock('@expo/config', () => ({
     },
   })),
 }));
+jest.mock('../resolveRuntimeVersionWithExpoUpdatesAsync');
 
 const asReq = (req: Partial<ServerRequest>) => req as ServerRequest;
 
@@ -690,5 +692,22 @@ describe('_getManifestResponseAsync', () => {
         })
       )
     );
+  });
+
+  it('delegates runtime version resolution to expo-updates if possible', async () => {
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('testrtv');
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+    const results = await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.MULTIPART_MIXED,
+      platform: 'android',
+      expectSignature: null,
+      hostname: 'localhost',
+    });
+    const { body } = nullthrows(await getMultipartPartAsync('manifest', results));
+    expect(JSON.parse(body)).toMatchObject({
+      runtimeVersion: 'testrtv',
+    });
   });
 });

--- a/packages/@expo/cli/src/start/server/middleware/resolveRuntimeVersionWithExpoUpdatesAsync.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolveRuntimeVersionWithExpoUpdatesAsync.ts
@@ -1,0 +1,39 @@
+import { RuntimePlatform } from './resolvePlatform';
+import { env } from '../../../utils/env';
+import {
+  ExpoUpdatesCLIModuleNotFoundError,
+  expoUpdatesCommandAsync,
+} from '../../../utils/expoUpdatesCli';
+
+const debug = require('debug')('expo:start:server:middleware:resolveRuntimeVersion');
+
+export async function resolveRuntimeVersionWithExpoUpdatesAsync({
+  projectRoot,
+  platform,
+}: {
+  projectRoot: string;
+  platform: RuntimePlatform;
+}): Promise<string | null> {
+  try {
+    debug('Using expo-updates runtimeversion:resolve CLI for runtime version resolution');
+    const extraArgs = env.EXPO_DEBUG ? ['--debug'] : [];
+    const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(projectRoot, [
+      'runtimeversion:resolve',
+      '--platform',
+      platform,
+      ...extraArgs,
+    ]);
+    const runtimeVersionResult: { runtimeVersion: string | null } = JSON.parse(
+      resolvedRuntimeVersionJSONResult
+    );
+    debug('runtimeversion:resolve output:');
+    debug(resolvedRuntimeVersionJSONResult);
+
+    return runtimeVersionResult.runtimeVersion ?? null;
+  } catch (e: any) {
+    if (e instanceof ExpoUpdatesCLIModuleNotFoundError) {
+      return null;
+    }
+    throw e;
+  }
+}

--- a/packages/@expo/cli/src/utils/expoUpdatesCli.ts
+++ b/packages/@expo/cli/src/utils/expoUpdatesCli.ts
@@ -1,0 +1,41 @@
+import spawnAsync from '@expo/spawn-async';
+import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
+
+export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
+export class ExpoUpdatesCLIInvalidCommandError extends Error {}
+export class ExpoUpdatesCLICommandFailedError extends Error {}
+
+export async function expoUpdatesCommandAsync(projectDir: string, args: string[]): Promise<string> {
+  let expoUpdatesCli;
+  try {
+    expoUpdatesCli =
+      silentResolveFrom(projectDir, 'expo-updates/bin/cli') ??
+      resolveFrom(projectDir, 'expo-updates/bin/cli.js');
+  } catch (e: any) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new ExpoUpdatesCLIModuleNotFoundError(`The \`expo-updates\` package was not found. `);
+    }
+    throw e;
+  }
+
+  try {
+    return (
+      await spawnAsync(expoUpdatesCli, args, {
+        stdio: 'pipe',
+        env: { ...process.env },
+      })
+    ).stdout;
+  } catch (e: any) {
+    if (e.stderr && typeof e.stderr === 'string') {
+      if (e.stderr.includes('Invalid command')) {
+        throw new ExpoUpdatesCLIInvalidCommandError(
+          `The command specified by ${args} was not valid in the \`expo-updates\` CLI.`
+        );
+      } else {
+        throw new ExpoUpdatesCLICommandFailedError(e.stderr);
+      }
+    }
+
+    throw e;
+  }
+}


### PR DESCRIPTION
# Why

As runtime version resolution gets more complex, the only place it can be fully resolved is by the expo-updates package. This is already true for eas-cli and during build.

This callsite though was forgotten, resulting in incorrect runtime versions for projects with runtime version policies that need to be resolved in special ways (fingerprint, for example).

# How

Add code to call the expo-updates CLI to resolve the runtime version. This code is very similar to eas-cli though could be trimmed down a bit since the version compatibility is guaranteed since both the callsite and the expo-updates CLI are versioned and compatibility-locked.

# Test Plan

Run new test.

Manual test:
1. Add to fabric-tester app.json:
```
"runtimeVersion": {
      "policy": "fingerprint"
    }
```
2. npx expo prebuild
3. Build ios client
4. yarn start
5. Load in ios, show dev menu, see correct runtime version (fingerprint).


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
