### PR TITLE
feat(cli): add `npx expo serve` command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `npx expo serve` command for hosting the release server locally.
+
 ### 🐛 Bug fixes
 
 - Add fallback method for determining internal IP address. ([#32273](https://github.com/expo/expo/pull/32273) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `npx expo serve` command for hosting the release server locally.
+- Add `npx expo serve` command for hosting the release server locally. ([#32602](https://github.com/expo/expo/pull/32602) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -100,6 +100,7 @@ if (!isSubcommand && args['--help']) {
     run: _run,
     // NOTE(cedric): Still pending the migration to ESLint's flat config
     lint: _lint,
+    serve,
     // All other commands
     ...others
   } = commands;
@@ -111,7 +112,7 @@ if (!isSubcommand && args['--help']) {
   {bold Commands}
     ${Object.keys({ start, export: _export, ...others }).join(', ')}
     ${Object.keys({ 'run:ios': runIos, 'run:android': runAndroid, prebuild }).join(', ')}
-    ${Object.keys({ install, customize, config }).join(', ')}
+    ${Object.keys({ install, customize, config, serve }).join(', ')}
     {dim ${Object.keys({ login, logout, whoami, register }).join(', ')}}
 
   {bold Options}

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -28,6 +28,8 @@ const commands: { [command: string]: () => Promise<Command> } = {
   'export:web': () => import('../src/export/web/index.js').then((i) => i.expoExportWeb),
   'export:embed': () => import('../src/export/embed/index.js').then((i) => i.expoExportEmbed),
 
+  serve: () => import('../src/serve/index.js').then((i) => i.expoServe),
+
   // Auxiliary commands
   install: () => import('../src/install/index.js').then((i) => i.expoInstall),
   add: () => import('../src/install/index.js').then((i) => i.expoInstall),

--- a/packages/@expo/cli/e2e/__tests__/index-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/index-test.ts
@@ -34,7 +34,7 @@ it('runs `npx expo --help`', async () => {
       Commands
         start, export
         run:ios, run:android, prebuild
-        install, customize, config
+        install, customize, config, serve
         login, logout, whoami, register
 
       Options

--- a/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
-import { bin, ServeLocalCommand } from '../../utils/command-instance';
+import { bin, ExpoServeLocalCommand } from '../../utils/command-instance';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -19,7 +19,7 @@ test.beforeAll(async () => {
   test.setTimeout(560 * 1000);
 });
 
-let serveCmd: ServeLocalCommand;
+let serveCmd: ExpoServeLocalCommand;
 
 test.beforeAll('bundle and serve', async () => {
   console.time('expo export');
@@ -44,13 +44,13 @@ test.beforeAll('bundle and serve', async () => {
     path.join(projectRoot, inputDir, 'client/second.html')
   );
 
-  serveCmd = new ServeLocalCommand(projectRoot, {
+  serveCmd = new ExpoServeLocalCommand(projectRoot, {
     NODE_ENV: 'production',
     TEST_SECRET_VALUE: 'test-secret-dynamic',
   });
 
   console.time('npx serve');
-  await serveCmd.startAsync(['serve.js', '--port=' + 3034, '--dist=' + inputDir]);
+  await serveCmd.startAsync([inputDir, '--port=' + 3034]);
   console.timeEnd('npx serve');
   console.log('Server running:', serveCmd.url);
 });
@@ -72,7 +72,7 @@ test.describe.serial(inputDir, () => {
 
     console.time('Open page');
     // Navigate to the app
-    await page.goto(serveCmd.url);
+    await page.goto(serveCmd.url!);
 
     console.timeEnd('Open page');
 

--- a/packages/@expo/cli/e2e/utils/command-instance.ts
+++ b/packages/@expo/cli/e2e/utils/command-instance.ts
@@ -379,3 +379,29 @@ export class ServeLocalCommand extends ServeAbstractCommand {
     return super.startAsync(['node', ...args]);
   }
 }
+
+export class ExpoServeLocalCommand extends ServeAbstractCommand {
+  isReadyCallback(message: string): boolean {
+    const tag = 'Server running at ';
+    for (const rawStr of stripAnsi(message)) {
+      if (rawStr.includes(tag)) {
+        const matchedLine = rawStr
+          .split('\n')
+          ?.find((line) => line.includes(tag))
+          ?.split(/Server running at\s+/)
+          ?.pop()
+          ?.trim();
+        if (!matchedLine) {
+          return false;
+        }
+        this.url = matchedLine;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async startAsync(args: string[] = []) {
+    return super.startAsync(['npx', 'expo', 'serve', ...args]);
+  }
+}

--- a/packages/@expo/cli/src/serve/index.ts
+++ b/packages/@expo/cli/src/serve/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+
+export const expoServe: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--port': Number,
+
+      // Aliases
+      '-h': '--help',
+    },
+    argv
+  );
+
+  if (args['--help']) {
+    printHelp(
+      `Host the production server locally`,
+      chalk`npx expo serve {dim <dir>}`,
+      [
+        chalk`<dir>            Directory of the Expo project. {dim Default: Current working directory}`,
+        `--port <number>  Port to host the server on`,
+        `-h, --help       Usage info`,
+      ].join('\n')
+    );
+  }
+
+  // Load modules after the help prompt so `npx expo config -h` shows as fast as possible.
+  const [
+    // ./configAsync
+    { serveAsync },
+    // ../utils/errors
+    { logCmdError },
+  ] = await Promise.all([import('./serveAsync.js'), import('../utils/errors.js')]);
+
+  return serveAsync(getProjectRoot(args), {
+    isDefaultDirectory: !args._[0],
+    // Parsed options
+    port: args['--port'],
+  }).catch(logCmdError);
+};

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -1,0 +1,123 @@
+import { createRequestHandler } from '@expo/server/build/vendor/http';
+import chalk from 'chalk';
+import connect from 'connect';
+import http from 'http';
+import path from 'path';
+import send from 'send';
+
+import * as Log from '../log';
+import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
+import { CommandError } from '../utils/errors';
+import { setNodeEnv } from '../utils/nodeEnv';
+
+type Options = {
+  port?: number;
+  isDefaultDirectory: boolean;
+};
+
+// Start a basic http server
+export async function serveAsync(projectRoot: string, options: Options) {
+  setNodeEnv('production');
+  require('@expo/env').load(projectRoot);
+
+  const serverDist = options.isDefaultDirectory ? path.join(projectRoot, 'dist') : projectRoot;
+  //  TODO: `.expo/server/ios`, `.expo/server/android`, etc.
+
+  if (!(await directoryExistsAsync(serverDist))) {
+    throw new CommandError(
+      `The server directory ${serverDist} does not exist. Run \`npx expo export\` first.`
+    );
+  }
+
+  const isStatic = await isStaticExportAsync(serverDist);
+
+  Log.log(chalk.dim(`Starting ${isStatic ? 'static ' : ''}server in ${serverDist}`));
+
+  if (isStatic) {
+    const server = http.createServer((req, res) => {
+      // Remove query strings and decode URI
+      const filePath = decodeURI(req.url?.split('?')[0] ?? '');
+
+      send(req, filePath, {
+        root: serverDist,
+        index: 'index.html',
+      })
+        .on('error', (err: any) => {
+          if (err.status === 404) {
+            res.statusCode = 404;
+            res.end('Not Found');
+            return;
+          }
+          res.statusCode = err.status || 500;
+          res.end('Internal Server Error');
+        })
+        .pipe(res);
+    });
+
+    const port = options.port ?? 3000;
+    server.listen(port);
+    Log.log(`Server running at http://localhost:${port}`);
+  } else {
+    const middleware = connect();
+
+    const staticDirectory = path.join(serverDist, 'client');
+    const serverDirectory = path.join(serverDist, 'server');
+
+    const serverHandler = createRequestHandler({ build: serverDirectory });
+
+    // DOM component CORS support
+    middleware.use((req, res, next) => {
+      // TODO: Only when origin is `file://` (iOS), and Android equivalent.
+
+      // Required for DOM components security in release builds.
+
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requested-With, Content-Type, Accept, expo-platform'
+      );
+
+      // Handle OPTIONS preflight requests
+      if (req.method === 'OPTIONS') {
+        res.statusCode = 200;
+        res.end();
+        return;
+      }
+      next();
+    });
+
+    middleware.use((req, res, next) => {
+      // Serve static files from the client directory first
+      if (req.url) {
+        send(req, decodeURI(req.url), {
+          root: staticDirectory,
+          index: false,
+        })
+          .on('error', (err: any) => {
+            if (err.status === 404) {
+              next();
+              return;
+            }
+            res.statusCode = err.status || 500;
+            res.end('Internal Server Error');
+          })
+          .pipe(res);
+        return;
+      }
+      next();
+    });
+    middleware.use(serverHandler);
+
+    const port = options.port ?? 3000;
+    middleware.listen(port);
+    Log.log(`Server running at http://localhost:${port}`);
+  }
+
+  // Detect the type of server we need to setup:
+}
+
+async function isStaticExportAsync(dist: string): Promise<boolean> {
+  const routesFile = path.join(dist, `server/_expo/routes.json`);
+  return !(await fileExistsAsync(routesFile));
+}

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -9,16 +9,29 @@ import * as Log from '../log';
 import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { setNodeEnv } from '../utils/nodeEnv';
+import { resolvePortAsync } from '../utils/port';
 
 type Options = {
   port?: number;
   isDefaultDirectory: boolean;
 };
 
+const debug = require('debug')('expo:serve') as typeof console.log;
+
 // Start a basic http server
 export async function serveAsync(projectRoot: string, options: Options) {
   setNodeEnv('production');
   require('@expo/env').load(projectRoot);
+
+  const port = await resolvePortAsync(projectRoot, {
+    defaultPort: options.port,
+    fallbackPort: 8081,
+  });
+
+  if (port == null) {
+    throw new CommandError('Could not start server. Port is not available.');
+  }
+  options.port = port;
 
   const serverDist = options.isDefaultDirectory ? path.join(projectRoot, 'dist') : projectRoot;
   //  TODO: `.expo/server/ios`, `.expo/server/android`, etc.
@@ -34,87 +47,108 @@ export async function serveAsync(projectRoot: string, options: Options) {
   Log.log(chalk.dim(`Starting ${isStatic ? 'static ' : ''}server in ${serverDist}`));
 
   if (isStatic) {
-    const server = http.createServer((req, res) => {
-      // Remove query strings and decode URI
-      const filePath = decodeURI(req.url?.split('?')[0] ?? '');
-
-      send(req, filePath, {
-        root: serverDist,
-        index: 'index.html',
-      })
-        .on('error', (err: any) => {
-          if (err.status === 404) {
-            res.statusCode = 404;
-            res.end('Not Found');
-            return;
-          }
-          res.statusCode = err.status || 500;
-          res.end('Internal Server Error');
-        })
-        .pipe(res);
-    });
-
-    const port = options.port ?? 3000;
-    server.listen(port);
-    Log.log(`Server running at http://localhost:${port}`);
+    await startStaticServerAsync(serverDist, options);
   } else {
-    const middleware = connect();
-
-    const staticDirectory = path.join(serverDist, 'client');
-    const serverDirectory = path.join(serverDist, 'server');
-
-    const serverHandler = createRequestHandler({ build: serverDirectory });
-
-    // DOM component CORS support
-    middleware.use((req, res, next) => {
-      // TODO: Only when origin is `file://` (iOS), and Android equivalent.
-
-      // Required for DOM components security in release builds.
-
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-      res.setHeader(
-        'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept, expo-platform'
-      );
-
-      // Handle OPTIONS preflight requests
-      if (req.method === 'OPTIONS') {
-        res.statusCode = 200;
-        res.end();
-        return;
-      }
-      next();
-    });
-
-    middleware.use((req, res, next) => {
-      // Serve static files from the client directory first
-      if (req.url) {
-        send(req, decodeURI(req.url), {
-          root: staticDirectory,
-          index: false,
-        })
-          .on('error', (err: any) => {
-            if (err.status === 404) {
-              next();
-              return;
-            }
-            res.statusCode = err.status || 500;
-            res.end('Internal Server Error');
-          })
-          .pipe(res);
-        return;
-      }
-      next();
-    });
-    middleware.use(serverHandler);
-
-    const port = options.port ?? 3000;
-    middleware.listen(port);
-    Log.log(`Server running at http://localhost:${port}`);
+    await startDynamicServerAsync(serverDist, options);
   }
-
+  Log.log(`Server running at http://localhost:${options.port}`);
   // Detect the type of server we need to setup:
+}
+
+async function startStaticServerAsync(dist: string, options: Options) {
+  const server = http.createServer((req, res) => {
+    // Remove query strings and decode URI
+    const filePath = decodeURI(req.url?.split('?')[0] ?? '');
+
+    send(req, filePath, {
+      root: dist,
+      index: 'index.html',
+    })
+      .on('error', (err: any) => {
+        if (err.status === 404) {
+          res.statusCode = 404;
+          res.end('Not Found');
+          return;
+        }
+        res.statusCode = err.status || 500;
+        res.end('Internal Server Error');
+      })
+      .pipe(res);
+  });
+
+  server.listen(options.port!);
+}
+
+async function startDynamicServerAsync(dist: string, options: Options) {
+  const middleware = connect();
+
+  const staticDirectory = path.join(dist, 'client');
+  const serverDirectory = path.join(dist, 'server');
+
+  const serverHandler = createRequestHandler({ build: serverDirectory });
+
+  // DOM component CORS support
+  middleware.use((req, res, next) => {
+    // TODO: Only when origin is `file://` (iOS), and Android equivalent.
+
+    // Required for DOM components security in release builds.
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept, expo-platform'
+    );
+
+    // Handle OPTIONS preflight requests
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 200;
+      res.end();
+      return;
+    }
+    next();
+  });
+
+  middleware.use((req, res, next) => {
+    if (!req?.url || (req.method !== 'GET' && req.method !== 'HEAD')) {
+      return next();
+    }
+
+    const pathname = URL.canParse(req.url) ? new URL(req.url).pathname : req.url;
+    if (!pathname) {
+      return next();
+    }
+
+    debug(`Maybe serve static:`, pathname);
+
+    const stream = send(req, pathname, {
+      root: staticDirectory,
+    });
+
+    // add file listener for fallthrough
+    let forwardError = false;
+    stream.on('file', function onFile() {
+      // once file is determined, always forward error
+      forwardError = true;
+    });
+
+    // forward errors
+    stream.on('error', function error(err: any) {
+      if (forwardError || !(err.statusCode < 500)) {
+        next(err);
+        return;
+      }
+
+      next();
+    });
+
+    // pipe
+    stream.pipe(res);
+  });
+
+  middleware.use(serverHandler);
+
+  middleware.listen(options.port!);
 }
 
 async function isStaticExportAsync(dist: string): Promise<boolean> {

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -123,6 +123,7 @@ async function startDynamicServerAsync(dist: string, options: Options) {
 
     const stream = send(req, pathname, {
       root: staticDirectory,
+      extensions: ['html'],
     });
 
     // add file listener for fallthrough

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -114,7 +114,7 @@ async function startDynamicServerAsync(dist: string, options: Options) {
       return next();
     }
 
-    const pathname = URL.canParse(req.url) ? new URL(req.url).pathname : req.url;
+    const pathname = canParseURL(req.url) ? new URL(req.url).pathname : req.url;
     if (!pathname) {
       return next();
     }
@@ -150,6 +150,16 @@ async function startDynamicServerAsync(dist: string, options: Options) {
   middleware.use(serverHandler);
 
   middleware.listen(options.port!);
+}
+
+function canParseURL(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function isStaticExportAsync(dist: string): Promise<boolean> {

--- a/packages/@expo/server/build/index.js
+++ b/packages/@expo/server/build/index.js
@@ -44,6 +44,7 @@ exports.getRoutesManifest = getRoutesManifest;
 function createRequestHandler(distFolder, { getRoutesManifest: getInternalRoutesManifest, getHtml = async (_request, route) => {
     // Serve a static file by exact route name
     const filePath = node_path_1.default.join(distFolder, route.page + '.html');
+    console.log('filePath', filePath)
     if (node_fs_1.default.existsSync(filePath)) {
         return node_fs_1.default.readFileSync(filePath, 'utf-8');
     }
@@ -118,6 +119,7 @@ function createRequestHandler(distFolder, { getRoutesManifest: getInternalRoutes
                 if (!route.namedRegex.test(sanitizedPathname)) {
                     continue;
                 }
+                console.log('match', sanitizedPathname)
                 // // Mutate to add the expoUrl object.
                 updateRequestWithConfig(request, route);
                 // serve a static file

--- a/packages/@expo/server/build/index.js
+++ b/packages/@expo/server/build/index.js
@@ -44,7 +44,6 @@ exports.getRoutesManifest = getRoutesManifest;
 function createRequestHandler(distFolder, { getRoutesManifest: getInternalRoutesManifest, getHtml = async (_request, route) => {
     // Serve a static file by exact route name
     const filePath = node_path_1.default.join(distFolder, route.page + '.html');
-    console.log('filePath', filePath)
     if (node_fs_1.default.existsSync(filePath)) {
         return node_fs_1.default.readFileSync(filePath, 'utf-8');
     }
@@ -119,7 +118,6 @@ function createRequestHandler(distFolder, { getRoutesManifest: getInternalRoutes
                 if (!route.namedRegex.test(sanitizedPathname)) {
                     continue;
                 }
-                console.log('match', sanitizedPathname)
                 // // Mutate to add the expoUrl object.
                 updateRequestWithConfig(request, route);
                 // serve a static file


### PR DESCRIPTION
# Why

- Create a command to easily run the release server for a project locally. This is useful for web projects, and React server components.
- In the future, we'll want some `npx expo run` flag which can set the local server URL as the origin, build the release app, and host the production server.
- One possibly useful but skewed case would be the ability to host any `npx expo export` contents, e.g. open a server in Expo Go. The problem with this is that we should generally keep this script as an extension of the public `expo/server` that devs will push to production, and the codesigning aspect of loading in a dev client is not a part of that (yet?).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Support `npx expo export` for both output static and dynamic servers.
- Automatically pull from `dist` if no directory is specified.

# Test Plan

- Migrate some E2E tests over to this from the repo scripts.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
