### PR TITLE
[docs] Specify `expo-build-properties` is required to install in New Architecture guide

### DIFF
--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -99,6 +99,8 @@ Set `newArchEnabled` on target platforms:
   </Tab>
 
   <Tab label="SDK 51 and below">
+    To enable it, you need to [install the `expo-build-properties` plugin](/versions/latest/sdk/build-properties/#installation) and set `newArchEnabled` on target platforms.
+
     ```json app.json
     {
       "expo": {
@@ -106,10 +108,10 @@ Set `newArchEnabled` on target platforms:
           [
             "expo-build-properties",
             {
-              "ios": {
+              "android": {
                 "newArchEnabled": true
               },
-              "android": {
+              "ios": {
                 "newArchEnabled": true
               }
             }
@@ -118,6 +120,7 @@ Set `newArchEnabled` on target platforms:
       }
     }
     ```
+
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Missing `expo-build-properties` installation reference as per [developer feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1730885555670609).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the New Architecture guide to add the link to installation section from `expo-build-properties` and mention it explicitly for SDK 51 and below.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-06 at 17 29 38](https://github.com/user-attachments/assets/020922eb-c252-4075-93f2-7988da71ac3c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
