### PR TITLE
[dev-launcher][ios] Fix handling deep links 

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fixed mutiple reload when pressing `r` in CLI on react-native old architecture mode. ([#32532](https://github.com/expo/expo/pull/32532) by [@kudo](https://github.com/kudo))
 - Fixed build error when `EX_DEV_CLIENT_NETWORK_INSPECTOR` is false. ([#32644](https://github.com/expo/expo/pull/32644) by [@kudo](https://github.com/kudo))
+- [iOS] Fix handling deep links ([#32677](https://github.com/expo/expo/pull/32677) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -18,6 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RCTAppDelegate;
 @class EXAppContext;
 @class EXDevLauncherInstallationIDHelper;
 @class EXDevLauncherPendingDeepLinkRegistry;
@@ -26,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class EXDevLauncherErrorManager;
 
 @protocol EXDevLauncherControllerDelegate <NSObject>
+
+@property (nonatomic, weak) RCTAppDelegate *rctAppDelegate;
 
 - (void)devLauncherController:(EXDevLauncherController *)developmentClientController
                 didStartWithSuccess:(BOOL)success;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -18,7 +18,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RCTAppDelegate;
 @class EXAppContext;
 @class EXDevLauncherInstallationIDHelper;
 @class EXDevLauncherPendingDeepLinkRegistry;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXDevLauncherControllerDelegate <NSObject>
 
-@property (nonatomic, weak) RCTAppDelegate *rctAppDelegate;
-
 - (void)devLauncherController:(EXDevLauncherController *)developmentClientController
                 didStartWithSuccess:(BOOL)success;
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -47,7 +47,7 @@
 @interface EXDevLauncherController ()
 
 @property (nonatomic, weak) UIWindow *window;
-@property (nonatomic, weak) id<EXDevLauncherControllerDelegate> delegate;
+@property (nonatomic, weak) ExpoDevLauncherReactDelegateHandler * delegate;
 @property (nonatomic, strong) NSDictionary *launchOptions;
 @property (nonatomic, strong) NSURL *sourceUrl;
 @property (nonatomic, assign) BOOL shouldPreferUpdatesInterfaceSourceUrl;
@@ -328,7 +328,7 @@
 
   [self _removeInitModuleObserver];
   // Reset app react host
-  [[self.delegate rctAppDelegate].rootViewFactory setReactHost:nil];
+  [self.delegate destroyReactInstance];
 
   _appDelegate.rootViewFactory = [_appDelegate createRCTRootViewFactory];
 
@@ -403,7 +403,7 @@
   self.pendingDeepLinkRegistry.pendingDeepLink = url;
 
   // cold boot -- need to initialize the dev launcher app RN app to handle the link
-  if (![_appDelegate.rootViewFactory.bridge isValid]) {
+  if (_appDelegate.rootViewFactory.reactHost == nil) {
     [self navigateToLauncher];
   }
 
@@ -608,8 +608,7 @@
 - (BOOL)isAppRunning
 {
   if([_appBridge isProxy]){
-    RCTHost *reactHost =  [self.delegate rctAppDelegate].rootViewFactory.reactHost;
-    return reactHost != nil;
+    return [self.delegate isReactInstanceValid];
   }
 
   return [_appBridge isValid];

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -208,7 +208,7 @@
 
 - (NSDictionary<UIApplicationLaunchOptionsKey, NSObject*> *)getLaunchOptions;
 {
-  NSMutableDictionary *launchOptions = [self.launchOptions mutableCopy];
+  NSMutableDictionary *launchOptions = [self.launchOptions ?: @{} mutableCopy];
   NSURL *deepLink = [self.pendingDeepLinkRegistry consumePendingDeepLink];
 
   if (deepLink) {
@@ -327,6 +327,8 @@
   [self _applyUserInterfaceStyle:UIUserInterfaceStyleUnspecified];
 
   [self _removeInitModuleObserver];
+  // Reset app react host
+  [[self.delegate rctAppDelegate].rootViewFactory setReactHost:nil];
 
   _appDelegate.rootViewFactory = [_appDelegate createRCTRootViewFactory];
 
@@ -605,6 +607,11 @@
 
 - (BOOL)isAppRunning
 {
+  if([_appBridge isProxy]){
+    RCTHost *reactHost =  [self.delegate rctAppDelegate].rootViewFactory.reactHost;
+    return reactHost != nil;
+  }
+
   return [_appBridge isValid];
 }
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -5,6 +5,7 @@ import EXUpdatesInterface
 
 @objc
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDevLauncherControllerDelegate {
+  public weak var rctAppDelegate: RCTAppDelegate?
   private weak var reactDelegate: ExpoReactDelegate?
   private var launchOptions: [AnyHashable: Any]?
   private var deferredRootView: EXDevLauncherDeferredRCTRootView?
@@ -42,6 +43,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     guard let rctAppDelegate = (UIApplication.shared.delegate as? RCTAppDelegate) else {
       fatalError("The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.")
     }
+    self.rctAppDelegate = rctAppDelegate
 
     // Reset rctAppDelegate so we can relaunch the app
     if rctAppDelegate.bridgelessEnabled() {
@@ -54,7 +56,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       withBundleURL: developmentClientController.sourceUrl(),
       moduleName: self.rootViewModuleName,
       initialProps: self.rootViewInitialProperties,
-      launchOptions: self.launchOptions
+      launchOptions: developmentClientController.getLaunchOptions()
     )
     developmentClientController.appBridge = RCTBridge.current()
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -5,7 +5,7 @@ import EXUpdatesInterface
 
 @objc
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDevLauncherControllerDelegate {
-  public weak var rctAppDelegate: RCTAppDelegate?
+  private weak var rctAppDelegate: RCTAppDelegate?
   private weak var reactDelegate: ExpoReactDelegate?
   private var launchOptions: [AnyHashable: Any]?
   private var deferredRootView: EXDevLauncherDeferredRCTRootView?
@@ -35,6 +35,16 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     self.rootViewInitialProperties = initialProperties
     self.deferredRootView = EXDevLauncherDeferredRCTRootView()
     return self.deferredRootView
+  }
+
+  @objc
+  public func isReactInstanceValid() -> Bool {
+      return self.rctAppDelegate?.rootViewFactory.value(forKey: "reactHost") != nil
+  }
+
+  @objc
+  public func destroyReactInstance() {
+    self.rctAppDelegate?.rootViewFactory.setValue(nil, forKey: "reactHost")
   }
 
   // MARK: EXDevelopmentClientControllerDelegate implementations

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -39,7 +39,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
 
   @objc
   public func isReactInstanceValid() -> Bool {
-      return self.rctAppDelegate?.rootViewFactory.value(forKey: "reactHost") != nil
+    return self.rctAppDelegate?.rootViewFactory.value(forKey: "reactHost") != nil
   }
 
   @objc


### PR DESCRIPTION
# Why

Closes ENG-14002
Closes #32496

# How

With bridgeless mode on by default we can no longer rely on `[_appBridge isValid]` to verify the state of the app, this PR updates the dev-launcher logic to check for the `reactHost` instance in order to determine if the app is running and then process the deep link. We we're also not proving the correct `launchOptions` when recreating the rootView

# Test Plan

FabricTester on iOS

https://github.com/user-attachments/assets/3efe3642-c2ae-46ed-8f86-573129cec199



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
