### PR TITLE
[splashscreen-51] Fix dev client crash

### DIFF
--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -189,7 +189,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
     // For unknown reasons, this function may be sometimes called twice with the same changes.
     // What leads to warnings like this one: `'SplashScreen.show' has already been called for given view controller`.
     // To prevent this weird behaviour, we check if the value was really changed.
-    if (newRootViewController != nil && newRootViewController != self.observingRootViewController) {
+    if (newRootViewController != nil && self.observingRootViewController != nil && newRootViewController != self.observingRootViewController) {
       [self removeRootViewControllerListener];
       [self showSplashScreenFor:newRootViewController options:EXSplashScreenDefault];
       [self addRootViewControllerListener];


### PR DESCRIPTION
# Why
Closes #32605
When running `expo run:ios` the app will launch correctly, but when running it a second time, the app is not shutdown and this causes `applicationDidFinishLaunching` not to be called. This leads to one of the checks in the splashscreen service to behave incorrectly
```objc
if (newRootViewController != nil && newRootViewController != self.observingRootViewController) {
```
observingRootViewController should never be nil but because `applicationDidFinishLaunching` never runs, it is, so the check effectively becomes
```objc
if (newRootViewController != nil && newRootViewController != nil) {
```
Instead of an object equality check it becomes a second nil check that will always pass.

# How
Added an extra check to ensure the `observingRootViewController` is not nil. This has the knock-on effect of not showing the splashscreen in this situation. The ideal fix is for expo CLI to shut down all current app instances before running a new one. This is the default behaviour in Xcode when you repeatedly run, the app shuts down and is then relaunched. 

# Test Plan
Tested in the provided repro. The crash no longer occurs.
