### PR TITLE
Fix incorrect width/height reported with EXIF tags 5 and 7

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix incorrect width/height reported with EXIF tags 5 and 7 ([#32534](https://github.com/expo/expo/pull/32534) by [@gaearon](https://github.com/gaearon))
+
 ### 💡 Others
 
 ## 16.0.0 — 2024-10-22

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
@@ -16,7 +16,12 @@ class RawImageExporter : ImageExporter {
     copyFile(source, output, contentResolver)
     val exifInterface = ExifInterface(output.absolutePath)
     val imageRotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0)
-    val isRotatedLandscape = (imageRotation == ExifInterface.ORIENTATION_ROTATE_90 || imageRotation == ExifInterface.ORIENTATION_ROTATE_270)
+    val isRotatedLandscape = (
+      imageRotation == ExifInterface.ORIENTATION_ROTATE_90 ||
+      imageRotation == ExifInterface.ORIENTATION_ROTATE_270
+      imageRotation == ExifInterface.ORIENTATION_TRANSPOSE ||
+      imageRotation == ExifInterface.ORIENTATION_TRANSVERSE
+    )
     val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
 
     BitmapFactory.decodeFile(output.absolutePath, options)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
@@ -18,10 +18,10 @@ class RawImageExporter : ImageExporter {
     val imageRotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0)
     val isRotatedLandscape = (
       imageRotation == ExifInterface.ORIENTATION_ROTATE_90 ||
-      imageRotation == ExifInterface.ORIENTATION_ROTATE_270 ||
-      imageRotation == ExifInterface.ORIENTATION_TRANSPOSE ||
-      imageRotation == ExifInterface.ORIENTATION_TRANSVERSE
-    )
+        imageRotation == ExifInterface.ORIENTATION_ROTATE_270 ||
+        imageRotation == ExifInterface.ORIENTATION_TRANSPOSE ||
+        imageRotation == ExifInterface.ORIENTATION_TRANSVERSE
+      )
     val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
 
     BitmapFactory.decodeFile(output.absolutePath, options)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
@@ -18,7 +18,7 @@ class RawImageExporter : ImageExporter {
     val imageRotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0)
     val isRotatedLandscape = (
       imageRotation == ExifInterface.ORIENTATION_ROTATE_90 ||
-      imageRotation == ExifInterface.ORIENTATION_ROTATE_270
+      imageRotation == ExifInterface.ORIENTATION_ROTATE_270 ||
       imageRotation == ExifInterface.ORIENTATION_TRANSPOSE ||
       imageRotation == ExifInterface.ORIENTATION_TRANSVERSE
     )


### PR DESCRIPTION
# Why

Fixes `width` and `height` calculation for `5` and `7` EXIF tags. You can use examples from https://github.com/recurser/exif-orientation-examples to verify.

# How

According to https://exiftool.org/TagNames/EXIF.html, tags `5` and `7` are also rotated, just like `6` and `8` (but also mirrored). So they should be taken into account. Here's similar code in React Native which handles these:

https://github.com/facebook/react-native/blob/e5dd7d68bf264669fc5c4ce5e69b24249d28558b/packages/react-native/Libraries/Image/RCTImageLoader.mm#L1030-L1031

# Test Plan

Patched this code into Bluesky. 

Above: after
Below: before

<img width="350" alt="Screenshot 2024-11-01 at 15 24 00" src="https://github.com/user-attachments/assets/a82cc4aa-7c89-4a7d-8777-7aaa466cf7f4">

Verified all examples from https://github.com/recurser/exif-orientation-examples (both portrait and landscape) work after the changes: https://bsky.app/profile/dansshadow.bsky.social/post/3l7vi74udg22c

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
