### PR TITLE
[video][android] Fix errors when setting a source with null uri

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix errors when passing a source with an `undefined` `uri` field. ([#32585](https://github.com/expo/expo/pull/32585) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 2.0.0-preview.0 — 2024-10-22

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -226,11 +226,12 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   }
 
   fun prepare() {
-    uncommittedSource?.let { videoSource ->
-      val mediaSource = videoSource.toMediaSource(context)
-      player.setMediaSource(mediaSource)
+    val newSource = uncommittedSource
+    val mediaSource = newSource?.toMediaSource(context)
+    mediaSource?.let {
+      player.setMediaSource(it)
       player.prepare()
-      lastLoadedSource = videoSource
+      lastLoadedSource = newSource
       uncommittedSource = null
     } ?: run {
       player.clearMediaItems()

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -38,7 +38,8 @@ class VideoSource(
       "NotificationDataArtwork:${this.metadata?.artwork?.path}"
   }
 
-  fun toMediaSource(context: Context): MediaSource {
+  fun toMediaSource(context: Context): MediaSource? {
+    this.uri ?: return null
     return buildMediaSourceWithHeaders(context, this)
   }
 


### PR DESCRIPTION
# Why

We allow a `undefined` uri in `VideoSource` type, but there is an error on Android when this is the case

# How

Return a null MediaSource when the uri is `null`

# Test Plan

Tested in BareExpo on Android

