### PR TITLE
[docs] Update fonts.mdx

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -382,7 +382,7 @@ import { useFonts } from 'expo-font';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 export default function RootLayout() {
-  useFonts([require('./assets/fonts/Inter-Black.otf', FontAwesome.font)]);
+  useFonts([require('./assets/fonts/Inter-Black.otf', Ionicons.font)]);
 
   return (
     /* @hide ... */ /* @end */


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
On the **Handle @expo/vector-icons initial load** section

The import target `Ionicons` but on useFonts it was called `FontAwesome`

# How

Use the correct font name

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
