### PR TITLE
[cli] Improve linking to modules in CLI E2E tests

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Improving linking to modules in E2E tests.
+- Improving linking to modules in E2E tests. ([#32769](https://github.com/expo/expo/pull/32769) by [@marklawlor](https://github.com/marklawlor))
 
 ## 0.20.6 — 2024-11-11
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Improving linking to modules in E2E tests.
+
 ## 0.20.6 — 2024-11-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -175,31 +175,14 @@ it(
   120 * 1000
 );
 
-it.only(
+it(
   'runs `npx expo customize tsconfig.json` sets up typed routes',
   async () => {
     const projectRoot = await setupTestProjectWithOptionsAsync(
       'expo-customize-typed-routes',
       'with-router-typed-routes',
-      { reuseExisting: false }
+      { reuseExisting: false, linkExpoPackages: ['expo-router'] }
     );
-
-    /*
-     * Before we can run `expo customize` we need to bundle the local version of Expo Router
-     * So we pack the local package and add it to the E2E test as a dependency
-     */
-
-    // `npm pack` on Expo Router
-    const packOutput = await execa('npm', ['pack', '--json', '--pack-destination', projectRoot], {
-      cwd: path.join(__dirname, '../../../../expo-router'),
-    });
-
-    const [{ filename }] = JSON.parse(packOutput.stdout);
-
-    // Add the local version of expo-router
-    await execa('bun', ['add', `expo-router@${filename}`], {
-      cwd: projectRoot,
-    });
 
     // `npx expo typescript`
     await execa('node', [bin, 'customize', 'tsconfig.json'], {

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -227,6 +227,7 @@ describe('expo-router integration', () => {
         {
           reuseExisting: false,
           sdkVersion: '52.0.0',
+          linkExpoPackages: ['expo-router'],
         }
       );
       const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -102,6 +102,10 @@ export async function createFromFixtureAsync(
     config?: Partial<ExpoConfig>;
     pkg?: Partial<PackageJSONConfig>;
     linkExpoPackages?: string[];
+    /**
+     * Note, this is linked by installing the workspace folder as dependency directly.
+     * This may cause other side-effects, like resolving monorepo dependencies instead of the test project.
+     */
     linkExpoPackagesDev?: string[];
   }
 ): Promise<string> {

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -101,6 +101,10 @@ export async function createFromFixtureAsync(
     fixtureName: string;
     config?: Partial<ExpoConfig>;
     pkg?: Partial<PackageJSONConfig>;
+    /**
+     * Note, this is linked by installing the workspace folder as dependency directly.
+     * This may cause other side-effects, like resolving monorepo dependencies instead of the test project.
+     */
     linkExpoPackages?: string[];
     /**
      * Note, this is linked by installing the workspace folder as dependency directly.


### PR DESCRIPTION
# Why

Expo Router now integrates with `@expo/cli` via Typed Routes and `expo install`. We need an easier way to write these tests using the current version in that commit.

# How

Previously the test suite used to `npm pack` the module to copy it across. This change allows you link modules via the setup comand.

Note: I originally planned to automatically link any Expo package being used but it was taking to much time and would require changes to `AppEntry`.  I still think this is a best approach, but probably too risky just before SDK 52 launch. 