### PR TITLE
[notifications] add enableBackgroundRemoteNotifications option to config plugin

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [android] run notification tasks from killed state ([#32531](https://github.com/expo/expo/pull/32531) by [@vonovak](https://github.com/vonovak))
+- add `enableBackgroundRemoteNotifications` option to config plugin ([#32716](https://github.com/expo/expo/pull/32716) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-notifications/plugin/build/withNotifications.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotifications.d.ts
@@ -28,6 +28,14 @@ export type NotificationsPluginProps = {
      * @platform ios
      */
     mode?: 'development' | 'production';
+    /**
+     * Whether to enable background remote notifications, as described in [Apple documentation](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app).
+     *
+     * This sets the `UIBackgroundModes` key in the `Info.plist` to include `remote-notification`.
+     * @default false
+     * @platform ios
+     */
+    enableBackgroundRemoteNotifications?: boolean;
 };
 declare const _default: ConfigPlugin<void | NotificationsPluginProps>;
 export default _default;

--- a/packages/expo-notifications/plugin/build/withNotificationsIOS.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotificationsIOS.d.ts
@@ -1,9 +1,6 @@
 import { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
 import { NotificationsPluginProps } from './withNotifications';
 export declare const withNotificationsIOS: ConfigPlugin<NotificationsPluginProps>;
-export declare const withNotificationSounds: ConfigPlugin<{
-    sounds: string[];
-}>;
 /**
  * Save sound files to the Xcode project root and add them to the Xcode project.
  */

--- a/packages/expo-notifications/plugin/build/withNotificationsIOS.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsIOS.js
@@ -1,21 +1,42 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setNotificationSounds = exports.withNotificationSounds = exports.withNotificationsIOS = void 0;
+exports.setNotificationSounds = exports.withNotificationsIOS = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = require("fs");
 const path_1 = require("path");
 const ERROR_MSG_PREFIX = 'An error occurred while configuring iOS notifications. ';
-const withNotificationsIOS = (config, { mode = 'development', sounds = [] }) => {
+const withNotificationsIOS = (config, { mode = 'development', sounds = [], enableBackgroundRemoteNotifications }) => {
     config = (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
         if (!config.modResults['aps-environment']) {
             config.modResults['aps-environment'] = mode;
         }
         return config;
     });
-    config = (0, exports.withNotificationSounds)(config, { sounds });
+    config = withNotificationSounds(config, { sounds });
+    config = withBackgroundRemoteNotifications(config, enableBackgroundRemoteNotifications);
     return config;
 };
 exports.withNotificationsIOS = withNotificationsIOS;
+const withBackgroundRemoteNotifications = (config, enableBackgroundRemoteNotifications) => {
+    if (!(enableBackgroundRemoteNotifications === undefined ||
+        typeof enableBackgroundRemoteNotifications === 'boolean')) {
+        throw new Error(ERROR_MSG_PREFIX +
+            `"enableBackgroundRemoteNotifications" has an invalid value: ${enableBackgroundRemoteNotifications}. Expected a boolean.`);
+    }
+    if (!enableBackgroundRemoteNotifications) {
+        return config;
+    }
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+            config.modResults.UIBackgroundModes = [];
+        }
+        const notificationBackgroundMode = 'remote-notification';
+        if (!config.modResults.UIBackgroundModes.includes(notificationBackgroundMode)) {
+            config.modResults.UIBackgroundModes.push(notificationBackgroundMode);
+        }
+        return config;
+    });
+};
 const withNotificationSounds = (config, { sounds }) => {
     return (0, config_plugins_1.withXcodeProject)(config, (config) => {
         setNotificationSounds(config.modRequest.projectRoot, {
@@ -26,7 +47,6 @@ const withNotificationSounds = (config, { sounds }) => {
         return config;
     });
 };
-exports.withNotificationSounds = withNotificationSounds;
 /**
  * Save sound files to the Xcode project root and add them to the Xcode project.
  */

--- a/packages/expo-notifications/plugin/src/withNotifications.ts
+++ b/packages/expo-notifications/plugin/src/withNotifications.ts
@@ -34,6 +34,15 @@ export type NotificationsPluginProps = {
    * @platform ios
    */
   mode?: 'development' | 'production';
+
+  /**
+   * Whether to enable background remote notifications, as described in [Apple documentation](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app).
+   *
+   * This sets the `UIBackgroundModes` key in the `Info.plist` to include `remote-notification`.
+   * @default false
+   * @platform ios
+   */
+  enableBackgroundRemoteNotifications?: boolean;
 };
 
 const withNotifications: ConfigPlugin<NotificationsPluginProps | void> = (config, props) => {

--- a/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
@@ -4,6 +4,7 @@ import {
   IOSConfig,
   withXcodeProject,
   XcodeProject,
+  withInfoPlist,
 } from 'expo/config-plugins';
 import { copyFileSync } from 'fs';
 import { basename, resolve } from 'path';
@@ -14,7 +15,7 @@ const ERROR_MSG_PREFIX = 'An error occurred while configuring iOS notifications.
 
 export const withNotificationsIOS: ConfigPlugin<NotificationsPluginProps> = (
   config,
-  { mode = 'development', sounds = [] }
+  { mode = 'development', sounds = [], enableBackgroundRemoteNotifications }
 ) => {
   config = withEntitlementsPlist(config, (config) => {
     if (!config.modResults['aps-environment']) {
@@ -23,10 +24,42 @@ export const withNotificationsIOS: ConfigPlugin<NotificationsPluginProps> = (
     return config;
   });
   config = withNotificationSounds(config, { sounds });
+  config = withBackgroundRemoteNotifications(config, enableBackgroundRemoteNotifications);
+
   return config;
 };
 
-export const withNotificationSounds: ConfigPlugin<{ sounds: string[] }> = (config, { sounds }) => {
+const withBackgroundRemoteNotifications: ConfigPlugin<boolean | undefined> = (
+  config,
+  enableBackgroundRemoteNotifications
+) => {
+  if (
+    !(
+      enableBackgroundRemoteNotifications === undefined ||
+      typeof enableBackgroundRemoteNotifications === 'boolean'
+    )
+  ) {
+    throw new Error(
+      ERROR_MSG_PREFIX +
+        `"enableBackgroundRemoteNotifications" has an invalid value: ${enableBackgroundRemoteNotifications}. Expected a boolean.`
+    );
+  }
+  if (!enableBackgroundRemoteNotifications) {
+    return config;
+  }
+  return withInfoPlist(config, (config) => {
+    if (!Array.isArray(config.modResults.UIBackgroundModes)) {
+      config.modResults.UIBackgroundModes = [];
+    }
+    const notificationBackgroundMode = 'remote-notification';
+    if (!config.modResults.UIBackgroundModes.includes(notificationBackgroundMode)) {
+      config.modResults.UIBackgroundModes.push(notificationBackgroundMode);
+    }
+    return config;
+  });
+};
+
+const withNotificationSounds: ConfigPlugin<{ sounds: string[] }> = (config, { sounds }) => {
   return withXcodeProject(config, (config) => {
     setNotificationSounds(config.modRequest.projectRoot, {
       sounds,


### PR DESCRIPTION
# Why

We previously instructed users to enable push-notification background mode using https://docs.expo.dev/versions/latest/config/app/#infoplist which works but is less convenient.

This adds support for background remote notifications in iOS through a new config plugin property `enableBackgroundRemoteNotifications`. 

When `true`, this allows apps to receive and process remote notifications while in the background and even while terminated.

# How

Added a new boolean property `enableBackgroundRemoteNotifications` to the NotificationsPluginProps interface. When enabled, this automatically adds the `remote-notification` mode to `UIBackgroundModes` in the app's Info.plist.



# Test Plan

1. Set `enableBackgroundRemoteNotifications: true` in the plugin configuration
2. Run `npx expo prebuild --clean`
3. Verify that `remote-notification` is added to `UIBackgroundModes` in Info.plist

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).