### PR TITLE
[docs] Update modification date and add info about SDK 52 & SDK 51, improve tag example

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: July 31st, 2024
+modificationDate: October 31st, 2024
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -19,11 +19,13 @@ Linux runners are hosted in Google Cloud Platform. macOS runners are hosted in o
 
 Images for each platform have one specific version of Node.js, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json). If there is no dedicated configuration option you are looking for, you can use [npm hooks](/build-reference/npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Consider that those customizations are applied during the build and will increase your build times.
 
-When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, `sdk-50` or `sdk-49`.
+When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, or for a particular SDK such as `sdk-52`.
 
 - The use of a specific name guarantees a consistent environment with only minor updates.
 - When using the `auto` alias, the build image will be selected based on the project configuration, Expo SDK version, and React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
 - The `latest` alias will be assigned to the image with the most up-to-date versions of the software.
+- The `sdk-52` alias will be assigned to the image best suited for SDK 52 builds.
+- The `sdk-51` alias will be assigned to the image best suited for SDK 51 builds.
 - The `sdk-50` alias will be assigned to the image best suited for SDK 50 builds.
 - The `sdk-49` alias will be assigned to the image best suited for SDK 49 builds.
 - SDK aliases will be updated with every new SDK release.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found that modification date wasn't up to date for this page after new image info was added in https://github.com/expo/expo/pull/32503.

Also, the example and usage of tag was outdated since it didn't mentioned SDK 51.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the modification date to reflect the changes from https://github.com/expo/expo/pull/32503
- Update the selecting an image verbiage for SDK to specify it as an example (so that we don't have to do update it every time).
- Add tag usage verbiage for SDK 52 and SDK 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-01 at 23 11 32](https://github.com/user-attachments/assets/3ada1d48-e7cd-4321-86b8-8b792dcc7114)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
