### PR TITLE
[expo-media-library] Fix asset types

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixes asset types not returned correctly.
+- [iOS] Fixes asset types not returned correctly. ([#32621](https://github.com/expo/expo/pull/32621) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixes asset types not returned correctly.
+
 ### 💡 Others
 
 ## 17.0.0 — 2024-10-22

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -271,6 +271,12 @@ func assetType(for localUri: URL) -> PHAssetMediaType {
     return .video
   case .audio:
     return .audio
+  case _ where type.conforms(to: .image):
+    return .image
+  case _ where type.conforms(to: .video):
+    return .video
+  case _ where type.conforms(to: .audio):
+    return .audio
   default:
     return .unknown
   }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/32526

# How

Made the function check type conformity.

# Test Plan

Tested this fixes the reported issue.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
