### PR TITLE
[router-e2e] fix broken test on web

### DIFF
--- a/apps/router-e2e/__e2e__/dom-components/app/index.tsx
+++ b/apps/router-e2e/__e2e__/dom-components/app/index.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from 'expo-router';
 import { useRef, useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import Actions from '../components/02-actions';
 import LocalAsset from '../components/03-local-asset';
@@ -75,6 +75,10 @@ export default function Page() {
         <Button
           title="Update color using webView ref"
           onPress={() => {
+            if (process.env.EXPO_OS === 'web') {
+              alert('WebView ref is not supported on Web.');
+              return;
+            }
             const hue = Math.floor(Math.random() * 360);
             const saturation = 100;
             const lightness = 85;
@@ -108,6 +112,14 @@ function TestCase({ name, children }) {
   );
 }
 
+function Button({ title, onPress }) {
+  return (
+    <Pressable style={styles.button} onPress={onPress}>
+      <Text style={styles.buttonText}>{title}</Text>
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   testcaseContainer: {
     marginBottom: 24,
@@ -130,5 +142,19 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666',
     marginBottom: 12,
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 4,
+    elevation: 3,
+    backgroundColor: '#007AFF',
+  },
+  buttonText: {
+    fontSize: 14,
+    color: 'white',
   },
 });

--- a/apps/router-e2e/__e2e__/dom-components/components/08-native-module-proxy.web.tsx
+++ b/apps/router-e2e/__e2e__/dom-components/components/08-native-module-proxy.web.tsx
@@ -1,0 +1,5 @@
+'use dom';
+
+export default function Page(_: { dom?: import('expo/dom').DOMProps }) {
+  return <div>Native module proxy is not supported on the web platform.</div>;
+}


### PR DESCRIPTION
# Why

fix broken tests on web.

# How

- show unsupported test case for NativeModulesProxy and webView ref
- use universal Button because the button text is not clear on web

# Test Plan

router-e2e on dom components on ios and web

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
