### PR TITLE
[video-thumbnails] Don't run generation on main thread

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Run thumnbnail generation on background thread. ([#32773](https://github.com/expo/expo/pull/32773) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 9.0.0 — 2024-10-22

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -7,7 +7,7 @@ public class VideoThumbnailsModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoVideoThumbnails")
 
-    AsyncFunction("getThumbnail", getVideoThumbnail).runOnQueue(.main)
+    AsyncFunction("getThumbnail", getVideoThumbnail)
   }
 
   internal func getVideoThumbnail(sourceFilename: URL, options: VideoThumbnailsOptions) throws -> [String: Any] {
@@ -17,8 +17,8 @@ public class VideoThumbnailsModule: Module {
       }
     }
 
-    let asset = AVURLAsset.init(url: sourceFilename, options: ["AVURLAssetHTTPHeaderFieldsKey": options.headers])
-    let generator = AVAssetImageGenerator.init(asset: asset)
+    let asset = AVURLAsset(url: sourceFilename, options: ["AVURLAssetHTTPHeaderFieldsKey": options.headers])
+    let generator = AVAssetImageGenerator(asset: asset)
 
     generator.appliesPreferredTrackTransform = true
     generator.requestedTimeToleranceAfter = CMTime.zero
@@ -32,7 +32,7 @@ public class VideoThumbnailsModule: Module {
     }
 
     let imgRef = try generator.copyCGImage(at: time, actualTime: nil)
-    let thumbnail = UIImage.init(cgImage: imgRef)
+    let thumbnail = UIImage(cgImage: imgRef)
     let savedImageUrl = try saveImage(image: thumbnail, quality: options.quality)
 
     return [

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Run thumnbnail gerneration on background thread.
+
 ### 💡 Others
 
 ## 2.0.0 — 2024-11-11

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Run thumnbnail generation on background thread. ([#32773](https://github.com/expo/expo/pull/32773) by [@alanjhughes](https://github.com/alanjhughes))
-
 ### 💡 Others
 
 ## 2.0.0 — 2024-11-11

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Run thumnbnail gerneration on background thread.
+- [iOS] Run thumnbnail generation on background thread. ([#32773](https://github.com/expo/expo/pull/32773) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why
Closes #32771

# How
Generating the thumbnails can be run on a background thread. 

# Test Plan
bare-expo

