### PR TITLE
[dev-client] fix multiple reload when pressing r in terminal

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed mutiple reload when pressing `r` in CLI on react-native old architecture mode. ([#32532](https://github.com/expo/expo/pull/32532) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 5.0.0-preview.6 — 2024-10-31

--- a/packages/expo-dev-client/android/src/androidTest/java/com/expo/modules/devclient/scenarios/DevLauncherBasicScenario.kt
+++ b/packages/expo-dev-client/android/src/androidTest/java/com/expo/modules/devclient/scenarios/DevLauncherBasicScenario.kt
@@ -55,7 +55,7 @@ internal class DevLauncherBasicScenario(
 
     val reactHost = ReactHostWrapper(
       reactNativeHost = reactApplication.reactNativeHost,
-      reactHost = reactApplication.reactHost
+      reactHostProvider = { reactApplication.reactHost }
     )
     DevLauncherController.initialize(appContext, reactHost, launcherClass = launcherClass)
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed mutiple reload when pressing `r` in CLI on react-native old architecture mode. ([#32532](https://github.com/expo/expo/pull/32532) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 5.0.8 — 2024-10-31

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -85,7 +85,7 @@ class DevLauncherController private constructor() :
   override val devClientHost by lazy {
     ReactHostWrapper(
       reactNativeHost = DevLauncherReactNativeHost(context as Application, DEV_LAUNCHER_HOST),
-      reactHost = DevLauncherReactHost.create(context as Application, DEV_LAUNCHER_HOST)
+      reactHostProvider = { DevLauncherReactHost.create(context as Application, DEV_LAUNCHER_HOST) }
     )
   }
 
@@ -435,7 +435,7 @@ class DevLauncherController private constructor() :
 
     @JvmStatic
     fun initialize(reactApplication: ReactApplication, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
-      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, reactApplication.reactHost))
+      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, { reactApplication.reactHost }))
       sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -228,7 +228,9 @@ fun injectDevServerHelper(context: Context, devSupportManager: DevSupportManager
     packagerConnection = devSettings.public_getPackagerConnectionSettings()
   )
   val oldDevServerHelper: DevServerHelper = DevSupportManagerBase::class.java.getProtectedFieldValue(
-    devSupportManager, "mDevServerHelper")
+    devSupportManager,
+    "mDevServerHelper"
+  )
   DevSupportManagerBase::class.java.setProtectedDeclaredField(
     devSupportManager,
     "mDevServerHelper",

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -227,11 +227,15 @@ fun injectDevServerHelper(context: Context, devSupportManager: DevSupportManager
     devSettings = devSettings,
     packagerConnection = devSettings.public_getPackagerConnectionSettings()
   )
+  val oldDevServerHelper: DevServerHelper = DevSupportManagerBase::class.java.getProtectedFieldValue(
+    devSupportManager, "mDevServerHelper")
   DevSupportManagerBase::class.java.setProtectedDeclaredField(
     devSupportManager,
     "mDevServerHelper",
     devLauncherDevServerHelper
   )
+  oldDevServerHelper.closePackagerConnection()
+  oldDevServerHelper.closeInspectorConnection()
 }
 
 fun findDevMenuPackage(): ReactPackage? {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -9,6 +9,8 @@ import com.facebook.react.ReactInstanceEventListener
 import com.facebook.react.bridge.ReactContext
 import expo.interfaces.devmenu.ReactHostWrapper
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -68,8 +70,8 @@ abstract class DevLauncherAppLoader(
     }
   }
 
-  open suspend fun launch(intent: Intent): Boolean {
-    return suspendCoroutine { callback ->
+  open suspend fun launch(intent: Intent): Boolean = withContext(Dispatchers.Main) {
+    suspendCoroutine { callback ->
       if (injectBundleLoader()) {
         continuation = callback
         launchIntent(intent)

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -111,7 +111,7 @@ class DevLauncherController private constructor() : DevLauncherControllerInterfa
 
     @JvmStatic
     fun initialize(reactApplication: ReactApplication, additionalPackages: List<*>? = null, launcherClass: Class<*>? = null) {
-      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, reactApplication.reactHost))
+      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, { reactApplication.reactHost }))
     }
 
     @JvmStatic

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
@@ -17,23 +17,15 @@ import java.lang.reflect.Field
  * An abstract wrapper to host [ReactNativeHost] and [ReactHost],
  * so that call-sites do not have to handle the difference between legacy bridge and bridgeless mode.
  */
-class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHost: ReactHost?) {
+class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHostProvider: () -> ReactHost?) {
   lateinit var reactNativeHost: ReactNativeHost
   lateinit var reactHost: ReactHost
 
   init {
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      this.reactHost = requireNotNull(reactHost)
+      this.reactHost = requireNotNull(reactHostProvider())
     } else {
       this.reactNativeHost = reactNativeHost
-    }
-  }
-
-  override fun hashCode(): Int {
-    return if (isBridgelessMode) {
-      reactHost.hashCode()
-    } else {
-      reactNativeHost.hashCode()
     }
   }
 
@@ -122,5 +114,25 @@ class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHost: ReactHost?) 
     } else {
       reactNativeHost.clear()
     }
+  }
+
+  override fun hashCode(): Int {
+    return if (isBridgelessMode) {
+      reactHost.hashCode()
+    } else {
+      reactNativeHost.hashCode()
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as ReactHostWrapper
+
+    if (reactNativeHost != other.reactNativeHost) return false
+    if (reactHost != other.reactHost) return false
+
+    return true
   }
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed mutiple reload when pressing `r` in CLI on react-native old architecture mode. ([#32532](https://github.com/expo/expo/pull/32532) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Remove unused `graphql` dependencies. ([#32065](https://github.com/expo/expo/pull/32065) by [@kitten](https://github.com/kitten))

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -93,7 +93,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
     if (!this::devMenuHost.isInitialized) {
       devMenuHost = ReactHostWrapper(
         reactNativeHost = DevMenuReactNativeHost(application, useDeveloperSupport),
-        reactHost = DevMenuReactHost.create(application, useDeveloperSupport)
+        reactHostProvider = { DevMenuReactHost.create(application, useDeveloperSupport) }
       )
       UiThreadUtil.runOnUiThread {
         devMenuHost.start()

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -19,7 +19,7 @@ abstract class DevMenuAwareReactActivity : ReactActivity() {
       DevMenuManager.initializeWithReactHost(
         ReactHostWrapper(
           reactNativeHost = reactNativeHost,
-          reactHost = (applicationContext as ReactApplication).reactHost
+          reactHostProvider = { (applicationContext as ReactApplication).reactHost }
         )
       )
     } else {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
@@ -38,7 +38,7 @@ class DevMenuPackage : Package, ReactPackage {
             DevMenuManager.initializeWithReactHost(
               ReactHostWrapper(
                 reactNativeHost = (activity.application as ReactApplication).reactNativeHost,
-                reactHost = (activity.application as ReactApplication).reactHost
+                reactHostProvider = { (activity.application as ReactApplication).reactHost }
               )
             )
           } else {


### PR DESCRIPTION
# Why

on android old architecture mode with dev-client installed, when pressing `r`, it shows 3~4 concurrent reloads:

![Screenshot 2024-11-01 at 10 48 16 PM](https://github.com/user-attachments/assets/711ca72b-2c33-42fe-9c9b-ee6fb722796f)

# How

there are a few root causes:
1. `BridgelessDevSupportManager` has being created, right after `appContext.reactHost` being called. this pr tries to update `ReactHostWrapper.reactHost` as a lazy functional provider. that would prevent `appContext.reactHost` being executed on old architecture mode.
2. race condition for DevSupportManager being created from main thread and worker thread. this pr tries to move the dev-launcher's react instance creation to main thread. that would prevent multiple DevSupportManager being created.
3. after inject the `DevLauncherDevServerHelper`, we have to close the old DevServerHelper's connection.

# Test Plan

- [x] reload on new arch mode
- [x] reload on old arch mode

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
