### PR TITLE
[config-types] add usesBroadcastPushNotifications option for iOS config

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -466,6 +466,10 @@ export interface IOS {
      */
     usesAppleSignIn?: boolean;
     /**
+     * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability.
+     */
+    usesBroadcastPushNotifications?: boolean;
+    /**
      * A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.
      */
     accessesContactNotes?: boolean;

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -466,7 +466,7 @@ export interface IOS {
      */
     usesAppleSignIn?: boolean;
     /**
-     * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability.
+     * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability should be enabled by EAS CLI during capability syncing.
      */
     usesBroadcastPushNotifications?: boolean;
     /**

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -470,6 +470,10 @@ export interface IOS {
    */
   usesAppleSignIn?: boolean;
   /**
+   * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability.
+   */
+  usesBroadcastPushNotifications?: boolean;
+  /**
    * A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.
    */
   accessesContactNotes?: boolean;

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -470,7 +470,7 @@ export interface IOS {
    */
   usesAppleSignIn?: boolean;
   /**
-   * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability.
+   * A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability should be enabled by EAS CLI during capability syncing.
    */
   usesBroadcastPushNotifications?: boolean;
   /**

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -391,8 +391,8 @@ exports[`built-in plugins compiles mods 1`] = `
     "supportsTablet": true,
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
-    "usesIcloudStorage": true,
     "usesBroadcastPushNotifications": true,
+    "usesIcloudStorage": true,
   },
   "locales": {
     "en": "./locales/en-US.json",
@@ -1602,8 +1602,8 @@ exports[`built-in plugins introspects mods 1`] = `
     "supportsTablet": true,
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
-    "usesIcloudStorage": true,
     "usesBroadcastPushNotifications": true,
+    "usesIcloudStorage": true,
   },
   "locales": {
     "en": "./locales/en-US.json",
@@ -2549,8 +2549,8 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
     "supportsTablet": true,
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
-    "usesIcloudStorage": true,
     "usesBroadcastPushNotifications": true,
+    "usesIcloudStorage": true,
   },
   "locales": {
     "en": "./locales/en-US.json",

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -392,6 +392,7 @@ exports[`built-in plugins compiles mods 1`] = `
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
     "usesIcloudStorage": true,
+    "usesBroadcastPushNotifications": true,
   },
   "locales": {
     "en": "./locales/en-US.json",
@@ -1602,6 +1603,7 @@ exports[`built-in plugins introspects mods 1`] = `
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
     "usesIcloudStorage": true,
+    "usesBroadcastPushNotifications": true,
   },
   "locales": {
     "en": "./locales/en-US.json",
@@ -2548,6 +2550,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
     "userInterfaceStyle": "automatic",
     "usesAppleSignIn": true,
     "usesIcloudStorage": true,
+    "usesBroadcastPushNotifications": true,
   },
   "locales": {
     "en": "./locales/en-US.json",

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -124,6 +124,7 @@ function getLargeConfig(): ExportedConfig {
       associatedDomains: ['applinks:https://pillarvalley.netlify.app'],
       usesIcloudStorage: true,
       usesAppleSignIn: true,
+      usesBroadcastPushNotifications: true,
       accessesContactNotes: true,
     },
     android: {


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1728981742266059

Add a new option to the iOS config to indicate whether EAS CLI should enable the Push Notifications Broadcast for Push Notifications capability option during capability syncing.

# How

Add a new field to the iOS config.

# Test Plan

Tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
