### PR TITLE
[core] fix self-signed connections in network inspector

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed broken self-signed connections from network inspector. ([#32670](https://github.com/expo/expo/pull/32670) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.0.0-preview.9 — 2024-10-31

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -138,6 +138,17 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
     completionHandler(request)
   }
 
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    let sender = URLAuthenticationChallengeForwardSender(completionHandler: completionHandler)
+    let challengeWithSender = URLAuthenticationChallenge(authenticationChallenge: challenge, sender: sender)
+    client?.urlProtocol(self, didReceive: challengeWithSender)
+  }
+
   /**
    Data structure to save the response for redirection
    */

--- a/packages/expo-modules-core/ios/DevTools/URLAuthenticationChallengeForwardSender.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLAuthenticationChallengeForwardSender.swift
@@ -1,0 +1,33 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ A helper class to forward URLAuthenticationChallenge completion handler to URLAuthenticationChallengeSender
+ */
+internal final class URLAuthenticationChallengeForwardSender: NSObject, URLAuthenticationChallengeSender {
+  let completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+
+  init(completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    self.completionHandler = completionHandler
+    super.init()
+  }
+
+  func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {
+    completionHandler(.useCredential, credential)
+  }
+
+  func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {
+    completionHandler(.useCredential, nil)
+  }
+
+  func cancel(_ challenge: URLAuthenticationChallenge) {
+    completionHandler(.cancelAuthenticationChallenge, nil)
+  }
+
+  func performDefaultHandling(for challenge: URLAuthenticationChallenge) {
+    completionHandler(.performDefaultHandling, nil)
+  }
+
+  func rejectProtectionSpaceAndContinue(with challenge: URLAuthenticationChallenge) {
+    completionHandler(.rejectProtectionSpace, nil)
+  }
+}

--- a/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
@@ -82,4 +82,19 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
         completionHandler: completionHandler)
     }
   }
+
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    if let delegate = getDelegate(task: task) {
+      delegate.urlSession?(
+        session,
+        task: task,
+        didReceive: challenge,
+        completionHandler: completionHandler)
+    }
+  }
 }


### PR DESCRIPTION
# Why

fixes broken self-signed connection from network inspector because we intercepted the URLSessionDelegate. the default delegate disallows self-signed connection.
fixes #24096
close ENG-9914

# How

- add `urlSession(_:task:didReceive:completionHandler:)` handler
- pass the completion handler to `URLProtocolClient`, which would be the original URLSessionDelegate handler
- since the URLProtocolClient's `urlProtocol(_:didReceive:)` is an old interface and not having a completion handler. this pr tries to introduce an `URLAuthenticationChallengeForwardSender` to forward the completion handler to URLAuthenticationChallengeSender

# Test Plan

- ci passed
- test repro from https://github.com/idrakimuhamad/repro-expo-ssl-self-sign

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
