### PR TITLE
[docs] expand supported ToC indent levels

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -117,6 +117,10 @@ function convertToIndentClass(spacing: number) {
       return 'pl-6';
     case 36:
       return 'pl-9';
+    case 48:
+      return 'pl-12';
+    case 60:
+      return 'pl-15';
     default:
       return '';
   }


### PR DESCRIPTION
# Why

Fixes #32746

# How

Expand supported ToC indent levels. We switch of passing numeric values in favor of TW classes, but the translation stopped before deep nested entries, which occurs only on app config page. 

Let's add support for two more levels, but we definitely should re-visit and discuss the way we render app config docs, since this page also cause issues for Algolia crawlers.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-11-10 095015](https://github.com/user-attachments/assets/403d606b-7e73-4821-b827-17ae7882ff27)
