### PR TITLE
[expo-go] Fix snack loading in the emulator

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
@@ -11,13 +11,20 @@ import versioned.host.exp.exponent.ExpoReanimatedPackage
 import versioned.host.exp.exponent.ExpoTurboPackage
 import versioned.host.exp.exponent.ExponentPackage
 
+interface ExpoNativeHost {
+  var devSupportEnabled: Boolean
+  var mainModuleName: String?
+}
+
 class ExpoGoReactNativeHost(
   application: Application,
   private val instanceManagerBuilderProperties: Exponent.InstanceManagerBuilderProperties,
-  private val mainModuleName: String? = null
-) : DefaultReactNativeHost(application) {
+) : DefaultReactNativeHost(application), ExpoNativeHost {
+  override var devSupportEnabled = false
+  override var mainModuleName: String? = null
+
   override fun getUseDeveloperSupport(): Boolean {
-    return true
+    return devSupportEnabled
   }
 
   override fun getJSMainModuleName(): String {
@@ -62,11 +69,9 @@ class KernelReactNativeHost(
   application: Application,
   private val exponentManifest: ExponentManifest,
   private val data: KernelData?
-) : DefaultReactNativeHost(application) {
-  val devSupportEnabled
-    get() =
-      !KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE &&
-        exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.isDevelopmentMode()
+) : DefaultReactNativeHost(application), ExpoNativeHost {
+  override var devSupportEnabled = false
+  override var mainModuleName: String? = null
 
   override fun getUseDeveloperSupport(): Boolean {
     return devSupportEnabled
@@ -84,7 +89,7 @@ class KernelReactNativeHost(
     return if (devSupportEnabled) {
       exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
     } else {
-      super.getJSMainModuleName()
+      mainModuleName ?: super.getJSMainModuleName()
     }
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExpoGoReactNativeHost.kt
@@ -5,7 +5,6 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.shell.MainReactPackage
 import host.exp.exponent.ExponentManifest
-import host.exp.exponent.kernel.KernelConfig
 import host.exp.expoview.Exponent
 import versioned.host.exp.exponent.ExpoReanimatedPackage
 import versioned.host.exp.exponent.ExpoTurboPackage
@@ -18,7 +17,7 @@ interface ExpoNativeHost {
 
 class ExpoGoReactNativeHost(
   application: Application,
-  private val instanceManagerBuilderProperties: Exponent.InstanceManagerBuilderProperties,
+  private val instanceManagerBuilderProperties: Exponent.InstanceManagerBuilderProperties
 ) : DefaultReactNativeHost(application), ExpoNativeHost {
   override var devSupportEnabled = false
   override var mainModuleName: String? = null

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -381,21 +381,21 @@ abstract class ReactNativeActivity :
     val nativeHost = ExpoGoReactNativeHost(
       application,
       instanceManagerBuilderProperties,
-      mainModuleName
     )
 
     val devBundleDownloadListener = ExponentDevBundleDownloadListener(progressListener)
     val hostWrapper = ReactNativeHostWrapper(application, nativeHost)
-    val reactHost = ReactHostFactory.createFromReactNativeHost(this, hostWrapper, devBundleDownloadListener)
-    reactNativeHost = nativeHost
 
     if (delegate.isDebugModeEnabled) {
       val debuggerHost = manifest!!.getDebuggerHost()
-      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName!!)
+      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName!!, nativeHost)
       DefaultDevLoadingViewImplementation.setDevLoadingEnabled(true)
     } else {
       waitForReactAndFinishLoading()
     }
+
+    val reactHost = ReactHostFactory.createFromReactNativeHost(this, hostWrapper, devBundleDownloadListener)
+    reactNativeHost = nativeHost
 
     val bundle = Bundle()
     val exponentProps = JSONObject()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -380,7 +380,7 @@ abstract class ReactNativeActivity :
 
     val nativeHost = ExpoGoReactNativeHost(
       application,
-      instanceManagerBuilderProperties,
+      instanceManagerBuilderProperties
     )
 
     val devBundleDownloadListener = ExponentDevBundleDownloadListener(progressListener)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -237,17 +237,17 @@ class InternalHeadlessAppLoader(private val context: Context) :
 
     val host = ExpoGoReactNativeHost(
       context,
-      instanceManagerBuilderProperties,
-      mainModuleName = manifest!!.getMainModuleName()
+      instanceManagerBuilderProperties
     )
-    val wrapper = ReactNativeHostWrapper(context, host)
-    val reactHost = ReactHostFactory.createFromReactNativeHost(context, wrapper)
 
     if (delegate.isDebugModeEnabled) {
       val debuggerHost = manifest!!.getDebuggerHost()
       val mainModuleName = manifest!!.getMainModuleName()
-      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName)
+      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName, host)
     }
+
+    val wrapper = ReactNativeHostWrapper(context, host)
+    val reactHost = ReactHostFactory.createFromReactNativeHost(context, wrapper)
 
     val devSupportManager = reactHost.devSupportManager
     if (devSupportManager != null) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -115,6 +115,9 @@ class Kernel : KernelInterface() {
       }
     }
 
+  private val manifest
+    get() = exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest
+
   private var optimisticActivity: ExperienceActivity? = null
 
   private var optimisticTaskId: Int? = null
@@ -164,7 +167,7 @@ class Kernel : KernelInterface() {
       try {
         // Make sure we can get the manifest successfully. This can fail in dev mode
         // if the kernel packager is not running.
-        exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest
+        manifest
       } catch (e: Throwable) {
         Exponent.instance
           .runOnUiThread { // Hack to make this show up for a while. Can't use an Alert because LauncherActivity has a transparent theme. This should only be seen by internal developers.
@@ -230,13 +233,12 @@ class Kernel : KernelInterface() {
               localBundlePath
             )
           )
-
           if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE &&
-            exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.isDevelopmentMode()
+            manifest.isDevelopmentMode()
           ) {
             Exponent.enableDeveloperSupport(
-              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost(),
-              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName(),
+              manifest.getDebuggerHost(),
+              manifest.getMainModuleName(),
               nativeHost
             )
           }
@@ -274,7 +276,7 @@ class Kernel : KernelInterface() {
   private val bundleUrl: String?
     get() {
       return try {
-        exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getBundleURL()
+        manifest.getBundleURL()
       } catch (e: JSONException) {
         KernelProvider.instance.handleError(e)
         null
@@ -304,7 +306,7 @@ class Kernel : KernelInterface() {
   private val kernelRevisionId: String?
     get() {
       return try {
-        exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getRevisionId()
+        manifest.getRevisionId()
       } catch (e: JSONException) {
         KernelProvider.instance.handleError(e)
         null

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -232,7 +232,8 @@ class Kernel : KernelInterface() {
           )
 
           if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE &&
-            exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.isDevelopmentMode()) {
+            exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.isDevelopmentMode()
+          ) {
             Exponent.enableDeveloperSupport(
               exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost(),
               exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName(),

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -230,19 +230,23 @@ class Kernel : KernelInterface() {
               localBundlePath
             )
           )
-          val hostWrapper = ReactNativeHostWrapper(applicationContext, nativeHost)
-          reactHost = ReactHostFactory.createFromReactNativeHost(applicationContext, hostWrapper)
 
-          if (nativeHost.devSupportEnabled) {
+          if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE &&
+            exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.isDevelopmentMode()) {
             Exponent.enableDeveloperSupport(
               exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getDebuggerHost(),
-              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName()
+              exponentManifest.getKernelManifestAndAssetRequestHeaders().manifest.getMainModuleName(),
+              nativeHost
             )
           }
+
+          val hostWrapper = ReactNativeHostWrapper(applicationContext, nativeHost)
+          reactHost = ReactHostFactory.createFromReactNativeHost(applicationContext, hostWrapper)
 
           reactNativeHost = nativeHost
           reactHost?.onHostResume(activityContext, null)
           isRunning = true
+
           EventBus.getDefault().postSticky(KernelStartedRunningEvent())
           EXL.d(TAG, "Kernel started running.")
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -27,6 +27,8 @@ import expo.modules.manifests.core.Manifest
 import host.exp.exponent.*
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
+import host.exp.exponent.experience.ExpoGoReactNativeHost
+import host.exp.exponent.experience.ExpoNativeHost
 import host.exp.exponent.kernel.ExponentUrls
 import host.exp.exponent.kernel.ExponentUrls.addHeadersFromJSONObject
 import host.exp.exponent.kernel.KernelConstants
@@ -366,7 +368,8 @@ class Exponent private constructor(val context: Context, val application: Applic
 
     @JvmStatic fun enableDeveloperSupport(
       debuggerHost: String,
-      mainModuleName: String
+      mainModuleName: String,
+      host: ExpoNativeHost
     ) {
       if (debuggerHost.isEmpty() || mainModuleName.isEmpty()) {
         return
@@ -381,6 +384,9 @@ class Exponent private constructor(val context: Context, val application: Applic
         AndroidInfoHelpers.EMULATOR_LOCALHOST = debuggerHostHostname
         AndroidInfoHelpers.setDevServerPort(debuggerHostPort)
         AndroidInfoHelpers.setInspectorProxyPort(debuggerHostPort)
+
+        host.devSupportEnabled = true
+        host.mainModuleName = mainModuleName
       } catch (e: IllegalAccessException) {
         e.printStackTrace()
       } catch (e: NoSuchFieldException) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -27,7 +27,6 @@ import expo.modules.manifests.core.Manifest
 import host.exp.exponent.*
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
-import host.exp.exponent.experience.ExpoGoReactNativeHost
 import host.exp.exponent.experience.ExpoNativeHost
 import host.exp.exponent.kernel.ExponentUrls
 import host.exp.exponent.kernel.ExponentUrls.addHeadersFromJSONObject


### PR DESCRIPTION
# Why
Closes ENG-14032
Enabling dev support and the mainModuleName cannot be set from the hosts constructor because these values depend on the manifest and they change depending on what experience is being loaded ie snack, local dev server 

# How
Added an interface that our host classes implement so these values can be set if required. 

# Test Plan
Tested expo go on an emulator and a physical device. It will now load local experiences or snacks correctly. 
