### PR TITLE
refactor(cli): add non-exiting visibility to `export:embed` and show warning when force-quitting

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Update `@urql/core` and related dependencies and remove `graphql` dependency. ([#32065](https://github.com/expo/expo/pull/32065) by [@kitten](https://github.com/kitten))
+- Increase visibility in stuck `export:embed` processes.
 
 ## 0.19.13 — 2024-10-31
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Update `@urql/core` and related dependencies and remove `graphql` dependency. ([#32065](https://github.com/expo/expo/pull/32065) by [@kitten](https://github.com/kitten))
-- Increase visibility in stuck `export:embed` processes.
+- Increase visibility in stuck `export:embed` processes. ([#32580](https://github.com/expo/expo/pull/32580) by [@byCedric](https://github.com/byCedric))
 
 ## 0.19.13 — 2024-10-31
 

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -44,6 +44,7 @@ import {
   persistMetroFilesAsync,
 } from '../saveAssets';
 import { exportStandaloneServerAsync } from './exportServer';
+import { ensureProcessExitsAfterDelay } from '../../utils/exit';
 
 const debug = require('debug')('expo:export:embed');
 
@@ -108,7 +109,10 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
     console.warn('warning: Eager bundle does not match new options, bundling again.');
   }
 
-  return exportEmbedInternalAsync(projectRoot, options);
+  await exportEmbedInternalAsync(projectRoot, options);
+
+  // Ensure the process closes after bundling
+  ensureProcessExitsAfterDelay();
 }
 
 export async function exportEmbedInternalAsync(projectRoot: string, options: Options) {

--- a/packages/@expo/cli/src/utils/__tests__/exit-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/exit-test.ts
@@ -1,4 +1,11 @@
-import { installExitHooks } from '../exit';
+import { fork } from 'node:child_process';
+import path from 'node:path';
+import timers from 'node:timers/promises';
+
+import { warn } from '../../log';
+import { installExitHooks, ensureProcessExitsAfterDelay } from '../exit';
+
+jest.mock('../../log');
 
 it('attaches and removes process listeners', () => {
   jest.spyOn(process, 'on');
@@ -26,4 +33,59 @@ it('attaches and removes process listeners', () => {
   // Unsub the second listener, this will remove the other listeners.
   unsub2();
   expect(process.removeListener).toBeCalledTimes(4);
+});
+
+describe(ensureProcessExitsAfterDelay, () => {
+  // This doesn't really fail on itself, but does cause a Jest warning about processes not exiting or crashing
+  it('detects the process can exit in its own', () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+
+    // Test if the process is force-exited after 0.2 seconds
+    ensureProcessExitsAfterDelay(200);
+
+    // Immediately let it pass
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('detects unexpected active resources and force exits', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+
+    // Test if the process is force-exited after 0.2 seconds
+    ensureProcessExitsAfterDelay(200);
+
+    // Wait longer than the exit timer (0.5s)
+    await timers.setTimeout(500);
+
+    // Ensure `process.exit` was called
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    // Ensure a warning was logged
+    expect(warn).toHaveBeenCalledWith(
+      'Something prevented Expo from exiting, forcefully exiting now.'
+    );
+  });
+
+  it('detects and logs unexpected active child processes and force exits', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+
+    // Get the file path to the process that will go on indefinitely
+    const processFile = path.join(__dirname, './fixtures/exit-indefinite-process.js');
+    // Start a process that will go on indefinitely
+    const pending = fork(processFile, { stdio: 'inherit' });
+    // Test if the process is force-exited after 0.2 seconds
+    ensureProcessExitsAfterDelay(200);
+
+    // Wait longer than the exit timer (0.5s)
+    await timers.setTimeout(500);
+
+    // Ensure `process.exit` was called
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    // Ensure a warning was logged
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(processFile));
+    expect(warn).toHaveBeenCalledWith(
+      'Detected 1 process preventing Expo from exiting, forcefully exiting now.'
+    );
+
+    exitSpy.mockReset();
+    pending.kill();
+  });
 });

--- a/packages/@expo/cli/src/utils/__tests__/fixtures/exit-indefinite-process.js
+++ b/packages/@expo/cli/src/utils/__tests__/fixtures/exit-indefinite-process.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const process = require('node:process');
+
+// keeping this process running indefinitely
+process.stdin.resume();
+process.stdin.on('data', (input) => {
+  //
+});

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -1,3 +1,4 @@
+import { ChildProcess } from 'node:child_process';
 import process from 'node:process';
 
 import { guardAsync } from './fn';
@@ -112,7 +113,7 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
   const elapsedTime = Date.now() - startedAtMs;
   if (elapsedTime > waitUntilExitMs) {
     debug('active handles detected past the exit delay, forcefully exiting:', activeResources);
-    warn('Something prevented the process from exiting, forcefully exiting.');
+    tryWarnActiveProcesses();
     return process.exit(0);
   }
 
@@ -122,4 +123,43 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
     // Check if the process can exit
     ensureProcessExitsAfterDelay(waitUntilExitMs, startedAtMs);
   }, 100);
+}
+
+/**
+ * Try to warn the user about unexpected active processes running in the background.
+ * This uses the internal `process._getActiveHandles` method, within a try-catch block.
+ * If active child processes are detected, the commands of these processes are logged.
+ *
+ * @example ```bash
+ * Done writing bundle output
+ * Detected 2 processes preventing Expo from exiting, forcefully exiting now.
+ *   - node /Users/cedric/../node_modules/nativewind/dist/metro/tailwind/v3/child.js
+ *   - node /Users/cedric/../node_modules/nativewind/dist/metro/tailwind/v3/child.js
+ * ```
+ */
+function tryWarnActiveProcesses() {
+  let activeProcesses: string[] = [];
+
+  try {
+    const children: ChildProcess[] = process
+      // @ts-expect-error - This is an internal method, not designed to be exposed. It's also our only way to get this info
+      ._getActiveHandles()
+      .filter((handle: any) => handle instanceof ChildProcess);
+
+    if (children.length) {
+      activeProcesses = children.map((child) => child.spawnargs.join(' '));
+    }
+  } catch (error) {
+    debug('failed to get active process information:', error);
+  }
+
+  if (!activeProcesses.length) {
+    warn('Something prevented Expo from exiting, forcefully exiting now.');
+  } else {
+    const singularOrPlural =
+      activeProcesses.length === 1 ? '1 process' : `${activeProcesses.length} processes`;
+
+    warn(`Detected ${singularOrPlural} preventing Expo from exiting, forcefully exiting now.`);
+    warn('  - ' + activeProcesses.join('\n  - '));
+  }
 }

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
 
 import { guardAsync } from './fn';
+import { warn } from '../log';
 
 const debug = require('debug')('expo:utils:exit') as typeof console.log;
 
@@ -88,6 +89,7 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
   const elapsedTime = Date.now() - startedAtMs;
   if (elapsedTime > waitUntilExitMs) {
     debug('active handles detected past the exit delay, forcefully exiting:', activeResources);
+    warn('Something prevented the process from exiting, rerun with `EXPO_DEBUG=1` to see why');
     return process.exit(0);
   }
 


### PR DESCRIPTION
# Why

We are getting some reports that the `export:embed --eager` stage in EAS is getting stuck. This change should help gain more visibility into this issue.

# How

- Added `ensureProcessExitsAfterDelay` to the `export:embed` command
- Added a warning whenever running into non-closing processes, without debug logs enabled
- Added on-best-effort-basis logging that should give accurate information about the process being stuck

# Test Plan

Hard to test this, but you should not get any warnings in a standard project. If you start a process in `metro.config.js`, and never close that process, this warning should pop up.

Reliable way to test nativewind getting stuck:

- `git clone https://github.com/keith-kurak/expo-router-london-2024-starter ./test-expo-stuck`
- `cd ./test-expo-stuck`
- `git checkout 291beddd9ed7b3adede6a327a19106cd4eeab9fc`
- `npm install`
- `expod export:embed --eager --platform ios`

This should output:

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/5a8a33c4-0cca-4634-bdfa-6a4fdfa0f04f">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
