### PR TITLE
#32268: update jest-expo transform ignore patterns

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update transform ignore patterns to replace deprecated Sentry SDK with current one. ([#32528](https://github.com/expo/expo/pull/32528) by [@KoenCa](https://github.com/KoenCa))
+
 ### 💡 Others
 
 ## 52.0.0-preview.4 — 2024-11-05

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -93,9 +93,9 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
   );
 }
 
-// Also please keep `testing-with-jest.md` file up to date
+// Also please keep `unit-testing.mdx` file up to date
 jestPreset.transformIgnorePatterns = [
-  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
+  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)',
   '/node_modules/react-native-reanimated/plugin/',
 ];
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I encountered the following issue: https://github.com/expo/expo/issues/32268. Using jest-expo preset with Sentry React Native SDK throws an error.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Gets solved by applying up-to-date `transformIgnorePatterns` that is also available in the docs. The code in jest-expo package also refers to the markdown file of that specific documentation page mentioning it should be kept up-to-date. Docs were up-to-date, but not the code itself.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn test` in the jest-expo package directory
- Like mentioned in the issue: apply the up-to-date pattern in the package.json which make the tests of the reproduction repo work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
