### PR TITLE
[go][Android] Invalidate experience's context

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -852,6 +852,17 @@ class Kernel : KernelInterface() {
     } else {
       manager.appTasks.find { it.taskInfo.id == activity.taskId }
     }?.also { task -> task.finishAndRemoveTask() }
+
+    // We're sure that it will be an `ExperienceActivity`. However we still need to do a cast and
+    // adding additional checks doesn't hurt
+    if (activity is ExperienceActivity) {
+      // Invalidate the experience that is not longer needed.
+      activity.reactHost?.invalidate()
+      activity.reactNativeHost?.clear()
+
+      activity.reactHost = null
+      activity.reactNativeHost = null
+    }
   }
 
   override fun reloadVisibleExperience(manifestUrl: String, forceCache: Boolean): Boolean {


### PR DESCRIPTION
# Why

We're not cleaning the react host of the experience activity correctly, which causes huge memory leaks when reloading. 

# How

This PR only fixes some memory leaks in Expo Go. Some issues remain in the third-party libraries. As far as I know, this fixes all the problems on our end. 

# Test Plan

- Expo Go ✅ 