### PR TITLE
[docs] Fix "The expected type comes from property 'ref'" error in screenshot tutorial

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -76,7 +76,7 @@ import { useState, useRef } from 'react';
 /* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {
-  /* @tutinfo Create an imageRef variable. */ const imageRef = useRef();/* @end */
+  /* @tutinfo Create an imageRef variable. */ const imageRef = useRef<View>(null);/* @end */
 
   // ...rest of the code remains same
 


### PR DESCRIPTION
# Why

While working through the tutorials I noticed an error in VSCode for `ref` in the `<View ref={imageRef}...` line (see docs/pages/tutorial/screenshot.mdx:86). The error was as follows: `The expected type comes from property 'ref'`

<details>
<summary>Full error shown in VSCode</summary>
No overload matches this call.
  Overload 1 of 2, '(props: ViewProps): View', gave the following error.
    Type 'MutableRefObject<undefined>' is not assignable to type 'LegacyRef<View> | undefined'.
      Type 'MutableRefObject<undefined>' is not assignable to type 'RefObject<View>'.
        Types of property 'current' are incompatible.
          Type 'undefined' is not assignable to type 'View | null'.
  Overload 2 of 2, '(props: ViewProps, context: any): View', gave the following error.
    Type 'MutableRefObject<undefined>' is not assignable to type 'LegacyRef<View> | undefined'.
      Type 'MutableRefObject<undefined>' is not assignable to type 'RefObject<View>'.
        Types of property 'current' are incompatible.
          Type 'undefined' is not assignable to type 'View | null'.ts(2769)
index.d.ts(303, 9): The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps>'
index.d.ts(303, 9): The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<View> & Readonly<ViewProps>'
(property) React.RefAttributes<View>.ref?: React.LegacyRef<View> | undefined
Allows getting a ref to the component instance. Once the component unmounts, React will set ref.current to null (or call the ref with null if you passed a callback ref).

@see — React Docs
</details>

![Screenshot 2024-11-05 at 09 33 40](https://github.com/user-attachments/assets/1a4b0d0e-1751-4a23-8eea-a36d8643c573)

As someone new to Expo and React Native I was confused by this error. However, in the next code snippet (line 137) the `imageRef` declaration changed and this fixed the error.

This commit makes the initial `imageRef` declaration consistent and removes the error.

# How

Updated the first `imageRef` declaration example to match the existing later one that works without error.

# Test Plan

I've run the docs locally and checked the change looks correct.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
