### PR TITLE
[TV] bump E2E test dependencies

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -364,8 +364,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.76.0-0rc4',
-        '@react-native-tvos/config-tv': '^0.0.11',
+        'react-native': 'npm:react-native-tvos@~0.76.1-0',
+        '@react-native-tvos/config-tv': '^0.0.13',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

Ensure that TV compile test uses RNTV 0.76.1-0, to align with RN 0.76.1 on mobile.

# Test Plan

CI should pass


