### PR TITLE
[docs] Fix minor issues expo modules api section

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -168,8 +168,8 @@ Now that you have learned how to initialize a module and make simple changes to 
 />
 
 <BoxLink
-  title="Expo Modules API: Reference"
-  description="A reference for the Expo Modules API with Kotlin and Swift and common patterns like sending events from native code to JavaScript."
+  title="Expo Modules API Reference"
+  description="A reference to create native modules using Swift and Kotlin."
   href="/modules/module-api/"
   Icon={Grid01Icon}
 />

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -4,7 +4,6 @@ sidebar_title: Get started
 description: Learn about getting started with Expo modules API.
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -162,15 +161,15 @@ You have to repeat the build step anytime you make a change to the native code t
 Now that you have learned how to initialize a module and make simple changes to it, you can continue to a tutorial or dive right into the API reference.
 
 <BoxLink
-  title="Create your first native module"
-  description="Create a simple, but complete, native module to interact with Android and iOS preferences APIs."
-  href="/modules/native-module-tutorial"
-  Icon={BookOpen02Icon}
+  title="Tutorial: Creating a native module"
+  description="A tutorial on creating a native module that persists settings with Expo Modules API."
+  href="/modules/native-module-tutorial/"
+  Icon={Grid01Icon}
 />
 
 <BoxLink
-  title="Module API Reference"
-  description="Outline for the Expo Module API and common patterns like sending events from native code to JavaScript."
-  href="/modules/module-api"
+  title="Expo Modules API: Reference"
+  description="A reference for the Expo Modules API with Kotlin and Swift and common patterns like sending events from native code to JavaScript."
+  href="/modules/module-api/"
   Icon={Grid01Icon}
 />

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -4,7 +4,6 @@ sidebar_title: Create a native view
 description: A tutorial on creating a native view that renders a WebView with Expo Modules API.
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -44,18 +43,6 @@ Clean up the default module to start with a clean slate by deleting the followin
 
 Locate the following files and replace them with the provided minimal boilerplate:
 
-```swift ios/ExpoWebViewModule.swift
-import ExpoModulesCore
-
-public class ExpoWebViewModule: Module {
-  public func definition() -> ModuleDefinition {
-    Name("ExpoWebView")
-
-    View(ExpoWebView.self) {}
-  }
-}
-```
-
 ```kotlin android/src/main/java/expo/modules/webview/ExpoWebViewModule.kt
 package expo.modules.webview
 
@@ -67,6 +54,18 @@ class ExpoWebViewModule : Module() {
     Name("ExpoWebView")
 
     View(ExpoWebView::class) {}
+  }
+}
+```
+
+```swift ios/ExpoWebViewModule.swift
+import ExpoModulesCore
+
+public class ExpoWebViewModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoWebView")
+
+    View(ExpoWebView.self) {}
   }
 }
 ```
@@ -114,14 +113,13 @@ To ensure everything is working, start the TypeScript compiler to watch for chan
 />
 
 <Terminal
-  cmdCopy="cd example && npx expo run:ios"
   cmd={[
     '# Navigate to the example directory',
     '$ cd example',
-    '# Run the example app on iOS',
-    '$ npx expo run:ios',
     '# Run the example app on Android',
     '$ npx expo run:android',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
   ]}
 />
 
@@ -193,7 +191,6 @@ class ExpoWebView: ExpoView {
 No changes are required. Rebuild and run the app using the following commands:
 
 <Terminal
-  cmdCopy="npx expo prebuild --clean && npx expo run:ios"
   cmd={[
     '# Prebuild the example app with the --clean flag to ensure a clean build',
     '$ npx expo prebuild --clean',
@@ -294,13 +291,12 @@ export default function App() {
 Rebuild the example app:
 
 <Terminal
-  cmdCopy="npx expo prebuild --clean && npx expo run:ios"
   cmd={[
     '$ npx expo prebuild --clean',
-    '# Run the example app on iOS',
-    '$ npx expo run:ios',
     '# Run the example app on Android',
     '$ npx expo run:android',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
   ]}
 />
 
@@ -481,7 +477,7 @@ Now that you have a WebView, build a web browser UI around it. Try rebuilding a 
 
 <Collapsible summary="example/App.tsx">
 
-```tsx
+```tsx App.tsx
 import { useState } from 'react';
 import { ActivityIndicator, Platform, Text, TextInput, View } from 'react-native';
 import { WebView } from 'expo-web-view';
@@ -576,5 +572,5 @@ Congratulations! You've created your first Expo module with a native view for An
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={BookOpen02Icon}
+  Icon={Grid01Icon}
 />

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -563,7 +563,7 @@ Congratulations! You've created your first Expo module with a native view for An
 
 <BoxLink
   title="Expo Modules API Reference"
-  description="Create native modules using Swift and Kotlin."
+  description="Create native modules using Kotlin and Swift."
   href="/modules/module-api/"
   Icon={Grid01Icon}
 />

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -98,7 +98,7 @@ Learn more about this in the [Integrate an existing library](/modules/existing-l
 
 <BoxLink
   title="Expo Modules API: Reference"
-  description="Create native modules using Swift and Kotlin."
+  description="A reference on creating native modules using Kotlin and Swfit."
   href="/modules/module-api/"
   Icon={Grid01Icon}
 />

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -4,7 +4,6 @@ sidebar_title: Overview
 description: An overview of the APIs and utilities provided by Expo to develop native modules.
 ---
 
-import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 
@@ -87,7 +86,7 @@ Learn more about this in the [Integrate an existing library](/modules/existing-l
   title="Tutorial: Creating a native module"
   description="A tutorial on creating a native module that persists settings with Expo Modules API."
   href="/modules/native-module-tutorial/"
-  Icon={AndroidIcon}
+  Icon={Grid01Icon}
 />
 
 <BoxLink
@@ -98,7 +97,7 @@ Learn more about this in the [Integrate an existing library](/modules/existing-l
 />
 
 <BoxLink
-  title="Expo Modules API Reference"
+  title="Expo Modules API: Reference"
   description="Create native modules using Swift and Kotlin."
   href="/modules/module-api/"
   Icon={Grid01Icon}

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -3,6 +3,9 @@ title: Wrap third-party native libraries
 description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules API.
 ---
 
+import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
@@ -38,7 +41,7 @@ To create an empty Expo module that can be published on npm and utilized in any 
 
 <Terminal cmd={['$ npx create-expo-module expo-radial-chart']} />
 
-> **Tip**: If you aren't going to ship this library, press <kbd>return</kbd> for all of the prompts to accept the default values in the terminal window.
+> **info** **Tip**: If you aren't going to ship this library, press <kbd>return</kbd> for all the prompts to accept the default values in the terminal window.
 
 Now, open the newly created `expo-radial-chart` directory to start editing the native code.
 
@@ -392,7 +395,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-> **Tip**: If you created the module inside an existing application, make sure to import it directly from your **modules** directory by using a relative import: `import { ExpoRadialChartView } from '../modules/expo-radial-chart';`
+> **info** **Tip**: If you created the module inside an existing application, make sure to import it directly from your **modules** directory by using a relative import: `import { ExpoRadialChartView } from '../modules/expo-radial-chart';`
 
 </Step>
 
@@ -408,6 +411,13 @@ To make sure your app builds successfully on both platforms, rerun the build com
 
 </Step>
 
+Congratulations! You have created your first simple wrapper around two separate third-party native libraries using Expo Modules.
+
 ## Next step
 
-Congratulations! You have created your first simple wrapper around two separate third-party native libraries using Expo Modules. Learn more about the API in the [Expo Module API reference](/modules/module-api/).
+<BoxLink
+  title="Expo Modules API Reference"
+  description="A reference to create native modules using Swift and Kotlin."
+  href="/modules/module-api/"
+  Icon={Grid01Icon}
+/>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of on going Expo Modules API section audit.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing minor formatting and other types of inconsistencies such as using the wrong icon in box links, differences between descriptions for same boxlinks, missing info type when using a Tip callout, and platform order not correct when presenting code blocks and prebuild commands in Terminal component. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
