### PR TITLE
[expo-file-system][next] Fix download function throwing an error if dst exists

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -359,6 +359,19 @@ export async function test({ describe, expect, it, ...t }) {
           expect(file.exists).toBe(true);
           expect(output.uri).toBe(file.uri);
         });
+
+        it('throws an error if destination file already exists', async () => {
+          const url = 'https://picsum.photos/id/237/200/300';
+          const file = new File(testDirectory + 'image.jpeg');
+          file.create();
+          let error;
+          try {
+            await File.downloadFileAsync(url, file);
+          } catch (e) {
+            error = e;
+          }
+          expect(error.message.includes('Destination already exists')).toBe(true);
+        });
       });
 
       describe('Computes file properties', () => {

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [expo-file-system][next] Fix download function throwing an unexpected error if destination already exists.
+- [expo-file-system][next] Fix download function throwing an unexpected error if destination already exists. ([#32626](https://github.com/expo/expo/pull/32626) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [expo-file-system][next] Fix download function throwing an unexpected error if destination already exists.
+
 ### 💡 Others
 
 ## 18.0.0 — 2024-10-22

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextExceptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextExceptions.kt
@@ -28,3 +28,8 @@ internal class InvalidPermissionException(permission: Permission) :
   CodedException(
     "Missing '${permission.name}' permission for accessing the file."
   )
+
+internal class DestinationAlreadyExistsException :
+  CodedException(
+    "Destination already exists"
+  )

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -52,7 +52,7 @@ class FileSystemNextModule : Module() {
         to.file
       }
 
-      if(destination.exists()) {
+      if (destination.exists()) {
         throw DestinationAlreadyExistsException()
       }
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -52,6 +52,10 @@ class FileSystemNextModule : Module() {
         to.file
       }
 
+      if(destination.exists()) {
+        throw DestinationAlreadyExistsException()
+      }
+
       val body = response.body ?: throw UnableToDownloadException("response body is null")
       body.byteStream().use { input ->
         FileOutputStream(destination).use { output ->

--- a/packages/expo-file-system/ios/Next/FileSystemNextExceptions.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemNextExceptions.swift
@@ -48,3 +48,9 @@ internal class UnableToCreateFileException: GenericException<String> {
     "Unable to create file: \(param)"
   }
 }
+
+internal class DestinationAlreadyExistsException: Exception {
+  override var reason: String {
+    "Destination already exists"
+  }
+}

--- a/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
@@ -33,17 +33,19 @@ public final class FileSystemNextModule: Module {
         }
 
         do {
+          let destination: URL
           if let to = to as? FileSystemDirectory {
             let filename = httpResponse.suggestedFilename ?? url.lastPathComponent
-            let destination = to.url.appendingPathComponent(filename)
-            try FileManager.default.copyItem(at: fileURL, to: to.url.appendingPathComponent(filename))
-            // TODO: Remove .url.absoluteString once returning shared objects works
-            promise.resolve(FileSystemFile(url: destination).url.absoluteString)
+            destination = to.url.appendingPathComponent(filename)
           } else {
-            try FileManager.default.moveItem(at: fileURL, to: to.url)
-            // TODO: Remove .url.absoluteString once returning shared objects works
-            promise.resolve(to.url.absoluteString)
+            destination = to.url
           }
+          if FileManager.default.fileExists(atPath: destination.path) {
+            throw DestinationAlreadyExistsException()
+          }
+          try FileManager.default.moveItem(at: fileURL, to: destination)
+          // TODO: Remove .url.absoluteString once returning shared objects works
+          promise.resolve(destination.absoluteString)
         } catch {
           promise.reject(error)
         }


### PR DESCRIPTION
# Why

Noticed in some issue reproduction that calling download multiple times results in a fairly generic error. Now it results in a clear error that indicates the destination exists.

# How

Checking if destination exists before moving.

# Test Plan

Added a unit test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
