### PR TITLE
[expo-go] Account for snack when setting query params

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -216,6 +216,9 @@ class ExponentManifest @Inject constructor(
     const val QUERY_PARAM_KEY_EXPO_UPDATES_RUNTIME_VERSION = "runtime-version"
     const val QUERY_PARAM_KEY_EXPO_UPDATES_CHANNEL_NAME = "channel-name"
 
+    // snack
+    const val QUERY_PARAM_KEY_SNACK_CHANNEL = "snack-channel"
+
     private const val MAX_BITMAP_SIZE = 192
     private const val REDIRECT_SNIPPET = "exp.host/--/to-exp/"
     private const val ANONYMOUS_SCOPE_KEY_PREFIX = "@anonymous/"

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -375,10 +375,16 @@ abstract class ReactNativeActivity :
       )
     )
 
+    val mainModuleName = if (delegate.isDebugModeEnabled) {
+      manifest?.getMainModuleName()
+    } else {
+      null
+    }
+
     val nativeHost = ExpoGoReactNativeHost(
       application,
       instanceManagerBuilderProperties,
-      manifest!!.getMainModuleName()
+      mainModuleName
     )
 
     val devBundleDownloadListener = ExponentDevBundleDownloadListener(progressListener)
@@ -388,8 +394,7 @@ abstract class ReactNativeActivity :
 
     if (delegate.isDebugModeEnabled) {
       val debuggerHost = manifest!!.getDebuggerHost()
-      val mainModuleName = manifest!!.getMainModuleName()
-      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName)
+      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName!!)
       DefaultDevLoadingViewImplementation.setDevLoadingEnabled(true)
     } else {
       waitForReactAndFinishLoading()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -621,7 +621,9 @@ class Kernel : KernelInterface() {
         object : AppLoaderCallback {
           override fun onOptimisticManifest(optimisticManifest: Manifest) {
             kernelScope.launch {
-              sendOptimisticManifestToExperienceActivity(optimisticManifest)
+              sendOptimisticManifestToExperienceActivity(
+                optimisticManifest
+              )
             }
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -526,7 +526,7 @@ class Kernel : KernelInterface() {
       )
     }
 
-    // transfer the expo-updates query params: runtime-version, channel-name )
+    // transfer the expo-updates query params: runtime-version, channel-name
     val expoUpdatesQueryParameters = listOf(
       ExponentManifest.QUERY_PARAM_KEY_EXPO_UPDATES_RUNTIME_VERSION,
       ExponentManifest.QUERY_PARAM_KEY_EXPO_UPDATES_CHANNEL_NAME
@@ -620,12 +620,13 @@ class Kernel : KernelInterface() {
         manifestUrl,
         object : AppLoaderCallback {
           override fun onOptimisticManifest(optimisticManifest: Manifest) {
-            Exponent.instance
-              .runOnUiThread { sendOptimisticManifestToExperienceActivity(optimisticManifest) }
+            kernelScope.launch {
+              sendOptimisticManifestToExperienceActivity(optimisticManifest)
+            }
           }
 
           override fun onManifestCompleted(manifest: Manifest) {
-            Exponent.instance.runOnUiThread {
+            kernelScope.launch {
               try {
                 openManifestUrlStep2(manifestUrl, manifest, finalExistingTask)
               } catch (e: JSONException) {
@@ -635,7 +636,11 @@ class Kernel : KernelInterface() {
           }
 
           override fun onBundleCompleted(localBundlePath: String) {
-            Exponent.instance.runOnUiThread { sendBundleToExperienceActivity(localBundlePath) }
+            kernelScope.launch {
+              sendBundleToExperienceActivity(
+                localBundlePath
+              )
+            }
           }
 
           override fun emitEvent(params: JSONObject) {
@@ -653,7 +658,7 @@ class Kernel : KernelInterface() {
           }
 
           override fun onError(e: Exception) {
-            Exponent.instance.runOnUiThread { handleError(e) }
+            kernelScope.launch { handleError(e) }
           }
         },
         forceCache

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -15,7 +15,6 @@ import com.facebook.common.internal.ByteStreams
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.imagepipeline.backends.okhttp3.OkHttpImagePipelineConfigFactory
 import com.facebook.imagepipeline.producers.HttpUrlConnectionNetworkFetcher
-import com.facebook.react.ReactInstanceManagerBuilder
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.raizlabs.android.dbflow.config.DatabaseConfig
 import com.raizlabs.android.dbflow.config.FlowConfig
@@ -367,7 +366,7 @@ class Exponent private constructor(val context: Context, val application: Applic
 
     @JvmStatic fun enableDeveloperSupport(
       debuggerHost: String,
-      mainModuleName: String,
+      mainModuleName: String
     ) {
       if (debuggerHost.isEmpty() || mainModuleName.isEmpty()) {
         return

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -368,7 +368,6 @@ class Exponent private constructor(val context: Context, val application: Applic
     @JvmStatic fun enableDeveloperSupport(
       debuggerHost: String,
       mainModuleName: String,
-      builder: ReactInstanceManagerBuilder? = null
     ) {
       if (debuggerHost.isEmpty() || mainModuleName.isEmpty()) {
         return
@@ -383,11 +382,6 @@ class Exponent private constructor(val context: Context, val application: Applic
         AndroidInfoHelpers.EMULATOR_LOCALHOST = debuggerHostHostname
         AndroidInfoHelpers.setDevServerPort(debuggerHostPort)
         AndroidInfoHelpers.setInspectorProxyPort(debuggerHostPort)
-
-        builder?.let {
-          it.setUseDeveloperSupport(true)
-          it.setJSMainModulePath(mainModuleName)
-        }
       } catch (e: IllegalAccessException) {
         e.printStackTrace()
       } catch (e: NoSuchFieldException) {

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.kt
@@ -37,7 +37,7 @@ class ExponentIntentModule(
   }
 
   override fun openURL(url: String?, promise: Promise) {
-    if (url == null || url.isEmpty()) {
+    if (url.isNullOrEmpty()) {
       promise.reject(JSApplicationIllegalArgumentException("Invalid URL: $url"))
       return
     }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -91,7 +91,7 @@ abstract class Manifest(protected val json: JSONObject) {
   abstract fun getSlug(): String?
 
   fun getDebuggerHost(): String = getExpoGoConfigRootObject()!!.require("debuggerHost")
-  fun getMainModuleName(): String = getExpoGoConfigRootObject()!!.require("mainModuleName")
+  fun getMainModuleName(): String = getExpoGoConfigRootObject()?.require("mainModuleName") ?: "main"
   fun getHostUri(): String? = getExpoClientConfigRootObject()?.getNullable("hostUri")
 
   fun isVerified(): Boolean = json.getNullable("isVerified") ?: false


### PR DESCRIPTION
# Why
When we receive a URL from a deep link, we strip the query parameters and only add back the ones relevant to expo updates. This causes the parameter necessary for snack to be lost.

# How
Check if the URL contains `snack-channel` and append it at the end. I've also made `getMainModuleName` nullable and provided a default of `main`. This makes the behaviour consistent with ios

# Test Plan
Expo go, the URL is parsed correctly