### PR TITLE
[cli] Don't show message about running `expo install` again when we're not

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Improve export eager cache key. ([#32600](https://github.com/expo/expo/pull/32600) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix issue where renderer overwrote existing SSR modules. ([#32601](https://github.com/expo/expo/pull/32601) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove message about running `npx expo install` again to install other package updates if no other packages or flags are specified. ([#32622](https://github.com/expo/expo/pull/32622) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 💡 Others
 - Catch all exceptions from telemetry flush to prevent upgrade errors. ([#32544](https://github.com/expo/expo/pull/32544) by [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -48,17 +48,16 @@ export async function installExpoPackageAsync(
     throw error;
   }
 
-  Log.log(chalk`\u203A Running {bold npx expo install} under the updated expo version`);
-
-  let commandSegments = ['expo', 'install', ...followUpCommandArgs];
-  if (packageManagerArguments.length) {
-    commandSegments = [...commandSegments, '--', ...packageManagerArguments];
-  }
-
-  Log.log('> ' + commandSegments.join(' '));
-
-  // Spawn a new process to install the rest of the packages, as only then will the latest Expo package be used
+  // Spawn a new process to install the rest of the packages if there are any, as only then will the latest Expo package be used
   if (followUpCommandArgs.length) {
+    let commandSegments = ['expo', 'install', ...followUpCommandArgs];
+    if (packageManagerArguments.length) {
+      commandSegments = [...commandSegments, '--', ...packageManagerArguments];
+    }
+
+    Log.log(chalk`\u203A Running {bold npx expo install} under the updated expo version`);
+    Log.log('> ' + commandSegments.join(' '));
+
     await spawnAsync('npx', commandSegments, {
       stdio: 'inherit',
       cwd: projectRoot,


### PR DESCRIPTION
# Why

`npx expo install expo@next` was showing`Running npx expo install under the updated expo version` after installing the `expo` package, but then wasn't doing anything else because there's nothing else to run. This message should only show when `npx expo install` is being run again under the latest `expo` version to install other packages.

# How
Moved the console logs to inside the conditional that checks if there's any follow-up commands to run and then runs them.

# Test Plan
- [x] No message when running `npx expo install expo@latest`
- [x] Shows the message when running `npx expo install@expo@next expo-router

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
