### PR TITLE
[docs] Update Manual instructions under install Expo modules in an existing React Native project

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -75,7 +75,7 @@ The last step is to install the project's CocoaPods again to pull in Expo module
 
 ### Configure Expo CLI for bundling on Android and iOS
 
-We recommend using Expo CLI to bundle your app JavaScript code and assets. This adds support for using the `"main"` field in **package.json** supports [Expo Router](/router/introduction/). Not using Expo CLI for bundling may result in unexpected behavior. [Learn more about Expo CLI](/bare/using-expo-cli/).
+We recommend using Expo CLI to bundle your app JavaScript code and assets. This adds support for using the `"main"` field in **package.json** to use [Expo Router](/router/introduction/) library. Not using Expo CLI for bundling may result in unexpected behavior. [Learn more about Expo CLI](/bare/using-expo-cli/).
 
 <Collapsible summary="Extend expo/metro-config in your metro.config.js">
   <DiffBlock source="/static/diffs/metro-config.diff" />

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.74.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.76.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 
@@ -54,7 +54,12 @@ Once installation is complete, apply the changes from the following diffs to con
 
 Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L28-L55).
 
-Save all of your changes. In Xcode, update the iOS Deployment Target under `Target → Build Settings → Deployment` to `iOS 13.4`. The last step is to install the project's CocoaPods again to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the `Podfile`:
+Save all of your changes and update your iOS Deployment Target in Xcode to `iOS 15.1`:
+
+- Open **your-project-name.xcworkspace** in Xcode, select your project in the left sidebar.
+- Select **Targets** > **your-project-name** > **Build Settings** > **iOS Deployment Target** and set it to `iOS 15.1`.
+
+The last step is to install the project's CocoaPods again to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the **Podfile**:
 
 <InstallSection
   packageName="expo"
@@ -82,9 +87,9 @@ We recommend using Expo CLI to bundle your app JavaScript code and assets. This 
 
 <Collapsible summary="Configure iOS project to bundle with Expo CLI">
 
-Replace the shell script in the "Bundle React Native code and images" phase under the "Build Phases" tab for your target in Xcode with the following:
+Replace the shell script under **Build Phases** > **Bundle React Native code and images** in Xcode with the following:
 
-```sh
+```sh /bin/sh
 if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
   source "$PODS_ROOT/../.xcode.env"
 fi
@@ -117,7 +122,7 @@ fi
 
 And add support the `"main"` field in **package.json** by making the following change to **AppDelegate.mm**:
 
-```diff
+```diff AppDelegate.mm
  - (NSURL *)getBundleURL
  {
  #if DEBUG

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -5,10 +5,10 @@ index cb23b47..13beb08 100644
 @@ -1,4 +1,5 @@
  package com.myapp
 +import expo.modules.ReactActivityDelegateWrapper
-
  import com.facebook.react.ReactActivity
  import com.facebook.react.ReactActivityDelegate
-@@ -18,5 +19,5 @@ class MainActivity : ReactActivity() {
+ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+@@ -18,5 +18,5 @@ class MainActivity : ReactActivity() {
     * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
     */
    override fun createReactActivityDelegate(): ReactActivityDelegate =
@@ -19,24 +19,35 @@ diff --git a/android/app/src/main/java/com/myapp/MainApplication.kt b/android/ap
 index 9fdd6df..2a521ff 100644
 --- a/android/app/src/main/java/com/myapp/MainApplication.kt
 +++ b/android/app/src/main/java/com/myapp/MainApplication.kt
-@@ -1,4 +1,7 @@
+@@ -1,5 +1,8 @@
  package com.myapp
 +import android.content.res.Configuration
 +import expo.modules.ApplicationLifecycleDispatcher
 +import expo.modules.ReactNativeHostWrapper
-
  import android.app.Application
  import com.facebook.react.PackageList
-@@ -14,7 +17,7 @@ import com.facebook.soloader.SoLoader
+ import com.facebook.react.ReactApplication
+@@ -15,12 +18,13 @@ import com.facebook.soloader.SoLoader
  class MainApplication : Application(), ReactApplication {
 
    override val reactNativeHost: ReactNativeHost =
 -      object : DefaultReactNativeHost(this) {
+-        override fun getPackages(): List<ReactPackage> =
+-            PackageList(this).packages.apply {
+-              // Packages that cannot be autolinked yet can be added manually here, for example:
+-              // add(MyReactNativePackage())
+-            }
 +      ReactNativeHostWrapper(this, object : DefaultReactNativeHost(this) {
-         override fun getPackages(): List<ReactPackage> =
-             PackageList(this).packages.apply {
-               // Packages that cannot be autolinked yet can be added manually here, for example:
-@@ -27,10 +30,10 @@ class MainApplication : Application(), ReactApplication {
++        override fun getPackages(): List<ReactPackage> {
++            val packages = PackageList(this).packages
++            // Packages that cannot be autolinked yet can be added manually here, for example:
++            // packages.add(new MyReactNativePackage());
++            return packages
++        }
+
+         override fun getJSMainModuleName(): String = "index"
+
+@@ -28,10 +32,10 @@ class MainApplication : Application(), ReactApplication {
 
          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
@@ -49,7 +60,7 @@ index 9fdd6df..2a521ff 100644
 
    override fun onCreate() {
      super.onCreate()
-@@ -39,5 +42,11 @@ class MainApplication : Application(), ReactApplication {
+@@ -40,5 +44,10 @@ class MainApplication : Application(), ReactApplication {
        // If you opted-in for the New Architecture, we load the native entry point for this app.
        load()
      }
@@ -65,8 +76,8 @@ diff --git a/android/settings.gradle b/android/settings.gradle
 index dd91c04..6b7789d 100644
 --- a/android/settings.gradle
 +++ b/android/settings.gradle
-@@ -2,3 +2,6 @@ rootProject.name = 'myapp'
- apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+@@ -4,3 +4,6 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autoli
+ rootProject.name = 'myapp'
  include ':app'
  includeBuild('../node_modules/@react-native/gradle-plugin')
 +

--- a/docs/public/static/diffs/expo-cli-android.diff
+++ b/docs/public/static/diffs/expo-cli-android.diff
@@ -2,13 +2,15 @@ diff --git a/android/app/build.gradle b/android/app/build.gradle
 index 01841f5..e1740a6 100644
 --- a/android/app/build.gradle
 +++ b/android/app/build.gradle
-@@ -49,6 +49,11 @@ react {
-     //
+@@ -50,6 +50,11 @@ react {
      //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
      // hermesFlags = ["-O", "-output-source-map"]
-+    //
+
 +    // Bundle with Expo CLI
 +    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", rootDir.getAbsoluteFile().getParentFile().getAbsolutePath(), "android", "absolute"].execute(null, rootDir).text.trim())
 +    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
 +    bundleCommand = "export:embed"
++
+     /* Autolinking */
+     autolinkLibrariesWithApp()
  }

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -20,7 +20,7 @@ index 6bb6b6f..8c3834c 100644
  # Resolve react_native_pods.rb with node to allow for hoisting
  require Pod::Executable.execute_command('node', ['-p',
    'require.resolve(
-@@ -26,6 +27,14 @@ if linkage != nil
+@@ -15,6 +16,14 @@ if linkage != nil
  end
 
  target 'myapp' do


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update Manual instructions under install Expo modules in an existing React Native project for SDK 52.

Fix ENG-13915

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the React Native version mentioned to `0.76`.
- Apply changes to `diff` blocks for Android and iOS configuration under Manual Instructions by creating a new React Native community CLI project. This includes updating static `expo-android.diff`, `expo-cli-android.diff`, and `expo-ios.diff` files.
- Make the iOS Deployment Tagret config instructions to be procedural and also fix Targets setting name
- Add file titles in code blocks under "Configure Expo CLI for bundling on Android and iOS" for iOS

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test if the manual instructions are working, I took the following steps:
- Created a new example project with React Native CLI: `npx @react-native-community/cli@latest init myapp`
- Followed the current instructions from the document version and then updated it accordingly for SDK 52 with bare template: https://github.com/expo/expo/blob/sdk-52/templates/expo-template-bare-minimum
- Copied the patches from the changes in the example project to `expo-android.diff`, `expo-cli-android.diff`, and `expo-ios.diff` files.
- Tested changes by install `expo-constants` to get the system fonts as the example in the current document version mentions

**Android**

![CleanShot 2024-11-03 at 22 27 56@2x](https://github.com/user-attachments/assets/8ed0f9e3-cef9-4a94-9752-8fe4beb62e02)

**iOS**

![CleanShot 2024-11-03 at 23 07 42@2x](https://github.com/user-attachments/assets/5c682c83-67d3-4105-89e2-929f69d4a202)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
