### PR TITLE
[docs] Add `isNew` flag to Router API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -4,6 +4,7 @@ description: A file-based routing library for React Native and web applications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/router.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router.mdx
@@ -4,6 +4,7 @@ description: A file-based routing library for React Native and web applications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'web']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Last week, `isNew` flag in the frontmatter was introduced to indicate new API reference docs for the SDK 52 release cycle.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `isNew` flag to the Router API reference. Changes applied to unversioned and SDK 52 version of the doc.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-04 at 18 06 38](https://github.com/user-attachments/assets/b37d3459-6250-4139-8d52-3bdaba377c06)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
