### PR TITLE
[docs] Update existing React Native instructions in DevClient reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -23,7 +23,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
-If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -21,7 +21,9 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Installation
 
-<APIInstallSection />
+<APIInstallSection hideBareInstructions />
+
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
@@ -25,7 +25,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
-If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
@@ -23,7 +23,9 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Installation
 
-<APIInstallSection />
+<APIInstallSection hideBareInstructions />
+
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -23,7 +23,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
-If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -21,7 +21,9 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Installation
 
-<APIInstallSection />
+<APIInstallSection hideBareInstructions />
+
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
@@ -23,7 +23,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 <APIInstallSection hideBareInstructions />
 
-If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 

--- a/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
@@ -21,7 +21,9 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Installation
 
-<APIInstallSection />
+<APIInstallSection hideBareInstructions />
+
+If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the additional instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 ## Configuration in app.json/app.config.js
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The "additional instructions" section isn't present in DevClient package's README. Also, we cover the instructions for installing `expo-dev-client` in an existing React Native project in a separate guide: https://docs.expo.dev/bare/install-dev-builds-in-bare/.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Hide the common bare instructions in the Installation section of DevClient reference
- Add instructions (following the similar verbiage from the common instructions) to point towards the https://docs.expo.dev/bare/install-dev-builds-in-bare/ guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-08 at 00 18 00@2x](https://github.com/user-attachments/assets/4c4e7768-3de4-4bfc-9152-13b5ce564c43)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
