### PR TITLE
[docs] Update `cleanCopyValue` to exclude annotation from Expo tutorial

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -30,6 +30,9 @@ export function cleanCopyValue(value: string) {
     .replace(/\/\*\s?@(info[^*]+|end|hide[^*]+).?\*\//g, '')
     .replace(/#\s?@(info[^#]+|end|hide[^#]+).?#/g, '')
     .replace(/<!--\s?@(info[^<>]+|end|hide[^<>]+).?-->/g, '')
+    .replace(/\/\*\s?@(tutinfo[^*]+|end|hide[^*]+).?\*\//g, '')
+    .replace(/#\s?@(tutinfo[^#]+|end|hide[^#]+).?#/g, '')
+    .replace(/<!--\s?@(tutinfo[^<>]+|end|hide[^<>]+).?-->/g, '')
     .replace(/^ +\r?\n|\n +\r?$/gm, '');
 }
 

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -10,13 +10,7 @@ type CopyActionProps = SnippetActionProps & {
 export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
   const [copyDone, setCopyDone] = useState(false);
   const onCopyClick = () => {
-    const filteredText = text
-      .split('\n')
-      .filter(line => !/^\s*\/\*.*@tutinfo.*\*\/\s*$/.test(line))
-      .map(line => line.replace(/\/\*.*@tutinfo.*\*\/|\/\/.*@tutinfo.*/g, '').trimEnd())
-      .join('\n');
-
-    navigator.clipboard?.writeText(filteredText);
+    navigator.clipboard?.writeText(text);
     setCopyDone(true);
     setTimeout(() => setCopyDone(false), 1500);
   };

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -10,7 +10,13 @@ type CopyActionProps = SnippetActionProps & {
 export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
   const [copyDone, setCopyDone] = useState(false);
   const onCopyClick = () => {
-    navigator.clipboard?.writeText(text);
+    const filteredText = text
+      .split('\n')
+      .filter(line => !/^\s*\/\*.*@tutinfo.*\*\/\s*$/.test(line))
+      .map(line => line.replace(/\/\*.*@tutinfo.*\*\/|\/\/.*@tutinfo.*/g, '').trimEnd())
+      .join('\n');
+
+    navigator.clipboard?.writeText(filteredText);
     setCopyDone(true);
     setTimeout(() => setCopyDone(false), 1500);
   };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix https://github.com/expo/expo/issues/32654

# How

<!--
How did you build this feature or fix this bug and why?
-->

By filtering the incoming text to check for `@tutinfo` annotation and using regex to remove it from being copied over when CopyAction is triggered for any code block on an Expo Tutorial page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and copy-paste a snippet that uses `@tutinfo` annotation (highlighted in green) from Expo Tutorial. For example: http://localhost:3002/tutorial/add-navigation/

https://github.com/user-attachments/assets/3f8c3f55-c54a-4b77-94bf-6023fc9a1e76

https://github.com/user-attachments/assets/b3ce0e86-4ff0-4604-88ff-a5f82c4ac623

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
