### PR TITLE
[docs] Tag docs PR S3 buckets as "intended to be public"

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -82,6 +82,9 @@ jobs:
           # Set bucket policy to public
           aws s3api put-bucket-policy --bucket docs.expo.dev-pr-${{ github.event.pull_request.number }} --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::docs.expo.dev-pr-${{ github.event.pull_request.number }}/*\"}]}"
 
+          # Tag bucket to tell compliance monitoring that it is intended to be public
+          aws s3api put-bucket-tagging --bucket docs.expo.dev-pr-${{ github.event.pull_request.number }} --tagging "{\"TagSet\":[{\"Key\":\"DrataExclude\",\"Value\":\"This is a test instance of our public docs page and is intended to be public.\"}]}"
+
           # Set up static website hosting
           aws s3 website s3://docs.expo.dev-pr-${{ github.event.pull_request.number }}/ --index-document index.html
       - name: 🚀 Deploy Docs website


### PR DESCRIPTION
# Why
We monitor to ensure S3 buckets are properly secured. These buckets are intended to be public, so we don't want these to flag.

# How

Looked up bucket tagging (https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-tagging.html) and added the tag as documented in our compliance platform.

# Test Plan
Tag this PR as needing a preview and see if it passes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
