### PR TITLE
[create-expo-module] Update messaging about re-building

### DIFF
--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -476,7 +476,7 @@ function printFurtherLocalInstructions(slug: string, name: string) {
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
   console.log(
     chalk.yellow(
-      `Remember you need to rebuild your development client or reinstall pods to see the changes.`
+      `Remember to re-build your native app (for example, with ${chalk.bold('npx expo run')}) when you make changes to the module. Native code changes are not reloaded with Fast Refresh.`
     )
   );
 }


### PR DESCRIPTION
# Why

I was testing create-expo-module and this message wasn't super clear to me:

> Remember you need to rebuild your development client or reinstall pods to see the changes.

So I thought I'd try to improve it