### PR TITLE
[Android] start headless js context on the main thread

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Ensure that the headless app loader is started on the main thread.
+
 ### 💡 Others
 
 ## 2.0.0-preview.10 — 2024-11-07

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Ensure that the headless app loader is started on the main thread.
+- [Android] Ensure that the headless app loader is started on the main thread. ([#32705](https://github.com/expo/expo/pull/32705) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -39,7 +39,10 @@ class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) 
               }
             }
           )
-          reactHost.start()
+          // Ensure that we're starting the react host on the main thread
+          android.os.Handler(context.mainLooper).post {
+            reactHost.start()
+          }
         } else {
           // Old architecture
           val reactInstanceManager = (context.applicationContext as ReactApplication).reactNativeHost.reactInstanceManager
@@ -53,7 +56,10 @@ class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) 
               }
             }
           )
-          reactInstanceManager.createReactContextInBackground()
+          // Ensure that we're starting the react host on the main thread
+          android.os.Handler(context.mainLooper).post {
+            reactInstanceManager.createReactContextInBackground()
+          }
         }
       } else {
         alreadyRunning?.run()


### PR DESCRIPTION
# Why

On Android our Headless JS context might be initialized from another thread than the UI thread. Typically it will originate from running something in response to an action like a remote notification, alarm etc. which might not be started on the UI thread.

# How

Follow the same pattern as when we do when destroying by calling the start methods explicitly on the main thread.

# Test Plan

Can be tested with a background task that should be run when a remote notification is received on Android.

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
