### PR TITLE
[docs] Enable `newArchEnabled` in Existing native apps > expo modules install guide

### DIFF
--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -37,7 +37,7 @@ index 20e2a01..e98ad88 100644
 --- a/android/gradle.properties
 +++ b/android/gradle.properties
 @@ -20,4 +20,8 @@ kotlin.code.style=official
-+newArchEnabled=false
++newArchEnabled=true
 +
 +hermesEnabled=true`}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After verifying from [React Native docs](https://reactnative.dev/docs/integration-with-existing-apps?language=kotlin&package-manager=yarn&ios-language=swift#configuring-gradle), the `newArchEnabled` should be enabled in installing expo modules guide under Existing native apps section

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
