### PR TITLE
[expo] Warn if new arch isn't explicitly enabled in app config when using Expo Go

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -76,6 +76,7 @@
     "@expo/vector-icons": "^14.0.0",
     "babel-preset-expo": "~12.0.0-preview.6",
     "expo-asset": "~11.0.0",
+    "expo-constants": "~17.0.2",
     "expo-file-system": "~18.0.1",
     "expo-font": "~13.0.1",
     "expo-keep-awake": "~14.0.1",

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -18,7 +18,7 @@ if (isRunningInExpoGo()) {
 // Warn if the New Architecture is not explicitly enabled in the app config and we are running in Expo Go.
 // This could be problematic because you will be developing your app with the New Architecture enabled and
 // but your builds will have the New Architecture disabled.
-if (__DEV__ && isRunningInExpoGo()) {
+if (__DEV__ && isRunningInExpoGo() && process.env.NODE_ENV === 'development') {
   ['android', 'ios'].forEach((platform) => {
     if (
       Platform.OS === platform &&
@@ -30,7 +30,7 @@ if (__DEV__ && isRunningInExpoGo()) {
         console.warn(
           `🚨 React Native's New Architecture is always enabled in Expo Go, but it is not explicitly enabled your project app config. This may lead to unexpected behavior when you create a production or development build. Set "newArchEnabled": true in your app.json.\nLearn more: https://docs.expo.dev/guides/new-architecture/`
         );
-      })
+      });
     }
   });
 }

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -2,7 +2,8 @@
 import './winter';
 import 'expo-asset';
 
-import { AppRegistry, NativeModules, LogBox } from 'react-native';
+import Constants from 'expo-constants';
+import { AppRegistry, NativeModules, LogBox, Platform } from 'react-native';
 
 import { isRunningInExpoGo } from './environment/ExpoGo';
 import { AppEntryNotFound } from './errors/AppEntryNotFound';
@@ -12,6 +13,26 @@ if (isRunningInExpoGo()) {
   // set up some improvements to commonly logged error messages stemming from react-native
   const globalHandler = ErrorUtils.getGlobalHandler();
   ErrorUtils.setGlobalHandler(createErrorHandler(globalHandler));
+}
+
+// Warn if the New Architecture is not explicitly enabled in the app config and we are running in Expo Go.
+// This could be problematic because you will be developing your app with the New Architecture enabled and
+// but your builds will have the New Architecture disabled.
+if (__DEV__ && isRunningInExpoGo()) {
+  ['android', 'ios'].forEach((platform) => {
+    if (
+      Platform.OS === platform &&
+      Constants.expoConfig?.[platform]?.newArchEnabled !== true &&
+      Constants.expoConfig?.newArchEnabled !== true
+    ) {
+      // Wrap it in rAF to show the warning after the React Native DevTools message
+      requestAnimationFrame(() => {
+        console.warn(
+          `🚨 React Native's New Architecture is always enabled in Expo Go, but it is not explicitly enabled your project app config. This may lead to unexpected behavior when you create a production or development build. Set "newArchEnabled": true in your app.json.\nLearn more: https://docs.expo.dev/guides/new-architecture/`
+        );
+      })
+    }
+  });
 }
 
 // Disable the "Open debugger to view warnings" React Native DevTools warning in


### PR DESCRIPTION
# Why

Self explanatory in the warning! This should help with cases like #32748

<img width="994" alt="image" src="https://github.com/user-attachments/assets/837eb4b5-6414-4933-abd8-89f2b90bb289">