### PR TITLE
[notifications][android] run notification tasks from killed state

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [android] run notification tasks from killed state ([#32531](https://github.com/expo/expo/pull/32531) by [@vonovak](https://github.com/vonovak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.RemoteMessage;
 
 import java.util.Map;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
@@ -19,7 +20,7 @@ public class RemoteMessageSerializer {
    * @param message {@link RemoteMessage} to serialize
    * @return Serialized message
    */
-  public static Bundle toBundle(RemoteMessage message) {
+  public static @NonNull Bundle toBundle(RemoteMessage message) {
     Bundle serializedMessage = new Bundle();
     serializedMessage.putString("collapseKey", message.getCollapseKey());
     serializedMessage.putBundle("data", toBundle(message.getData()));

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.util.Log;
 
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -118,6 +119,10 @@ public class BackgroundRemoteNotificationTaskConsumer extends TaskConsumer imple
       Log.e("expo-notifications", "Could not parse notification from JSON string. " + e.getMessage());
     }
     return bundle;
+  }
+
+  public void executeTask(@NotNull Bundle bundle) {
+    mTask.execute(bundle, null);
   }
 
   //endregion

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
@@ -6,8 +6,8 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.util.Log;
+import androidx.annotation.NonNull;
 
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -121,7 +121,7 @@ public class BackgroundRemoteNotificationTaskConsumer extends TaskConsumer imple
     return bundle;
   }
 
-  public void executeTask(@NotNull Bundle bundle) {
+  public void executeTask(@NonNull Bundle bundle) {
     mTask.execute(bundle, null);
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -45,7 +45,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       }
 
       sListenersReferences[listener] = WeakReference(listener)
-      if (!sPendingNotificationResponses.isEmpty()) {
+      if (sPendingNotificationResponses.isNotEmpty()) {
         val responseIterator = sPendingNotificationResponses.iterator()
         while (responseIterator.hasNext()) {
           listener.onNotificationResponseReceived(responseIterator.next())
@@ -139,11 +139,11 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     if (notificationResponse.action.opensAppToForeground()) {
       openAppToForeground(context, notificationResponse)
     }
-
-    if (getListeners().isEmpty()) {
+    val listeners = getListeners()
+    if (listeners.isEmpty()) {
       sPendingNotificationResponses.add(notificationResponse)
     } else {
-      getListeners().forEach {
+      listeners.forEach {
         it.onNotificationResponseReceived(notificationResponse)
       }
     }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -1,7 +1,10 @@
 package expo.modules.notifications.service.delegates
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.google.firebase.messaging.RemoteMessage
+import expo.modules.interfaces.taskManager.TaskServiceProviderHelper
 import expo.modules.notifications.notifications.RemoteMessageSerializer
 import expo.modules.notifications.notifications.background.BackgroundRemoteNotificationTaskConsumer
 import expo.modules.notifications.notifications.debug.DebugLogging
@@ -94,9 +97,16 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
     val notification = createNotification(remoteMessage)
     DebugLogging.logNotification("FirebaseMessagingDelegate.onMessageReceived: notification", notification)
     NotificationsService.receive(context, notification)
-    // background tasks are separate from the main notification handling flow; they are executed through task-manager
+    runTaskManagerTasks(remoteMessage)
+  }
+
+  private fun runTaskManagerTasks(remoteMessage: RemoteMessage) {
+    // getTaskServiceImpl() has a side effect:
+    // the TaskService constructor calls restoreTasks which then constructs a BackgroundRemoteNotificationTaskConsumer,
+    // and the getBackgroundTasks() call below doesn't return an empty collection.
+    TaskServiceProviderHelper.getTaskServiceImpl(context.applicationContext)
     getBackgroundTasks().forEach {
-      it.scheduleJob(RemoteMessageSerializer.toBundle(remoteMessage))
+      it.executeTask(RemoteMessageSerializer.toBundle(remoteMessage))
     }
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -1,8 +1,6 @@
 package expo.modules.notifications.service.delegates
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.google.firebase.messaging.RemoteMessage
 import expo.modules.interfaces.taskManager.TaskServiceProviderHelper
 import expo.modules.notifications.notifications.RemoteMessageSerializer


### PR DESCRIPTION
# Why
replaces https://github.com/expo/expo/pull/32531

Enable [notification tasks](https://docs.expo.dev/versions/v52.0.0/sdk/notifications/#registertaskasynctaskname) to run when the app is in a killed state on Android. Previously, background tasks associated with notifications weren't properly initialized when the app was launched from a killed state.

# How

- Modified `FirebaseMessagingDelegate` to explicitly initialize the task service before running background tasks


# Test Plan

this assumes that a [task](https://docs.expo.dev/versions/latest/sdk/notifications/#registertaskasynctaskname) is registered.

1. define a task with the following body:

```
 defineTask(BACKGROUND_NOTIFICATION_TASK, async ({ data, error }) => {
    console.log(
      `${Platform.OS} ${BACKGROUND_NOTIFICATION_TASK}: App in ${
        AppState.currentState
      } state. data: ${JSON.stringify(data, null, 2)}`
    );
    const id = await Notifications.scheduleNotificationAsync({
      content: {
        title: "Here is a scheduled notification!",
        data: {
          hello: "there",
          future: "self",
        },
      },
      trigger: null,
    });
    console.log("Scheduled notification with id:", id);
  });
```
2. Kill the app (usually a swipe up gesture in the app switcher)
3. Send a headless notification (== it has to be data-only on Android / `content-available` on iOS!) whose data payload contains

```
    title: 'some-title',
```

Notification with `some-title` is displayed now on Android (because of [this](https://github.com/expo/expo/pull/32162)). Notification with `Here is a scheduled notification!` title is _also_ displayed, proving that the BACKGROUND_NOTIFICATION_TASK was executed.

No interaction with the notification is needed. 

On iOS, only the `Here is a scheduled notification!` notification is presented, also proving that BACKGROUND_NOTIFICATION_TASK was executed.  That is, android presents 2 notifications and iOS only 1. This behavior should be unified across platforms in the future. If you only want to present 1 notification, use an `if (Platform.OS === "ios")` condition.

Also, the console logs should be visible in logcat.

# TODO

- [ ] need to update the docs too, probably in another PR

# Checklist


- [ ] Documentation is up to date to reflect these changes
- [ ] Conforms with the Documentation Writing Style Guide
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build