### PR TITLE
[templates] add react-native-webview to default template

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -38,7 +38,8 @@
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.0.0-beta.16",
-    "react-native-web": "~0.19.13"
+    "react-native-web": "~0.19.13",
+    "react-native-webview": "13.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
# Why

for people to try out dom components for onboarding expo.new projects
close ENG-13392

# How

add react-native-webview to default template

# Test Plan

n/a

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
