### PR TITLE
[dev-launcher] fix build error when EX_DEV_CLIENT_NETWORK_INSPECTOR is off

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed mutiple reload when pressing `r` in CLI on react-native old architecture mode. ([#32532](https://github.com/expo/expo/pull/32532) by [@kudo](https://github.com/kudo))
+- Fixed build error when `EX_DEV_CLIENT_NETWORK_INSPECTOR` is false. ([#32644](https://github.com/expo/expo/pull/32644) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/DevLauncherNetworkInterceptor.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherNetworkInterceptor.swift
@@ -83,6 +83,10 @@ extension URLSessionConfiguration {
 
 @objc(EXDevLauncherNetworkInterceptor)
 public final class DevLauncherNetworkInterceptor: NSObject {
+  @objc
+  public init(bundleUrl: URL) {
+    super.init()
+  }
 }
 
 #endif


### PR DESCRIPTION
# Why

fixes #32577

# How

interface changes since #32290 and i didn't update the initializer interface to the other 

# Test Plan

- ci passed
- bare-expo and turned `EX_DEV_CLIENT_NETWORK_INSPECTOR=false`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
