### PR TITLE
chore(ci): use default macos version of GHA for Expo Router E2E tests

### DIFF
--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   expo-go-dev-maestro-router:
-    runs-on: macos-12
+    runs-on: macos-latest
     env:
       E2E_ROUTER_USE_PUBLISHED_EXPO_GO: true
       E2E_ROUTER_SRC: expo-go-dev-maestro-router


### PR DESCRIPTION
# Why

It's currently failing with:

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/ecf483e4-32e8-4d52-b4c0-9585bc05d390">


# How

- Since we likely lag behind GHA changes, this uses the default MacOS version to keep us on the latest.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
