### PR TITLE
[docs] Home: community links section update

### DIFF
--- a/docs/ui/components/Footer/NewsletterSignUp.tsx
+++ b/docs/ui/components/Footer/NewsletterSignUp.tsx
@@ -40,7 +40,7 @@ export const NewsletterSignUp = () => {
 
   return (
     <div className="flex-1 max-w-[350px] max-md-gutters:max-w-full">
-      <CALLOUT theme="secondary" weight="medium" className="flex gap-2 items-center">
+      <CALLOUT className="text-secondary font-medium flex gap-2 items-center" id="newsletter-label">
         <Mail01Icon className="text-icon-tertiary shrink-0" />
         Sign up for the Expo Newsletter
       </CALLOUT>
@@ -64,6 +64,7 @@ export const NewsletterSignUp = () => {
             className={mergeClasses('pr-[68px]', error && 'border-danger text-danger')}
             type="email"
             placeholder="reader@email.com"
+            aria-labelledby="newsletter-label"
           />
         )}
         {!userSignedUp ? (
@@ -77,7 +78,7 @@ export const NewsletterSignUp = () => {
           </Button>
         ) : null}
       </form>
-      <FOOTNOTE theme="secondary">
+      <FOOTNOTE theme="tertiary">
         Unsubscribe at any time. Read our{' '}
         <A href="https://expo.dev/privacy" openInNewTab>
           privacy policy

--- a/docs/ui/components/Home/sections/JoinTheCommunity.tsx
+++ b/docs/ui/components/Home/sections/JoinTheCommunity.tsx
@@ -2,14 +2,16 @@ import { mergeClasses } from '@expo/styleguide';
 import { BlueskyIcon } from '@expo/styleguide-icons/custom/BlueskyIcon';
 import { DiscordIcon } from '@expo/styleguide-icons/custom/DiscordIcon';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { LinkedinIcon } from '@expo/styleguide-icons/custom/LinkedinIcon';
 import { RedditIcon } from '@expo/styleguide-icons/custom/RedditIcon';
 import { XLogoIcon } from '@expo/styleguide-icons/custom/XLogoIcon';
+import { YoutubeIcon } from '@expo/styleguide-icons/custom/YoutubeIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import { Lightbulb02Icon } from '@expo/styleguide-icons/outline/Lightbulb02Icon';
 import { type ReactNode } from 'react';
 
 import { HeaderDescription } from '~/ui/components/Home';
-import { RawH3, P, A } from '~/ui/components/Text';
+import { RawH3, P, A, CALLOUT } from '~/ui/components/Text';
 
 export function JoinTheCommunity() {
   return (
@@ -20,7 +22,8 @@ export function JoinTheCommunity() {
       </HeaderDescription>
       <div
         className={mergeClasses(
-          'inline-grid grid-cols-2 w-full gap-y-6 gap-x-8 my-4',
+          'inline-grid grid-cols-2 w-full gap-y-1.5 gap-x-8 my-4',
+          'border border-default rounded-lg p-3 shadow-xs',
           'max-xl-gutters:grid-cols-1',
           'max-lg-gutters:grid-cols-2',
           'max-md-gutters:grid-cols-1'
@@ -29,44 +32,57 @@ export function JoinTheCommunity() {
           title="Discord and Forums"
           description="Join our Discord to chat or ask questions."
           link="https://chat.expo.dev"
-          icon={<DiscordIcon className="icon-lg text-palette-white" />}
+          icon={<DiscordIcon className="icon-xl text-palette-white" />}
           iconClassName="bg-[#3131E8]"
           shouldLeakReferrer
         />
         <CommunityGridCell
           title="GitHub"
-          description="View our SDK, submit a PR, or report an issue."
+          description="View SDK and docs code, submit a PR, or report an issue."
           link="https://github.com/expo/expo"
-          iconClassName="bg-palette-gray10"
-          icon={<GithubIcon className="icon-lg text-palette-white" />}
+          iconClassName="bg-palette-gray11 dark:bg-palette-gray7"
+          icon={<GithubIcon className="icon-xl text-palette-white" />}
         />
         <CommunityGridCell
-          title="X"
-          description="Follow Expo on X for news and updates."
-          link="https://x.com/expo"
-          icon={<XLogoIcon className="icon-lg text-palette-white" />}
-          iconClassName="bg-[#000000]"
+          title="YouTube"
+          description="Follow our channel to explore tutorials and other content."
+          link="https://www.youtube.com/channel/UCx_YiR733cfqVPRsQ1n8Fag"
+          iconClassName="bg-[#FF0033]"
+          icon={<YoutubeIcon className="icon-xl text-palette-white" />}
+        />
+        <CommunityGridCell
+          title="LinkedIn"
+          description="Follow Expo on LinkedIn for news and updates."
+          link="https://www.linkedin.com/company/expo-dev/"
+          iconClassName="bg-[#0B66C2]"
+          icon={<LinkedinIcon className="icon-xl text-palette-white" />}
         />
         <CommunityGridCell
           title="Bluesky"
           description="Follow Expo on Bluesky for news and updates."
           link="https://bsky.app/profile/expo.dev"
-          icon={<BlueskyIcon className="icon-lg text-palette-white" />}
+          icon={<BlueskyIcon className="icon-xl text-palette-white" />}
           iconClassName="bg-[#1083fe]"
-          shouldLeakReferrer
+        />
+        <CommunityGridCell
+          title="X"
+          description="Follow Expo on X for news and updates."
+          link="https://x.com/expo"
+          icon={<XLogoIcon className="size-7 text-palette-white" />}
+          iconClassName="bg-[#000000]"
         />
         <CommunityGridCell
           title="Reddit"
           description="Get the latest on r/expo."
           link="https://www.reddit.com/r/expo"
-          icon={<RedditIcon className="icon-lg text-palette-white" />}
+          icon={<RedditIcon className="icon-xl text-palette-white" />}
           iconClassName="bg-[#FC471E]"
         />
         <CommunityGridCell
           title="Canny"
           description="Give us a feedback or request a feature."
           link="https://expo.canny.io/"
-          icon={<Lightbulb02Icon className="icon-lg text-palette-white" />}
+          icon={<Lightbulb02Icon className="icon-xl text-palette-white" />}
           iconClassName="bg-[#525df9]"
         />
       </div>
@@ -97,27 +113,28 @@ function CommunityGridCell({
     <A
       href={link}
       className={mergeClasses(
-        'flex justify-between items-center bg-default p-4 min-h-[30px] overflow-hidden relative border border-default rounded-lg transition shadow-xs',
-        '[&_h2]:!my-0 [&_h3]:!mt-0',
-        'hocus:shadow-sm',
+        'flex justify-between items-center bg-default p-2 pr-3 min-h-[30px] overflow-hidden relative rounded-lg transition gap-3',
+        'hocus:bg-element hocus:opacity-100',
         className
       )}
       shouldLeakReferrer={shouldLeakReferrer}
       isStyled>
       <div
         className={mergeClasses(
-          'size-12 inline-flex justify-center items-center rounded-lg mr-4',
+          'size-12 shrink-0 inline-flex justify-center items-center rounded-lg',
           iconClassName
         )}>
         {icon}
       </div>
-      <div className="grow">
-        <P weight="medium">{title}</P>
-        <P theme="secondary" className="!text-xs">
-          {description}
+      <div className="flex flex-col grow gap-0.5">
+        <P weight="medium" className="leading-snug">
+          {title}
         </P>
+        <CALLOUT theme="secondary" className="leading-snug">
+          {description}
+        </CALLOUT>
       </div>
-      <ArrowUpRightIcon className="text-icon-secondary self-center ml-1.5" />
+      <ArrowUpRightIcon className="text-icon-tertiary self-center shrink-0" />
     </A>
   );
 }


### PR DESCRIPTION
# Why

Add missing social profile links, streamline the community links section.

# How

Change the appearance of "Join the community" section, tweak layout to better fit more entries, increase icons size slightly.

Add YouTube channel and LinkedIn profile links. 

In the process, I have also bumped the Next to the newest minor version.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-11-07 at 17 14 12](https://github.com/user-attachments/assets/3956cffe-4797-42e4-833d-b1a2b60ad0bd)

![Screenshot 2024-11-07 at 17 16 16](https://github.com/user-attachments/assets/3939455c-77fb-42df-b7f1-de3939dcd3df)
