### PR TITLE
[docs] Fix code snippet in Expo tutorial configuration chapter

### DIFF
--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-In this chapter, we'll address some app details before deploying our app to an app store, such as theming the statusbar, add a splash screen, and customizing the app icon.
+In this chapter, we'll address some app details before deploying our app to an app store, such as theming the status bar, add a splash screen, and customizing the app icon.
 
 <VideoBoxLink
   videoId="OgGCYdElcZo"
@@ -51,24 +51,6 @@ export default function RootLayout() {
     <Stack>
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
     </Stack>
-  );
-}
-
-// ...rest of the import statements remain same
-import { StatusBar } from 'expo-status-bar';
-
-export default function Index() {
-  // ...rest of the code remains same
-
-  return (
-    <>
-      <GestureHandlerRootView style={styles.container}>
-        {/* ...rest of the code remains same */}
-      </GestureHandlerRootView>
-      /* @tutinfo Mount the <CODE>StatusBar</CODE> component and set the <CODE>style</CODE> prop to <CODE>light</CODE>. */
-      <StatusBar style="light" />
-      /* @end */
-    </>
   );
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on [feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1730414556004899), the code block wasn't removed.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the old code block under step 1 and fix a typo.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-01 at 22 39 59@2x](https://github.com/user-attachments/assets/f66cbb45-4125-4c84-91d0-8af1ed092dea)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
