### PR TITLE
[docs] Update DOM components guide description

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using React DOM in Expo native apps
 sidebar_title: DOM components
-description: Learn about rendering React DOM components in Expo native apps.
+description: Learn about rendering React DOM components in Expo native apps using the 'use dom' directive.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -1,13 +1,13 @@
 ---
 title: Using React DOM in Expo native apps
 sidebar_title: DOM components
-description: Learn about rendering React DOM elements in Expo native apps.
+description: Learn about rendering React DOM components in Expo native apps.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-> Available in **SDK 52 and above**.
+> **info** Available in **SDK 52 and above**.
 
 Expo offers a novel approach to work with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app by moving on a per-component basis.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Searching for DOM components in the docs shows a section from the DOM components guide instead of the page. This leads to confusion whether as a developer I'm looking at the right page.

![CleanShot 2024-11-09 at 22 50 30](https://github.com/user-attachments/assets/24992152-a2f4-49ff-9598-db667f9cfb3b)




# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update DOM components guide's description to use components as a keyword and also mention the directive.
- Update availability callout to use info type.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-09 at 22 52 11](https://github.com/user-attachments/assets/295e5a35-1aed-4e8f-9d78-3a3e5d9dcb75)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
