### PR TITLE
[docs] Update required sizes for app store screenshots

### DIFF
--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -104,7 +104,7 @@ For the iOS App Store, you can upload screenshots (images) and previews (videos)
 
 ### Screenshots
 
-At a minimum, Apple requires you to upload screenshots for the iPhone with the dynamic island (6.9 inch). You can optionally upload additional screenshots for the other screen sizes. By default, Apple will use scaled down screenshots from the closest uploaded size.
+At a minimum, Apple requires you to upload screenshots for iPhone with the dynamic island (6.9 inch). You can optionally upload additional screenshots for other screen sizes. If specific screenshots are not provided, scaled down screenshots from the closest uploaded size will be used instead.
 
 If your app runs on iPad, you must also provide one set of iPad screenshots (12.9 inch).
 

--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -104,9 +104,11 @@ For the iOS App Store, you can upload screenshots (images) and previews (videos)
 
 ### Screenshots
 
-At a minimum, Apple requires you to upload two screenshots for an iPhone without the notch and two screenshots for an iPhone with the notch. You can upload up to ten screenshots per localization. If your app is available in multiple languages and your screenshots include text, you should upload screenshots with the appropriate language for each localization.
+At a minimum, Apple requires you to upload screenshots for the iPhone with the dynamic island (6.9 inch). You can optionally upload additional screenshots for the other screen sizes. By default, Apple will use scaled down screenshots from the closest uploaded size.
 
-If your app runs on an iPad, you must also provide iPad-sized screenshots.
+If your app runs on iPad, you must also provide one set of iPad screenshots (12.9 inch).
+
+You can upload up to ten screenshots per localization. If your app is available in multiple languages and your screenshots include text, you should upload screenshots with the appropriate language for each localization.
 
 Screenshots can be portrait or landscape.
 
@@ -130,15 +132,14 @@ Below is the bare minimum needed to publish your apps.
 
 ### App Store - iPhone
 
-| Type                                   | Amount | Dimensions                                  | Requirements          |
-| -------------------------------------- | ------ | ------------------------------------------- | --------------------- |
-| Screenshots (iPhone without the notch) | 2-10   | 1242 × 2208                                 | JPG or PNG (no alpha) |
-| Screenshots (iPhone with the notch)    | 2-10   | 1290 × 2796<br/>1284 × 2778<br/>1242 × 2688 | JPG or PNG (no alpha) |
+| Type                                         | Amount | Dimensions (coose one)         | Requirements          |
+| -------------------------------------------- | ------ | ------------------------------ | --------------------- |
+| Screenshots (iPhone with the dynamic island) | 2-10   | 1320 × 2868<br/>1290 × 2796    | JPG or PNG (no alpha) |
 
 ### App Store - iPad
 
 If your app also runs on an iPad, you need to supply additional screenshots.
 
-| Type        | Amount | Dimensions  | Requirements          |
-| ----------- | ------ | ----------- | --------------------- |
-| Screenshots | 2-10   | 2048 × 2732 | JPG or PNG (no alpha) |
+| Type        | Amount | Dimensions (choose one)     | Requirements          |
+| ----------- | ------ | --------------------------- | --------------------- |
+| Screenshots | 2-10   | 2064 × 2752<br/>2048 × 2732 | JPG or PNG (no alpha) |

--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -132,9 +132,9 @@ Below is the bare minimum needed to publish your apps.
 
 ### App Store - iPhone
 
-| Type                                         | Amount | Dimensions (coose one)         | Requirements          |
-| -------------------------------------------- | ------ | ------------------------------ | --------------------- |
-| Screenshots (iPhone with the dynamic island) | 2-10   | 1320 × 2868<br/>1290 × 2796    | JPG or PNG (no alpha) |
+| Type                                         | Amount | Dimensions (coose one)      | Requirements          |
+| -------------------------------------------- | ------ | --------------------------- | --------------------- |
+| Screenshots (iPhone with the dynamic island) | 2-10   | 1320 × 2868<br/>1290 × 2796 | JPG or PNG (no alpha) |
 
 ### App Store - iPad
 

--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -106,7 +106,7 @@ For the iOS App Store, you can upload screenshots (images) and previews (videos)
 
 At a minimum, Apple requires you to upload screenshots for iPhone with the dynamic island (6.9 inch). You can optionally upload additional screenshots for other screen sizes. If specific screenshots are not provided, scaled down screenshots from the closest uploaded size will be used instead.
 
-If your app runs on iPad, you must also provide one set of iPad screenshots (12.9 inch).
+If your app runs on iPad, you must also provide one set of iPad screenshots (13 inch).
 
 You can upload up to ten screenshots per localization. If your app is available in multiple languages and your screenshots include text, you should upload screenshots with the appropriate language for each localization.
 


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/32364

With the latest release, Apple have updated the app store screenshots requirements:

- the 5'5 screenshots (iPhone without a notch) are no longer required
- must upload screenshots for the iPhone with the dynamic island
- an additional size option has been added to the iPad screenshots

# How

Updated the docs to reflect the change. The Figma template is also updated.

# Test Plan

Review against the updated [requirements](https://developer.apple.com/help/app-store-connect/reference/app-preview-specifications/).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
