### PR TITLE
[expo][doc] replace EXPO_DOM_BASE_URL with EXPO_BASE_URL

### DIFF
--- a/apps/router-e2e/__e2e__/dom-components/components/05-public-asset.tsx
+++ b/apps/router-e2e/__e2e__/dom-components/components/05-public-asset.tsx
@@ -3,7 +3,7 @@
 export default function Page(_: { dom?: import('expo/dom').DOMProps }) {
   return (
     <img
-      src={`${process.env.EXPO_DOM_BASE_URL}/react-logo.png`}
+      src={`${process.env.EXPO_BASE_URL}/react-logo.png`}
       width={128}
       height={128}
       alt="React logo"

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -245,10 +245,10 @@ const IS_DOM = typeof ReactNativeWebView !== 'undefined';
 
 ## Public assets
 
-The contents of the root **public** directory are copied to the native app's binary to support the use of public assets in DOM components. Since these public assets will be served from the local filesystem, use the `process.env.EXPO_DOM_BASE_URL` prefix to reference the correct path. For example:
+The contents of the root **public** directory are copied to the native app's binary to support the use of public assets in DOM components. Since these public assets will be served from the local filesystem, use the `process.env.EXPO_BASE_URL` prefix to reference the correct path. For example:
 
 ```tsx
-<img src={`${process.env.EXPO_DOM_BASE_URL}/img.png`} />
+<img src={`${process.env.EXPO_BASE_URL}/img.png`} />
 ```
 
 {/* TODO: This is likely to change. */}

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Re-exported `@expo/fingerprint` as `expo/fingerprint`. ([#32494](https://github.com/expo/expo/pull/32494) by [@quinlanj](https://github.com/quinlanj))
+- Deprecated `process.env.EXPO_DOM_BASE_URL` and replaced with `process.env.EXPO_BASE_URL`. ([#32596](https://github.com/expo/expo/pull/32596) by [@kudo](https://github.com/kudo))
 
 ## 52.0.0-preview.18 — 2024-10-31
 

--- a/packages/expo/src/dom/injection.ts
+++ b/packages/expo/src/dom/injection.ts
@@ -17,14 +17,14 @@ export const getInjectEventScript = <T extends BridgeMessage<any>>(detail: T) =>
 
 export function getInjectEnvsScript() {
   return `;(function injectEnvs() {
-  let domBaseUrl = '';
+  let baseUrl = '';
   if (window.location.protocol === 'file:') {
-    domBaseUrl = window.location.href.substring(0, window.location.href.lastIndexOf('/'));
+    baseUrl = window.location.href.substring(0, window.location.href.lastIndexOf('/'));
   }
   window.process = window.process || {};
   window.process.env = {
     ...(window.process.env || {}),
-    EXPO_DOM_BASE_URL: domBaseUrl,
+    EXPO_BASE_URL: baseUrl,
   };
   })();
   true;`;


### PR DESCRIPTION
# Why

we have introduced many base urls in process.env. as `process.env.EXPO_BASE_URL` is not being used in the webview runtime of dom componets. let's just use it.

# How

- replace `process.env.EXPO_DOM_BASE_URL` with `process.env.EXPO_BASE_URL`. as sdk 52 is not officially released yet, let's just remove it without backward compatibility.
- also fix original `process.env.EXPO_DOM_BASE_URL` undefined issue on web. close ENG-13383

# Test Plan

router e2e dom components on ios and web

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
