### PR TITLE
[docs] Allow selecting file names in SnippetHeader

### DIFF
--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -33,7 +33,7 @@ export const SnippetHeader = ({
     )}>
     <LABEL
       className={mergeClasses(
-        'flex items-center gap-2 min-h-10 !leading-tight py-1 pr-4 select-none font-medium w-full',
+        'flex items-center gap-2 min-h-10 !leading-tight py-1 pr-4 font-medium w-full',
         alwaysDark && 'text-palette-white'
       )}>
       {Icon && <Icon className="icon-sm shrink-0" />}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on recent developer feedback and after discussing with @keith-kurak.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `select-none` style from `SnippetHeader` component to allow selecting file names in the code block.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


https://github.com/user-attachments/assets/710895f3-082c-4a26-8190-2d3a6b50e9e0



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
