### PR TITLE
[ncl] Fix failing ts lint in native component list

### DIFF
--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -5,7 +5,7 @@ import { ThemeType } from 'ThemeProvider';
 import * as React from 'react';
 import { View, Platform, TouchableOpacity, StyleSheet } from 'react-native';
 
-import ThemeToggler from '../../../common/ThemeToggler';
+// import ThemeToggler from '../../../common/ThemeToggler';
 
 export default function getStackConfig(navigation: BottomTabNavigationProp<any>, theme: ThemeType) {
   return {

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -5,8 +5,6 @@ import { ThemeType } from 'ThemeProvider';
 import * as React from 'react';
 import { View, Platform, TouchableOpacity, StyleSheet } from 'react-native';
 
-// import ThemeToggler from '../../../common/ThemeToggler';
-
 export default function getStackConfig(navigation: BottomTabNavigationProp<any>, theme: ThemeType) {
   return {
     cardStyle: {


### PR DESCRIPTION
# Why

After this change: a75d3e562c913373d03ed12932bcf7f8ae8c00c3 we got a ci lint failure:

```
/home/runner/work/expo/expo/apps/native-component-list/src/navigation/StackConfig.tsx
Warning:   8:8  warning  'ThemeToggler' is defined but never used  @typescript-eslint/no-unused-vars
```

# How

Commenting out offending line

# Test Plan

Make sure ci runs without the following exception when running `Lint NCL App`:

´Warning:   8:8  warning  'ThemeToggler' is defined but never used  @typescript-eslint/no-unused-vars`

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
