### PR TITLE
Fix static module view name in template

### DIFF
--- a/packages/expo-module-template-local/index.ts
+++ b/packages/expo-module-template-local/index.ts
@@ -1,5 +1,5 @@
-// Reexport the native module. On web, it will be resolved to MyModule.web.ts
-// and on native platforms to MyModule.ts
+// Reexport the native module. On web, it will be resolved to <%- project.moduleName %>.web.ts
+// and on native platforms to <%- project.moduleName %>.ts
 export { default } from './src/<%- project.moduleName %>';
 export { default as <%- project.viewName %> } from './src/<%- project.viewName %>';
 export * from  './src/<%- project.name %>.types';

--- a/packages/expo-module-template-local/ios/{%- project.moduleName %}.swift
+++ b/packages/expo-module-template-local/ios/{%- project.moduleName %}.swift
@@ -36,7 +36,7 @@ public class <%- project.moduleName %>: Module {
     // view definition: Prop, Events.
     View(<%- project.viewName %>.self) {
       // Defines a setter for the `url` prop.
-      Prop("url") { (view: MyModuleView, url: URL) in
+      Prop("url") { (view: <%- project.viewName %>, url: URL) in
         if view.webView.url != url {
           view.webView.load(URLRequest(url: url))
         }

--- a/packages/expo-module-template/ios/{%- project.moduleName %}.swift
+++ b/packages/expo-module-template/ios/{%- project.moduleName %}.swift
@@ -36,7 +36,7 @@ public class <%- project.moduleName %>: Module {
     // view definition: Prop, Events.
     View(<%- project.viewName %>.self) {
       // Defines a setter for the `url` prop.
-      Prop("url") { (view: MyModuleView, url: URL) in
+      Prop("url") { (view: <%- project.viewName %>, url: URL) in
         if view.webView.url != url {
           view.webView.load(URLRequest(url: url))
         }

--- a/packages/expo-module-template/src/index.ts
+++ b/packages/expo-module-template/src/index.ts
@@ -1,5 +1,5 @@
-// Reexport the native module. On web, it will be resolved to MyModule.web.ts
-// and on native platforms to MyModule.ts
+// Reexport the native module. On web, it will be resolved to <%- project.moduleName %>.web.ts
+// and on native platforms to <%- project.moduleName %>.ts
 export { default } from './<%- project.moduleName %>';
 export { default as <%- project.viewName %> } from './<%- project.viewName %>';
 export * from  './<%- project.name %>.types';


### PR DESCRIPTION
# Why
Fixes a mistake I made updating the template.

Also fixes [expo-module-template-local].

Closes https://linear.app/expo/issue/ENG-14013/create-expo-module-local-regex-misses-a-spot.



# How

One of module view names was not templated correctly. I didn't pick it up since I always used default names when verifying the code compiles and works.

# Test Plan

Verified this now generates correctly and the default name is not used anywhere else in the template.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
