### PR TITLE
Manually set runtime version in bare-expo

### DIFF
--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -48,9 +48,7 @@
         "projectId": "2c28de10-a2cd-11e6-b8ce-59d1587e6774"
       }
     },
-    "runtimeVersion": {
-      "policy": "appVersion"
-    },
+    "runtimeVersion": "1.0.0",
     "updates": {
       "url": "https://u.expo.dev/2c28de10-a2cd-11e6-b8ce-59d1587e6774"
     },


### PR DESCRIPTION
# Why

I'm getting this error when trying to launch bare-expo:
```
Error: CommandError: You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions
```

# How

I followed the suggestion to manually set the runtime version

# Test Plan

I can launch bare-expo without issues now