### PR TITLE
[expo-go] Request local network access at better times

### DIFF
--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -38,15 +38,4 @@ class AppDelegate: ExpoAppDelegate {
 
     window?.makeKeyAndVisible()
   }
-
-  override func applicationDidBecomeActive(_ application: UIApplication) {
-    super.applicationDidBecomeActive(application)
-    Task {
-      do {
-        try await requestLocalNetworkAuthorization()
-      } catch {
-        log.error(error)
-      }
-    }
-  }
 }

--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -22,7 +22,7 @@
 
 NSString * const kEXHomeDisableNuxDefaultsKey = @"EXKernelDisableNuxDefaultsKey";
 NSString * const kEXHomeIsNuxFinishedDefaultsKey = @"EXHomeIsNuxFinishedDefaultsKey";
-NSString * const kEXisLocalNetworkAccessGrantedKey = @"EXisLocalNetworkAccessGranted";
+NSString * const kEXIsLocalNetworkAccessGrantedKey = @"EXIsLocalNetworkAccessGranted";
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -53,8 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isLocalNetworkAccessGranted {
-  if ([[NSUserDefaults standardUserDefaults] objectForKey:kEXisLocalNetworkAccessGrantedKey] != nil) {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:kEXisLocalNetworkAccessGrantedKey];
+  if ([[NSUserDefaults standardUserDefaults] objectForKey:kEXIsLocalNetworkAccessGrantedKey] != nil) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kEXIsLocalNetworkAccessGrantedKey];
   } else {
     return NO;
   }
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_async(dispatch_get_main_queue(), ^{
       if (success) {
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        [userDefaults setBool:YES forKey:kEXisLocalNetworkAccessGrantedKey];
+        [userDefaults setBool:YES forKey:kEXIsLocalNetworkAccessGrantedKey];
         [self foregroundApp:appRecord];
       } else {
         [self createLocalNetworkDeniedAlert];
@@ -135,8 +135,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)createLocalNetworkDeniedAlert
 {
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Local Network Access required"
-                                                                 message:@"Local network access has been denied. This permission is required to run projects in expo go. Please go to your device settings and grant this permission."
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Local network access required"
+                                                                 message:@"Local network access has been denied. This permission is required to run projects in Expo Go. Enable \"Local Network\" for Expo Go from the Settings app."
                                                           preferredStyle:UIAlertControllerStyleAlert];
   UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
   [alert addAction:okAction];

--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -16,11 +16,13 @@
 #import "EXDevMenuManager.h"
 #import "EXEmbeddedHomeLoader.h"
 #import "EXBuildConstants.h"
+#import "Expo_Go-Swift.h"
 
 @import ExpoScreenOrientation;
 
 NSString * const kEXHomeDisableNuxDefaultsKey = @"EXKernelDisableNuxDefaultsKey";
 NSString * const kEXHomeIsNuxFinishedDefaultsKey = @"EXHomeIsNuxFinishedDefaultsKey";
+NSString * const kEXisLocalNetworkAccessGrantedKey = @"EXisLocalNetworkAccessGranted";
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL isAnimatingAppTransition;
 @property (nonatomic, weak) UIViewController *transitioningToViewController;
+@property (nonatomic, readonly) BOOL isLocalNetworkAccessGranted;
 
 @end
 
@@ -47,6 +50,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldAutorotate
 {
   return YES;
+}
+
+- (BOOL)isLocalNetworkAccessGranted {
+  if ([[NSUserDefaults standardUserDefaults] objectForKey:kEXisLocalNetworkAccessGrantedKey] != nil) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kEXisLocalNetworkAccessGrantedKey];
+  } else {
+    return NO;
+  }
 }
 
 /**
@@ -94,13 +105,42 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)moveAppToVisible:(EXKernelAppRecord *)appRecord
 {
-  [self _foregroundAppRecord:appRecord];
+  BOOL isHomeApp = appRecord == [EXKernel sharedInstance].appRegistry.homeAppRecord;
+  if (isHomeApp || [self isLocalNetworkAccessGranted]) {
+    [self foregroundApp:appRecord];
+    return;
+  }
+  
+  [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success, NSError *error) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (success) {
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:YES forKey:kEXisLocalNetworkAccessGrantedKey];
+        [self foregroundApp:appRecord];
+      } else {
+        [self createLocalNetworkDeniedAlert];
+      }
+    });
+  }];
+}
 
+- (void)foregroundApp:(EXKernelAppRecord *)appRecord
+{
+  [self _foregroundAppRecord:appRecord];
   // When foregrounding the app record we want to add it to the history to handle the edge case
   // where a user opened a project, then went to home and cleared history, then went back to a
   // the already open project.
   [self addHistoryItemWithUrl:appRecord.appLoader.manifestUrl manifest:appRecord.appLoader.manifest];
+}
 
+- (void)createLocalNetworkDeniedAlert
+{
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Local Network Access required"
+                                                                 message:@"Local network access has been denied. This permission is required to run projects in expo go. Please go to your device settings and grant this permission."
+                                                          preferredStyle:UIAlertControllerStyleAlert];
+  UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+  [alert addAction:okAction];
+  [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)showQRReader

--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
     return;
   }
   
-  [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success, NSError *error) {
+  [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success) {
     dispatch_async(dispatch_get_main_queue(), ^{
       if (success) {
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];

--- a/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
+++ b/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
@@ -5,13 +5,13 @@ private let type = "_preflight_check._tcp"
 
 @objc(EXLocalNetworkAccessManager)
 class LocalNetworkAccessManager: NSObject {
-  @objc static func requestAccess(completion: @escaping (Bool, NSError?) -> Void) {
+  @objc static func requestAccess(completion: @escaping (Bool) -> Void) {
     Task {
       do {
         let result = try await requestLocalNetworkAuthorization()
-        completion(result, nil)
+        completion(result)
       } catch {
-        completion(false, nil)
+        completion(false)
       }
     }
   }

--- a/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
+++ b/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
@@ -3,6 +3,20 @@ import Network
 
 private let type = "_preflight_check._tcp"
 
+@objc(EXLocalNetworkAccessManager)
+class LocalNetworkAccessManager: NSObject {
+  @objc static func requestAccess(completion: @escaping (Bool, NSError?) -> Void) {
+    Task {
+      do {
+        let result = try await requestLocalNetworkAuthorization()
+        completion(result, nil)
+      } catch {
+        completion(false, nil)
+      }
+    }
+  }
+}
+
 /// Code taken from https://gist.github.com/mac-cain13/fa684f54a7ae1bba8669e78d28611784
 @discardableResult
 func requestLocalNetworkAuthorization() async throws -> Bool {

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		31E6D48020B845830082B09F /* EXSensorsManagerBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E6D47F20B845830082B09F /* EXSensorsManagerBinding.m */; };
 		31E8B2FD23D090E200E6C2BF /* EXClientReleaseType.m in Sources */ = {isa = PBXBuildFile; fileRef = 31E8B2FC23D090E200E6C2BF /* EXClientReleaseType.m */; };
 		31F8E27E255F05D5005AA063 /* EXDeviceInstallationUUIDService.m in Sources */ = {isa = PBXBuildFile; fileRef = 31F8E27D255F05D5005AA063 /* EXDeviceInstallationUUIDService.m */; };
-		402B73292CC90F7100FA17BC /* RequestLocalNetworkAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */; };
+		402B73292CC90F7100FA17BC /* LocalNetworkAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402B73282CC90F7100FA17BC /* LocalNetworkAccessManager.swift */; };
 		4089335A2CAAF7A20095810E /* ExpoAppInstance.mm in Sources */ = {isa = PBXBuildFile; fileRef = 408933592CAAF7A20095810E /* ExpoAppInstance.mm */; };
 		40CB1D752CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D722CD2A0C200CB3717 /* EXSplashScreenViewNativeProvider.m */; };
 		40CB1D762CD2A0C200CB3717 /* EXSplashScreenModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 40CB1D6C2CD2A0C200CB3717 /* EXSplashScreenModule.m */; };
@@ -249,7 +249,7 @@
 		3451876A2368FE9E008C4171 /* cp-bundle-resources-conditionally.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "cp-bundle-resources-conditionally.sh"; sourceTree = "<group>"; };
 		34656423B7AD3C99D408EF4F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Expo Go-Tests/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		39E8C61B17879D7B4A44D983 /* Pods-ExponentIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExponentIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-ExponentIntegrationTests/Pods-ExponentIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
-		402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestLocalNetworkAccess.swift; sourceTree = "<group>"; };
+		402B73282CC90F7100FA17BC /* LocalNetworkAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkAccessManager.swift; sourceTree = "<group>"; };
 		408933582CAAF7870095810E /* ExpoAppInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpoAppInstance.h; sourceTree = "<group>"; };
 		408933592CAAF7A20095810E /* ExpoAppInstance.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExpoAppInstance.mm; sourceTree = "<group>"; };
 		40CB1D6B2CD2A0C200CB3717 /* EXSplashScreenModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSplashScreenModule.h; sourceTree = "<group>"; };
@@ -825,7 +825,7 @@
 				B2E2CCC62AA7D33E00E2260C /* HomeAppLoader.swift */,
 				B2E2CCC92AA7DAD400E2260C /* ManifestAndAssetRequestHeaders.swift */,
 				B2E2CCCF2AA7DF9C00E2260C /* HomeAppLoaderTask.swift */,
-				402B73282CC90F7100FA17BC /* RequestLocalNetworkAccess.swift */,
+				402B73282CC90F7100FA17BC /* LocalNetworkAccessManager.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1867,7 +1867,7 @@
 				B5576085204A423B0041D9C8 /* EXHomeModuleManager.m in Sources */,
 				B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */,
 				31361A5A2260B2F600662769 /* EXScopedSecureStore.m in Sources */,
-				402B73292CC90F7100FA17BC /* RequestLocalNetworkAccess.swift in Sources */,
+				402B73292CC90F7100FA17BC /* LocalNetworkAccessManager.swift in Sources */,
 				B5FB74F01FF6DADC001C764B /* EXScopedBridgeModule.m in Sources */,
 				31361A612261C65A00662769 /* EXPermissionsManager.m in Sources */,
 				B248B8842AD8888C003C9C10 /* UpdatesBinding.swift in Sources */,
@@ -2043,10 +2043,7 @@
 				LDPLUSPLUS = "";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -2109,10 +2106,7 @@
 				LD = "";
 				LDPLUSPLUS = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
@@ -89,7 +89,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
     [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success) {
       if (success) {
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        [userDefaults setBool:YES forKey:@"EXisLocalNetworkAccessGranted"];
+        [userDefaults setBool:YES forKey:@"EXIsLocalNetworkAccessGranted"];
         [EXUtil performSynchronouslyOnMainThread:^{
           [RCTSharedApplication() openURL:URL options:@{} completionHandler:^(BOOL success) {
             if (success) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Internal/EXLinkingManager.m
@@ -83,10 +83,10 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
   } else {
     /**
      [RCTSharedApplication() openURL: options:completionHandler:) will request local network access before attempting to open the link but
-      it won't present the alert over the app. Instead the app becomes unresponsive and the user needs to background it to see the alert. To workaround this
+      it won't present the alert in expo go. Instead the app becomes unresponsive and the user needs to background it to see the alert. To workaround this
       we wrap the call in our own check so the alert is presented in expo go.
      */
-    [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success, NSError *error) {
+    [EXLocalNetworkAccessManager requestAccessWithCompletion:^(BOOL success) {
       if (success) {
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setBool:YES forKey:@"EXisLocalNetworkAccessGranted"];

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3038,7 +3038,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: cbea5780295649ccd9dd85298de15df181cb22c8
+  hermes-engine: d467e918d930453f2ae3dccf22712c3134ce9d28
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f


### PR DESCRIPTION
# Why
part of ENG-10893
Currently, expo go requests local network access on launch. This fixes the problem of the app crashing when it doesn't have this permission but it's not a great experience to be asked immediately before the splashscreen has been hidden. Instead, we should wait until the user attempts to load a project and then make the request.

# How
One place to do it is in `moveAppToVisible`. I've added a new value to user defaults as the request does have some overhead so we only do it once. The issue with this approach is a user could deny the permission from the device settings but I don't think this is a likely scenario. There is a notable lag when attempting to open a project if we run the check every time.

I've also added a check in the `EXLinkingManager`. When `RCTSharedApplication() openURL:)` is used, it will trigger the request dialog but it will not present it in expo go. Instead, the app becomes unresponsive and the user needs to background it to see the dialog. Wrapping this in our own check prevents this and ensures the dialog is presented in expo go.

# Test Plan
expo go on a physical device. Scanning the QR Code will dismiss the camera and then show the alert. 

