### PR TITLE
[docs] Update `react-native init` to `@react-native-community/cli@latest`

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -26,7 +26,7 @@ To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-nativ
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured.** If you created your project with `npx react-native init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
 
 <Step label="1">
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -17,7 +17,7 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured.** If you created your project with `npx react-native init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
 
 ## Installation
 
@@ -39,7 +39,7 @@ Run `eas update:configure` to set the `updates` URL and `projectId` in **app.jso
 
 <Terminal cmd={['$ eas update:configure']} />
 
-Modify the `expo` section of **app.json**. (If you created your project using `npx react-native init`, you will need to add this section.)
+Modify the `expo` section of **app.json**. (If you created your project using `npx @react-native-community/cli@latest init`, you will need to add the following changes.)
 
 The changes below add the [`updates` URL](/versions/latest/config/app/#url) to the Expo configuration.
 
@@ -72,7 +72,7 @@ The changes below add the [`updates` URL](/versions/latest/config/app/#url) to t
  }
 ```
 
-If you want to set up a [custom expo-updates server](https://github.com/expo/custom-expo-updates-server) instead, add your URL to `updates.url` in **app.json**.
+If you want to set up a [custom `expo-updates` server](https://github.com/expo/custom-expo-updates-server) instead, add your URL to `updates.url` in **app.json**.
 
 ```diff app.json
  {

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { DEMI } from '~/ui/components/Text';
 
-To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package, which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
+To migrate from `npx @react-native-community/cli@latest init` to Expo CLI, you'll need to install the `expo` package, which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
 
 It is strongly recommended to use Expo CLI when using other Expo tools. It is required for many tools, such as EAS Update, Expo Router, and expo-dev-client, and other features may not work as well without it.
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -11,7 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using ad hoc and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
-It's designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx react-native init` to app stores.
+It's designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx @react-native-community/cli@latest init` to app stores.
 
 ### Get started
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -5,7 +5,7 @@ description: Learn how to adopt Expo Prebuild in a project that was bootstrapped
 
 import { Terminal } from '~/ui/components/Snippet';
 
-There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx react-native init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
+There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx @react-native-community/cli@latest init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
 
 Adopting prebuild will automatically add support for developing modules with the [Expo native module API][expo-modules-core] by linking `expo-modules-core` natively. You can also use any command from [Expo CLI][cli] in your project.
 

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -43,8 +43,8 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
   href="/bare/installing-expo-modules"
   description={
     <>
-      Learn more about configuring projects created with <CODE>npx react-native init</CODE> to Expo
-      SDK packages.
+      Learn more about configuring projects created with{' '}
+      <CODE>npx @react-native-community/cli@latest init</CODE> to Expo SDK packages.
     </>
   }
   Icon={BookOpen02Icon}

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -43,8 +43,8 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
   href="/bare/installing-expo-modules"
   description={
     <>
-      Learn more about configuring projects created with <CODE>npx react-native init</CODE> to Expo
-      SDK packages.
+      Learn more about configuring projects created with{' '}
+      <CODE>npx @react-native-community/cli@latest init</CODE> to Expo SDK packages.
     </>
   }
   Icon={BookOpen02Icon}

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -109,7 +109,7 @@ The following three commands result in more or less the same project:
     '',
     '$ npx create-expo-app --template bare-minimum',
     '',
-    '$ npx react-native init MyApp && cd MyApp && npx install-expo-modules',
+    '$ npx @react-native-community/cli@latest init MyApp && cd MyApp && npx install-expo-modules',
   ]}
 />
 

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -41,7 +41,7 @@ To use a library from the Expo SDK, find the one you are looking for in the [API
 
 <ConfigReactNative>
 
-If you initialized your app using `npx react-native init` and you don't have the `expo` package installed in it yet, see the [installing Expo modules guide](/bare/installing-expo-modules) for more information.
+If you initialized your app using `npx @react-native-community/cli@latest init` and you don't have the `expo` package installed in it yet, see the [installing Expo modules guide](/bare/installing-expo-modules) for more information.
 
 </ConfigReactNative>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As per the instructions in React Native docs when using the community CLI: https://reactnative.dev/docs/getting-started-without-a-framework#step-1-creating-a-new-application.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update multiple `npx `react-native init` references to `npx @react-native-community/cli@latest init`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff for all changes. An example preview:

![CleanShot 2024-11-04 at 01 45 26@2x](https://github.com/user-attachments/assets/e7635964-ede3-429b-b7cf-5259ccccc26a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
