### PR TITLE
[docs] Prioritize vercel.json v3

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -392,6 +392,30 @@ module.exports = createRequestHandler({
 Create a Vercel configuration file (**vercel.json**) at the root of your project to redirect all requests to the server function.
 
 <Tabs>
+<Tab label="vercel.json v3">
+
+```json vercel.json
+{
+  "buildCommand": "expo export -p web",
+  "outputDirectory": "dist/client",
+  "functions": {
+    "api/index.ts": {
+      "runtime": "@vercel/node@3.0.11",
+      "includeFiles": "dist/server/**"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/index.ts"
+    }
+  ]
+}
+```
+
+The newer version of the **vercel.json** does not use `routes` and `builds` configuration options anymore, and serves your public assets from the **dist/client** output directory automatically.
+
+</Tab>
 <Tab label="vercel.json v2">
 
 ```json vercel.json
@@ -427,30 +451,6 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
 ```
 
 The **legacy** version of the **vercel.json** needs a `@vercel/static-build` runtime to serve your assets from the **dist/client** output directory.
-
-</Tab>
-<Tab label="vercel.json v3">
-
-```json vercel.json
-{
-  "buildCommand": "expo export -p web",
-  "outputDirectory": "dist/client",
-  "functions": {
-    "api/index.ts": {
-      "runtime": "@vercel/node@3.0.11",
-      "includeFiles": "dist/server/**"
-    }
-  },
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/api/index.ts"
-    }
-  ]
-}
-```
-
-The newer version of the **vercel.json** does not use `routes` and `builds` configuration options anymore, and serves your public assets from the **dist/client** output directory automatically.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[The Expo Router API Routes deployment docs section](https://docs.expo.dev/router/reference/api-routes/#vercel) suggests Vercel `vercel.json` v2 as the first selected option:

![Screenshot 2024-11-04 at 11 33 57](https://github.com/user-attachments/assets/7d48c894-6b87-4bcc-9338-e7c28aa6865e)


But Vercel `vercel.json` v2 is legacy

# How

<!--
How did you build this feature or fix this bug and why?
-->

Prioritize the non-legacy `vercel.json` v3 file to show up first in the docs by reordering in the MDX file

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check that the docs are ok with presenting `vercel.json` v3 first

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

cc @amandeepmittal 