### PR TITLE
[expo-go][android] Fix experience loading

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -203,10 +203,6 @@ abstract class ReactNativeActivity :
 
   // Loop until a view is added to the ReactRootView and once it happens run callback
   private fun waitForReactRootViewToHaveChildrenAndRunCallback(callback: Runnable) {
-    if (reactSurface == null) {
-      return
-    }
-
     if ((reactSurface?.view?.childCount ?: 0) > 0) {
       callback.run()
     } else {


### PR DESCRIPTION
# Why

Trying to debug the snack issue, noticed that my non-snacks also didn't load. This PR should fix that, though I'm not sure I understand the full scope of the commit that changes the behavior ([96600e8783cf18939e33251916c940665dd77c1e](https://github.com/expo/expo/commit/96600e8783cf18939e33251916c940665dd77c1e)), so I'm not sure this is a fully-sufficient fix.

# How

The guard clause returning causes the "wait" portion of this function not to poll for the condition. Instead, I believe the poll should still happen? Will wait for reviewers.

# Test Plan

Open `exp://staging-u.expo.dev/a272f2db-e136-4a61-ab63-451bb22fc195/group/deabda0b-e426-4175-a91c-08e52d398a44` in Expo Go, see it works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
