### PR TITLE
[expo] Disable the fusebox debugger warning to prevent opening React Native DevTools for incorrect target

### DIFF
--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -18,7 +18,7 @@ if (isRunningInExpoGo()) {
 // Expo Go and expo-dev-client, because launching the debugger from there will not
 // get the correct JS target.
 const IS_RUNNING_IN_DEV_CLIENT = !!NativeModules.EXDevLauncher;
-if (__DEV__ && (isRunningInExpoGo() || IS_RUNNING_IN_DEV_CLIENT)) {
+if (__DEV__ && LogBox?.ignoreLogs && (isRunningInExpoGo() || IS_RUNNING_IN_DEV_CLIENT)) {
   LogBox.ignoreLogs([/Open debugger to view warnings/]);
 }
 

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -2,7 +2,7 @@
 import './winter';
 import 'expo-asset';
 
-import { AppRegistry } from 'react-native';
+import { AppRegistry, NativeModules, LogBox } from 'react-native';
 
 import { isRunningInExpoGo } from './environment/ExpoGo';
 import { AppEntryNotFound } from './errors/AppEntryNotFound';
@@ -12,6 +12,14 @@ if (isRunningInExpoGo()) {
   // set up some improvements to commonly logged error messages stemming from react-native
   const globalHandler = ErrorUtils.getGlobalHandler();
   ErrorUtils.setGlobalHandler(createErrorHandler(globalHandler));
+}
+
+// Disable the "Open debugger to view warnings" React Native DevTools warning in
+// Expo Go and expo-dev-client, because launching the debugger from there will not
+// get the correct JS target.
+const IS_RUNNING_IN_DEV_CLIENT = !!NativeModules.EXDevLauncher;
+if (__DEV__ && (isRunningInExpoGo() || IS_RUNNING_IN_DEV_CLIENT)) {
+  LogBox.ignoreLogs([/Open debugger to view warnings/]);
 }
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
# Why

#32322 solves the problem of launching React Native DevTools for the correct target from the CLI, but from the other side - launching from within the app - we don't have a good solution yet. As @Kudo pointed out, ideally it would be possible "to disable inspector for some specific react instances for home, dev-launcher and dev-menu" - this requires changes by Meta.

# How

Ignore the fusebox warning from JS.

# Test Plan

Open an app in Expo Go with this code in place, no warning. Open it without, warning. 