### PR TITLE
[docs] Fix grammar issue in expo-router tabs docs

### DIFF
--- a/docs/pages/router/ui/tabs.mdx
+++ b/docs/pages/router/ui/tabs.mdx
@@ -49,11 +49,11 @@ Dynamic routes are allowed and can be provided with values via the `href`
 
 The trigger `<Trigger name="dynamic page" href="/hello-world" />` will create a tab for `[slug].tsx` with the params `{ slug: 'hello-world' }`
 
-### Ambagious routes
+### Ambiguous routes
 
 <FileTree files={['_layout.tsx', ['(one,two)/route.tsx', 'A route within a shared group']]} />
 
-The `href` values provided to `<TabTrigger />` cannot be ambagious and must always point to a single route. The href `/route` is not allowed, as it could refer to either `/(one)/route` or `/(two)/route`.
+The `href` values provided to `<TabTrigger />` cannot be ambiguous and must always point to a single route. The href `/route` is not allowed, as it could refer to either `/(one)/route` or `/(two)/route`.
 
 ### Nested routes
 


### PR DESCRIPTION
# Why

While 'ambagious' is technically possible, I think it's mostly used in a different context (more like 'vague'), and somewhat archaic. The way this section is described, 'ambiguous' seems like a better, more common, term to use.

# How

Changed the wording in the header and the text.

# Test Plan

Read and determine if this communicates the intended meaning.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
