### PR TITLE
[modules-core] Fix UIKit import when targeting macOS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed broken self-signed connections from network inspector. ([#32670](https://github.com/expo/expo/pull/32670) by [@kudo](https://github.com/kudo))
+- [macOS] Fix UIKit import ([#32727](https://github.com/expo/expo/pull/32727) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.0.0-preview.9 — 2024-10-31
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -2,7 +2,9 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#endif // !TARGET_OS_OSX
 #import <React/React-Core-umbrella.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Why

While upgrading Orbit to SDK 52 along with react-native-macos 0.76  I noticed that our building for macOS was broken

# How

Wrap the `<UIKit/UIKit.h>` import into a target check

# Test Plan

Run expo-modules-core on Orbit 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
