### PR TITLE
[docs] add expo/fetch api doc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -23,7 +23,7 @@ import * as Expo from 'expo';
 
 ### `expo/fetch` API
 
-`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile enironments, ensuring a standardized and cross-platform fetch experience within Expo applications.
+`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile environments, ensuring a standardized and cross-platform fetch experience within Expo applications.
 
 ```ts Streaming fetch
 import { fetch } from 'expo/fetch';

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -21,6 +21,29 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import * as Expo from 'expo';
 ```
 
+### `expo/fetch` API
+
+`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile enironments, ensuring a standardized and cross-platform fetch experience within Expo applications.
+
+```ts Streaming fetch
+import { fetch } from 'expo/fetch';
+
+const resp = await fetch('https://httpbin.org/drip?numbytes=512&duration=2', {
+  headers: { Accept: 'text/event-stream' },
+});
+const reader = resp.body.getReader();
+const chunks = [];
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) {
+    break;
+  }
+  chunks.push(value);
+}
+const buffer = new Uint8Array(chunks.reduce((acc, chunk) => acc + chunk.length, 0));
+console.log(buffer.length); // 512
+```
+
 <APISection packageName="expo" />
 
 ## Common questions

--- a/docs/pages/versions/v52.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/expo.mdx
@@ -23,7 +23,7 @@ import * as Expo from 'expo';
 
 ### `expo/fetch` API
 
-`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile enironments, ensuring a standardized and cross-platform fetch experience within Expo applications.
+`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile environments, ensuring a standardized and cross-platform fetch experience within Expo applications.
 
 ```ts Streaming fetch
 import { fetch } from 'expo/fetch';

--- a/docs/pages/versions/v52.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/expo.mdx
@@ -21,6 +21,29 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import * as Expo from 'expo';
 ```
 
+### `expo/fetch` API
+
+`expo/fetch` provides a [WinterCG-compliant Fetch API](https://fetch.spec.wintercg.org/) that works consistently across web and mobile enironments, ensuring a standardized and cross-platform fetch experience within Expo applications.
+
+```ts Streaming fetch
+import { fetch } from 'expo/fetch';
+
+const resp = await fetch('https://httpbin.org/drip?numbytes=512&duration=2', {
+  headers: { Accept: 'text/event-stream' },
+});
+const reader = resp.body.getReader();
+const chunks = [];
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) {
+    break;
+  }
+  chunks.push(value);
+}
+const buffer = new Uint8Array(chunks.reduce((acc, chunk) => acc + chunk.length, 0));
+console.log(buffer.length); // 512
+```
+
 <APISection packageName="expo" />
 
 ## Common questions


### PR DESCRIPTION
# Why

add `expo/fetch` to doc

# How

at the api generated doc we don't have much submodule support, e.g. `expo/fetch` or `expo/config`. this pr tries to add doc manually.

![Screenshot 2024-11-11 at 9 48 41 PM](https://github.com/user-attachments/assets/fc80eb21-2618-422d-93dd-ef14e764ccc6)

# Test Plan

n/a

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
