### PR TITLE
[notifications][android] run notification tasks from killed state

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [android] run notification tasks from killed state ([#32531](https://github.com/expo/expo/pull/32531) by [@vonovak](https://github.com/vonovak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -45,7 +45,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       }
 
       sListenersReferences[listener] = WeakReference(listener)
-      if (!sPendingNotificationResponses.isEmpty()) {
+      if (sPendingNotificationResponses.isNotEmpty()) {
         val responseIterator = sPendingNotificationResponses.iterator()
         while (responseIterator.hasNext()) {
           listener.onNotificationResponseReceived(responseIterator.next())
@@ -139,11 +139,11 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     if (notificationResponse.action.opensAppToForeground()) {
       openAppToForeground(context, notificationResponse)
     }
-
-    if (getListeners().isEmpty()) {
+    val listeners = getListeners()
+    if (listeners.isEmpty()) {
       sPendingNotificationResponses.add(notificationResponse)
     } else {
-      getListeners().forEach {
+      listeners.forEach {
         it.onNotificationResponseReceived(notificationResponse)
       }
     }


### PR DESCRIPTION
# Why

Enable notification tasks to run when the app is in a killed state on Android. Previously, background tasks associated with notifications weren't properly initialized when the app was launched from a killed state.

# How

- Modified `FirebaseMessagingDelegate` to explicitly initialize the task service before running background tasks


# Test Plan

this assumes that a [task](https://docs.expo.dev/versions/latest/sdk/notifications/#registertaskasynctaskname) is registered and so is a [category](https://docs.expo.dev/versions/latest/sdk/notifications/#setnotificationcategoryasyncidentifier-actions-options)

1. Kill the app (usually a swipe up gesture in the task switcher)
2. Send a data-only notification (it has to be data-only!) whose data payload contains

```
    categoryId: 'some-category',
    title: 'some-title',
```

notification is displayed now on Android (because of [this](https://github.com/expo/expo/pull/32162)). No interaction with the notification is needed. On iOS, notification is not presented, but can be presented if `Notifications.scheduleNotificationAsync` is called inside of the background task. This behavior should be unified across platforms in the future.

3. have the task write something to `AsyncStorage`
4. when the app is launched, read the data from `AsyncStorage`

> [!CAUTION]
> console.log from the task won't be visible in logcat! That's why the test plan uses AsyncStorage.

~I'm not sure at this point that the equivalent works on iOS, need to test it out.~

# TODO

- [ ] need to update the docs too
- [x] test iOS

edit: as it turns out, iOS already supports running tasks from killed state, when using `content-available` flag set to 1. The behavior is not consistent across platforms now (see the test plan) but can be made the same with 1 `if (Platform.OS === "ios")` condition.

# Checklist


- [ ] Documentation is up to date to reflect these changes
- [ ] Conforms with the Documentation Writing Style Guide
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build