### PR TITLE
[docs] Add tutorial to reflect adding styles.container.backgroundColor property to <View>

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -144,7 +144,7 @@ import { Text, View, /* @tutinfo Import <CODE>StyleSheet</CODE> to define styles
 
 export default function Index() {
   return (
-    <View style={styles.container}>
+    <View /* @tutinfo Add styles.container.backgroundColor property to <View> */ style={styles.container}/* @end */>
       /* @tutinfo This used to say "Edit app/index.tsx to edit this screen". Now it says, "Home screen". */
       <Text style={styles.text}>Home screen</Text>
       /* @end */


### PR DESCRIPTION
Added tutorial to reflect adding styles.container.backgroundColor property to "View"

# Why

The current documentation doesn't accurately reflect all code changes that should be highlighted during the tutorial. Specifically, the addition of styles.container.backgroundColor property to the <View> component is not marked as a highlighted change, which could confuse new developers following the tutorial.

# How

Updated the tutorial documentation to properly highlight the backgroundColor property addition in the code example. This ensures consistency between the documentation and the actual development experience.

# Test Plan

1. Follow the tutorial steps here (https://docs.expo.dev/tutorial/create-your-first-app/)
2. Verify that the backgroundColor property is now properly highlighted in the documentation
3. Compare with the actual development experience to confirm accuracy

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
