### PR TITLE
[splashscreen] Old arch preventAutoHide fix

### DIFF
--- a/packages/expo-splash-screen/ios/SplashScreenManager.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenManager.swift
@@ -39,7 +39,6 @@ public class SplashScreenManager: NSObject {
     }
 
     NotificationCenter.default.addObserver(self, selector: #selector(onAppReady), name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(onAppReady), name: Notification.Name.RCTJavaScriptDidLoad, object: nil)
   }
 
   @objc private func onAppReady() {


### PR DESCRIPTION
# Why
Closes #32760
We don't need to listen for `RCTJavaScriptDidLoad` notification. It is called too early, `RCTContentDidAppearNotification` works for both architectures.

# How
Remove the observer for `RCTJavaScriptDidLoad` 

# Test Plan
Tested in the provided repro on the old and new architecture.
