### PR TITLE
[Android] Add initialised check when accessing splashScreen property

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Added guard to prevent null pointer exception when the splashScreen property is referenced without an activity (headless JS)
+- [Android] Added guard to prevent null pointer exception when the splashScreen property is referenced without an activity (headless JS) ([#32707](https://github.com/expo/expo/pull/32707) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Added guard to prevent null pointer exception when the splashScreen property is referenced without an activity (headless JS)
+
 ### 💡 Others
 
 ## 0.29.4 — 2024-11-07

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -23,6 +23,12 @@ object SplashScreenManager {
   }
 
   private fun configureSplashScreen(options: SplashScreenOptions = SplashScreenOptions()) {
+    // If loaded in a headless JS context we might not have initialized the splash screen
+    // lateinit variable, so let's check to be nice citizens
+    if (!::splashScreen.isInitialized) {
+      return
+    }
+
     val duration = options.duration
 
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->


### PR DESCRIPTION
# Why

To avoid crashes if a splash screen is used in a headless (non-activity) context, we need to test if the splash screen variable is set before trying to initialise it.

The use case we're trying to avoid is that we have an app that uses a splash screen and also calls `setOptions()` on load (from JS) in a headless JS context. This is not uncommon when using `expo-task-manager` from push notifications, locations, background-fetch where all of our JS is loaded but we're not creating the splash screen since we don't have an activity.

# How

This PR fixes this by adding a check to see if the lateinit splashScreen property has been initialized.

# Test Plan

Test using push notifications starting from a killed state and ensure that we're not crashing.

# Checklist
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
