### PR TITLE
[docs] add Prettier plugin for formatting Tailwind classes

### DIFF
--- a/docs/.prettierrc
+++ b/docs/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "bracketSameLine": true,
   "trailingComma": "es5",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/docs/.prettierrc
+++ b/docs/.prettierrc
@@ -5,5 +5,6 @@
   "bracketSameLine": true,
   "trailingComma": "es5",
   "arrowParens": "avoid",
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["mergeClasses"]
 }

--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -52,12 +52,12 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
     } = this.props;
 
     return (
-      <div className="w-full h-dvh overflow-hidden mx-auto flex flex-col">
+      <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
         <div className="max-lg-gutters:sticky">{header}</div>
-        <div className="flex mx-auto justify-between items-center w-full h-[calc(100vh-60px)]">
+        <div className="mx-auto flex h-[calc(100vh-60px)] w-full items-center justify-between">
           <div
             className={mergeClasses(
-              'flex flex-col shrink-0 max-w-[280px] h-full overflow-hidden border-r border-r-default',
+              'flex h-full max-w-[280px] shrink-0 flex-col overflow-hidden border-r border-r-default',
               'max-lg-gutters:hidden'
             )}>
             <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
@@ -71,18 +71,18 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
           </div>
           <div
             className={mergeClasses(
-              'w-full h-[calc(100vh-60px)] flex overflow-hidden',
+              'flex h-[calc(100vh-60px)] w-full overflow-hidden',
               'max-lg-gutters:overflow-auto',
               isMobileMenuVisible && 'hidden'
             )}>
             <ScrollContainer ref={this.contentRef} scrollHandler={this.scrollHandler}>
-              <div className="max-w-screen-xl mx-auto">{children}</div>
+              <div className="mx-auto max-w-screen-xl">{children}</div>
             </ScrollContainer>
           </div>
           {!hideTOC && (
             <div
               className={mergeClasses(
-                'flex flex-col shrink-0 max-w-[280px] h-[calc(100dvh-60px)] overflow-hidden border-l border-l-default',
+                'flex h-[calc(100dvh-60px)] max-w-[280px] shrink-0 flex-col overflow-hidden border-l border-l-default',
                 'max-xl-gutters:hidden'
               )}>
               <ScrollContainer ref={this.sidebarRightRef}>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -137,11 +137,11 @@ export default function DocumentationPage({
       </Head>
       <div
         className={mergeClasses(
-          'mx-auto py-10 px-14',
-          'max-lg-gutters:px-4 max-lg-gutters:pt-5 max-lg-gutters:pb-12'
+          'mx-auto px-14 py-10',
+          'max-lg-gutters:px-4 max-lg-gutters:pb-12 max-lg-gutters:pt-5'
         )}>
         {version && version === 'unversioned' && (
-          <Callout type="default" size="sm" className="!inline-flex w-full !mb-5">
+          <Callout type="default" size="sm" className="!mb-5 !inline-flex w-full">
             This is documentation for the next SDK version. For up-to-date documentation, see the{' '}
             <A href={pathname.replace('unversioned', 'latest')}>latest version</A> (
             {versionToText(LATEST_VERSION)}).

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -82,17 +82,17 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     );
 
     return (
-      <nav className="pt-14 pb-12 px-6 w-[280px]" data-sidebar>
+      <nav className="w-[280px] px-6 pb-12 pt-14" data-sidebar>
         <CALLOUT
           weight="medium"
-          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
+          className="absolute z-10 -mt-14 mb-2 flex min-h-[32px] w-[248px] select-none items-center gap-2 bg-default pb-2 pt-4">
           <LayoutAlt03Icon className="icon-sm" /> On this page
           <Button
             theme="quaternary"
             size="xs"
             className={mergeClasses(
               'ml-auto mr-2 px-2 transition-opacity duration-300',
-              !this.state.showScrollTop && 'opacity-0 pointer-events-none'
+              !this.state.showScrollTop && 'pointer-events-none opacity-0'
             )}
             onClick={e => this.handleTopClick(e)}>
             <ArrowCircleUpIcon className="icon-sm text-icon-secondary" />

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -50,7 +50,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
             href={'#' + slug}
             onClick={onClick}
             className={mergeClasses(
-              'flex mb-1.5 truncate items-center justify-between !text-pretty',
+              'mb-1.5 flex items-center justify-between truncate !text-pretty',
               convertToIndentClass(paddingLeft),
               'focus-visible:relative focus-visible:z-10'
             )}>
@@ -59,7 +59,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
                 'w-full !text-secondary hocus:!text-link',
                 isCodeOrFilePath && 'truncate !text-2xs',
                 isActive && '!text-link',
-                isDeprecated && 'opacity-80 line-through'
+                isDeprecated && 'line-through opacity-80'
               )}>
               {displayTitle}
             </TitleElement>

--- a/docs/components/ScrollContainer.tsx
+++ b/docs/components/ScrollContainer.tsx
@@ -28,7 +28,7 @@ export class ScrollContainer extends Component<ScrollContainerProps> {
     return (
       <div
         className={mergeClasses(
-          'size-full overflow-x-hidden overflow-y-auto',
+          'size-full overflow-y-auto overflow-x-hidden',
           this.props.className
         )}
         ref={this.scrollRef}

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="pt-14 pb-12 px-6 w-[280px]"
+    class="w-[280px] px-6 pb-12 pt-14"
     data-sidebar="true"
   >
     <p
-      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10"
+      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute z-10 -mt-14 mb-2 flex min-h-[32px] w-[248px] select-none items-center gap-2 bg-default pb-2 pt-4"
       data-text="true"
     >
       <svg
@@ -32,7 +32,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </svg>
        On this page
       <button
-        class="cursor-pointer inline-flex border border-solid rounded-md font-medium items-center whitespace-nowrap gap-1.5 h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity duration-300 opacity-0 pointer-events-none"
+        class="cursor-pointer inline-flex border border-solid rounded-md font-medium items-center whitespace-nowrap gap-1.5 h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity duration-300 pointer-events-none opacity-0"
         type="button"
       >
         <span
@@ -62,7 +62,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </button>
     </p>
     <a
-      class="flex mb-1.5 truncate items-center justify-between !text-pretty focus-visible:relative focus-visible:z-10"
+      class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
       data-state="closed"
       href="#base-level-heading"
     >
@@ -74,7 +74,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </p>
     </a>
     <a
-      class="flex mb-1.5 truncate items-center justify-between !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+      class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
       data-state="closed"
       href="#level-3-subheading"
     >
@@ -86,7 +86,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </p>
     </a>
     <a
-      class="flex mb-1.5 truncate items-center justify-between !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+      class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
       data-state="closed"
       href="#code-heading-depth-1"
     >

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#code-heading-depth-1"
     >
       <code
-        class="text-default leading-[1.6154] w-full !text-secondary hocus:!text-link truncate !text-2xs"
+        class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -86,7 +86,7 @@ export function Code({ className, children, title }: CodeProps) {
   }
 
   const commonClasses = mergeClasses(
-    wordWrap && '!whitespace-pre-wrap !break-words',
+    wordWrap && '!break-words !whitespace-pre-wrap',
     showExpand && !isExpanded && `!overflow-hidden`
   );
 
@@ -102,7 +102,7 @@ export function Code({ className, children, title }: CodeProps) {
           style={{
             maxHeight: collapseBound,
           }}
-          className={mergeClasses('relative p-4 whitespace-pre', commonClasses)}
+          className={mergeClasses('relative whitespace-pre p-4', commonClasses)}
           {...attributes}>
           <code
             className="text-2xs text-default"
@@ -119,7 +119,7 @@ export function Code({ className, children, title }: CodeProps) {
         maxHeight: collapseBound,
       }}
       className={mergeClasses(
-        'whitespace-pre relative border border-secondary p-4 my-4 bg-subtle rounded-md overflow-x-auto',
+        'relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4',
         preferredTheme === Themes.DARK && 'dark-theme',
         commonClasses,
         '[p+&]:mt-0'
@@ -144,7 +144,7 @@ export const CodeBlock = ({ children, theme, className, inline = false }: CodeBl
   const Element = inline ? 'span' : 'pre';
   return (
     <Element
-      className={mergeClasses('whitespace-pre m-0 px-1 py-1.5', inline && 'inline-flex !p-0')}
+      className={mergeClasses('m-0 whitespace-pre px-1 py-1.5', inline && 'inline-flex !p-0')}
       {...attributes}>
       <CODE
         className={mergeClasses(

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -40,11 +40,11 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
     <div
       className={mergeClasses(
         'grid grid-cols-2 gap-4',
-        connected && 'lg-gutters:gap-0 lg-gutters:mb-4',
+        connected && 'lg-gutters:mb-4 lg-gutters:gap-0',
         connected &&
-          '[&>div:nth-child(odd)>div]:lg-gutters:border-r-0 [&>div:nth-child(odd)>div]:lg-gutters:!rounded-r-none',
+          '[&>div:nth-child(odd)>div]:lg-gutters:!rounded-r-none [&>div:nth-child(odd)>div]:lg-gutters:border-r-0',
         connected && '[&>div:nth-child(even)>div]:lg-gutters:!rounded-l-none',
-        '[&_pre]:border-0 [&_pre]:m-0',
+        '[&_pre]:m-0 [&_pre]:border-0',
         'max-lg-gutters:grid-cols-1'
       )}
       {...rest}>
@@ -53,7 +53,7 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
           <SnippetHeader title={tabNames[index]} Icon={FileCode01Icon}>
             <CopyAction text={cleanCopyValue(codeBlock.props.children.props.children)} />
           </SnippetHeader>
-          <SnippetContent className="p-0 h-full">{codeBlock}</SnippetContent>
+          <SnippetContent className="h-full p-0">{codeBlock}</SnippetContent>
         </Snippet>
       ))}
     </div>

--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -25,7 +25,7 @@ function getInfo(isSupported: IsSupported, { title }: Platform) {
   } else if (typeof isSupported === 'object') {
     return {
       children: (
-        <A className="grid gap-2 grid-cols-[20px_auto]" href={isSupported.pending}>
+        <A className="grid grid-cols-[20px_auto] gap-2" href={isSupported.pending}>
           <StatusWaitingIcon className="icon-md text-icon-info" /> Pending
         </A>
       ),

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#component"
       id="component"
     >
@@ -18,7 +18,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -43,14 +43,14 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !shadow-none"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !shadow-none"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationbutton"
         id="appleauthenticationbutton"
       >
@@ -66,7 +66,7 @@ exports[`APISection expo-apple-authentication 1`] = `
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -225,11 +225,11 @@ button.
 not appear on the screen.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -251,7 +251,7 @@ not appear on the screen.
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="w-full leading-normal text-default last:mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -280,7 +280,7 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4"
         data-text="true"
       >
         <span
@@ -288,7 +288,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 text-tertiary flex flex-row gap-2 items-center font-medium"
+            class="relative decoration-0 scroll-m-6 flex flex-row items-center gap-2 font-medium text-tertiary"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -299,7 +299,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -329,14 +329,14 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#buttonstyle"
             id="buttonstyle"
           >
@@ -352,7 +352,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -377,7 +377,7 @@ for more details.
           </a>
         </h3>
         <div
-          class="text-secondary font-medium text-[14px] mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-3.5"
         >
           Type:
            
@@ -401,14 +401,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#buttontype"
             id="buttontype"
           >
@@ -424,7 +424,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -449,7 +449,7 @@ for more details.
           </a>
         </h3>
         <div
-          class="text-secondary font-medium text-[14px] mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-3.5"
         >
           Type:
            
@@ -473,14 +473,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#cornerradius"
             id="cornerradius"
           >
@@ -496,7 +496,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -521,7 +521,7 @@ for more details.
           </a>
         </h3>
         <div
-          class="text-secondary font-medium text-[14px] mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-3.5"
         >
           Optional • 
           Type:
@@ -549,14 +549,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#onpress"
             id="onpress"
           >
@@ -572,7 +572,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -597,7 +597,7 @@ for more details.
           </a>
         </h3>
         <div
-          class="text-secondary font-medium text-[14px] mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-3.5"
         >
           Type:
            
@@ -640,14 +640,14 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#style"
             id="style"
           >
@@ -663,7 +663,7 @@ in here.
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -688,7 +688,7 @@ in here.
           </a>
         </h3>
         <div
-          class="text-secondary font-medium text-[14px] mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-3.5"
         >
           Optional • 
           Type:
@@ -781,11 +781,11 @@ properties.
         </p>
       </div>
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#inherited-props"
           id="inherited-props"
         >
@@ -796,7 +796,7 @@ properties.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -845,11 +845,11 @@ properties.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#methods"
       id="methods"
     >
@@ -860,7 +860,7 @@ properties.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -885,14 +885,14 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#getcredentialstateasyncuser"
         id="getcredentialstateasyncuser"
       >
@@ -908,7 +908,7 @@ properties.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -933,29 +933,29 @@ properties.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -966,7 +966,7 @@ properties.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -976,7 +976,7 @@ properties.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -986,7 +986,7 @@ properties.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1022,7 +1022,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
       data-testid="callout-container"
     >
       <div
@@ -1048,7 +1048,7 @@ This should come from the user field of an
         </svg>
       </div>
       <div
-        class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         
 
@@ -1069,13 +1069,13 @@ This should come from the user field of an
       </div>
     </blockquote>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1139,7 +1139,7 @@ This should come from the user field of an
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1163,14 +1163,14 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -1186,7 +1186,7 @@ value depending on the state of the credential.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -1217,13 +1217,13 @@ value depending on the state of the credential.
       Determine if the current device's operating system supports Apple authentication.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1282,7 +1282,7 @@ value depending on the state of the credential.
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1307,14 +1307,14 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#refreshasyncoptions"
         id="refreshasyncoptions"
       >
@@ -1330,7 +1330,7 @@ value depending on the state of the credential.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -1355,29 +1355,29 @@ value depending on the state of the credential.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1388,7 +1388,7 @@ value depending on the state of the credential.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -1398,7 +1398,7 @@ value depending on the state of the credential.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1413,7 +1413,7 @@ value depending on the state of the credential.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1447,13 +1447,13 @@ value depending on the state of the credential.
 Calling this method will show the sign in modal before actually refreshing the user credentials.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1517,7 +1517,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1549,14 +1549,14 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#signinasyncoptions"
         id="signinasyncoptions"
       >
@@ -1572,7 +1572,7 @@ refresh operation.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -1597,29 +1597,29 @@ refresh operation.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1630,7 +1630,7 @@ refresh operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -1640,13 +1640,13 @@ refresh operation.
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1661,7 +1661,7 @@ refresh operation.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1736,13 +1736,13 @@ You can use
 the user, since this remains the same for apps released by the same developer.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1806,7 +1806,7 @@ the user, since this remains the same for apps released by the same developer.
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -1838,14 +1838,14 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#signoutasyncoptions"
         id="signoutasyncoptions"
       >
@@ -1861,7 +1861,7 @@ sign-in operation.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -1886,29 +1886,29 @@ sign-in operation.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1919,7 +1919,7 @@ sign-in operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -1929,7 +1929,7 @@ sign-in operation.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1944,7 +1944,7 @@ sign-in operation.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2012,13 +2012,13 @@ from using
        methods.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -2082,7 +2082,7 @@ from using
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2114,11 +2114,11 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#event-subscriptions"
       id="event-subscriptions"
     >
@@ -2129,7 +2129,7 @@ sign-out operation.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -2154,14 +2154,14 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#addrevokelistenerlistener"
         id="addrevokelistenerlistener"
       >
@@ -2177,7 +2177,7 @@ sign-out operation.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -2202,24 +2202,24 @@ sign-out operation.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
@@ -2230,7 +2230,7 @@ sign-out operation.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2240,7 +2240,7 @@ sign-out operation.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2261,13 +2261,13 @@ sign-out operation.
     </div>
     <br />
     <div
-      class="flex flex-row gap-2 items-start mb-3.5"
+      class="flex flex-row items-start gap-2 mb-3.5"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -2307,11 +2307,11 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#types"
       id="types"
     >
@@ -2322,7 +2322,7 @@ sign-out operation.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -2347,14 +2347,14 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationcredential"
         id="appleauthenticationcredential"
       >
@@ -2370,7 +2370,7 @@ sign-out operation.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -2439,11 +2439,11 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -2465,7 +2465,7 @@ which contains all of the pertinent user and credential information.
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="w-full leading-normal text-default last:mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2493,29 +2493,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -2526,7 +2526,7 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2536,7 +2536,7 @@ for more details.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2556,7 +2556,7 @@ for more details.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2578,7 +2578,7 @@ the app's server counterpart. Unlike
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2588,7 +2588,7 @@ the app's server counterpart. Unlike
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2608,7 +2608,7 @@ the app's server counterpart. Unlike
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2632,7 +2632,7 @@ an Apple domain.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2642,7 +2642,7 @@ an Apple domain.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2667,7 +2667,7 @@ an Apple domain.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2704,7 +2704,7 @@ your app.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2714,7 +2714,7 @@ your app.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2734,7 +2734,7 @@ your app.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2748,7 +2748,7 @@ your app.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2758,7 +2758,7 @@ your app.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2773,7 +2773,7 @@ your app.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2787,7 +2787,7 @@ your app.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2797,7 +2797,7 @@ your app.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2817,7 +2817,7 @@ your app.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2855,7 +2855,7 @@ will be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2865,7 +2865,7 @@ will be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2875,7 +2875,7 @@ will be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -2893,14 +2893,14 @@ developers.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationfullname"
         id="appleauthenticationfullname"
       >
@@ -2916,7 +2916,7 @@ developers.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -2955,29 +2955,29 @@ may be
       . Only applicable fields that the user has allowed your app to access will be nonnull.
     </p>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -2988,7 +2988,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -2998,7 +2998,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3018,7 +3018,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3031,7 +3031,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3041,7 +3041,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3061,7 +3061,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3074,7 +3074,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3084,7 +3084,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3104,7 +3104,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3117,7 +3117,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3127,7 +3127,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3147,7 +3147,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3160,7 +3160,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3170,7 +3170,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3190,7 +3190,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3203,7 +3203,7 @@ may be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3213,7 +3213,7 @@ may be
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3233,7 +3233,7 @@ may be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3247,14 +3247,14 @@ may be
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationrefreshoptions"
         id="appleauthenticationrefreshoptions"
       >
@@ -3270,7 +3270,7 @@ may be
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -3314,11 +3314,11 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3340,7 +3340,7 @@ You must include the ID string of the user whose credentials you'd like to refre
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="w-full leading-normal text-default last:mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3368,29 +3368,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3401,7 +3401,7 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3411,13 +3411,13 @@ for more details.
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3433,7 +3433,7 @@ for more details.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3472,7 +3472,7 @@ requests they will be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3482,13 +3482,13 @@ requests they will be
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3498,7 +3498,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3524,7 +3524,7 @@ OAuth 2.0 protocol
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3534,7 +3534,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3544,7 +3544,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -3558,14 +3558,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationsigninoptions"
         id="appleauthenticationsigninoptions"
       >
@@ -3581,7 +3581,7 @@ OAuth 2.0 protocol
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -3625,11 +3625,11 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3651,7 +3651,7 @@ None of these options are required.
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="w-full leading-normal text-default last:mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3679,29 +3679,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3712,7 +3712,7 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3722,13 +3722,13 @@ for more details.
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3738,7 +3738,7 @@ for more details.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3762,7 +3762,7 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3772,13 +3772,13 @@ for more details.
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3794,7 +3794,7 @@ for more details.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3833,7 +3833,7 @@ requests they will be
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -3843,13 +3843,13 @@ requests they will be
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3859,7 +3859,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -3886,14 +3886,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#appleauthenticationsignoutoptions"
         id="appleauthenticationsignoutoptions"
       >
@@ -3909,7 +3909,7 @@ OAuth 2.0 protocol
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -3953,11 +3953,11 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
       data-testid="callout-container"
     >
       <div
-        class="select-none mt-1 [table_&]:mt-0.5"
+        class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3979,7 +3979,7 @@ You must include the ID string of the user to sign out.
         </svg>
       </div>
       <div
-        class="text-default w-full leading-normal last:mb-0"
+        class="w-full leading-normal text-default last:mb-0"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -4007,29 +4007,29 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4040,7 +4040,7 @@ for more details.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -4050,13 +4050,13 @@ for more details.
               </span>
               <br />
               <span
-                class="text-secondary pt-5 !text-[13px]"
+                class="pt-5 !text-[13px] text-secondary"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4066,7 +4066,7 @@ for more details.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -4092,7 +4092,7 @@ OAuth 2.0 protocol
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -4102,7 +4102,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4112,7 +4112,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="text-quaternary"
@@ -4126,14 +4126,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -4149,7 +4149,7 @@ OAuth 2.0 protocol
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -4180,29 +4180,29 @@ OAuth 2.0 protocol
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4213,7 +4213,7 @@ OAuth 2.0 protocol
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -4223,7 +4223,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -4244,7 +4244,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -4260,11 +4260,11 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#enums"
       id="enums"
     >
@@ -4275,7 +4275,7 @@ After calling this function, the listener will no longer receive any events from
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -4300,17 +4300,17 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationbuttonstyle"
           id="appleauthenticationbuttonstyle"
         >
@@ -4326,7 +4326,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4369,11 +4369,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationButtonStyle Values
@@ -4384,11 +4384,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#white"
           id="white"
         >
@@ -4404,7 +4404,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4429,7 +4429,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -4445,11 +4445,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#white_outline"
           id="white_outline"
         >
@@ -4465,7 +4465,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4490,7 +4490,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -4506,11 +4506,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#black"
           id="black"
         >
@@ -4526,7 +4526,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4551,7 +4551,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -4565,17 +4565,17 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationbuttontype"
           id="appleauthenticationbuttontype"
         >
@@ -4591,7 +4591,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4634,11 +4634,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationButtonType Values
@@ -4649,11 +4649,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#sign_in"
           id="sign_in"
         >
@@ -4669,7 +4669,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4694,7 +4694,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -4710,11 +4710,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#continue"
           id="continue"
         >
@@ -4730,7 +4730,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4755,7 +4755,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -4771,7 +4771,7 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <div
-        class="flex flex-row items-center mb-2"
+        class="mb-2 flex flex-row items-center"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -4785,10 +4785,10 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
+            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
           >
             <svg
-              class="opacity-80 icon-xs text-palette-blue12 mt-[-0.5px]"
+              class="icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -4805,7 +4805,7 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-2xs !leading-[16px] font-normal [table_&]:text-3xs"
+              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
             >
               iOS 13.2+
             </span>
@@ -4814,11 +4814,11 @@ After calling this function, the listener will no longer receive any events from
         </span>
       </div>
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#sign_up"
           id="sign_up"
         >
@@ -4834,7 +4834,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4859,7 +4859,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -4873,17 +4873,17 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationcredentialstate"
           id="appleauthenticationcredentialstate"
         >
@@ -4899,7 +4899,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4942,11 +4942,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -4968,7 +4968,7 @@ After calling this function, the listener will no longer receive any events from
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="w-full leading-normal text-default last:mb-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -4996,11 +4996,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationCredentialState Values
@@ -5011,11 +5011,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#revoked"
           id="revoked"
         >
@@ -5031,7 +5031,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5056,7 +5056,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5066,11 +5066,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#authorized"
           id="authorized"
         >
@@ -5086,7 +5086,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5111,7 +5111,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5121,11 +5121,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#not_found"
           id="not_found"
         >
@@ -5141,7 +5141,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5166,7 +5166,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5176,11 +5176,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#transferred"
           id="transferred"
         >
@@ -5196,7 +5196,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5221,7 +5221,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5229,17 +5229,17 @@ for more details.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationoperation"
           id="appleauthenticationoperation"
         >
@@ -5255,7 +5255,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5280,11 +5280,11 @@ for more details.
         </a>
       </h3>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationOperation Values
@@ -5295,11 +5295,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#implicit"
           id="implicit"
         >
@@ -5315,7 +5315,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5340,7 +5340,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -5356,11 +5356,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#login"
           id="login"
         >
@@ -5376,7 +5376,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5401,7 +5401,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5411,11 +5411,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#refresh"
           id="refresh"
         >
@@ -5431,7 +5431,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5456,7 +5456,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5466,11 +5466,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#logout"
           id="logout"
         >
@@ -5486,7 +5486,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5511,7 +5511,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5519,17 +5519,17 @@ for more details.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationscope"
           id="appleauthenticationscope"
         >
@@ -5545,7 +5545,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5590,7 +5590,7 @@ for more details.
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
@@ -5616,7 +5616,7 @@ for more details.
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           
 
@@ -5632,11 +5632,11 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5658,7 +5658,7 @@ You will still need to handle null values for any fields you request.
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="w-full leading-normal text-default last:mb-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -5686,11 +5686,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationScope Values
@@ -5701,11 +5701,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#full_name"
           id="full_name"
         >
@@ -5721,7 +5721,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5746,7 +5746,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -5756,11 +5756,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#email"
           id="email"
         >
@@ -5776,7 +5776,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5801,7 +5801,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -5809,17 +5809,17 @@ for more details.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationuserdetectionstatus"
           id="appleauthenticationuserdetectionstatus"
         >
@@ -5835,7 +5835,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5866,11 +5866,11 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3.5"
         data-testid="callout-container"
       >
         <div
-          class="select-none mt-1 [table_&]:mt-0.5"
+          class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5892,7 +5892,7 @@ for more details.
           </svg>
         </div>
         <div
-          class="text-default w-full leading-normal last:mb-0"
+          class="w-full leading-normal text-default last:mb-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -5920,11 +5920,11 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           AppleAuthenticationUserDetectionStatus Values
@@ -5935,11 +5935,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#unsupported"
           id="unsupported"
         >
@@ -5955,7 +5955,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5980,7 +5980,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -5996,11 +5996,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#unknown"
           id="unknown"
         >
@@ -6016,7 +6016,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6041,7 +6041,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -6057,11 +6057,11 @@ for more details.
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#likely_real"
           id="likely_real"
         >
@@ -6077,7 +6077,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6102,7 +6102,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -6121,11 +6121,11 @@ for more details.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#methods"
       id="methods"
     >
@@ -6136,7 +6136,7 @@ exports[`APISection expo-pedometer 1`] = `
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -6161,14 +6161,14 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#getpermissionsasync"
         id="getpermissionsasync"
       >
@@ -6184,7 +6184,7 @@ exports[`APISection expo-pedometer 1`] = `
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -6215,13 +6215,13 @@ exports[`APISection expo-pedometer 1`] = `
       Checks user's permissions for accessing pedometer.
     </p>
     <div
-      class="flex flex-row gap-2 items-start mb-3.5"
+      class="flex flex-row items-start gap-2 mb-3.5"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6286,20 +6286,20 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-row items-center mb-2"
+      class="mb-2 flex flex-row items-center"
     >
       <span
         class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
         data-text="true"
       >
         <div
-          class="select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
+          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
         >
           <svg
-            class="opacity-80 icon-xs text-palette-blue12 mt-[-0.5px]"
+            class="icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -6316,7 +6316,7 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="text-2xs !leading-[16px] font-normal [table_&]:text-3xs"
+            class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
           >
             iOS
           </span>
@@ -6324,11 +6324,11 @@ exports[`APISection expo-pedometer 1`] = `
       </span>
     </div>
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#getstepcountasyncstart-end"
         id="getstepcountasyncstart-end"
       >
@@ -6344,7 +6344,7 @@ exports[`APISection expo-pedometer 1`] = `
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -6369,29 +6369,29 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -6402,7 +6402,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -6412,7 +6412,7 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -6429,7 +6429,7 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -6443,7 +6443,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -6453,7 +6453,7 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -6470,7 +6470,7 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -6491,13 +6491,13 @@ exports[`APISection expo-pedometer 1`] = `
       Get the step count between two dates.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6561,7 +6561,7 @@ exports[`APISection expo-pedometer 1`] = `
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -6601,7 +6601,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
@@ -6627,7 +6627,7 @@ exports[`APISection expo-pedometer 1`] = `
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           
 
@@ -6645,14 +6645,14 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -6668,7 +6668,7 @@ a start date that is more than seven days in the past returns only the available
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -6699,13 +6699,13 @@ a start date that is more than seven days in the past returns only the available
       Returns whether the pedometer is enabled on the device.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6764,7 +6764,7 @@ a start date that is more than seven days in the past returns only the available
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -6783,14 +6783,14 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#requestpermissionsasync"
         id="requestpermissionsasync"
       >
@@ -6806,7 +6806,7 @@ available on this device.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -6837,13 +6837,13 @@ available on this device.
       Asks the user to grant permissions for accessing pedometer.
     </p>
     <div
-      class="flex flex-row gap-2 items-start mb-3.5"
+      class="flex flex-row items-start gap-2 mb-3.5"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6908,14 +6908,14 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#watchstepcountcallback"
         id="watchstepcountcallback"
       >
@@ -6931,7 +6931,7 @@ available on this device.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -6956,29 +6956,29 @@ available on this device.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -6989,7 +6989,7 @@ available on this device.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -6999,7 +6999,7 @@ available on this device.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7014,7 +7014,7 @@ available on this device.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7048,13 +7048,13 @@ provided with a single argument that is
       Subscribe to pedometer updates.
     </p>
     <div
-      class="flex flex-row gap-2 items-start"
+      class="flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7093,7 +7093,7 @@ provided with a single argument that is
       </p>
     </div>
     <div
-      class="flex flex-col mt-1.5 mb-1 pl-6"
+      class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7124,7 +7124,7 @@ provided with a single argument that is
       
 
       <blockquote
-        class="bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
         data-testid="callout-container"
       >
         <div
@@ -7150,7 +7150,7 @@ provided with a single argument that is
           </svg>
         </div>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_p]:text-xs [&_code]:text-[90%]"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           
 
@@ -7190,11 +7190,11 @@ On iOS, the
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#interfaces"
       id="interfaces"
     >
@@ -7205,7 +7205,7 @@ On iOS, the
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -7230,14 +7230,14 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#permissionresponse"
         id="permissionresponse"
       >
@@ -7253,7 +7253,7 @@ On iOS, the
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -7284,40 +7284,40 @@ On iOS, the
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4"
       data-text="true"
     >
       <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
         data-text="true"
       >
         PermissionResponse Properties
       </span>
     </p>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -7328,7 +7328,7 @@ On iOS, the
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7338,7 +7338,7 @@ On iOS, the
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7348,7 +7348,7 @@ On iOS, the
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7364,7 +7364,7 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7374,7 +7374,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7389,7 +7389,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7403,7 +7403,7 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7413,7 +7413,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7423,7 +7423,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7437,7 +7437,7 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7447,7 +7447,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7462,7 +7462,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7478,11 +7478,11 @@ in order to enable/disable the permission.
     <br />
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#types"
       id="types"
     >
@@ -7493,7 +7493,7 @@ in order to enable/disable the permission.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -7518,14 +7518,14 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#pedometerresult"
         id="pedometerresult"
       >
@@ -7541,7 +7541,7 @@ in order to enable/disable the permission.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -7566,29 +7566,29 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -7599,7 +7599,7 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7609,7 +7609,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7619,7 +7619,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -7634,14 +7634,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#pedometerupdatecallback"
         id="pedometerupdatecallback"
       >
@@ -7658,7 +7658,7 @@ in order to enable/disable the permission.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -7690,24 +7690,24 @@ in order to enable/disable the permission.
     </p>
     <div>
       <div
-        class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
       >
         <table
-          class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+          class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
-            class="bg-subtle border-b border-b-default"
+            class="border-b border-b-default bg-subtle"
           >
             <tr
               class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Parameter
               </th>
               <th
-                class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Type
               </th>
@@ -7718,7 +7718,7 @@ in order to enable/disable the permission.
               class="even:bg-subtle even:[&_summary]:bg-element"
             >
               <td
-                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <span
                   class="leading-[1.6154] text-default font-semibold"
@@ -7728,7 +7728,7 @@ in order to enable/disable the permission.
                 </span>
               </td>
               <td
-                class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <code
                   class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7748,13 +7748,13 @@ in order to enable/disable the permission.
       </div>
     </div>
     <div
-      class="flex flex-row gap-2 items-start mt-4"
+      class="mt-4 flex flex-row items-start gap-2"
     >
       <div
-        class="flex flex-row gap-2 items-center"
+        class="flex flex-row items-center gap-2"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary"
+          class="icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7794,14 +7794,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
         href="#permissionexpiration"
         id="permissionexpiration"
       >
@@ -7817,7 +7817,7 @@ in order to enable/disable the permission.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -7861,7 +7861,7 @@ in order to enable/disable the permission.
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="tracking-[-0.006rem] text-secondary font-medium text-[14px]"
+      class="tracking-[-0.006rem] text-[14px] font-medium text-secondary"
       data-text="true"
     >
       Acceptable values are:
@@ -7882,14 +7882,14 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -7905,7 +7905,7 @@ in order to enable/disable the permission.
         </span>
         <svg
           aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
           fill="none"
           height="24"
           viewBox="0 0 24 24"
@@ -7936,29 +7936,29 @@ in order to enable/disable the permission.
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
       <table
-        class="w-full border-0 rounded-none text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="bg-subtle border-b border-b-default"
+          class="border-b border-b-default bg-subtle"
         >
           <tr
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Name
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="px-4 py-3.5 font-medium text-secondary border-r border-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-r border-secondary px-4 py-3.5 font-medium text-secondary text-left text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -7969,7 +7969,7 @@ in order to enable/disable the permission.
             class="even:bg-subtle even:[&_summary]:bg-element"
           >
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
                 class="leading-[1.6154] text-default font-semibold"
@@ -7979,7 +7979,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -8000,7 +8000,7 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
                 class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -8016,11 +8016,11 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
+    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group"
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
       href="#enums"
       id="enums"
     >
@@ -8031,7 +8031,7 @@ After calling this function, the listener will no longer receive any events from
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -8056,17 +8056,17 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 shadow-xs mb-6 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#permissionstatus"
           id="permissionstatus"
         >
@@ -8082,7 +8082,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8107,11 +8107,11 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
         data-text="true"
       >
         <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
           data-text="true"
         >
           PermissionStatus Values
@@ -8122,11 +8122,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#denied"
           id="denied"
         >
@@ -8142,7 +8142,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8167,7 +8167,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -8183,11 +8183,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#granted"
           id="granted"
         >
@@ -8203,7 +8203,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8228,7 +8228,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -8244,11 +8244,11 @@ After calling this function, the listener will no longer receive any events from
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group"
+        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
           href="#undetermined"
           id="undetermined"
         >
@@ -8264,7 +8264,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8289,7 +8289,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary text-xs inline-flex mb-3"
+        class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -108,7 +108,7 @@ exports[`APISection expo-apple-authentication 1`] = `
         React.Element
         &lt;
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbuttonprops"
         >
           AppleAuthenticationButtonProps
@@ -133,7 +133,7 @@ available via the provided properties.
     >
       You should only attempt to render this if 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationisavailableasync"
       >
         <code
@@ -258,14 +258,14 @@ not appear on the screen.
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             See:
           </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
             rel="noopener noreferrer"
             target="_blank"
@@ -344,7 +344,7 @@ for more details.
               class="inline"
             >
               <code
-                class="text-default leading-[1.6154] font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
                 data-text="true"
               >
                 buttonStyle
@@ -386,7 +386,7 @@ for more details.
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationbuttonstyle"
             >
               AppleAuthenticationButtonStyle
@@ -416,7 +416,7 @@ for more details.
               class="inline"
             >
               <code
-                class="text-default leading-[1.6154] font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
                 data-text="true"
               >
                 buttonType
@@ -458,7 +458,7 @@ for more details.
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationbuttontype"
             >
               AppleAuthenticationButtonType
@@ -488,7 +488,7 @@ for more details.
               class="inline"
             >
               <code
-                class="text-default leading-[1.6154] font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
                 data-text="true"
               >
                 cornerRadius
@@ -564,7 +564,7 @@ for more details.
               class="inline"
             >
               <code
-                class="text-default leading-[1.6154] font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
                 data-text="true"
               >
                 onPress
@@ -625,7 +625,7 @@ for more details.
         >
           The method to call when the user presses the button. You should call 
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="#appleauthenticationisavailableasync"
           >
             <code
@@ -655,7 +655,7 @@ in here.
               class="inline"
             >
               <code
-                class="text-default leading-[1.6154] font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
                 data-text="true"
               >
                 style
@@ -705,7 +705,7 @@ in here.
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                 href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -719,7 +719,7 @@ in here.
               </span>
               <span>
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://reactnative.dev/docs/view-style-props"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -821,7 +821,7 @@ properties.
         </a>
       </h4>
       <ul
-        class="text-default leading-[1.6154] list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
+        class="leading-[1.6154] text-default list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
       >
         <li
           class="text-default text-[16px] font-normal leading-relaxed tracking-[-0.011rem] mb-2"
@@ -832,7 +832,7 @@ properties.
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://reactnative.dev/docs/view#props"
               rel="noopener noreferrer"
               target="_blank"
@@ -900,7 +900,7 @@ properties.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -969,7 +969,7 @@ properties.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 user
@@ -995,7 +995,7 @@ properties.
                 The unique identifier for the user whose credential state you'd like to check.
 This should come from the user field of an 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
@@ -1057,7 +1057,7 @@ This should come from the user field of an
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             Note:
@@ -1110,7 +1110,7 @@ This should come from the user field of an
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1124,7 +1124,7 @@ This should come from the user field of an
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredentialstate"
             >
               AppleAuthenticationCredentialState
@@ -1147,7 +1147,7 @@ This should come from the user field of an
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredentialstate"
         >
           <code
@@ -1178,7 +1178,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             isAvailableAsync()
@@ -1258,7 +1258,7 @@ value depending on the state of the credential.
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1322,7 +1322,7 @@ value depending on the state of the credential.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             refreshAsync(options)
@@ -1391,7 +1391,7 @@ value depending on the state of the credential.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 options
@@ -1405,7 +1405,7 @@ value depending on the state of the credential.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationrefreshoptions"
                 >
                   AppleAuthenticationRefreshOptions
@@ -1421,7 +1421,7 @@ value depending on the state of the credential.
               >
                 An 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
@@ -1488,7 +1488,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1502,7 +1502,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1525,7 +1525,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
@@ -1564,7 +1564,7 @@ refresh operation.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             signInAsync(options)
@@ -1633,7 +1633,7 @@ refresh operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 options
@@ -1653,7 +1653,7 @@ refresh operation.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsigninoptions"
                 >
                   AppleAuthenticationSignInOptions
@@ -1669,7 +1669,7 @@ refresh operation.
               >
                 An optional 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
@@ -1714,7 +1714,7 @@ of these options at runtime.
 into your app, so you must store it for later use. It's best to store this information either
 server-side, or using 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="./securestore"
       >
         SecureStore
@@ -1722,7 +1722,7 @@ server-side, or using
       , so that the data persists across app installs.
 You can use 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationcredential"
       >
         <code
@@ -1777,7 +1777,7 @@ the user, since this remains the same for apps released by the same developer.
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1791,7 +1791,7 @@ the user, since this remains the same for apps released by the same developer.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1814,7 +1814,7 @@ the user, since this remains the same for apps released by the same developer.
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
@@ -1853,7 +1853,7 @@ sign-in operation.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             signOutAsync(options)
@@ -1922,7 +1922,7 @@ sign-in operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 options
@@ -1936,7 +1936,7 @@ sign-in operation.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsignoutoptions"
                 >
                   AppleAuthenticationSignOutOptions
@@ -1952,7 +1952,7 @@ sign-in operation.
               >
                 An 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
@@ -1987,7 +1987,7 @@ Calling this method will show the sign in modal before actually signing the user
 Instead of using this method it is recommended to simply clear all the user's data collected
 from using 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="./#signinasync"
       >
         <code
@@ -1999,7 +1999,7 @@ from using
       </a>
        or 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="./#refreshasync"
       >
         <code
@@ -2053,7 +2053,7 @@ from using
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -2067,7 +2067,7 @@ from using
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -2090,7 +2090,7 @@ from using
       >
         A promise that fulfills with an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
@@ -2169,7 +2169,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2233,7 +2233,7 @@ sign-out operation.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 listener
@@ -2362,7 +2362,7 @@ sign-out operation.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2400,7 +2400,7 @@ sign-out operation.
     >
       The object type returned from a successful call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
@@ -2413,7 +2413,7 @@ sign-out operation.
       ,
 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
@@ -2425,7 +2425,7 @@ sign-out operation.
       </a>
       , or 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
@@ -2472,14 +2472,14 @@ which contains all of the pertinent user and credential information.
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             See:
           </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
             rel="noopener noreferrer"
             target="_blank"
@@ -2529,7 +2529,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 authorizationCode
@@ -2581,7 +2581,7 @@ the app's server counterpart. Unlike
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 email
@@ -2635,7 +2635,7 @@ an Apple domain.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 fullName
@@ -2650,7 +2650,7 @@ an Apple domain.
               >
                 <span>
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationfullname"
                   >
                     AppleAuthenticationFullName
@@ -2707,7 +2707,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 identityToken
@@ -2751,7 +2751,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 realUserStatus
@@ -2765,7 +2765,7 @@ your app.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationuserdetectionstatus"
                 >
                   AppleAuthenticationUserDetectionStatus
@@ -2790,7 +2790,7 @@ your app.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 state
@@ -2858,7 +2858,7 @@ will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 user
@@ -2908,7 +2908,7 @@ developers.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -2991,7 +2991,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 familyName
@@ -3034,7 +3034,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 givenName
@@ -3077,7 +3077,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 middleName
@@ -3120,7 +3120,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 namePrefix
@@ -3163,7 +3163,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 nameSuffix
@@ -3206,7 +3206,7 @@ may be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 nickname
@@ -3262,7 +3262,7 @@ may be
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3300,7 +3300,7 @@ may be
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
@@ -3347,14 +3347,14 @@ You must include the ID string of the user whose credentials you'd like to refre
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             See:
           </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3404,7 +3404,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 requestedScopes
@@ -3424,7 +3424,7 @@ for more details.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3475,7 +3475,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 state
@@ -3509,7 +3509,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3527,7 +3527,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 user
@@ -3573,7 +3573,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3611,7 +3611,7 @@ OAuth 2.0 protocol
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
@@ -3658,14 +3658,14 @@ None of these options are required.
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             See:
           </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -3715,7 +3715,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 nonce
@@ -3747,7 +3747,7 @@ for more details.
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3765,7 +3765,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 requestedScopes
@@ -3785,7 +3785,7 @@ for more details.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -3836,7 +3836,7 @@ requests they will be
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 state
@@ -3870,7 +3870,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -3901,7 +3901,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -3939,7 +3939,7 @@ OAuth 2.0 protocol
     >
       The options you can supply when making a call to 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
@@ -3986,14 +3986,14 @@ You must include the ID string of the user to sign out.
           data-text="true"
         >
           <span
-            class="text-default leading-[1.6154] font-semibold"
+            class="leading-[1.6154] text-default font-semibold"
             data-text="true"
           >
             See:
           </span>
            
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
             rel="noopener noreferrer"
             target="_blank"
@@ -4043,7 +4043,7 @@ for more details.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 state
@@ -4077,7 +4077,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://tools.ietf.org/html/rfc6749#section-10.12"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -4095,7 +4095,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 user
@@ -4141,7 +4141,7 @@ OAuth 2.0 protocol
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             Subscription
@@ -4216,7 +4216,7 @@ OAuth 2.0 protocol
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 remove
@@ -4318,7 +4318,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationButtonStyle
@@ -4356,7 +4356,7 @@ After calling this function, the listener will no longer receive any events from
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
@@ -4396,7 +4396,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               WHITE
@@ -4457,7 +4457,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               WHITE_OUTLINE
@@ -4518,7 +4518,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               BLACK
@@ -4583,7 +4583,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationButtonType
@@ -4621,7 +4621,7 @@ After calling this function, the listener will no longer receive any events from
       >
         An enum whose values control which pre-defined text to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
@@ -4661,7 +4661,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               SIGN_IN
@@ -4722,7 +4722,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               CONTINUE
@@ -4826,7 +4826,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               SIGN_UP
@@ -4891,7 +4891,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationCredentialState
@@ -4929,7 +4929,7 @@ After calling this function, the listener will no longer receive any events from
       >
         An enum whose values specify state of the credential when checked with 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
@@ -4975,14 +4975,14 @@ After calling this function, the listener will no longer receive any events from
             data-text="true"
           >
             <span
-              class="text-default leading-[1.6154] font-semibold"
+              class="leading-[1.6154] text-default font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
               rel="noopener noreferrer"
               target="_blank"
@@ -5023,7 +5023,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               REVOKED
@@ -5078,7 +5078,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               AUTHORIZED
@@ -5133,7 +5133,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               NOT_FOUND
@@ -5188,7 +5188,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               TRANSFERRED
@@ -5247,7 +5247,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationOperation
@@ -5307,7 +5307,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               IMPLICIT
@@ -5368,7 +5368,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               LOGIN
@@ -5423,7 +5423,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               REFRESH
@@ -5478,7 +5478,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               LOGOUT
@@ -5537,7 +5537,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationScope
@@ -5575,7 +5575,7 @@ for more details.
       >
         An enum whose values specify scopes you can request when calling 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
@@ -5665,14 +5665,14 @@ You will still need to handle null values for any fields you request.
             data-text="true"
           >
             <span
-              class="text-default leading-[1.6154] font-semibold"
+              class="leading-[1.6154] text-default font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
               rel="noopener noreferrer"
               target="_blank"
@@ -5713,7 +5713,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               FULL_NAME
@@ -5768,7 +5768,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               EMAIL
@@ -5827,7 +5827,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               AppleAuthenticationUserDetectionStatus
@@ -5899,14 +5899,14 @@ for more details.
             data-text="true"
           >
             <span
-              class="text-default leading-[1.6154] font-semibold"
+              class="leading-[1.6154] text-default font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
               rel="noopener noreferrer"
               target="_blank"
@@ -5947,7 +5947,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               UNSUPPORTED
@@ -6008,7 +6008,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               UNKNOWN
@@ -6069,7 +6069,7 @@ for more details.
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               LIKELY_REAL
@@ -6176,7 +6176,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             getPermissionsAsync()
@@ -6256,7 +6256,7 @@ exports[`APISection expo-pedometer 1`] = `
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -6270,7 +6270,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -6336,7 +6336,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -6405,7 +6405,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 start
@@ -6419,7 +6419,7 @@ exports[`APISection expo-pedometer 1`] = `
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -6446,7 +6446,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 end
@@ -6460,7 +6460,7 @@ exports[`APISection expo-pedometer 1`] = `
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -6532,7 +6532,7 @@ exports[`APISection expo-pedometer 1`] = `
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -6546,7 +6546,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#pedometerresult"
             >
               PedometerResult
@@ -6569,7 +6569,7 @@ exports[`APISection expo-pedometer 1`] = `
       >
         Returns a promise that fulfills with a 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#pedometerresult"
         >
           <code
@@ -6589,7 +6589,7 @@ exports[`APISection expo-pedometer 1`] = `
       >
         As 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
           rel="noopener noreferrer"
           target="_blank"
@@ -6660,7 +6660,7 @@ a start date that is more than seven days in the past returns only the available
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             isAvailableAsync()
@@ -6740,7 +6740,7 @@ a start date that is more than seven days in the past returns only the available
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -6798,7 +6798,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -6878,7 +6878,7 @@ available on this device.
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -6892,7 +6892,7 @@ available on this device.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#permissionresponse"
             >
               PermissionResponse
@@ -6923,7 +6923,7 @@ available on this device.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             watchStepCount(callback)
@@ -6992,7 +6992,7 @@ available on this device.
               class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 callback
@@ -7006,7 +7006,7 @@ available on this device.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#pedometerupdatecallback"
                 >
                   PedometerUpdateCallback
@@ -7023,7 +7023,7 @@ available on this device.
                 A callback that is invoked when new step count data is available. The callback is
 provided with a single argument that is 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#pedometerresult"
                 >
                   <code
@@ -7101,7 +7101,7 @@ provided with a single argument that is
       >
         Returns a 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#subscription"
         >
           <code
@@ -7161,7 +7161,7 @@ provided with a single argument that is
             Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.android.com/health-and-fitness/guides/health-connect"
               rel="noopener noreferrer"
               target="_blank"
@@ -7245,7 +7245,7 @@ On iOS, the
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionResponse
@@ -7331,7 +7331,7 @@ On iOS, the
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 canAskAgain
@@ -7367,7 +7367,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 expires
@@ -7381,7 +7381,7 @@ in order to enable/disable the permission.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#permissionexpiration"
                 >
                   PermissionExpiration
@@ -7406,7 +7406,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 granted
@@ -7440,7 +7440,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 status
@@ -7454,7 +7454,7 @@ in order to enable/disable the permission.
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#permissionstatus"
                 >
                   PermissionStatus
@@ -7533,7 +7533,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             PedometerResult
@@ -7602,7 +7602,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 steps
@@ -7649,7 +7649,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -7721,7 +7721,7 @@ in order to enable/disable the permission.
                 class="p-4 border-r border-secondary text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <span
-                  class="text-default leading-[1.6154] font-semibold"
+                  class="leading-[1.6154] text-default font-semibold"
                   data-text="true"
                 >
                   result
@@ -7735,7 +7735,7 @@ in order to enable/disable the permission.
                   data-text="true"
                 >
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#pedometerresult"
                   >
                     PedometerResult
@@ -7809,7 +7809,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium wrap-anywhere"
             data-text="true"
           >
             PermissionExpiration
@@ -7897,7 +7897,7 @@ in order to enable/disable the permission.
           class="inline"
         >
           <code
-            class="text-default leading-[1.6154] font-medium"
+            class="leading-[1.6154] text-default font-medium"
             data-text="true"
           >
             Subscription
@@ -7972,7 +7972,7 @@ in order to enable/disable the permission.
               class="p-4 border-r border-secondary text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="text-default leading-[1.6154] font-semibold"
+                class="leading-[1.6154] text-default font-semibold"
                 data-text="true"
               >
                 remove
@@ -8074,7 +8074,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] font-medium wrap-anywhere"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
               data-text="true"
             >
               PermissionStatus
@@ -8134,7 +8134,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               DENIED
@@ -8195,7 +8195,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               GRANTED
@@ -8256,7 +8256,7 @@ After calling this function, the listener will no longer receive any events from
             class="inline"
           >
             <code
-              class="text-default leading-[1.6154] !text-inherit"
+              class="leading-[1.6154] text-default !text-inherit"
               data-text="true"
             >
               UNDETERMINED

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -140,9 +140,9 @@ const renderClass = (
         includePlatforms={false}
         afterContent={
           returnComment && (
-            <div className="flex flex-col gap-2 items-start">
-              <div className="flex flex-row gap-2 items-center">
-                <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+            <div className="flex flex-col items-start gap-2">
+              <div className="flex flex-row items-center gap-2">
+                <CornerDownRightIcon className="icon-sm inline-block text-icon-secondary" />
                 <CALLOUT tag="span" theme="secondary" weight="medium">
                   Returns
                 </CALLOUT>

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -33,7 +33,7 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
         key="deprecation-note"
         className={mergeClasses(
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4'
+          sticky && 'rounded-b-none rounded-t-lg pl-6 pr-4 shadow-none max-md-gutters:px-4'
         )}>
         {content.length ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -47,7 +47,7 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           <H4 hideInSidebar>
             <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
           </H4>
-          <MONOSPACE theme="secondary" className="text-xs inline-flex mb-3">
+          <MONOSPACE theme="secondary" className="mb-3 inline-flex text-xs">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -101,11 +101,11 @@ export const renderMethod = (
               <>
                 <div
                   className={mergeClasses(
-                    'flex flex-row gap-2 items-start',
+                    'flex flex-row items-start gap-2',
                     !returnComment && getAllTagData('example', comment) && ELEMENT_SPACING
                   )}>
-                  <div className="flex flex-row gap-2 items-center">
-                    <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+                  <div className="flex flex-row items-center gap-2">
+                    <CornerDownRightIcon className="icon-sm inline-block text-icon-secondary" />
                     <CALLOUT tag="span" theme="secondary" weight="medium">
                       Returns:
                     </CALLOUT>
@@ -115,7 +115,7 @@ export const renderMethod = (
                   </CALLOUT>
                 </div>
                 {returnComment ? (
-                  <div className="flex flex-col mt-1.5 mb-1 pl-6">
+                  <div className="mb-1 mt-1.5 flex flex-col pl-6">
                     <CommentTextBlock comment={{ summary: returnComment.content }} />
                   </div>
                 ) : undefined}

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -41,7 +41,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="flex flex-row items-center mb-2">
+    <div className="mb-2 flex flex-row items-center">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -160,9 +160,9 @@ const renderType = (
             ))
           : null}
         {type.declaration.signatures && type.declaration.signatures[0].type && (
-          <div className="flex flex-row gap-2 items-start mt-4">
-            <div className="flex flex-row gap-2 items-center">
-              <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+          <div className="mt-4 flex flex-row items-start gap-2">
+            <div className="flex flex-row items-center gap-2">
+              <CornerDownRightIcon className="icon-sm inline-block text-icon-secondary" />
               <CALLOUT tag="span" theme="secondary" weight="medium">
                 Returns:
               </CALLOUT>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -637,11 +637,11 @@ export const BoxSectionHeader = ({
   return (
     <CALLOUT
       className={mergeClasses(
-        'flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle',
+        '-mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2',
         'max-lg-gutters:-mx-4',
         className
       )}>
-      <TextWrapper className="text-tertiary flex flex-row gap-2 items-center font-medium">
+      <TextWrapper className="flex flex-row items-center gap-2 font-medium text-tertiary">
         {Icon && <Icon className="icon-sm text-icon-secondary" />}
         {text}
       </TextWrapper>
@@ -863,7 +863,7 @@ export const CommentTextBlock = ({
   const exampleText = examples?.map((example, index) => (
     <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:mb-0')}>
       {inlineHeaders ? (
-        <DEMI className="flex flex-row gap-1.5 items-center mb-1.5 text-secondary">
+        <DEMI className="mb-1.5 flex flex-row items-center gap-1.5 text-secondary">
           <CodeSquare01Icon className="icon-sm" />
           Example
         </DEMI>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
   >
     Gets the referrer URL of the installed app with the 
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://developer.android.com/google/play/installreferrer"
       rel="noopener noreferrer"
       target="_blank"
@@ -161,7 +161,7 @@ exports[`APISectionUtils.CommentTextBlock component no comment 1`] = `<div />`;
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -187,7 +187,7 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -201,7 +201,7 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#appleauthenticationcredential"
     >
       AppleAuthenticationCredential
@@ -306,7 +306,7 @@ exports[`APISectionUtils.resolveTypeName alternative generic object notation 1`]
 exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent"
     rel="noopener noreferrer"
     target="_blank"
@@ -319,7 +319,7 @@ exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type array 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="#appleauthenticationscope"
   >
     AppleAuthenticationScope
@@ -337,7 +337,7 @@ exports[`APISectionUtils.resolveTypeName custom type non-linkable array 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys"
     rel="noopener noreferrer"
     target="_blank"
@@ -351,7 +351,7 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#fontresource"
     >
       FontResource
@@ -391,7 +391,7 @@ exports[`APISectionUtils.resolveTypeName function 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -416,7 +416,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -440,7 +440,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -465,7 +465,7 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -492,7 +492,7 @@ exports[`APISectionUtils.resolveTypeName generic type 1`] = `
 exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="#pagedinfo"
   >
     PagedInfo
@@ -504,7 +504,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="/versions/latest/sdk/asset#asset"
     >
       Asset
@@ -521,7 +521,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -535,7 +535,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#pagedinfo"
     >
       PagedInfo
@@ -547,7 +547,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="/versions/latest/sdk/asset#asset"
       >
         Asset
@@ -608,7 +608,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
       rel="noopener noreferrer"
       target="_blank"
@@ -622,7 +622,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="https://reactnative.dev/docs/view-style-props"
         rel="noopener noreferrer"
         target="_blank"
@@ -690,7 +690,7 @@ exports[`APISectionUtils.resolveTypeName tuple type 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#sortbykey"
     >
       SortByKey
@@ -716,7 +716,7 @@ exports[`APISectionUtils.resolveTypeName union 1`] = `
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#speecheventcallback"
     >
       SpeechEventCallback
@@ -742,7 +742,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#resultseterror"
     >
       ResultSetError
@@ -755,7 +755,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#resultset"
     >
       ResultSet
@@ -794,7 +794,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#assetref"
     >
       AssetRef
@@ -808,7 +808,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#assetref"
     >
       AssetRef

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,17 +14,17 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="flex flex-row items-center mb-2"
+    class="mb-2 flex flex-row items-center"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
       <div
-        class="select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-green3 !text-palette-green12 !border-palette-green4"
+        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-green3 !text-palette-green12 !border-palette-green4"
       >
         <svg
-          class="opacity-80 icon-xs text-palette-green12 mt-[-0.5px]"
+          class="icon-xs mt-[-0.5px] text-palette-green12 opacity-80"
           fill="none"
           role="img"
           viewBox="0 0 24 24"
@@ -41,7 +41,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           </g>
         </svg>
         <span
-          class="text-2xs !leading-[16px] font-normal [table_&]:text-3xs"
+          class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
         >
           Android
         </span>
@@ -73,11 +73,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
     class="mb-3.5 last:[&>*]:mb-0"
   >
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] flex border-y border-secondary -mx-5 my-4 px-5 py-2 bg-subtle max-lg-gutters:-mx-4 !mt-1"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mt-1"
       data-text="true"
     >
       <span
-        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-tertiary flex flex-row gap-2 items-center font-medium"
+        class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
         data-text="true"
       >
         <svg
@@ -104,7 +104,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       </span>
     </p>
     <pre
-      class="whitespace-pre relative border border-secondary p-4 my-4 bg-subtle rounded-md overflow-x-auto [p+&]:mt-0"
+      class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4 [p+&]:mt-0"
       data-text="true"
     >
       <code

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -2,24 +2,24 @@ import { mergeClasses } from '@expo/styleguide';
 
 export const ELEMENT_SPACING = mergeClasses('mb-3.5');
 
-export const STYLES_SECONDARY = mergeClasses('text-secondary font-medium text-[14px]');
+export const STYLES_SECONDARY = mergeClasses('text-[14px] font-medium text-secondary');
 
-export const STYLES_OPTIONAL = mergeClasses('text-secondary pt-5 !text-[13px]');
+export const STYLES_OPTIONAL = mergeClasses('pt-5 !text-[13px] text-secondary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'rounded-lg border border-secondary p-5 shadow-xs mb-6',
+  'mb-6 rounded-lg border border-secondary p-5 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-2.5',
   '[&_li]:mb-0',
-  '[&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4',
-  '[&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0',
-  '[&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4',
+  '[&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary',
+  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none',
+  '[&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary',
   'max-lg-gutters:px-4'
 );
 
-export const STYLES_APIBOX_NESTED = mergeClasses('shadow-none mb-5 pt-4 px-5 pb-0 [&_h4]:mt-0');
+export const STYLES_APIBOX_NESTED = mergeClasses('mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0');
 
 export const STYLES_APIBOX_WRAPPER = mergeClasses(
-  'mb-3.5 pt-4 px-5',
+  'mb-3.5 px-5 pt-4',
   '[&_.table-wrapper]:last:mb-4'
 );

--- a/docs/components/plugins/permissions/AndroidPermissions.tsx
+++ b/docs/components/plugins/permissions/AndroidPermissions.tsx
@@ -63,12 +63,12 @@ function AndroidPermissionRow({
           <P className={mergeClasses((warning || explanation) && '!mb-4')}>{description}</P>
         )}
         {!!warning && (
-          <Callout className="mt-1.5 mb-0" type="warning">
+          <Callout className="mb-0 mt-1.5" type="warning">
             {warning}
           </Callout>
         )}
         {explanation && !warning && (
-          <Callout className="mt-1.5 mb-0">
+          <Callout className="mb-0 mt-1.5">
             <span dangerouslySetInnerHTML={{ __html: explanation }} />
           </Callout>
         )}

--- a/docs/package.json
+++ b/docs/package.json
@@ -101,6 +101,7 @@
     "postcss": "^8.4.38",
     "postcss-import": "^16.1.0",
     "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.8",
     "react-test-renderer": "^18.3.1",
     "rehype-slug": "^6.0.0",
     "remark-cli": "^12.0.1",

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -51,14 +51,14 @@ const Error = () => {
   }, [redirectPath]);
 
   return (
-    <Layout className="flex items-center justify-center flex-col !pb-20">
+    <Layout className="flex flex-col items-center justify-center !pb-20">
       {redirectPath && (
         <>
           <Head title="Redirecting" />
           <RedirectImage />
           <H1 className="!mt-8">Redirecting</H1>
           {/* note(simek): "redirect-link" ID is needed for test-links script */}
-          <P theme="secondary" className="text-center max-w-[450px] mb-8" id="redirect-link">
+          <P theme="secondary" className="mb-8 max-w-[450px] text-center" id="redirect-link">
             Just a moment…
           </P>
         </>
@@ -69,12 +69,12 @@ const Error = () => {
           {redirectFailed ? <ServerErrorImage /> : <NotFoundImage />}
           <H1 className="!mt-8">404: Not Found</H1>
           {redirectFailed ? (
-            <P theme="secondary" className="text-center max-w-[450px] mb-8" id="__redirect_failed">
+            <P theme="secondary" className="mb-8 max-w-[450px] text-center" id="__redirect_failed">
               We took an educated guess and tried to direct you to the right page, but it seems that
               did not work out! Maybe it doesn't exist anymore! 😔
             </P>
           ) : (
-            <P theme="secondary" className="text-center max-w-[450px] mb-8" id="__not_found">
+            <P theme="secondary" className="mb-8 max-w-[450px] text-center" id="__not_found">
               We couldn't find the page you were looking for. Check the URL to make sure it's
               correct and try again.
             </P>

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -23,14 +23,14 @@ It's common to restrict specific routes to users who are not authenticated. This
     [
       'app/sign-in.tsx',
       <span>
-        Always accessible <LockUnlocked01Icon className="inline mb-1" />
+        Always accessible <LockUnlocked01Icon className="mb-1 inline" />
       </span>,
     ],
     ['app/(app)/_layout.tsx', <span>Protects child routes</span>],
     [
       'app/(app)/index.tsx',
       <span>
-        Requires authorization <Lock01Icon className="inline mb-1" />
+        Requires authorization <Lock01Icon className="mb-1 inline" />
       </span>,
     ],
   ]}
@@ -300,7 +300,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
     [
       'app/(app)/(root)/index.tsx',
       <span>
-        Requires authorization <Lock01Icon className="inline mb-1" />
+        Requires authorization <Lock01Icon className="mb-1 inline" />
       </span>,
     ],
   ]}

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -96,7 +96,7 @@ function HookComponent() {
 
 <BoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
+<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
 </APIBox>
 

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -99,7 +99,7 @@ function HookComponent() {
 
 <BoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
+<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
 </APIBox>
 

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -97,7 +97,7 @@ function HookComponent() {
 
 <BoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
+<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
 </APIBox>
 

--- a/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
@@ -96,7 +96,7 @@ function HookComponent() {
 
 <BoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
+<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
 </APIBox>
 

--- a/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
@@ -50,7 +50,7 @@ export function BuildEnvironmentSwitch() {
   }
 
   return (
-    <div className="flex gap-3 items-start px-4 py-3 bg-subtle border border-default rounded-lg">
+    <div className="flex items-start gap-3 rounded-lg border border-default bg-subtle px-4 py-3">
       <div className="mt-1">
         <Switch onChange={onSwitchChange} value={!buildEnv} />{' '}
       </div>

--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -28,7 +28,7 @@ export function SelectCard({
     <ButtonBase onClick={onClick}>
       <div
         className={mergeClasses(
-          'w-[250px] shadow-xs overflow-hidden rounded-lg flex flex-col border border-default transition-all',
+          'flex w-[250px] flex-col overflow-hidden rounded-lg border border-default shadow-xs transition-all',
           'hocus:scale-[102%] hocus:shadow-sm'
         )}>
         <div
@@ -36,17 +36,17 @@ export function SelectCard({
             'border-b border-default',
             isSelected ? 'bg-gradient-to-b from-palette-blue3 to-palette-blue4' : 'bg-subtle'
           )}>
-          <picture className="relative w-auto h-full flex items-end">
+          <picture className="relative flex h-full w-auto items-end">
             {isDarkMode && <source srcSet={darkImgSrc} type="image/png" />}
             <img
               src={imgSrc}
               alt={alt}
-              className={mergeClasses(isSelected ? 'grayscale-0' : 'grayscale opacity-80')}
+              className={mergeClasses(isSelected ? 'grayscale-0' : 'opacity-80 grayscale')}
             />
           </picture>
         </div>
-        <div className="p-4 flex flex-col gap-2">
-          <div className="flex gap-2 items-center">
+        <div className="flex flex-col gap-2 p-4">
+          <div className="flex items-center gap-2">
             <div className="relative">
               <div
                 className={mergeClasses(
@@ -56,7 +56,7 @@ export function SelectCard({
               />
               <div
                 className={mergeClasses(
-                  'size-3 rounded-full absolute top-1 right-1',
+                  'absolute right-1 top-1 size-3 rounded-full',
                   isSelected ? 'border-palette-blue9 bg-palette-blue9' : 'bg-transparent'
                 )}
               />

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
@@ -4,7 +4,7 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the Google Play Store, or visit the Expo Go page on the [Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs).
 
-<div className="p-4 rounded-lg border border-default inline-block bg-palette-white">
+<div className="inline-block rounded-lg border border-default bg-palette-white p-4">
   <QRCodeReact
     value="https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs"
     size={228}

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalExpoGo.mdx
@@ -4,6 +4,6 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the App Store, or visit the Expo Go page on the [App Store](https://itunes.apple.com/app/apple-store/id982107779).
 
-<div className="p-4 rounded-lg border border-default inline-block bg-palette-white">
+<div className="inline-block rounded-lg border border-default bg-palette-white p-4">
   <QRCodeReact value="https://itunes.apple.com/app/apple-store/id982107779" size={228} />
 </div>

--- a/docs/scenes/get-started/start-developing/ProjectStructure/Tab.tsx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/Tab.tsx
@@ -17,11 +17,11 @@ export function Tab({ title, onClick, isSelected, type }: Props) {
     <ButtonBase
       onClick={onClick}
       className={mergeClasses(
-        'py-1.5 px-3 rounded-md hocus:bg-hover border border-transparent text-left gap-1.5 items-center',
-        isSelected && 'bg-default border-default border shadow-xs'
+        'items-center gap-1.5 rounded-md border border-transparent px-3 py-1.5 text-left hocus:bg-hover',
+        isSelected && 'border border-default bg-default shadow-xs'
       )}>
-      {type === 'directory' ? <FolderIcon className="text-icon-tertiary icon-sm" /> : null}
-      {type === 'file' ? <FileCode01Icon className="text-icon-tertiary icon-sm" /> : null}
+      {type === 'directory' ? <FolderIcon className="icon-sm text-icon-tertiary" /> : null}
+      {type === 'file' ? <FileCode01Icon className="icon-sm text-icon-tertiary" /> : null}
       <CALLOUT theme={isSelected ? 'default' : 'secondary'}>{title}</CALLOUT>
     </ButtonBase>
   );

--- a/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
@@ -18,15 +18,15 @@ export function ProjectStructure() {
   const [selected, setSelected] = useState('app');
 
   return (
-    <div className="text-default rounded-md overflow-hidden border border-default">
-      <div className="bg-subtle p-3 flex pl-4 border-b border-default">
+    <div className="overflow-hidden rounded-md border border-default text-default">
+      <div className="flex border-b border-default bg-subtle p-3 pl-4">
         <HEADLINE>Files</HEADLINE>
       </div>
       <div className="grid grid-cols-[250px_minmax(0,_1fr)] max-md-gutters:grid-cols-1">
         <div
           className={mergeClasses(
-            'p-3 flex flex-col gap-1 border-r border-default',
-            'max-md-gutters:border-r-0 max-md-gutters:border-b'
+            'flex flex-col gap-1 border-r border-default p-3',
+            'max-md-gutters:border-b max-md-gutters:border-r-0'
           )}>
           <Tab
             title="app"

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
@@ -32,7 +32,7 @@ export function Content({ imgSrc, darkImgSrc, alt, href, content }: Props) {
           <img src={imgSrc} alt={alt} className="size-[300px]" />
         </picture>
       </div>
-      <div className="flex flex-col gap-3 items-start px-6 pb-6 border-t border-default bg-default">
+      <div className="flex flex-col items-start gap-3 border-t border-default bg-default px-6 pb-6">
         <div>
           {content}
           {href && (

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/Tab.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/Tab.tsx
@@ -14,8 +14,8 @@ export function Tab({ title, onClick, isSelected }: Props) {
     <ButtonBase
       onClick={onClick}
       className={mergeClasses(
-        'py-1.5 px-3 rounded-md hocus:bg-hover border border-transparent text-left',
-        isSelected && 'bg-default border-default border shadow-xs'
+        'rounded-md border border-transparent px-3 py-1.5 text-left hocus:bg-hover',
+        isSelected && 'border border-default bg-default shadow-xs'
       )}>
       <CALLOUT theme={isSelected ? 'default' : 'secondary'}>{title}</CALLOUT>
     </ButtonBase>

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
@@ -16,15 +16,15 @@ export function TemplateFeatures() {
   const [selected, setSelected] = useState('navigation');
 
   return (
-    <div className="text-default rounded-md overflow-hidden border border-default">
-      <div className="bg-subtle p-3 flex pl-4 border-b border-default">
+    <div className="overflow-hidden rounded-md border border-default text-default">
+      <div className="flex border-b border-default bg-subtle p-3 pl-4">
         <HEADLINE>Default project</HEADLINE>
       </div>
       <div className="grid grid-cols-[250px_minmax(0,_1fr)] max-md-gutters:grid-cols-1">
         <div
           className={mergeClasses(
-            'p-3 flex flex-col gap-1 border-r border-default',
-            'max-md-gutters:border-r-0 max-md-gutters:border-b'
+            'flex flex-col gap-1 border-r border-default p-3',
+            'max-md-gutters:border-b max-md-gutters:border-r-0'
           )}>
           <Tab
             title="File-based routing"

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#name"
           id="name"
         >
@@ -27,7 +27,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -70,17 +70,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Name of your app.
       </p>
       <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -98,18 +98,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
-            class="inline ml-auto"
+            class="ml-auto inline"
             href="#bare-workflow"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -135,7 +135,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -147,14 +147,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#androidnavigationbar"
           id="androidnavigationbar"
         >
@@ -170,7 +170,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -213,17 +213,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="expokit"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -241,18 +241,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             ExpoKit
           </span>
           <a
-            class="inline ml-auto"
+            class="ml-auto inline"
             href="#expokit"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -278,7 +278,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -289,17 +289,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow-1"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -317,18 +317,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
-            class="inline ml-auto"
+            class="ml-auto inline"
             href="#bare-workflow-1"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -354,7 +354,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -365,14 +365,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#visible"
             id="visible"
           >
@@ -388,7 +388,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -426,7 +426,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
            • Path:
            
           <code
-            class="text-secondary px-1 break-words"
+            class="break-words px-1 text-secondary"
           >
             androidNavigationBar
             .
@@ -440,17 +440,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+          class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
           id="expokit-1"
         >
           <summary
-            class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+            class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
           >
             <div
-              class="mt-[5px] ml-1.5 mr-2 self-baseline"
+              class="ml-1.5 mr-2 mt-[5px] self-baseline"
             >
               <svg
-                class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+                class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -468,18 +468,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
               data-text="true"
             >
               ExpoKit
             </span>
             <a
-              class="inline ml-auto"
+              class="ml-auto inline"
               href="#expokit-1"
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+                class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -505,7 +505,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             <div />
           </summary>
           <div
-            class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
             <p
               class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -516,14 +516,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
-              class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
               href="#always"
               id="always"
             >
@@ -539,7 +539,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </span>
               <svg
                 aria-label="permalink"
-                class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -577,7 +577,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="text-secondary px-1 break-words"
+              class="break-words px-1 text-secondary"
             >
               androidNavigationBar.visible
               .
@@ -593,14 +593,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#backgroundcolor"
             id="backgroundcolor"
           >
@@ -616,7 +616,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -654,7 +654,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
            • Path:
            
           <code
-            class="text-secondary px-1 break-words"
+            class="break-words px-1 text-secondary"
           >
             androidNavigationBar
             .
@@ -684,14 +684,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
           href="#intentfilters"
           id="intentfilters"
         >
@@ -707,7 +707,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -750,17 +750,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="bg-default border border-default rounded-md p-0 mb-3 [&[open]]:shadow-xs [h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3"
+        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow-2"
       >
         <summary
-          class="group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer [&_h4]:my-0 [&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="mt-[5px] ml-1.5 mr-2 self-baseline"
+            class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default transition-transform duration-200 -rotate-90 [details[open]>summary_&]:rotate-0"
+              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -778,18 +778,18 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
-            class="inline ml-auto"
+            class="ml-auto inline"
             href="#bare-workflow-2"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -815,7 +815,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="py-4 px-5 [&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1"
+          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
@@ -826,7 +826,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <span
-        class="grid grid-cols-1 gap-2 mb-6"
+        class="mb-6 grid grid-cols-1 gap-2"
       >
         <p
           class="text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary font-bold"
@@ -835,7 +835,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Example
         </p>
         <span
-          class="whitespace-pre m-0 px-1 py-1.5 inline-flex !p-0"
+          class="m-0 whitespace-pre px-1 py-1.5 inline-flex !p-0"
           data-text="true"
         >
           <code
@@ -854,14 +854,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#autoverify"
             id="autoverify"
           >
@@ -877,7 +877,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -915,7 +915,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
            • Path:
            
           <code
-            class="text-secondary px-1 break-words"
+            class="break-words px-1 text-secondary"
           >
             intentFilters
             .
@@ -930,14 +930,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
             href="#data"
             id="data"
           >
@@ -953,7 +953,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -991,7 +991,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
            • Path:
            
           <code
-            class="text-secondary px-1 break-words"
+            class="break-words px-1 text-secondary"
           >
             intentFilters
             .
@@ -999,14 +999,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:shadow-none [&_.table-wrapper]:mb-0 [&_th]:text-tertiary [&_th]:py-2.5 [&_th]:px-4 max-lg-gutters:px-4 mb-3.5 pt-4 px-5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
-              class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
               href="#host"
               id="host"
             >
@@ -1022,7 +1022,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </span>
               <svg
                 aria-label="permalink"
-                class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -1060,7 +1060,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="text-secondary px-1 break-words"
+              class="break-words px-1 text-secondary"
             >
               intentFilters.data
               .

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
@@ -241,7 +241,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             ExpoKit
@@ -317,7 +317,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
@@ -468,7 +468,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
               data-text="true"
             >
               ExpoKit
@@ -778,7 +778,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="text-default leading-[1.6154] font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium inline gap-1.5 items-center scroll-m-5 mr-2 relative group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow

--- a/docs/ui/components/AppConfigSchemaTable/index.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/index.tsx
@@ -67,10 +67,10 @@ function AppConfigProperty({
       <PropertyName name={name} nestingLevel={nestingLevel} />
       <CALLOUT theme="secondary" data-text="true" className="my-3">
         {Array.isArray(type) ? (
-          <span className="grid grid-cols-1 gap-2 mb-2">
+          <span className="mb-2 grid grid-cols-1 gap-2">
             One of types:{' '}
             {type.map((oneOfType, index) => (
-              <CodeBlock className="!text-secondary !text-balance" inline key={`${name}-${index}`}>
+              <CodeBlock className="!text-balance !text-secondary" inline key={`${name}-${index}`}>
                 {oneOfType}
               </CodeBlock>
             ))}
@@ -83,7 +83,7 @@ function AppConfigProperty({
         {nestingLevel > 0 && (
           <>
             &emsp;&bull;&emsp;Path:{' '}
-            <code className="text-secondary px-1 break-words">
+            <code className="break-words px-1 text-secondary">
               {parent}.{name}
             </code>
           </>
@@ -101,7 +101,7 @@ function AppConfigProperty({
         </Collapsible>
       )}
       {example && (
-        <span className="grid grid-cols-1 gap-2 mb-6">
+        <span className="mb-6 grid grid-cols-1 gap-2">
           <CALLOUT theme="secondary" className="font-bold">
             Example
           </CALLOUT>

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -20,14 +20,14 @@ export function AppJSBanner() {
   return (
     <div
       className={mergeClasses(
-        'relative flex items-center justify-between gap-3 py-4 px-6 overflow-hidden rounded-lg mt-6 mb-4',
+        'relative mb-4 mt-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg px-6 py-4',
         'bg-appjs bg-cover bg-left bg-no-repeat',
         'border border-[#03c] dark:border-[#1e51e7]',
         'max-md-gutters:flex-wrap'
       )}>
       <div className="flex items-center gap-4">
         <div className="relative z-10 p-2 max-sm-gutters:hidden">
-          <div className="absolute inset-0 rounded-md bg-[#1e51e7] asset-sm-shadow" />
+          <div className="asset-sm-shadow absolute inset-0 rounded-md bg-[#1e51e7]" />
           <AppJSIcon className="icon-lg relative z-10 text-palette-white" />
         </div>
         <div className="relative grid grid-cols-1 gap-0.5">
@@ -44,7 +44,7 @@ export function AppJSBanner() {
           openInNewTab
           rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-white opacity-75" />}
           className={mergeClasses(
-            'gap-1.5 border-[#5d82ff] bg-[#1e51e7] text-palette-white shadow-none asset-sm-shadow',
+            'asset-sm-shadow gap-1.5 border-[#5d82ff] bg-[#1e51e7] text-palette-white shadow-none',
             'hocus:bg-[#2b5ef3]'
           )}>
           Learn More

--- a/docs/ui/components/Authentication/Box.tsx
+++ b/docs/ui/components/Authentication/Box.tsx
@@ -14,8 +14,8 @@ type BoxProps = PropsWithChildren<{
 
 export const Box = ({ name, image, createUrl, children }: BoxProps) => (
   <APIBox className="mt-6">
-    <div className="inline-flex flex-row items-center gap-4 pb-4 w-full max-md-gutters::gap-3 max-md-gutters::flex-col">
-      <div className="flex flex-row gap-3 items-center w-[inherit] [&>h3]:!mb-0">
+    <div className="max-md-gutters::gap-3 max-md-gutters::flex-col inline-flex w-full flex-row items-center gap-4 pb-4">
+      <div className="flex w-[inherit] flex-row items-center gap-3 [&>h3]:!mb-0">
         <Icon title={name} image={image} className="size-12" />
         <H3>{name}</H3>
       </div>

--- a/docs/ui/components/Authentication/CreateAppButton.tsx
+++ b/docs/ui/components/Authentication/CreateAppButton.tsx
@@ -5,7 +5,7 @@ type CreateAppButtonProps = { href: string; name: string };
 
 export const CreateAppButton = ({ href, name }: CreateAppButtonProps) => (
   <Button
-    className="flex w-fit justify-center max-medium:min-w-full"
+    className="max-medium:min-w-full flex w-fit justify-center"
     href={href}
     openInNewTab
     rightSlot={<ArrowUpRightIcon />}>

--- a/docs/ui/components/Authentication/Grid.tsx
+++ b/docs/ui/components/Authentication/Grid.tsx
@@ -1,7 +1,7 @@
 import { type PropsWithChildren } from 'react';
 
 export const Grid = ({ children }: PropsWithChildren) => (
-  <div className="inline-grid w-full gap-5 grid-cols-[repeat(auto-fit,minmax(200px,1fr))]">
+  <div className="inline-grid w-full grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-5">
     {children}
   </div>
 );

--- a/docs/ui/components/Authentication/GridItem.tsx
+++ b/docs/ui/components/Authentication/GridItem.tsx
@@ -20,8 +20,8 @@ export const GridItem = ({
   <A
     href={href}
     className={mergeClasses(
-      'flex flex-col group items-center justify-center p-6 gap-1.5 rounded-md border border-default shadow-xs transition-all',
-      'hocus:shadow-md hocus:scale-105'
+      'group flex flex-col items-center justify-center gap-1.5 rounded-md border border-default p-6 shadow-xs transition-all',
+      'hocus:scale-105 hocus:shadow-md'
     )}
     isStyled>
     <Icon title={title} image={image} />
@@ -30,8 +30,8 @@ export const GridItem = ({
       <CALLOUT
         theme="secondary"
         className={mergeClasses(
-          'relative opacity-0 top-1.5 transition-all duration-300',
-          'group-hover:opacity-75 group-hover:top-0 group-hover:scale-100'
+          'relative top-1.5 opacity-0 transition-all duration-300',
+          'group-hover:top-0 group-hover:scale-100 group-hover:opacity-75'
         )}>
         {protocol.join(' | ')}
       </CALLOUT>

--- a/docs/ui/components/Authentication/Icon.tsx
+++ b/docs/ui/components/Authentication/Icon.tsx
@@ -9,7 +9,7 @@ type IconProps = {
 
 export const Icon = ({ title, image, className }: IconProps) => (
   <img
-    className={mergeClasses('rounded-full p-1 bg-element size-16', className)}
+    className={mergeClasses('size-16 rounded-full bg-element p-1', className)}
     alt={title}
     src={image}
   />

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -18,23 +18,23 @@ export function BoxLink({ title, description, href, testID, Icon, imageUrl }: Bo
   return (
     <A
       href={href}
-      className="flex flex-row justify-between border border-solid border-default rounded-md py-3 px-4 mb-3 hocus:shadow-xs"
+      className="mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 hocus:shadow-xs"
       data-testid={testID}
       openInNewTab={isExternal}
       isStyled>
       <div className="flex flex-row gap-4">
         {Icon && (
-          <div className="flex bg-element rounded-md self-center items-center justify-center min-w-[36px] h-9">
+          <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element">
             <Icon className="icon-lg text-icon-default" />
           </div>
         )}
-        {imageUrl && <img className="!w-9 !h-9 self-center" src={imageUrl} alt="Icon" />}
+        {imageUrl && <img className="!h-9 !w-9 self-center" src={imageUrl} alt="Icon" />}
         <div>
           <DEMI>{title}</DEMI>
           <CALLOUT theme="secondary">{description}</CALLOUT>
         </div>
       </div>
-      <ArrowIcon className="text-icon-secondary self-center content-end ml-3 min-w-[20px]" />
+      <ArrowIcon className="ml-3 min-w-[20px] content-end self-center text-icon-secondary" />
     </A>
   );
 }

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -52,7 +52,7 @@ export const Callout = ({
   return (
     <blockquote
       className={mergeClasses(
-        'bg-subtle border border-default flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4',
+        'mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs',
         '[table_&]:last:mb-0',
         '[&_code]:bg-element',
         getCalloutColor(finalType),
@@ -62,7 +62,7 @@ export const Callout = ({
       )}
       data-testid="callout-container">
       <div
-        className={mergeClasses('select-none mt-1', '[table_&]:mt-0.5', size === 'sm' && 'mt-0.5')}>
+        className={mergeClasses('mt-1 select-none', '[table_&]:mt-0.5', size === 'sm' && 'mt-0.5')}>
         {typeof icon === 'string' ? (
           icon
         ) : (
@@ -71,9 +71,9 @@ export const Callout = ({
       </div>
       <div
         className={mergeClasses(
-          'text-default w-full leading-normal',
+          'w-full leading-normal text-default',
           'last:mb-0',
-          size === 'sm' && 'text-xs [&_p]:text-xs [&_code]:text-[90%]'
+          size === 'sm' && 'text-xs [&_code]:text-[90%] [&_p]:text-xs'
         )}>
         {type === finalType ? children : contentChildren.filter((_, i) => i !== 0)}
       </div>
@@ -85,19 +85,19 @@ function getCalloutColor(type: CalloutType) {
   switch (type) {
     case 'warning':
       return mergeClasses(
-        'bg-warning border-warning',
-        `[&_code]:bg-palette-yellow4 [&_code]:border-palette-yellow6`,
-        `dark:[&_code]:bg-palette-yellow5 dark:[&_code]:border-palette-yellow7`
+        'border-warning bg-warning',
+        `[&_code]:border-palette-yellow6 [&_code]:bg-palette-yellow4`,
+        `dark:[&_code]:border-palette-yellow7 dark:[&_code]:bg-palette-yellow5`
       );
     case 'error':
       return mergeClasses(
-        'bg-danger border-danger',
-        `[&_code]:bg-palette-red5 [&_code]:border-palette-red7`
+        'border-danger bg-danger',
+        `[&_code]:border-palette-red7 [&_code]:bg-palette-red5`
       );
     case 'info':
       return mergeClasses(
-        'bg-info border-info',
-        `[&_code]:bg-palette-blue4 [&_code]:border-palette-blue6`
+        'border-info bg-info',
+        `[&_code]:border-palette-blue6 [&_code]:bg-palette-blue4`
       );
     default:
       return null;

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -76,33 +76,33 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
       <details
         id={heading.current.slug}
         className={mergeClasses(
-          'bg-default border border-default rounded-md p-0 mb-3',
+          'mb-3 rounded-md border border-default bg-default p-0',
           '[&[open]]:shadow-xs',
-          '[h4+&]:mt-3 [p+&]:mt-3 [li>&]:mt-3',
+          '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
         )}
         open={isOpen}
         data-testid={testID}>
         <summary
           className={mergeClasses(
-            'group grid grid-cols-[min-content_auto_min-content_1fr] items-center select-none bg-subtle p-1.5 pr-3 m-0 rounded-md cursor-pointer',
+            'group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3',
             isOpen && 'rounded-b-none',
             '[&_h4]:my-0',
-            '[&_code]:bg-element [&_code]:inline [&_code]:text-[85%] [&_code]:leading-snug [&_code]:pb-px [&_code]:mt-px'
+            '[&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug'
           )}
           onClick={onToggle}>
-          <div className="mt-[5px] ml-1.5 mr-2 self-baseline">
+          <div className="ml-1.5 mr-2 mt-[5px] self-baseline">
             <TriangleDownIcon
               className={mergeClasses(
                 'icon-sm text-icon-default',
-                'transition-transform duration-200 -rotate-90',
+                '-rotate-90 transition-transform duration-200',
                 '[details[open]>summary_&]:rotate-0'
               )}
             />
           </div>
           <DEMI
             className={mergeClasses(
-              'inline gap-1.5 items-center scroll-m-5 mr-2 relative',
+              'relative mr-2 inline scroll-m-5 items-center gap-1.5',
               'group-hover:text-secondary group-hover:[&_code]:text-secondary'
             )}>
             {summary}
@@ -110,12 +110,12 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           <LinkBase
             href={'#' + heading.current.slug}
             ref={heading.current.ref}
-            className="inline ml-auto">
-            <PermalinkIcon className="icon-sm inline-flex mb-auto invisible group-hover:visible group-focus-visible:visible" />
+            className="ml-auto inline">
+            <PermalinkIcon className="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible" />
           </LinkBase>
           <div />
         </summary>
-        <div className={mergeClasses('py-4 px-5', '[&_p]:ml-0 [&_pre>pre]:mt-0 last:[&>*]:!mb-1')}>
+        <div className={mergeClasses('px-5 py-4', 'last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
           {children}
         </div>
       </details>

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -37,7 +37,7 @@ export function ContentSpotlight({
   return (
     <figure
       className={mergeClasses(
-        'text-center py-2.5 my-5 rounded-lg cursor-pointer',
+        'my-5 cursor-pointer rounded-lg py-2.5 text-center',
         containerClassName,
         !isVideo && 'bg-subtle'
       )}
@@ -58,7 +58,7 @@ export function ContentSpotlight({
       ) : isVideo ? (
         <VisibilitySensor partialVisibility>
           {({ isVisible }: { isVisible: boolean }) => (
-            <div className="relative aspect-video bg-palette-black rounded-lg overflow-hidden">
+            <div className="relative aspect-video overflow-hidden rounded-lg bg-palette-black">
               <ReactPlayer
                 url={`/static/videos/${file}`}
                 className="react-player"
@@ -83,7 +83,7 @@ export function ContentSpotlight({
       {caption && (
         <figcaption
           className={mergeClasses(
-            'mt-3.5 text-secondary text-center text-xs px-8 py-2 cursor-text',
+            'mt-3.5 cursor-text px-8 py-2 text-center text-xs text-secondary',
             isVideo && 'bg-transparent'
           )}>
           {caption}

--- a/docs/ui/components/Diagram/Diagram.tsx
+++ b/docs/ui/components/Diagram/Diagram.tsx
@@ -15,7 +15,7 @@ export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
 
   if (!source.match(/\.png$/)) {
     return (
-      <div className="bg-default border relative border-default rounded-md overflow-hidden my-6 max-w-[750px] m-auto">
+      <div className="relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border border-default bg-default">
         <DotGrid />
         <picture className="relative">
           {isDark && darkSource && <source srcSet={darkSource} />}
@@ -26,7 +26,7 @@ export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
   }
 
   return (
-    <div className="bg-default border relative border-default rounded-md overflow-hidden my-6 max-w-[750px] m-auto">
+    <div className="relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border border-default bg-default">
       <DotGrid />
       <picture className="relative">
         {!isDark && !disableSrcSet && (

--- a/docs/ui/components/Diagram/DotGrid.tsx
+++ b/docs/ui/components/Diagram/DotGrid.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export function DotGrid() {
   return (
-    <div className="z-0 absolute size-full">
+    <div className="absolute z-0 size-full">
       <svg width="100%" height="100%">
         <defs>
           <pattern id="dot-grid" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">

--- a/docs/ui/components/DocIcons/IconBase.tsx
+++ b/docs/ui/components/DocIcons/IconBase.tsx
@@ -15,7 +15,7 @@ export const IconBase = ({ className, small, Icon, ...rest }: DocIconProps) => {
         'inline-block',
         small ? 'icon-sm' : 'icon-md',
         'text-icon-default',
-        '[table_&]:align-middle [li_&]:align-middle [li_&]:-mt-0.5',
+        '[li_&]:-mt-0.5 [li_&]:align-middle [table_&]:align-middle',
         className
       )}
       {...rest}

--- a/docs/ui/components/Dropdown/Item.tsx
+++ b/docs/ui/components/Dropdown/Item.tsx
@@ -34,7 +34,7 @@ export function Item({
       aria-disabled={disabled}
       className={mergeClasses(
         'relative z-40 flex cursor-pointer select-none items-center justify-between rounded-sm px-2 py-1',
-        'hocus:bg-hover hover:outline-0',
+        'hover:outline-0 hocus:bg-hover',
         disabled && 'cursor-default opacity-60 hocus:bg-default'
       )}
       onSelect={event => {

--- a/docs/ui/components/FileTree/TextWithNote.tsx
+++ b/docs/ui/components/FileTree/TextWithNote.tsx
@@ -8,13 +8,13 @@ export function TextWithNote({
   className: string;
 }) {
   return (
-    <span className="flex items-center flex-1">
+    <span className="flex flex-1 items-center">
       {/* File/folder name  */}
       <code className={className}>{name}</code>
       {note && (
         <>
           {/* divider pushing  */}
-          <span className="flex-1 border-b border-default opacity-60 mx-3 min-w-8 max-md-gutters:mx-2" />
+          <span className="mx-3 min-w-8 flex-1 border-b border-default opacity-60 max-md-gutters:mx-2" />
           {/* Optional note */}
           <code className="text-default">{note}</code>
         </>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -19,7 +19,7 @@ type FileObject = {
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
     <div
-      className="text-xs border border-default rounded-md bg-default mb-4 p-2 pr-4 pb-4 whitespace-nowrap overflow-x-auto"
+      className="mb-4 overflow-x-auto whitespace-nowrap rounded-md border border-default bg-default p-2 pb-4 pr-4 text-xs"
       {...rest}>
       {renderStructure(generateStructure(files))}
     </div>
@@ -70,18 +70,18 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
   return structure.map(({ name, note, files }, index) => {
     const FileIcon = getIconForFile(name);
     return files.length ? (
-      <div key={name + '_' + index} className="mt-1 pt-1 pl-2 rounded-sm flex flex-col">
+      <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pl-2 pt-1">
         <div className="flex items-center">
           {' '.repeat(level)}
-          <FolderIcon className="text-icon-tertiary mr-2 opacity-60 min-w-[20px]" />
+          <FolderIcon className="mr-2 min-w-[20px] text-icon-tertiary opacity-60" />
           <TextWithNote name={name} note={note} className="text-secondary" />
         </div>
         {renderStructure(files, level + 1)}
       </div>
     ) : (
-      <div key={name + '_' + index} className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
+      <div key={name + '_' + index} className="mt-1 flex items-center rounded-sm pl-2 pt-1">
         {' '.repeat(Math.max(level, 0))}
-        <FileIcon className="text-icon-tertiary mr-2 min-w-[20px]" />
+        <FileIcon className="mr-2 min-w-[20px] text-icon-tertiary" />
         <TextWithNote name={name} note={note} className="text-default" />
       </div>
     );

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -65,22 +65,22 @@ export const FeedbackDialog = ({ pathname }: Props) => {
           <Dialog.Content
             className={mergeClasses(
               'dialog-content',
-              'backface-hidden left-0 top-0 max-h-[90vh] w-[90vw] max-w-[500px] overflow-hidden break-words rounded-lg border border-default bg-default shadow-md outline-0',
+              'break-words backface-hidden left-0 top-0 max-h-[90vh] w-[90vw] max-w-[500px] overflow-hidden rounded-lg border border-default bg-default shadow-md outline-0',
               'data-[state=open]:animate-slideUpAndFadeIn',
               'data-[state=closed]:animate-fadeOut'
             )}>
             {isSuccess ? (
               <>
-                <div className="px-6 py-12 flex flex-col items-center">
-                  <div className="flex bg-success border-2 border-success size-[72px] rounded-full items-center justify-center">
-                    <CheckIcon className="text-icon-success icon-2xl" />
+                <div className="flex flex-col items-center px-6 py-12">
+                  <div className="flex size-[72px] items-center justify-center rounded-full border-2 border-success bg-success">
+                    <CheckIcon className="icon-2xl text-icon-success" />
                   </div>
-                  <RawH2 className="!mt-5 !mb-2">Feedback received</RawH2>
+                  <RawH2 className="!mb-2 !mt-5">Feedback received</RawH2>
                   <CALLOUT theme="secondary">
                     Your feedback will help us make our docs better. Thanks for sharing!
                   </CALLOUT>
                 </div>
-                <div className="bg-subtle flex justify-end items-center gap-2 min-h-[56px] px-3">
+                <div className="flex min-h-[56px] items-center justify-end gap-2 bg-subtle px-3">
                   <Dialog.Close asChild>
                     <Button type="submit">Done</Button>
                   </Dialog.Close>
@@ -102,7 +102,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                   <CALLOUT theme="secondary">
                     Add your feedback to help us improve this doc.
                   </CALLOUT>
-                  <div className="grid gap-4 mt-4">
+                  <div className="mt-4 grid gap-4">
                     <div>
                       <LABEL>Feedback</LABEL>
                       <Textarea
@@ -141,7 +141,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     </Callout>
                   )}
                 </div>
-                <div className="bg-subtle flex justify-end items-center gap-2 min-h-[56px] px-3">
+                <div className="flex min-h-[56px] items-center justify-end gap-2 bg-subtle px-3">
                   <Dialog.Close asChild>
                     <Button theme="quaternary">No Thanks</Button>
                   </Dialog.Close>

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -50,10 +50,10 @@ export const Footer = ({
             <LinkBase
               href={previousPage.href}
               className={mergeClasses(
-                'flex border items-center gap-3 border-solid border-default rounded-md py-3 px-4 w-full transition',
-                'hocus:shadow-xs hocus:bg-subtle'
+                'flex w-full items-center gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'hocus:bg-subtle hocus:shadow-xs'
               )}>
-              <ArrowLeftIcon className="text-icon-secondary shrink-0" />
+              <ArrowLeftIcon className="shrink-0 text-icon-secondary" />
               <div>
                 <FOOTNOTE theme="secondary">
                   Previous{previousPage.section ? ` (${previousPage.section})` : ''}
@@ -68,8 +68,8 @@ export const Footer = ({
             <LinkBase
               href={nextPage.href}
               className={mergeClasses(
-                'flex border justify-between items-center gap-3 border-solid border-default rounded-md py-3 px-4 w-full transition',
-                'hocus:shadow-xs hocus:bg-subtle'
+                'flex w-full items-center justify-between gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'hocus:bg-subtle hocus:shadow-xs'
               )}>
               <div>
                 <FOOTNOTE theme="secondary">
@@ -77,7 +77,7 @@ export const Footer = ({
                 </FOOTNOTE>
                 <P weight="medium">{nextPage.sidebarTitle ?? nextPage.name}</P>
               </div>
-              <ArrowRightIcon className="text-icon-secondary shrink-0" />
+              <ArrowRightIcon className="shrink-0 text-icon-secondary" />
             </LinkBase>
           ) : (
             <div className="w-full" />
@@ -85,10 +85,10 @@ export const Footer = ({
         </div>
       )}
       <div
-        className={mergeClasses('flex flex-row gap-4 justify-between', 'max-md-gutters:flex-col')}>
+        className={mergeClasses('flex flex-row justify-between gap-4', 'max-md-gutters:flex-col')}>
         <div>
           <PageVote />
-          <UL className="flex-1 !mt-0 !ml-0 !list-none">
+          <UL className="!ml-0 !mt-0 flex-1 !list-none">
             <ShareFeedbackLink pathname={router?.pathname} />
             {title && <ForumsLink isAPIPage={isAPIPage} title={title} />}
             {title && isAPIPage && (
@@ -96,12 +96,12 @@ export const Footer = ({
             )}
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
             {!isDev && shouldShowModifiedDate && modificationDate && (
-              <LI className="!text-quaternary !text-2xs !mt-4">
+              <LI className="!mt-4 !text-2xs !text-quaternary">
                 Last updated on {modificationDate}
               </LI>
             )}
             {isDev && shouldShowModifiedDate && (
-              <LI className="!text-quaternary !text-2xs !mt-4">
+              <LI className="!mt-4 !text-2xs !text-quaternary">
                 Last updated data is not available in dev mode
               </LI>
             )}

--- a/docs/ui/components/Footer/NewsletterSignUp.tsx
+++ b/docs/ui/components/Footer/NewsletterSignUp.tsx
@@ -39,9 +39,9 @@ export const NewsletterSignUp = () => {
   }
 
   return (
-    <div className="flex-1 max-w-[350px] max-md-gutters:max-w-full">
-      <CALLOUT className="text-secondary font-medium flex gap-2 items-center" id="newsletter-label">
-        <Mail01Icon className="text-icon-tertiary shrink-0" />
+    <div className="max-w-[350px] flex-1 max-md-gutters:max-w-full">
+      <CALLOUT className="flex items-center gap-2 font-medium text-secondary" id="newsletter-label">
+        <Mail01Icon className="shrink-0 text-icon-tertiary" />
         Sign up for the Expo Newsletter
       </CALLOUT>
       <form
@@ -51,7 +51,7 @@ export const NewsletterSignUp = () => {
           signUp();
         }}>
         {userSignedUp ? (
-          <LABEL className="flex items-center my-2.5 h-12">Thank you for the sign up! 💙</LABEL>
+          <LABEL className="my-2.5 flex h-12 items-center">Thank you for the sign up! 💙</LABEL>
         ) : (
           <Input
             onChange={event => {

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -12,9 +12,9 @@ export const PageVote = () => {
   return (
     <div
       className={mergeClasses(
-        'mb-4 flex items-center min-h-[32px]',
+        'mb-4 flex min-h-[32px] items-center',
         userVoted ? 'content-start' : 'content-center',
-        'max-md-gutters:mb-8 max-md-gutters:mx-auto max-md-gutters:justify-center'
+        'max-md-gutters:mx-auto max-md-gutters:mb-8 max-md-gutters:justify-center'
       )}>
       {userVoted ? (
         <CALLOUT theme="secondary">Thank you for your vote! 💙</CALLOUT>

--- a/docs/ui/components/Form/Checkbox.tsx
+++ b/docs/ui/components/Form/Checkbox.tsx
@@ -13,7 +13,7 @@ export const Checkbox = forwardRef(function Checkbox(
   ref?: Ref<HTMLInputElement>
 ) {
   return (
-    <div className={mergeClasses('flex items-center gap-2 relative', className)}>
+    <div className={mergeClasses('relative flex items-center gap-2', className)}>
       {checked && (
         <CheckIcon className="absolute w-4 px-0.5 text-palette-white [&_path]:!stroke-[3px]" />
       )}
@@ -25,11 +25,11 @@ export const Checkbox = forwardRef(function Checkbox(
         data-label={label}
         disabled={disabled}
         className={mergeClasses(
-          'rounded-sm border-palette-gray8 bg-default transition-colors border size-4',
+          'size-4 rounded-sm border border-palette-gray8 bg-default transition-colors',
           !disabled &&
             'focus-within:ring-palette-blue10 hocus:cursor-pointer hocus:border-palette-blue10 hocus:bg-palette-blue3',
           !disabled && 'dark:focus:ring-palette-blue8 dark:hocus:border-palette-blue8',
-          'checked:bg-palette-blue10 checked:border-palette-blue10 checked:hocus:bg-palette-blue10',
+          'checked:border-palette-blue10 checked:bg-palette-blue10 checked:hocus:bg-palette-blue10',
           'dark:checked:bg-palette-blue8 dark:checked:hocus:bg-palette-blue8'
         )}
         {...rest}

--- a/docs/ui/components/Form/Input.tsx
+++ b/docs/ui/components/Form/Input.tsx
@@ -7,7 +7,7 @@ export function Input({ className, ...rest }: Props) {
   return (
     <input
       className={mergeClasses(
-        'block shadow-xs border border-default rounded-md text-default bg-default h-12 w-full my-2.5 px-4 placeholder:text-icon-quaternary',
+        'my-2.5 block h-12 w-full rounded-md border border-default bg-default px-4 text-default shadow-xs placeholder:text-icon-quaternary',
         className
       )}
       {...rest}

--- a/docs/ui/components/Form/Textarea.tsx
+++ b/docs/ui/components/Form/Textarea.tsx
@@ -18,7 +18,7 @@ export function Textarea({ characterLimit, className, onChange, ...rest }: Props
           if (onChange) onChange(e);
         }}
         className={mergeClasses(
-          'block shadow-xs border border-default rounded-sm text-default bg-default h-12 w-full my-2.5 p-4 leading-5 placeholder:text-icon-tertiary',
+          'my-2.5 block h-12 w-full rounded-sm border border-default bg-default p-4 leading-5 text-default shadow-xs placeholder:text-icon-tertiary',
           className
         )}
         {...rest}

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -26,7 +26,7 @@ export const Header = ({
   const isArchive = sidebarActiveGroup === 'archive';
   return (
     <>
-      <nav className="flex items-center justify-between relative bg-default z-10 mx-auto p-0 px-4 h-[60px] border-b border-default gap-2">
+      <nav className="relative z-10 mx-auto flex h-[60px] items-center justify-between gap-2 border-b border-default bg-default p-0 px-4">
         <div className="flex items-center gap-8">
           <Logo subgroup={isArchive ? 'Archive' : undefined} />
         </div>
@@ -58,7 +58,7 @@ export const Header = ({
             theme="quaternary"
             href="https://github.com/expo/expo"
             aria-label="GitHub"
-            className={mergeClasses('px-2 hidden', 'max-lg-gutters:flex')}>
+            className={mergeClasses('hidden px-2', 'max-lg-gutters:flex')}>
             <GithubIcon className="icon-lg" />
           </Button>
           <div className="max-lg-gutters:hidden">
@@ -83,7 +83,7 @@ export const Header = ({
       {isMobileMenuVisible && (
         <nav
           className={mergeClasses(
-            'items-center justify-between relative bg-default z-10 mx-auto p-0 px-4 h-[60px] border-b border-default hidden',
+            'relative z-10 mx-auto hidden h-[60px] items-center justify-between border-b border-default bg-default p-0 px-4',
             'max-lg-gutters:flex'
           )}>
           <div className="flex items-center">
@@ -95,7 +95,7 @@ export const Header = ({
         </nav>
       )}
       {isMobileMenuVisible && (
-        <div className="bg-subtle h-[calc(100dvh-(60px*2))] overflow-x-hidden overflow-y-auto">
+        <div className="h-[calc(100dvh-(60px*2))] overflow-y-auto overflow-x-hidden bg-subtle">
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
           <SidebarFooter isMobileMenuVisible={isMobileMenuVisible} />

--- a/docs/ui/components/Header/Logo.tsx
+++ b/docs/ui/components/Header/Logo.tsx
@@ -10,26 +10,26 @@ type Props = {
 export const Logo = ({ subgroup }: Props) => (
   <div className="flex items-center gap-4">
     <LinkBase
-      className="flex flex-row items-center decoration-0 select-none gap-2 outline-offset-1"
+      className="flex select-none flex-row items-center gap-2 decoration-0 outline-offset-1"
       href="https://expo.dev">
       <WordMarkLogo
-        className={mergeClasses('w-[72px] mt-px h-5 text-default my-1', 'max-md-gutters:hidden')}
+        className={mergeClasses('my-1 mt-px h-5 w-[72px] text-default', 'max-md-gutters:hidden')}
         title="Expo"
       />
       <LogoIcon
-        className={mergeClasses('icon-lg mr-1.5 text-default hidden', 'max-md-gutters:flex')}
+        className={mergeClasses('icon-lg mr-1.5 hidden text-default', 'max-md-gutters:flex')}
         title="Expo"
       />
     </LinkBase>
     <LinkBase
-      className="flex flex-row items-center decoration-0 select-none gap-2 outline-offset-1"
+      className="flex select-none flex-row items-center gap-2 decoration-0 outline-offset-1"
       href="/">
-      <div className="flex items-center justify-center bg-palette-blue4 rounded-sm size-6">
+      <div className="flex size-6 items-center justify-center rounded-sm bg-palette-blue4">
         <DocumentationIcon className="icon-sm" />
       </div>
       <span
         className={mergeClasses(
-          'text-default font-medium text-lg select-none',
+          'select-none text-lg font-medium text-default',
           subgroup && 'max-md-gutters:hidden'
         )}>
         Docs
@@ -38,9 +38,9 @@ export const Logo = ({ subgroup }: Props) => (
     {subgroup && (
       <>
         <ChevronRightIcon
-          className={mergeClasses('text-icon-secondary -mx-2', 'max-md-gutters:hidden')}
+          className={mergeClasses('-mx-2 text-icon-secondary', 'max-md-gutters:hidden')}
         />
-        <span className="text-default font-medium text-lg select-none">{subgroup}</span>
+        <span className="select-none text-lg font-medium text-default">{subgroup}</span>
       </>
     )}
   </div>

--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -19,9 +19,9 @@ export const ThemeSelector = () => {
         aria-label="Theme selector"
         title="Select theme"
         className={mergeClasses(
-          'flex items-center justify-center h-9 text-default leading-[1.3] p-0 m-0 w-[50px] border border-default shadow-xs rounded-md indent-[-9999px] appearance-none bg-default text-sm',
+          'm-0 flex h-9 w-[50px] appearance-none items-center justify-center rounded-md border border-default bg-default p-0 indent-[-9999px] text-sm leading-[1.3] text-default shadow-xs',
           'hocus:bg-element',
-          'max-lg-gutters:w-auto max-lg-gutters:min-w-[100px] max-lg-gutters:px-2 max-lg-gutters:text-secondary max-lg-gutters:indent-0 max-lg-gutters:pl-8'
+          'max-lg-gutters:w-auto max-lg-gutters:min-w-[100px] max-lg-gutters:px-2 max-lg-gutters:pl-8 max-lg-gutters:indent-0 max-lg-gutters:text-secondary'
         )}
         value={themeName}
         onChange={e => {
@@ -41,7 +41,7 @@ export const ThemeSelector = () => {
           {themeName === 'light' && <SunSolidIcon className={ICON_CLASSES} />}
         </>
       )}
-      <ChevronDownIcon className="icon-xs text-icon-secondary absolute right-2 top-3 pointer-events-none" />
+      <ChevronDownIcon className="icon-xs pointer-events-none absolute right-2 top-3 text-icon-secondary" />
     </div>
   );
 };

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -9,7 +9,7 @@ export function GridContainer({ children, className }: GridContainerProps) {
   return (
     <div
       className={mergeClasses(
-        'inline-grid w-full grid-cols-2 gap-8 my-4',
+        'my-4 inline-grid w-full grid-cols-2 gap-8',
         'max-xl-gutters:grid-cols-1',
         'max-lg-gutters:grid-cols-2',
         'max-md-gutters:grid-cols-1',
@@ -27,7 +27,7 @@ type GridCellProps = PropsWithChildren<{
 export const GridCell = ({ children, className }: GridCellProps) => (
   <div
     className={mergeClasses(
-      'p-8 min-h-[200px] overflow-hidden relative border border-default rounded-lg shadow-xs',
+      'relative min-h-[200px] overflow-hidden rounded-lg border border-default p-8 shadow-xs',
       '[&_h2]:!my-0 [&_h3]:!mt-0',
       className
     )}>

--- a/docs/ui/components/Home/HeaderDescription.tsx
+++ b/docs/ui/components/Home/HeaderDescription.tsx
@@ -4,7 +4,7 @@ import { P } from '~/ui/components/Text';
 
 export function HeaderDescription({ children }: PropsWithChildren) {
   return (
-    <P theme="secondary" className="mt-0 mb-3">
+    <P theme="secondary" className="mb-3 mt-0">
       {children}
     </P>
   );

--- a/docs/ui/components/Home/HomeButton.tsx
+++ b/docs/ui/components/Home/HomeButton.tsx
@@ -5,7 +5,7 @@ export const HomeButton = ({ children, style, href, className, ...rest }: Button
     {...rest}
     href={href}
     openInNewTab={href?.startsWith('http')}
-    className={mergeClasses('px-3.5 absolute bottom-7 z-10', 'hocus:opacity-80', className)}>
+    className={mergeClasses('absolute bottom-7 z-10 px-3.5', 'hocus:opacity-80', className)}>
     {children}
   </Button>
 );

--- a/docs/ui/components/Home/resources/CodecademyImage.tsx
+++ b/docs/ui/components/Home/resources/CodecademyImage.tsx
@@ -2,7 +2,7 @@ import { theme } from '@expo/styleguide';
 
 export const CodecademyImage = () => (
   <svg
-    className="absolute right-5 bottom-5"
+    className="absolute bottom-5 right-5"
     width="126"
     height="154"
     viewBox="0 0 126 154"

--- a/docs/ui/components/Home/resources/DevicesImage.tsx
+++ b/docs/ui/components/Home/resources/DevicesImage.tsx
@@ -4,7 +4,7 @@ import { palette } from '@expo/styleguide-base';
 export const DevicesImage = () => (
   <svg
     className={mergeClasses(
-      'asset-shadow absolute right-0 bottom-0 max-w-[60%] z-[1]',
+      'asset-shadow absolute bottom-0 right-0 z-[1] max-w-[60%]',
       'max-lg-gutters:-bottom-4',
       'max-sm-gutters:-bottom-8'
     )}

--- a/docs/ui/components/Home/resources/OfficeHoursImage.tsx
+++ b/docs/ui/components/Home/resources/OfficeHoursImage.tsx
@@ -1,6 +1,6 @@
 export const OfficeHoursImage = () => (
   <svg
-    className="absolute right-2 bottom-2.5"
+    className="absolute bottom-2.5 right-2"
     width="109"
     height="109"
     viewBox="0 0 119 119"

--- a/docs/ui/components/Home/resources/QuickStartIcon.tsx
+++ b/docs/ui/components/Home/resources/QuickStartIcon.tsx
@@ -1,6 +1,6 @@
 export const QuickStartIcon = () => (
   <svg
-    className="mr-3 mt-1.5 float-left"
+    className="float-left mr-3 mt-1.5"
     width="18"
     height="23"
     viewBox="0 0 18 23"

--- a/docs/ui/components/Home/resources/SnackImage.tsx
+++ b/docs/ui/components/Home/resources/SnackImage.tsx
@@ -2,7 +2,7 @@ import { palette } from '@expo/styleguide-base';
 
 export const SnackImage = () => (
   <svg
-    className="absolute right-5 bottom-6"
+    className="absolute bottom-6 right-5"
     width="80"
     height="81"
     viewBox="0 0 80 81"

--- a/docs/ui/components/Home/resources/WhyImage.tsx
+++ b/docs/ui/components/Home/resources/WhyImage.tsx
@@ -2,7 +2,7 @@ import { theme } from '@expo/styleguide';
 
 export const WhyImage = () => (
   <svg
-    className="absolute right-5 bottom-5"
+    className="absolute bottom-5 right-5"
     width="144"
     height="82"
     viewBox="0 0 144 82"

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -14,60 +14,60 @@ export function DiscoverMore() {
         Try out Expo in minutes and learn how to get the most out of Expo.
       </HeaderDescription>
       <GridContainer>
-        <GridCell className="bg-palette-orange3 border-palette-orange6 selection:bg-palette-orange5">
+        <GridCell className="border-palette-orange6 bg-palette-orange3 selection:bg-palette-orange5">
           <SnackImage />
-          <RawH3 className="!text-palette-orange11 !font-bold">Try Expo in your browser</RawH3>
-          <P className="!text-palette-orange11 !text-xs max-w-[24ch]">
+          <RawH3 className="!font-bold !text-palette-orange11">Try Expo in your browser</RawH3>
+          <P className="max-w-[24ch] !text-xs !text-palette-orange11">
             Expo’s Snack lets you try Expo with zero local setup.
           </P>
           <HomeButton
-            className="bg-palette-orange11 border-palette-orange11 text-palette-orange3 hocus:bg-palette-orange11"
+            className="border-palette-orange11 bg-palette-orange11 text-palette-orange3 hocus:bg-palette-orange11"
             href="https://snack.expo.dev/"
             target="_blank"
-            rightSlot={<ArrowUpRightIcon className="text-palette-orange3 icon-md" />}>
+            rightSlot={<ArrowUpRightIcon className="icon-md text-palette-orange3" />}>
             Create a Snack
           </HomeButton>
         </GridCell>
-        <GridCell className="bg-palette-green3 border-palette-green6 selection:bg-palette-green5">
+        <GridCell className="border-palette-green6 bg-palette-green3 selection:bg-palette-green5">
           <WhyImage />
-          <RawH3 className="!text-palette-green11 !font-bold">Frequently Asked Questions</RawH3>
-          <P className="!text-palette-green11 !text-xs max-w-[36ch]">
+          <RawH3 className="!font-bold !text-palette-green11">Frequently Asked Questions</RawH3>
+          <P className="max-w-[36ch] !text-xs !text-palette-green11">
             Answers to common questions about Expo, EAS, and React Native.
           </P>
           <HomeButton
-            className="bg-palette-green11 border-palette-green11 text-palette-green2 hocus:bg-palette-green11"
+            className="border-palette-green11 bg-palette-green11 text-palette-green2 hocus:bg-palette-green11"
             href="/faq"
-            rightSlot={<ArrowRightIcon className="text-palette-green2 icon-md" />}>
+            rightSlot={<ArrowRightIcon className="icon-md text-palette-green2" />}>
             Read FAQ
           </HomeButton>
         </GridCell>
-        <GridCell className="bg-palette-yellow3 border-palette-yellow7 dark:border-palette-yellow6 selection:bg-palette-yellow5">
+        <GridCell className="border-palette-yellow7 bg-palette-yellow3 selection:bg-palette-yellow5 dark:border-palette-yellow6">
           <OfficeHoursImage />
-          <RawH3 className="!text-palette-yellow11 !font-bold">Join us for Office Hours</RawH3>
-          <P className="!text-palette-yellow11 !text-xs max-w-[28ch]">
+          <RawH3 className="!font-bold !text-palette-yellow11">Join us for Office Hours</RawH3>
+          <P className="max-w-[28ch] !text-xs !text-palette-yellow11">
             Check our Discord events for the next live Q&A session.
           </P>
           <HomeButton
-            className="bg-palette-yellow11 border-palette-yellow11 text-palette-yellow2 hocus:bg-palette-yellow11"
+            className="border-palette-yellow11 bg-palette-yellow11 text-palette-yellow2 hocus:bg-palette-yellow11"
             href="https://chat.expo.dev"
-            rightSlot={<ArrowUpRightIcon className="text-palette-yellow2 icon-md" />}>
+            rightSlot={<ArrowUpRightIcon className="icon-md text-palette-yellow2" />}>
             Go to Discord
           </HomeButton>
         </GridCell>
-        <GridCell className="bg-palette-blue3 border-palette-blue6 selection:bg-palette-blue5">
-          <div className="absolute bottom-6 right-6 p-4 bg-palette-blue5 rounded-full">
+        <GridCell className="border-palette-blue6 bg-palette-blue3 selection:bg-palette-blue5">
+          <div className="absolute bottom-6 right-6 rounded-full bg-palette-blue5 p-4">
             <DiscordIcon className="size-12 text-palette-blue9 dark:text-palette-blue9" />
           </div>
-          <RawH3 className="!text-palette-blue11 !font-bold">Chat with the community</RawH3>
-          <P className="!text-palette-blue11 !text-xs max-w-[32ch]">
+          <RawH3 className="!font-bold !text-palette-blue11">Chat with the community</RawH3>
+          <P className="max-w-[32ch] !text-xs !text-palette-blue11">
             Join over 40,000 other developers
             <br />
             on the Expo Community Discord.
           </P>
           <HomeButton
-            className="text-palette-blue1 hocus:bg-button-primary dark:bg-palette-blue9 dark:border-palette-blue9"
+            className="text-palette-blue1 hocus:bg-button-primary dark:border-palette-blue9 dark:bg-palette-blue9"
             href="https://chat.expo.dev"
-            rightSlot={<ArrowUpRightIcon className="text-palette-blue2 icon-md" />}>
+            rightSlot={<ArrowUpRightIcon className="icon-md text-palette-blue2" />}>
             Go to Discord
           </HomeButton>
         </GridCell>

--- a/docs/ui/components/Home/sections/ExploreAPIs.tsx
+++ b/docs/ui/components/Home/sections/ExploreAPIs.tsx
@@ -17,7 +17,7 @@ export function ExploreAPIs() {
       </HeaderDescription>
       <div
         className={mergeClasses(
-          'inline-grid w-full grid-cols-4 gap-8 my-4',
+          'my-4 inline-grid w-full grid-cols-4 gap-8',
           'max-xl-gutters:grid-cols-2',
           'max-lg-gutters:grid-cols-4',
           'max-md-gutters:grid-cols-2',
@@ -60,16 +60,16 @@ function APIGridCell({ icon, title, link, className }: APIGridCellProps) {
     <A
       href={link}
       className={mergeClasses(
-        'min-h-[200px] overflow-hidden relative border border-default rounded-lg block bg-subtle transition group shadow-xs',
+        'group relative block min-h-[200px] overflow-hidden rounded-lg border border-default bg-subtle shadow-xs transition',
         '[&_h2]:!my-0 [&_h3]:!mt-0',
         'hocus:shadow-sm',
         className
       )}
       isStyled>
-      <div className="flex min-h-[142px] justify-center items-center transition-transform group-hover:scale-105">
+      <div className="flex min-h-[142px] items-center justify-center transition-transform group-hover:scale-105">
         {icon}
       </div>
-      <LABEL className="flex justify-between items-center bg-default min-h-[30px] p-4">
+      <LABEL className="flex min-h-[30px] items-center justify-between bg-default p-4">
         {title}
         <ArrowRightIcon className="text-icon-secondary" />
       </LABEL>

--- a/docs/ui/components/Home/sections/JoinTheCommunity.tsx
+++ b/docs/ui/components/Home/sections/JoinTheCommunity.tsx
@@ -22,8 +22,8 @@ export function JoinTheCommunity() {
       </HeaderDescription>
       <div
         className={mergeClasses(
-          'inline-grid grid-cols-2 w-full gap-y-1.5 gap-x-8 my-4',
-          'border border-default rounded-lg p-3 shadow-xs',
+          'my-4 inline-grid w-full grid-cols-2 gap-x-8 gap-y-1.5',
+          'rounded-lg border border-default p-3 shadow-xs',
           'max-xl-gutters:grid-cols-1',
           'max-lg-gutters:grid-cols-2',
           'max-md-gutters:grid-cols-1'
@@ -113,7 +113,7 @@ function CommunityGridCell({
     <A
       href={link}
       className={mergeClasses(
-        'flex justify-between items-center bg-default p-2 pr-3 min-h-[30px] overflow-hidden relative rounded-lg transition gap-3',
+        'relative flex min-h-[30px] items-center justify-between gap-3 overflow-hidden rounded-lg bg-default p-2 pr-3 transition',
         'hocus:bg-element hocus:opacity-100',
         className
       )}
@@ -121,12 +121,12 @@ function CommunityGridCell({
       isStyled>
       <div
         className={mergeClasses(
-          'size-12 shrink-0 inline-flex justify-center items-center rounded-lg',
+          'inline-flex size-12 shrink-0 items-center justify-center rounded-lg',
           iconClassName
         )}>
         {icon}
       </div>
-      <div className="flex flex-col grow gap-0.5">
+      <div className="flex grow flex-col gap-0.5">
         <P weight="medium" className="leading-snug">
           {title}
         </P>
@@ -134,7 +134,7 @@ function CommunityGridCell({
           {description}
         </CALLOUT>
       </div>
-      <ArrowUpRightIcon className="text-icon-tertiary self-center shrink-0" />
+      <ArrowUpRightIcon className="shrink-0 self-center text-icon-tertiary" />
     </A>
   );
 }

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -10,7 +10,7 @@ import { H1, RawH2, CALLOUT, A } from '~/ui/components/Text';
 export function QuickStart() {
   return (
     <>
-      <H1 className="mt-2 pb-0 border-0 !font-extrabold">
+      <H1 className="mt-2 border-0 pb-0 !font-extrabold">
         Create amazing apps that run everywhere
       </H1>
       <HeaderDescription>
@@ -19,16 +19,16 @@ export function QuickStart() {
       <GridContainer>
         <GridCell
           className={mergeClasses(
-            'bg-element min-h-[250px] !bg-cell-quickstart-pattern bg-blend-multiply',
+            'min-h-[250px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply',
             'max-md-gutters:min-h-[200px]'
           )}>
           <div
             className={mergeClasses(
-              'inset-0 size-full absolute rounded-lg bg-gradient-to-b from-15% from-subtle to-[#21262d00]',
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
               'dark:from-[#181a1b]'
             )}
           />
-          <div className="flex flex-col gap-4 relative z-10">
+          <div className="relative z-10 flex flex-col gap-4">
             <RawH2 className="!font-bold">
               <QuickStartIcon /> Quick Start
             </RawH2>
@@ -43,18 +43,18 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'bg-palette-blue4 border-palette-blue6 relative z-0 min-h-[250px] !bg-cell-tutorial-pattern bg-blend-multiply',
+            'relative z-0 min-h-[250px] border-palette-blue6 bg-palette-blue4 !bg-cell-tutorial-pattern bg-blend-multiply',
             'dark:bg-palette-blue3',
             'max-md-gutters:min-h-[200px]'
           )}>
           <div
             className={mergeClasses(
-              'inset-0 size-full absolute rounded-lg bg-gradient-to-b from-15% from-palette-blue3 to-[#201d5200]',
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-palette-blue3 from-15% to-[#201d5200]',
               'dark:from-palette-blue3 dark:to-transparent'
             )}
           />
           <DevicesImage />
-          <RawH2 className="!font-bold !text-palette-blue12 relative z-10">
+          <RawH2 className="relative z-10 !font-bold !text-palette-blue12">
             Create a universal Android, iOS, and web app
           </RawH2>
           <HomeButton
@@ -66,27 +66,27 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'bg-palette-pink3 border-palette-pink6 relative z-0 min-h-[164px] dark:bg-palette-pink3',
+            'relative z-0 min-h-[164px] border-palette-pink6 bg-palette-pink3 dark:bg-palette-pink3',
             'selection:bg-palette-pink5',
             'max-md-gutters:min-h-[200px]'
           )}>
           <RouterLogo
             className={mergeClasses(
-              'size-[340px] absolute rotate-[20deg] -left-24 -bottom-20 opacity-[0.12]',
-              'text-palette-pink7 stroke-[0.01rem] stroke-palette-pink7'
+              'absolute -bottom-20 -left-24 size-[340px] rotate-[20deg] opacity-[0.12]',
+              'stroke-palette-pink7 stroke-[0.01rem] text-palette-pink7'
             )}
           />
           <RouterLogo
             className={mergeClasses(
-              'size-[72px] absolute right-6 bottom-6 border-[6px] rounded-xl p-3',
-              'stroke-[0.01rem] stroke-palette-pink8 text-palette-pink8 bg-palette-pink4 border-palette-pink5'
+              'absolute bottom-6 right-6 size-[72px] rounded-xl border-[6px] p-3',
+              'border-palette-pink5 bg-palette-pink4 stroke-palette-pink8 stroke-[0.01rem] text-palette-pink8'
             )}
           />
-          <RawH2 className="!text-palette-pink11 relative z-10 !text-lg">
+          <RawH2 className="relative z-10 !text-lg !text-palette-pink11">
             Discover the benefits of file-based routing with Expo Router
           </RawH2>
           <HomeButton
-            className="bg-palette-pink10 border-palette-pink10 dark:text-palette-pink2 hocus:bg-palette-pink9"
+            className="border-palette-pink10 bg-palette-pink10 hocus:bg-palette-pink9 dark:text-palette-pink2"
             href="/router/introduction/"
             size="sm"
             rightSlot={<ArrowRightIcon className="icon-md dark:text-palette-pink2" />}>
@@ -95,27 +95,27 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'bg-palette-purple3 border-palette-purple6 relative z-0 min-h-[172px]',
+            'relative z-0 min-h-[172px] border-palette-purple6 bg-palette-purple3',
             'selection:bg-palette-purple5',
             'max-md-gutters:min-h-[200px]'
           )}>
           <PlanEnterpriseIcon
             className={mergeClasses(
-              'size-[350px] absolute rotate-[40deg] -left-20 -bottom-12 opacity-[0.12]',
+              'absolute -bottom-12 -left-20 size-[350px] rotate-[40deg] opacity-[0.12]',
               'text-palette-purple7'
             )}
           />
           <PlanEnterpriseIcon
             className={mergeClasses(
-              'size-[72px] absolute right-6 bottom-6 border-[6px] rounded-xl p-2',
-              'text-palette-purple8 bg-palette-purple4 border-palette-purple5'
+              'absolute bottom-6 right-6 size-[72px] rounded-xl border-[6px] p-2',
+              'border-palette-purple5 bg-palette-purple4 text-palette-purple8'
             )}
           />
-          <RawH2 className="!text-palette-purple11 relative z-10 !text-lg">
+          <RawH2 className="relative z-10 !text-lg !text-palette-purple11">
             Speed up your development with Expo Application Services
           </RawH2>
           <HomeButton
-            className="bg-palette-purple10 border-palette-purple10 dark:text-palette-purple2 hocus:bg-palette-purple9"
+            className="border-palette-purple10 bg-palette-purple10 hocus:bg-palette-purple9 dark:text-palette-purple2"
             href="/tutorial/eas/introduction/"
             size="sm"
             rightSlot={<ArrowRightIcon className="icon-md dark:text-palette-purple2" />}>

--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -40,7 +40,7 @@ export function TalkGridWrapper({ children }: PropsWithChildren) {
   return (
     <div
       className={mergeClasses(
-        'inline-grid w-full grid-cols-4 gap-8 my-4',
+        'my-4 inline-grid w-full grid-cols-4 gap-8',
         'max-2xl-gutters:grid-cols-3',
         'max-xl-gutters:grid-cols-2',
         'max-sm-gutters:grid-cols-1'
@@ -68,7 +68,7 @@ export function TalkGridCell({
       openInNewTab
       href={link ?? `https://www.youtube.com/watch?v=${videoId}`}
       className={mergeClasses(
-        'flex flex-col h-full min-h-[266px] overflow-hidden relative border border-default rounded-lg bg-default justify-between transition shadow-xs',
+        'relative flex h-full min-h-[266px] flex-col justify-between overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
         '[&_h2]:!my-0 [&_h3]:!mt-0',
         'hocus:shadow-sm',
         className
@@ -83,22 +83,22 @@ export function TalkGridCell({
                 : `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`
             })`,
           }}
-          className="border-b border-b-default bg-cover bg-center h-[138px] max-sm-gutters:h-[168px]"
+          className="h-[138px] border-b border-b-default bg-cover bg-center max-sm-gutters:h-[168px]"
         />
-        <div className="flex justify-between items-start bg-default min-h-[30px] px-4 py-3 gap-1">
+        <div className="flex min-h-[30px] items-start justify-between gap-1 bg-default px-4 py-3">
           <LABEL className="block leading-normal">{title}</LABEL>
-          <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm mt-1" />
+          <ArrowUpRightIcon className="icon-sm mt-1 shrink-0 text-icon-secondary" />
         </div>
       </div>
-      <div className="px-4 pb-2 bg-default flex flex-col gap-0.5">
+      <div className="flex flex-col gap-0.5 bg-default px-4 pb-2">
         {description && (
-          <CALLOUT theme="secondary" className="flex gap-2 items-center">
-            <Users02Icon className="icon-xs text-icon-tertiary shrink-0" />
+          <CALLOUT theme="secondary" className="flex items-center gap-2">
+            <Users02Icon className="icon-xs shrink-0 text-icon-tertiary" />
             {description}
           </CALLOUT>
         )}
-        <CALLOUT theme="secondary" className="flex gap-2 items-center">
-          <AtSignIcon className="icon-xs text-icon-tertiary shrink-0" />
+        <CALLOUT theme="secondary" className="flex items-center gap-2">
+          <AtSignIcon className="icon-xs shrink-0 text-icon-tertiary" />
           {event}
         </CALLOUT>
       </div>

--- a/docs/ui/components/LaunchPartyBanner/index.tsx
+++ b/docs/ui/components/LaunchPartyBanner/index.tsx
@@ -62,7 +62,7 @@ export function LaunchPartyBanner({ currentDateAsString }: Props) {
       </div>
       <div
         className={mergeClasses(
-          'flex min-w-[39.5%] items-center justify-end gap-3 bg-launch-party-banner bg-left bg-no-repeat pr-5 z-10 shrink-0',
+          'z-10 flex min-w-[39.5%] shrink-0 items-center justify-end gap-3 bg-launch-party-banner bg-left bg-no-repeat pr-5',
           'max-md-gutters:mb-4 max-md-gutters:h-[unset] max-md-gutters:min-w-[unset] max-md-gutters:bg-none max-md-gutters:px-5'
         )}>
         <Button

--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -42,14 +42,14 @@ export function Layout({
 }: LayoutProps) {
   return (
     <>
-      <header className="fixed top-0 w-full h-[60px] z-[100]">{header}</header>
+      <header className="fixed top-0 z-[100] h-[60px] w-full">{header}</header>
       <main
-        className={mergeClasses('flex items-stretch mt-[60px]', 'max-md-gutters:max-h-[unset]')}>
+        className={mergeClasses('mt-[60px] flex items-stretch', 'max-md-gutters:max-h-[unset]')}>
         {navigation && <nav className="basis-[256px] max-md-gutters:hidden">{navigation}</nav>}
         <LayoutScroll>
           <article
             className={mergeClasses(
-              'mx-auto min-h-[calc(100vh-60px)] max-w-screen-lg py-8 px-4',
+              'mx-auto min-h-[calc(100vh-60px)] max-w-screen-lg px-4 py-8',
               className
             )}>
             {children}

--- a/docs/ui/components/Navigation/GroupList.tsx
+++ b/docs/ui/components/Navigation/GroupList.tsx
@@ -13,7 +13,7 @@ export function GroupList({ route, children }: GroupListProps) {
 
   return (
     <>
-      <CALLOUT className="font-semibold border-b border-default p-1 pl-[5.5] ml-4 mb-2">
+      <CALLOUT className="mb-2 ml-4 border-b border-default p-1 pl-[5.5] font-semibold">
         {route.name}
       </CALLOUT>
       {children}

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -19,7 +19,7 @@ export function Navigation({ routes }: NavigationProps) {
   const persistScroll = usePersistScroll('navigation');
 
   return (
-    <nav className="w-[280px] h-full bg-subtle dark:bg-default">
+    <nav className="h-full w-[280px] bg-subtle dark:bg-default">
       <LayoutScroll {...persistScroll}>
         {routes.map(route => navigationRenderer(route, activeRoutes))}
       </LayoutScroll>

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -12,13 +12,13 @@ export function PageLink({ route, isActive }: NavigationRenderProps) {
   return (
     <A
       className={mergeClasses(
-        'flex items-center rounded-md px-1.5 py-2 mx-1 my-4 shadow-xs bg-default',
+        'mx-1 my-4 flex items-center rounded-md bg-default px-1.5 py-2 shadow-xs',
         'dark:bg-element'
       )}
       href={route.href}>
       <i
         className={mergeClasses(
-          'shrink-0 text-icon-secondary rounded-full size-1 mr-2 invisible',
+          'invisible mr-2 size-1 shrink-0 rounded-full text-icon-secondary',
           isActive && 'visible'
         )}
       />

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -16,17 +16,17 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
 
   return (
     <Collapsible
-      className="pt-3 mb-3"
+      className="mb-3 pt-3"
       open={isActive || route.expanded}
       summary={
-        <div className="flex items-center select-none mx-4">
+        <div className="mx-4 flex select-none items-center">
           <ChevronDownIcon
             className={mergeClasses(
-              'icon-sm text-icon-default shrink-0 -rotate-90 transition-transform duration-150',
+              'icon-sm shrink-0 -rotate-90 text-icon-default transition-transform duration-150',
               '[details[open]>summary_&]:rotate-0'
             )}
           />
-          <CALLOUT className="font-medium p-1.5" tag="span">
+          <CALLOUT className="p-1.5 font-medium" tag="span">
             {route.name}
           </CALLOUT>
         </div>

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function PagePlatformTags({ platforms }: Props) {
   return (
-    <div className="inline-flex mt-3 flex-wrap gap-y-1.5">
+    <div className="mt-3 inline-flex flex-wrap gap-y-1.5">
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -17,14 +17,14 @@ export const PageTitle = ({ title, description, packageName, iconUrl, sourceCode
     <>
       <div
         className={mergeClasses(
-          'flex my-2 items-start justify-between gap-4',
+          'my-2 flex items-start justify-between gap-4',
           'max-xl-gutters:flex-col max-xl-gutters:items-start'
         )}>
         <H1 className="!my-0">
           {iconUrl && (
             <img
               src={iconUrl}
-              className="float-left mr-3.5 relative -top-0.5 size-[42px]"
+              className="relative -top-0.5 float-left mr-3.5 size-[42px]"
               alt={`Expo ${title} icon`}
             />
           )}
@@ -40,7 +40,7 @@ export const PageTitle = ({ title, description, packageName, iconUrl, sourceCode
           {description}
         </P>
       )}
-      <span className="hidden gap-1 mt-3 mb-1 max-xl-gutters:flex">
+      <span className="mb-1 mt-3 hidden gap-1 max-xl-gutters:flex">
         <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
       </span>
     </>

--- a/docs/ui/components/PageTitle/PageTitleButtons.tsx
+++ b/docs/ui/components/PageTitle/PageTitleButtons.tsx
@@ -19,12 +19,12 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
       {!sourceCodeUrl && !packageName && router?.pathname && (
         <Button
           theme="quaternary"
-          className="px-2 justify-center"
+          className="justify-center px-2"
           openInNewTab
           href={githubUrl(router.pathname)}
           title="Edit content of this page on GitHub">
           <div className="flex flex-row items-center gap-2">
-            <Edit05Icon className="text-icon-secondary icon-sm" />
+            <Edit05Icon className="icon-sm text-icon-secondary" />
             <CALLOUT crawlable={false} theme="secondary">
               Edit this page
             </CALLOUT>
@@ -34,7 +34,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
       {sourceCodeUrl && (
         <Button
           theme="quaternary"
-          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
+          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
           openInNewTab
           href={sourceCodeUrl}
           title={`View source code of ${packageName} on GitHub`}>
@@ -54,7 +54,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
         <Button
           theme="quaternary"
           openInNewTab
-          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
+          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
           href={`https://www.npmjs.com/package/${packageName}`}
           title="View package in npm Registry">
           <div

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -37,7 +37,7 @@ const Permalink: ComponentType<Props> = withHeadingManager((props: Props & Headi
     <PermalinkBase component={component} className="group">
       <LinkBase
         className={mergeClasses(
-          'inline-flex gap-1.5 items-center relative text-[inherit] decoration-0',
+          'relative inline-flex items-center gap-1.5 text-[inherit] decoration-0',
           props.additionalProps?.sidebarType === 'text' ? 'scroll-m-6' : 'scroll-m-12',
           props.additionalProps?.className
         )}
@@ -47,7 +47,7 @@ const Permalink: ComponentType<Props> = withHeadingManager((props: Props & Headi
         <span className="inline">{children}</span>
         <PermalinkIcon
           className={mergeClasses(
-            'icon-md inline-flex invisible group-hover:visible group-focus-visible:visible',
+            'icon-md invisible inline-flex group-hover:visible group-focus-visible:visible',
             props.nestingLevel >= 4 && 'icon-sm'
           )}
         />

--- a/docs/ui/components/PossibleRedirectNotification.tsx
+++ b/docs/ui/components/PossibleRedirectNotification.tsx
@@ -19,7 +19,7 @@ export default function PossibleRedirectNotification({ newUrl }: Props) {
 
   if (targetId) {
     return (
-      <div className="bg-warning border border-solid border-warning p-4 mt-1 rounded-sm">
+      <div className="mt-1 rounded-sm border border-solid border-warning bg-warning p-4">
         <P className="mb-0">
           ⚠️ The information you are looking for (addressed by <em>"{targetId}"</em>) has moved.{' '}
           <A href={`${newUrl}#${targetId}`}>Continue to the new location.</A>

--- a/docs/ui/components/ProgressTracker/CircularProgressBar.tsx
+++ b/docs/ui/components/ProgressTracker/CircularProgressBar.tsx
@@ -12,7 +12,7 @@ export function CircularProgressBar({ progress }: CircularProgressBarProps) {
   const strokeDashoffset = circumference - (progress / 100) * circumference;
 
   return (
-    <div className="flex items-center justify-center mr-1">
+    <div className="mr-1 flex items-center justify-center">
       <svg width={size} height={size}>
         {/* The background circle */}
         <circle

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -91,19 +91,19 @@ export function ProgressTracker({
 
   return (
     <>
-      <div className="w-full border border-solid border-default rounded-md p-3 mx-auto mt-6 max-h-96 bg-subtle">
+      <div className="mx-auto mt-6 max-h-96 w-full rounded-md border border-solid border-default bg-subtle p-3">
         <div className="flex items-center justify-center pt-2">
           <SuccessCheckmark />
         </div>
-        <div className="flex items-center justify-center flex-col">
-          <p className="flex items-center mt-6  text-center text-default heading-lg font-semibold">
+        <div className="flex flex-col items-center justify-center">
+          <p className="mt-6 flex items-center text-center font-semibold text-default heading-lg">
             <BookOpen02Icon className="mr-2 size-6" /> {currentChapter.title}
           </p>
-          <div className="flex items-center justify-center mt-2 max-w-lg leading-7">
-            <p className="text-center text-default pb-2">{summary}</p>
+          <div className="mt-2 flex max-w-lg items-center justify-center leading-7">
+            <p className="pb-2 text-center text-default">{summary}</p>
           </div>
         </div>
-        <div className="flex items-center justify-center mt-4">
+        <div className="mt-4 flex items-center justify-center">
           <Checkbox
             id={`chapter-${currentChapterIndex}`}
             checked={currentChapter.completed}
@@ -120,17 +120,17 @@ export function ProgressTracker({
         <P className="my-4">{nextChapterDescription}</P>
         <A
           href={nextChapterLink}
-          className="flex flex-row justify-between border border-solid border-default rounded-md py-3 px-4 mb-3 hocus:shadow-xs"
+          className="mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 hocus:shadow-xs"
           isStyled>
-          <div className="flex flex-row gap-4 items-center">
-            <div className="flex bg-element rounded-md self-center items-center justify-center min-w-[36px] h-9">
+          <div className="flex flex-row items-center gap-4">
+            <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element">
               <BookOpen02Icon className="icon-lg text-icon-default" />
             </div>
             <div>
               <DEMI>Next: {nextChapterTitle}</DEMI>
             </div>
           </div>
-          <ArrowRightIcon className="text-icon-secondary self-center content-end ml-3 min-w-[20px]" />
+          <ArrowRightIcon className="ml-3 min-w-[20px] content-end self-center text-icon-secondary" />
         </A>
       </>
     </>

--- a/docs/ui/components/RouteUrl/RouteUrlInner.tsx
+++ b/docs/ui/components/RouteUrl/RouteUrlInner.tsx
@@ -47,7 +47,7 @@ export function RouteUrlInner({
       float
       title={
         <span className="select-all">
-          <span className="text-icon-secondary ">{parsedProtocol}</span>
+          <span className="text-icon-secondary">{parsedProtocol}</span>
           {inputUrl}
         </span>
       }

--- a/docs/ui/components/RouteUrl/RuntimePopup.tsx
+++ b/docs/ui/components/RouteUrl/RuntimePopup.tsx
@@ -30,10 +30,10 @@ export function RuntimePopup<T extends string>({
         aria-label="Runtime URL format selector"
         title="Select runtime URL format"
         className={mergeClasses(
-          'flex items-center justify-center text-default h-10 px-10 m-0 min-w-[100px] rounded-none border-l indent-0 border-l-default shadow-xs appearance-none bg-default text-sm',
+          'm-0 flex h-10 min-w-[100px] appearance-none items-center justify-center rounded-none border-l border-l-default bg-default px-10 indent-0 text-sm text-default shadow-xs',
           'hocus:bg-subtle hocus:shadow-none',
           'focus-visible:-outline-offset-2',
-          'max-md-gutters:indent-[-9999px] max-md-gutters:min-w-[unset] max-md-gutters:max-w-[60px] max-md-gutters:px-6'
+          'max-md-gutters:min-w-[unset] max-md-gutters:max-w-[60px] max-md-gutters:px-6 max-md-gutters:indent-[-9999px]'
         )}
         value={selected}
         onChange={e => {
@@ -46,9 +46,9 @@ export function RuntimePopup<T extends string>({
         ))}
       </select>
       {isLoaded && (
-        <div className="absolute inset-x-3 inset-y-0 flex items-center justify-between gap-2 text-icon-secondary pointer-events-none select-none">
+        <div className="pointer-events-none absolute inset-x-3 inset-y-0 flex select-none items-center justify-between gap-2 text-icon-secondary">
           <Icon className={ICON_CLASSES} />
-          <ChevronDownIcon className="icon-xs text-icon-secondary pointer-events-none" />
+          <ChevronDownIcon className="icon-xs pointer-events-none text-icon-secondary" />
         </div>
       )}
     </div>

--- a/docs/ui/components/Search/ExpoDashboardItem.tsx
+++ b/docs/ui/components/Search/ExpoDashboardItem.tsx
@@ -23,8 +23,8 @@ export const ExpoDashboardItem = ({ item, onSelect, query }: Props) => {
       url={item.url}
       onSelect={onSelect}
       isExternalLink>
-      <div className="flex gap-3 justify-between">
-        <div className="inline-flex gap-3 items-center justify-between">
+      <div className="flex justify-between gap-3">
+        <div className="inline-flex items-center justify-between gap-3">
           <Icon className="text-icon-secondary" />
           <p
             className="text-xs font-medium"

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -1,3 +1,3 @@
 export function Separator() {
-  return <hr className="mt-4 mb-6 bg-palette-gray6 border-0 h-[0.05rem]" />;
+  return <hr className="mb-6 mt-4 h-[0.05rem] border-0 bg-palette-gray6" />;
 }

--- a/docs/ui/components/Sidebar/ApiVersionSelect.tsx
+++ b/docs/ui/components/Sidebar/ApiVersionSelect.tsx
@@ -17,18 +17,18 @@ export function ApiVersionSelect() {
   return (
     <div
       className={mergeClasses(
-        'px-4 pt-3 pb-4 flex flex-col gap-1 border-b border-b-default bg-default',
+        'flex flex-col gap-1 border-b border-b-default bg-default px-4 pb-4 pt-3',
         'max-lg-gutters:sticky max-lg-gutters:top-0 max-lg-gutters:z-10'
       )}>
       <FOOTNOTE theme="tertiary">Reference version</FOOTNOTE>
-      <div className="relative bg-default border border-default rounded-md shadow-xs py-2 px-3">
+      <div className="relative rounded-md border border-default bg-default px-3 py-2 shadow-xs">
         <label className="flex flex-row items-center justify-between" htmlFor="api-version-select">
           <CALLOUT className="flex">{versionToText(version)}</CALLOUT>
           <ChevronDownIcon className="icon-sm shrink-0" />
         </label>
         <select
           id="api-version-select"
-          className="absolute opacity-0 inset-0 size-full text-xs cursor-pointer"
+          className="absolute inset-0 size-full cursor-pointer text-xs opacity-0"
           value={version}
           onChange={event => setVersion(event.target.value)}>
           {VERSIONS.map(version => (

--- a/docs/ui/components/Sidebar/Sidebar.tsx
+++ b/docs/ui/components/Sidebar/Sidebar.tsx
@@ -22,10 +22,10 @@ export const Sidebar = ({ routes = [] }: SidebarProps) => {
   };
 
   return (
-    <nav className="p-4 w-[280px] relative bg-default max-lg-gutters:w-full" data-sidebar>
+    <nav className="relative w-[280px] bg-default p-4 max-lg-gutters:w-full" data-sidebar>
       <div
         className={mergeClasses(
-          'fixed w-[273px] h-8 mt-[-22px] left-0 z-10 pointer-events-none bg-gradient-to-b from-default to-transparent',
+          'pointer-events-none fixed left-0 z-10 mt-[-22px] h-8 w-[273px] bg-gradient-to-b from-default to-transparent',
           'max-lg-gutters:hidden'
         )}
       />

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -75,17 +75,17 @@ export function SidebarCollapsible({ info, children }: Props) {
       <ButtonBase
         ref={ref}
         className={mergeClasses(
-          'flex items-center gap-2 relative select-none duration-150 px-3 py-1.5 w-full cursor-pointer rounded-md transition',
+          'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 py-1.5 transition duration-150',
           'hocus:bg-element'
         )}
         aria-expanded={isOpen ? 'true' : 'false'}
         onClick={toggleIsOpen}
         {...customDataAttributes}>
-        <div className="bg-default border border-default rounded-sm flex items-center justify-center shadow-xs size-4">
+        <div className="flex size-4 items-center justify-center rounded-sm border border-default bg-default shadow-xs">
           <ChevronDownIcon
             className={mergeClasses(
               'icon-xs text-icon-secondary transition-transform duration-150',
-              !isOpen && '-rotate-90 translate-x-[0.5px]'
+              !isOpen && 'translate-x-[0.5px] -rotate-90'
             )}
           />
         </div>

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -17,7 +17,7 @@ export const SidebarFooter = ({ isMobileMenuVisible }: SideBarFooterProps) => {
   const router = useRouter();
   const isArchive = router?.pathname ? getPageSection(router.pathname) === 'archive' : false;
   return (
-    <div className="flex flex-col p-4 border-t border-t-default bg-default gap-0.5">
+    <div className="flex flex-col gap-0.5 border-t border-t-default bg-default p-4">
       <SidebarSingleEntry
         secondary
         href="/archive"

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -84,11 +84,11 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
     return (
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
-          <div className="flex flex-row justify-between items-center py-0">
+          <div className="flex flex-row items-center justify-between py-0">
             <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="ml-2 text-secondary text-sm">{`${completedChaptersCount} of ${totalChapters}`}</p>
+              <p className="ml-2 text-sm text-secondary">{`${completedChaptersCount} of ${totalChapters}`}</p>
             </div>
           </div>
         )}
@@ -97,7 +97,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isChapterCompleted(childSlug);
 
           return (
-            <div className="flex justify-between items-center" key={`${route.name}-${child.name}`}>
+            <div className="flex items-center justify-between" key={`${route.name}-${child.name}`}>
               <div className="flex-1">
                 <SidebarLink info={child}>{child.sidebarTitle || child.name}</SidebarLink>
               </div>
@@ -109,7 +109,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           <Button
             onClick={resetTutorial}
             theme="secondary"
-            className="w-full flex items-center justify-center"
+            className="flex w-full items-center justify-center"
             href="/tutorial/eas/introduction/">
             Reset tutorial
           </Button>
@@ -123,11 +123,11 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
     return (
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
-          <div className="flex flex-row justify-between items-center py-0">
+          <div className="flex flex-row items-center justify-between py-0">
             <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentageForGetStarted} />{' '}
-              <p className="ml-2 text-secondary text-sm">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
+              <p className="ml-2 text-sm text-secondary">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
             </div>
           </div>
         )}
@@ -136,7 +136,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isGetStartedChapterCompleted(childSlug);
 
           return (
-            <div className="flex justify-between items-center" key={`${route.name}-${child.name}`}>
+            <div className="flex items-center justify-between" key={`${route.name}-${child.name}`}>
               <div className="flex-1">
                 <SidebarLink info={child}>{child.sidebarTitle || child.name}</SidebarLink>
               </div>
@@ -148,7 +148,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           <Button
             onClick={resetGetStartedTutorial}
             theme="secondary"
-            className="w-full flex items-center justify-center"
+            className="flex w-full items-center justify-center"
             href="/tutorial/eas/introduction/">
             Reset tutorial
           </Button>

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -18,10 +18,10 @@ type SidebarHeadProps = {
 export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
   if (sidebarActiveGroup === 'archive') {
     return (
-      <div className="flex flex-col p-1.5 border-b border-default bg-default gap-0.5">
+      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-1.5">
         <LinkBase
           href="/"
-          className="flex gap-3 items-center p-2.5 rounded-md text-secondary hocus:bg-element">
+          className="flex items-center gap-3 rounded-md p-2.5 text-secondary hocus:bg-element">
           <ArrowLeftIcon className="text-icon-secondary" />
           Back
         </LinkBase>
@@ -31,7 +31,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
 
   return (
     <>
-      <div className="flex flex-col p-4 border-b border-default bg-default gap-0.5">
+      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-4">
         <Search />
         <SidebarSingleEntry
           href="/"

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -49,7 +49,7 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
         href={info.href as string}
         ref={ref}
         className={mergeClasses(
-          'group text-xs flex decoration-0 text-secondary items-center scroll-m-[60px] w-full -ml-2.5',
+          'group -ml-2.5 flex w-full scroll-m-[60px] items-center text-xs text-secondary decoration-0',
           'hocus:text-link hocus:[&_svg]:text-icon-tertiary',
           isSelected && 'text-link',
           info.isDeprecated && 'line-through'
@@ -57,7 +57,7 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
         {...customDataAttributes}>
         <div
           className={mergeClasses(
-            'size-1.5 shrink-0 rounded-full my-2 mx-1.5 self-start',
+            'mx-1.5 my-2 size-1.5 shrink-0 self-start rounded-full',
             isSelected && 'bg-palette-blue11'
           )}
         />
@@ -65,16 +65,16 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
         {info.isNew && (
           <div
             className={mergeClasses(
-              'inline-flex ml-2 -mt-px border border-palette-blue10 text-palette-white text-[11px] font-semibold rounded-full px-[5px] leading-none items-center h-[17px]',
+              '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[11px] font-semibold leading-none text-palette-white',
               isSelected
                 ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
-                : 'bg-none border-palette-blue10 text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
+                : 'border-palette-blue10 bg-none text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
             )}>
             NEW
           </div>
         )}
         {isExternal && (
-          <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto group-hover:text-icon-info" />
+          <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
         )}
       </LinkBase>
     </div>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -27,11 +27,11 @@ export const SidebarSingleEntry = ({
     <A
       href={href}
       className={mergeClasses(
-        'flex items-center gap-3 text-secondary rounded-md text-sm min-h-[32px] px-2 py-1 !leading-[100%] !opacity-100',
+        'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary !opacity-100',
         'hocus:bg-element',
         'focus-visible:relative focus-visible:z-10',
         secondary && 'text-xs',
-        isActive && 'bg-palette-blue3 text-link font-medium hocus:text-link hocus:bg-palette-blue4'
+        isActive && 'bg-palette-blue3 font-medium text-link hocus:bg-palette-blue4 hocus:text-link'
       )}
       shouldLeakReferrer={shouldLeakReferrer}
       isStyled>
@@ -42,7 +42,7 @@ export const SidebarSingleEntry = ({
         )}
       />
       {title}
-      {isExternal && <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto" />}
+      {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
     </A>
   );
 };

--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -7,7 +7,7 @@ type SidebarTitleProps = {
 } & PropsWithChildren;
 
 export const SidebarTitle = ({ children, Icon }: SidebarTitleProps) => (
-  <div className="flex gap-2 items-center relative ml-3 -mr-4 pb-1">
+  <div className="relative -mr-4 ml-3 flex items-center gap-2 pb-1">
     {Icon && <Icon className="icon-sm" />}
     <LABEL weight="medium" crawlable={false}>
       {children}

--- a/docs/ui/components/Snippet/FileStatus.tsx
+++ b/docs/ui/components/Snippet/FileStatus.tsx
@@ -15,7 +15,7 @@ export const FileStatus = ({ type }: FileStatusProps) => {
   return (
     <div
       className={mergeClasses(
-        'inline-flex font-semibold h-[21px] text-3xs py-1 px-1.5 rounded-sm border gap-1 items-center',
+        'inline-flex h-[21px] items-center gap-1 rounded-sm border px-1.5 py-1 text-3xs font-semibold',
         getStatusTheme(type)
       )}>
       {STATUS_LABELS[type as keyof typeof STATUS_LABELS]}

--- a/docs/ui/components/Snippet/Snippet.tsx
+++ b/docs/ui/components/Snippet/Snippet.tsx
@@ -4,7 +4,7 @@ import type { HTMLAttributes } from 'react';
 type SnippetProps = HTMLAttributes<HTMLDivElement>;
 
 export const Snippet = ({ children, className, ...rest }: SnippetProps) => (
-  <div className={mergeClasses('flex flex-col mb-4 last:mb-0', className)} {...rest}>
+  <div className={mergeClasses('mb-4 flex flex-col last:mb-0', className)} {...rest}>
     {children}
   </div>
 );

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -23,9 +23,9 @@ export const SnippetAction = ({
       className={mergeClasses(
         'gap-1.5 focus-visible:-outline-offset-2',
         alwaysDark &&
-          'dark-theme border-transparent bg-transparent hocus:shadow-xs hocus:border-palette-gray9 hocus:bg-palette-gray5',
+          'dark-theme border-transparent bg-transparent hocus:border-palette-gray9 hocus:bg-palette-gray5 hocus:shadow-xs',
         !alwaysDark &&
-          'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4 hocus:bg-subtle hocus:shadow-none',
+          'h-10 rounded-none border-0 border-l border-l-default px-4 leading-10 hocus:bg-subtle hocus:shadow-none',
         className
       )}
       {...rest}>

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -18,10 +18,10 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         ref={ref}
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
-          wordWrap && '!whitespace-pre-wrap !break-words',
-          'relative text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[18px]',
+          wordWrap && '!break-words !whitespace-pre-wrap',
+          'relative overflow-x-auto rounded-b-md border border-default bg-subtle p-4 !leading-[18px] text-default',
           'prose-code:!px-0',
-          alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
+          alwaysDark && 'dark-theme whitespace-nowrap border-transparent bg-palette-black',
           hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
           className
         )}>

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function SnippetExpandOverlay({ onClick }: Props) {
   return (
-    <div className="flex absolute bottom-0 left-0 p-6 w-full bg-gradient-to-b from-transparent to-default">
+    <div className="absolute bottom-0 left-0 flex w-full bg-gradient-to-b from-transparent to-default p-6">
       <Button theme="secondary" onClick={onClick} className="mx-auto">
         Show more
       </Button>

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -25,21 +25,21 @@ export const SnippetHeader = ({
 }: SnippetHeaderProps) => (
   <div
     className={mergeClasses(
-      'flex pl-4 overflow-hidden justify-between bg-default border border-default min-h-[40px]',
+      'flex min-h-[40px] justify-between overflow-hidden border border-default bg-default pl-4',
       !float && 'rounded-t-md border-b-0',
       float && 'rounded-md',
       Icon && 'pl-3',
-      alwaysDark && 'dark-theme pr-2 dark:border-transparent !bg-palette-gray3'
+      alwaysDark && 'dark-theme !bg-palette-gray3 pr-2 dark:border-transparent'
     )}>
     <LABEL
       className={mergeClasses(
-        'flex items-center gap-2 min-h-10 !leading-tight py-1 pr-4 font-medium w-full',
+        'flex min-h-10 w-full items-center gap-2 py-1 pr-4 font-medium !leading-tight',
         alwaysDark && 'text-palette-white'
       )}>
       {Icon && <Icon className="icon-sm shrink-0" />}
       <span className="break-words">{title}</span>
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
     </LABEL>
-    {!!children && <div className="flex justify-end items-center">{children}</div>}
+    {!!children && <div className="flex items-center justify-end">{children}</div>}
   </div>
 );

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -28,8 +28,8 @@ export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
       trigger={
         <div>
           <SnippetAction
-            className="px-3 min-w-[44px]"
-            leftSlot={<DotsVerticalIcon className="shrink-0 icon-md text-icon-secondary" />}
+            className="min-w-[44px] px-3"
+            leftSlot={<DotsVerticalIcon className="icon-md shrink-0 text-icon-secondary" />}
             {...rest}
           />
         </div>

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -82,7 +82,7 @@ export const DiffBlock = ({
           float={collapseDeletedFiles && type === 'delete'}>
           {newPath && filenameToLinkUrl && type !== 'delete' ? (
             <SnippetAction
-              rightSlot={<ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />}
+              rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
               onClick={() => {
                 window.open(filenameToLinkUrl(newPath), '_blank');
               }}>

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -76,7 +76,7 @@ export const SnackInline = ({
   const codeLanguage = prismBlockClassName ? prismBlockClassName.split('-')[1] : 'jsx';
 
   return (
-    <Snippet className="flex flex-col mb-3 prose-pre:!m-0 prose-pre:!border-0">
+    <Snippet className="mb-3 flex flex-col prose-pre:!m-0 prose-pre:!border-0">
       <SnippetHeader title={label || 'Example'} Icon={SnackLogo}>
         <form action={SNACK_URL} method="POST" target="_blank" className="contents">
           <input type="hidden" name="platform" value={defaultPlatform || DEFAULT_PLATFORM} />

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -62,7 +62,7 @@ function cmdMapper(line: string, index: number) {
     return (
       <CODE
         key={key}
-        className="whitespace-pre !bg-transparent !border-none select-none !text-palette-gray10">
+        className="select-none whitespace-pre !border-none !bg-transparent !text-palette-gray10">
         {line}
       </CODE>
     );
@@ -71,11 +71,11 @@ function cmdMapper(line: string, index: number) {
   if (line.startsWith('$')) {
     return (
       <div key={key}>
-        <CODE className="whitespace-pre !bg-transparent !border-none select-none !text-secondary">
+        <CODE className="select-none whitespace-pre !border-none !bg-transparent !text-secondary">
           -&nbsp;
         </CODE>
         <CODE
-          className="whitespace-pre !bg-transparent !border-none text-default"
+          className="whitespace-pre !border-none !bg-transparent text-default"
           dangerouslySetInnerHTML={{
             __html: Prism.highlight(
               line.substring(1).trim(),
@@ -89,7 +89,7 @@ function cmdMapper(line: string, index: number) {
   }
 
   return (
-    <CODE key={key} className="whitespace-pre !bg-transparent !border-none text-default">
+    <CODE key={key} className="whitespace-pre !border-none !bg-transparent text-default">
       {line}
     </CODE>
   );

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -9,16 +9,16 @@ type Props = PropsWithChildren<{
 
 export const Step = ({ children, label }: Props) => {
   return (
-    <div className="flex gap-4 mt-6 mb-8">
+    <div className="mb-8 mt-6 flex gap-4">
       <HEADLINE
         theme="secondary"
         className={mergeClasses(
-          'flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1',
+          'mt-1 flex h-7 min-w-[28px] items-center justify-center rounded-full bg-element',
           label.length >= 3 && '!text-xs'
         )}>
         {label}
       </HEADLINE>
-      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-px [&>*:last-child]:!mb-0">
+      <div className="w-full max-w-[calc(100%-44px)] pt-1.5 prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-px [&>*:last-child]:!mb-0">
         {typeof children === 'string' ? <P>{children}</P> : children}
       </div>
     </div>

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -13,7 +13,7 @@ type CellProps = PropsWithChildren<{
 export const Cell = ({ children, colSpan, fitContent = false, align = 'left' }: CellProps) => (
   <td
     className={mergeClasses(
-      'p-4 border-r border-secondary',
+      'border-r border-secondary p-4',
       convertAlignToClass(align),
       fitContent && 'w-fit',
       'last:border-r-0',

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -12,7 +12,7 @@ type HeaderCellProps = PropsWithChildren<{
 export const HeaderCell = ({ children, align = 'left', size = 'md' }: HeaderCellProps) => (
   <th
     className={mergeClasses(
-      'px-4 py-3.5 font-medium text-secondary border-r border-secondary',
+      'border-r border-secondary px-4 py-3.5 font-medium text-secondary',
       convertAlignToClass(align),
       size === 'sm' ? 'text-3xs' : 'text-2xs',
       '[&_code]:text-3xs [&_code]:text-secondary',

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -11,10 +11,10 @@ type TableProps = PropsWithChildren<{
 }>;
 
 export const Table = ({ children, headers = [], headersAlign, className }: TableProps) => (
-  <div className="table-wrapper border border-default rounded-md overflow-y-hidden overflow-x-auto mb-4 shadow-xs">
+  <div className="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs">
     <table
       className={mergeClasses(
-        'w-full border-0 rounded-none text-xs text-default',
+        'w-full rounded-none border-0 text-xs text-default',
         '[&_p]:text-xs',
         '[&_li]:text-xs',
         '[&_span]:text-xs',

--- a/docs/ui/components/Table/TableHead.tsx
+++ b/docs/ui/components/Table/TableHead.tsx
@@ -3,5 +3,5 @@ import { PropsWithChildren } from 'react';
 type TableHeadProps = PropsWithChildren<object>;
 
 export const TableHead = ({ children }: TableHeadProps) => (
-  <thead className="bg-subtle border-b border-b-default">{children}</thead>
+  <thead className="border-b border-b-default bg-subtle">{children}</thead>
 );

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -17,7 +17,7 @@ export function TableOfContents() {
   return (
     <LayoutScroll ref={autoScroll.ref}>
       <nav className="block w-full p-8">
-        <CALLOUT className="mt-4 mb-1.5" weight="medium">
+        <CALLOUT className="mb-1.5 mt-4" weight="medium">
           On this page
         </CALLOUT>
         <ul className="list-none">

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -51,16 +51,16 @@ const InnerTabs = ({
     <ReachTabs
       index={tabIndex}
       onChange={setIndex}
-      className="border border-default rounded-md shadow-xs my-4">
-      <TabList className="flex px-4 py-3 gap-1 flex-wrap border-b border-secondary">
+      className="my-4 rounded-md border border-default shadow-xs">
+      <TabList className="flex flex-wrap gap-1 border-b border-secondary px-4 py-3">
         {tabTitles.map((title, index) => (
           <TabButton key={index} active={index === tabIndex} label={title} layoutId={layoutId} />
         ))}
       </TabList>
       <TabPanels
         className={mergeClasses(
-          'py-4 px-5',
-          '[&_ul]:mb-3 [&_pre]:first-of-type:mt-1',
+          'px-5 py-4',
+          '[&_pre]:first-of-type:mt-1 [&_ul]:mb-3',
           'last:[&>div>*]:!mb-0'
         )}>
         {children}

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -17,18 +17,18 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return (
         <AppleIcon
           className={mergeClasses(
-            'opacity-80 icon-xs text-palette-blue12 mt-[-0.5px]',
+            'icon-xs mt-[-0.5px] text-palette-blue12 opacity-80',
             platform === 'macos' && 'text-palette-purple12',
             platform === 'tvos' && 'text-palette-pink12'
           )}
         />
       );
     case 'android':
-      return <AndroidIcon className="opacity-80 icon-xs text-palette-green12 mt-[-0.5px]" />;
+      return <AndroidIcon className="icon-xs mt-[-0.5px] text-palette-green12 opacity-80" />;
     case 'web':
-      return <AtSignIcon className="opacity-80 icon-2xs text-palette-orange12" />;
+      return <AtSignIcon className="icon-2xs text-palette-orange12 opacity-80" />;
     case 'expo':
-      return <ExpoGoLogo className="opacity-80 icon-xs text-palette-purple12" />;
+      return <ExpoGoLogo className="icon-xs text-palette-purple12 opacity-80" />;
     default:
       return null;
   }

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -16,14 +16,14 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
   return (
     <div
       className={mergeClasses(
-        'select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default',
+        'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         getTagClasses(platformName),
         className
       )}>
       <PlatformIcon platform={platformName} />
-      <span className={mergeClasses('text-2xs !leading-[16px] font-normal', '[table_&]:text-3xs')}>
+      <span className={mergeClasses('text-2xs font-normal !leading-[16px]', '[table_&]:text-3xs')}>
         {formatName(platform)}
       </span>
     </div>

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -14,7 +14,7 @@ export const StatusTag = ({ status, note, className }: StatusTagProps) => {
   return (
     <div
       className={mergeClasses(
-        'select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default',
+        'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         status === 'deprecated' && getTagClasses('deprecated'),
@@ -22,7 +22,7 @@ export const StatusTag = ({ status, note, className }: StatusTagProps) => {
         className
       )}>
       {status === 'experimental' && <Star06Icon className="icon-xs text-palette-pink12" />}
-      <span className={mergeClasses('text-2xs !leading-[16px] font-normal', '[table_&]:text-3xs')}>
+      <span className={mergeClasses('text-2xs font-normal !leading-[16px]', '[table_&]:text-3xs')}>
         {status ? formatName(status) + (note ? `: ${note}` : '') : note}
       </span>
     </div>

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
@@ -22,7 +22,7 @@ export const VersionSelector = ({
     <div className="relative">
       <select
         id="version-menu"
-        className="text-xs text-default m-0 mt-1 px-3 py-2 min-h-[40px] w-full border border-default shadow-xs rounded-md cursor-pointer appearance-none bg-default"
+        className="m-0 mt-1 min-h-[40px] w-full cursor-pointer appearance-none rounded-md border border-default bg-default px-3 py-2 text-xs text-default shadow-xs"
         value={version}
         onChange={e => setVersion(e.target.value)}>
         {availableVersions.map(version => (
@@ -33,7 +33,7 @@ export const VersionSelector = ({
           </option>
         ))}
       </select>
-      <ChevronDownIcon className="icon-sm text-icon-secondary absolute right-3 top-4 pointer-events-none" />
+      <ChevronDownIcon className="icon-sm pointer-events-none absolute right-3 top-4 text-icon-secondary" />
     </div>
   );
 };

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -72,7 +72,7 @@ export function createTextComponent(Element: TextElement, textClassName?: string
     return (
       <TextElementTag
         className={mergeClasses(
-          'text-inherit text-default leading-[1.6154]',
+          'text-inherit leading-[1.6154] text-default',
           textClassName,
           getTextWeightClassName(textWeight),
           getTextColorClassName(textTheme),
@@ -102,7 +102,7 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
         !isStyled &&
           'font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline',
         !isStyled &&
-          '[&_span]:text-link [&_code]:text-link [&_strong]:text-link [&_em]:text-link [&_b]:text-link [&_i]:text-link',
+          '[&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link',
         className
       )}
       {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -166,7 +166,7 @@ export const RawH2 = createTextComponent(
   TextElement.H2,
   mergeClasses(
     'text-[25px] font-bold leading-[1.4] tracking-[-0.021rem]',
-    'mt-8 mb-3.5 [&_code]:text-[90%]',
+    'mb-3.5 mt-8 [&_code]:text-[90%]',
     'max-md-gutters:text-[22px] max-md-gutters:leading-[1.409]',
     'max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263]'
   )
@@ -175,7 +175,7 @@ export const RawH3 = createTextComponent(
   TextElement.H3,
   mergeClasses(
     'text-[20px] font-semibold leading-normal tracking-[-0.017rem]',
-    'mt-7 mb-3 [&_code]:text-[90%]',
+    'mb-3 mt-7 [&_code]:text-[90%]',
     'max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555]',
     'max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed'
   )
@@ -184,14 +184,14 @@ export const RawH4 = createTextComponent(
   TextElement.H4,
   mergeClasses(
     'text-[16px] font-semibold leading-relaxed tracking-[-0.011rem]',
-    'mt-6 mb-2 [&_code]:text-[90%]'
+    'mb-2 mt-6 [&_code]:text-[90%]'
   )
 );
 export const RawH5 = createTextComponent(
   TextElement.H5,
   mergeClasses(
     'text-[13px] font-medium leading-[1.5833] tracking-[-0.003rem]',
-    'mt-4 mb-1 [&_code]:text-[90%]'
+    'mb-1 mt-4 [&_code]:text-[90%]'
   )
 );
 

--- a/docs/ui/components/Text/withAnchor.tsx
+++ b/docs/ui/components/Text/withAnchor.tsx
@@ -26,7 +26,7 @@ export function withAnchor(Component: FC<PropsWithChildren<TextComponentProps>>)
     const slug = useSlug(id, children);
     return (
       <Component className="relative" data-id={slug} {...rest}>
-        <span className="relative top-[-100px] invisible" id={slug} />
+        <span className="invisible relative top-[-100px]" id={slug} />
         <A href={`#${slug}`}>{children}</A>
       </Component>
     );

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -18,7 +18,7 @@ export function VideoBoxLink({ title, description, videoId, className }: VideoBo
       openInNewTab
       href={`https://www.youtube.com/watch?v=${videoId}`}
       className={mergeClasses(
-        'flex overflow-hidden items-stretch relative border border-default rounded-lg bg-default transition shadow-xs',
+        'relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
         'hocus:shadow-sm',
         'max-sm-gutters:flex-col',
         '[&+hr]:!mt-6',
@@ -27,27 +27,27 @@ export function VideoBoxLink({ title, description, videoId, className }: VideoBo
       isStyled>
       <div
         className={mergeClasses(
-          'bg-element flex items-center max-w-[200px] justify-center relative border-r border-secondary',
-          'max-sm-gutters:max-w-full max-sm-gutters:border-r-0 max-sm-gutters:border-b'
+          'relative flex max-w-[200px] items-center justify-center border-r border-secondary bg-element',
+          'max-sm-gutters:max-w-full max-sm-gutters:border-b max-sm-gutters:border-r-0'
         )}>
         <img
           src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`}
           className="aspect-video"
           alt={title}
         />
-        <div className="size-[44px] flex items-center justify-center bg-[#000a] rounded-full absolute top-[calc(50%-22px)] right-[calc(50%-22px)]">
-          <PlaySolidIcon className="icon-lg text-palette-white ml-0.5" />
+        <div className="absolute right-[calc(50%-22px)] top-[calc(50%-22px)] flex size-[44px] items-center justify-center rounded-full bg-[#000a]">
+          <PlaySolidIcon className="icon-lg ml-0.5 text-palette-white" />
         </div>
       </div>
-      <div className="px-4 py-2 bg-default flex flex-col gap-1 justify-center">
-        <LABEL className="leading-normal flex gap-1.5 items-center">{title}</LABEL>
+      <div className="flex flex-col justify-center gap-1 bg-default px-4 py-2">
+        <LABEL className="flex items-center gap-1.5 leading-normal">{title}</LABEL>
         {description && (
-          <CALLOUT theme="secondary" className="flex gap-2 items-center">
+          <CALLOUT theme="secondary" className="flex items-center gap-2">
             {description}
           </CALLOUT>
         )}
       </div>
-      <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-md ml-auto my-auto mr-4 max-sm-gutters:hidden" />
+      <ArrowUpRightIcon className="icon-md my-auto ml-auto mr-4 shrink-0 text-icon-secondary max-sm-gutters:hidden" />
     </A>
   );
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7282,6 +7282,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-tailwindcss@^0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.8.tgz#8a178e1679e3f941cc9de396f109c6cffea676d8"
+  integrity sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==
+
 prettier@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"


### PR DESCRIPTION
# Why

To align with lint stack setup used in our other web apps.

# How

Add `prettier-plugin-tailwindcss` dependency and hook it up. Fix all reported warnings.

# Test Plan

All lint checks are passing.