### PR TITLE
[cli] Wrap telemetry flush in try/catch so it doesn't crash an upgrade from a previous SDK

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Wrap telemetry flush in error handling. ([#32543](https://github.com/expo/expo/pull/32543) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 0.18.30 — 2024-09-30

--- a/packages/@expo/cli/src/utils/telemetry/DetachedClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/DetachedClient.ts
@@ -33,27 +33,33 @@ export class DetachedClient implements TelemetryClient {
   }
 
   async flush() {
-    if (!this.records.length) {
-      return debug('No records to flush, skipping...');
+    try {
+      if (!this.records.length) {
+        return debug('No records to flush, skipping...');
+      }
+
+      const file = tempy.file({ name: 'expo-telemetry.json' });
+      const data: DetachedTelemetry = { actor: this.actor, records: this.records };
+
+      this.records = [];
+
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
+      await fs.promises.writeFile(file, JSON.stringify(data));
+
+      const child = spawn(process.execPath, [require.resolve('./flushDetached'), file], {
+        detached: true,
+        windowsHide: true,
+        shell: false,
+        stdio: 'ignore',
+      });
+
+      child.unref();
+
+      debug('Detached flush started');
+    } catch (error) {
+      // This could fail if any direct or indirect import used by this code changes during an upgrade to the `expo` dependency via `npx expo install --fix`,
+      // since this file may no longer be present after the upgrade, but before the process under the old Expo CLI version is terminated.
+      debug('Exception while initiating detached flush:', error);
     }
-
-    const file = tempy.file({ name: 'expo-telemetry.json' });
-    const data: DetachedTelemetry = { actor: this.actor, records: this.records };
-
-    this.records = [];
-
-    await fs.promises.mkdir(path.dirname(file), { recursive: true });
-    await fs.promises.writeFile(file, JSON.stringify(data));
-
-    const child = spawn(process.execPath, [require.resolve('./flushDetached'), file], {
-      detached: true,
-      windowsHide: true,
-      shell: false,
-      stdio: 'ignore',
-    });
-
-    child.unref();
-
-    debug('Detached flush started');
   }
 }

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/DetachedClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/DetachedClient.test.ts
@@ -69,6 +69,21 @@ it('flushes in detached process', async () => {
   );
 });
 
+it("doesn't throw when the spawn fails with an exception", async () => {
+  // Mock the `spawn` method
+  jest.mocked(spawn).mockImplementation(() => {
+    throw new Error('Failed to spawn');
+  });
+  vol.fromJSON({});
+
+  // Create a client, record an event, and flush it
+  const client = new DetachedClient();
+  await client.record({ event: 'Start Project' });
+
+  await expect(client.flush()).resolves.not.toThrow();
+  expect(spawn).toThrow();
+});
+
 it('skips flushing when no events are recorded', async () => {
   const client = new DetachedClient();
   await client.flush();


### PR DESCRIPTION
# Why

When upgrading via `npx expo install expo@next --fix`, almost nothing runs after Expo upgrades itself... except for the detached telemetry flush. Unfortunately, #32490 didn't completely solve the problem, as projects using Yarn tended to error out on the reference to `tempy`, which was removed for SDK 52, rather than the reference to `./flushDetached` (which tends to fail NPM projects). So, [tempy has also returned](https://github.com/expo/expo/commit/ebad0e0e71aa0a9f81f1f8645d85170bbc1ee7be).

This change backports a try/catch around the entirety of `flush` to prevent it from crashing after an `expo` upgrade if any of the underlying imports have been changed since the last version. So, at least if someone is on the latest SDK 51, they wouldn't experience this crash on upgrade to SDK 52, even if `tempy` or `./flushDetached` was no longer there, allowing us to remove these fully in a future release without affecting so many users.

This would also be cherry-picked to SDK 50.

# How
Wrapped all of `flush` in a try/catch.

# Test Plan

- [x] test an upgade

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
