### PR TITLE
[docs] Add w-full to VideoBoxLink component image class to take full width

### DIFF
--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -35,7 +35,7 @@ export function VideoBoxLink({ title, description, videoId, className }: VideoBo
             backgroundImage: `url(https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg)`,
           }}
           className={mergeClasses(
-            'aspect-video bg-cover bg-center h-[112px]',
+            'aspect-video bg-cover bg-center w-full h-[112px]',
             'max-sm-gutters:h-[200px]'
           )}
         />


### PR DESCRIPTION
# Why

Thumbnail is not taking the entire space on mobile devices. This happens on iPhone 16 Pro Max screens.

<img width="723" alt="image" src="https://github.com/user-attachments/assets/86b59d47-76ab-427d-bff5-39594f30a418">

# How

Update image class to take full width

# Test Plan

Ran docs locally and validate that image looks good in web and mobile.

<img width="724" alt="image" src="https://github.com/user-attachments/assets/b0948bc1-e5c6-455f-921a-8ebb07a12390">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
