### PR TITLE
[contacts][android] Fix `ContactQuery` `id` field not accepting arrays

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `ContactQuery` `id` field not accepting arrays. ([#32651](https://github.com/expo/expo/pull/32651) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 14.0.1 — 2024-10-22

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -110,7 +110,7 @@ class ContactQuery : Record {
   val name: String? = null
 
   @Field
-  val id: String? = null
+  val id: List<String>? = null
 }
 
 class QueryArguments(
@@ -154,9 +154,11 @@ class ContactsModule : Module() {
       appContext
         .backgroundCoroutineScope
         .launch {
-          if (options.id != null) {
-            val contact = getContactById(options.id, options.fields)
-            promise.resolve(contact.toBundle(options.fields))
+          if (!options.id.isNullOrEmpty()) {
+            val contacts = options.id.mapNotNull { id ->
+              getContactById(id, options.fields)
+            }
+            promise.resolve(ContactPage(data = contacts).toBundle(options.fields))
             return@launch
           }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/32157
Our docs specify that the `id` field of `ContactsQuery` can be a list, but on Android only a single value is accepted

# How

Changed the id field into a List<String>? and made it iterate over all passed ids

# Test Plan

Tested in Bare Expo on Android by running tests and checking for a single id fetch and a list of ids fetch
