### PR TITLE
[docs] Update Expo tutorial as per changes in `reset-project` script and splash screen section

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
 
 Let's divide the code into multiple files as we add more components to this screen. Throughout this tutorial, we'll use the components directory to create custom components.
 
-1. Create **components** directory, and inside it, create a **ImageViewer.tsx** file.
+1. Create a **components** directory, and inside it, create the **ImageViewer.tsx** file.
 2. Move the code to display the image in this file along with the `image` styles.
 
 {/* prettier-ignore */}

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
 
 Let's divide the code into multiple files as we add more components to this screen. Throughout this tutorial, we'll use the components directory to create custom components.
 
-1. Inside the **components** directory, create a **ImageViewer.tsx** file.
+1. Create **components** directory, and inside it, create a **ImageViewer.tsx** file.
 2. Move the code to display the image in this file along with the `image` styles.
 
 {/* prettier-ignore */}

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -79,6 +79,18 @@ Setting the `"splash.image"` property with a valid file path in the [**app.json*
   className="max-w-[250px]"
 />
 
+Add the following `splash` object in **app.json** to configure the splash screen:
+
+```json app.json
+{
+  "splash": {
+    "image": "./assets/images/splash.png",
+    "resizeMode": "contain",
+    "backgroundColor": "#25292e"
+  }
+}
+```
+
 Let's take a look at our app now on Android and iOS:
 
 <ContentSpotlight file="tutorial/splash-screen.mp4" />
@@ -101,20 +113,6 @@ setTimeout(SplashScreen.hideAsync, 5000);
 Don't forget to remove this code when you are done testing your splash screen.
 
 </Collapsible>
-
-Depending on the device's resolution, a white bar may be visible on the edges of an Android device's screen. To resolve this, set the `backgroundColor` for the splash screen in **app.json** to match the background in the splash image:
-
-{/* prettier-ignore */}
-```json app.json
-{
-  "splash": {
-    "image": "./assets/images/splash.png",
-    "resizeMode": "contain",
-    /* @tutinfo Use #25292e (black) instead of the default #ffffff (white). */
-    "backgroundColor": "#25292e" /* @end */
-  }
-}
-```
 
 The `backgroundColor` value in the above snippet matches the background of the splash screen image.
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -91,6 +91,8 @@ Add the following `splash` object in **app.json** to configure the splash screen
 }
 ```
 
+Depending on the device's resolution, a white bar may be visible on the edges of an Android device's screen but the `backgroundColor` will resolve this by matching the background in the splash image.
+
 Let's take a look at our app now on Android and iOS:
 
 <ContentSpotlight file="tutorial/splash-screen.mp4" />

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -89,11 +89,11 @@ In this tutorial, we'll build our app from scratch and understand the fundamenta
 
 <Terminal cmd={['$ npm run reset-project']} />
 
-After running the above command, there are two files (**index.tsx** and **\_layout.tsx**) left inside the **app** directory. The other directories (**components**, **constants**, and **hooks**) also contain boilerplate code. We can delete all files inside these directories because we'll create our own components.
+After running the above command, there are two files (**index.tsx** and **\_layout.tsx**) left inside the **app** directory. The previous files from **app** and other directories (**components**, **constants**, and **hooks** &mdash; containing boilerplate code) are moved inside the **app-example** directory by the script. We'll create our own directories and component files as we go along.
 
 <Collapsible summary={<>What does the <CODE>reset-project</CODE> script do?</>}>
 
-`reset-project` script resets the **app** directory structure in a project and copies the previous files from **app** directory to another directory called **app-example**. We can delete it since it is not part of our main app's structure.
+`reset-project` script resets the **app** directory structure in a project and copies the previous boilerplate files from the project's root directory to another sub-directory called **app-example**. We can delete it since it is not part of our main app's structure.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-13924

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating the verbiage around `reset-project` script explanation according to the changes for SDK 52
- There's only one new directory created during the tutorial (**components**). Update its first reference to add instruction about creating the directory itself.
- **Update on 12 Nov**: Update splash screen section to provide instructions on adding `splash` object manually in app config.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- For project changes verification: Create a new project with `yarn create expo-app --template default@beta` and run `yarn run reset-project` which will give the following output:

![CleanShot 2024-11-04 at 18 12 43@2x](https://github.com/user-attachments/assets/980f41d8-e501-40fd-80df-4d46106e30ef)

- Preview of docs changes:

![CleanShot 2024-11-04 at 18 31 27](https://github.com/user-attachments/assets/29f9c1b0-a3af-43f8-a809-b80bc779b54f)

![CleanShot 2024-11-04 at 18 31 37](https://github.com/user-attachments/assets/6b6767d5-e940-4d41-abad-c0cbe2c2ac43)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
