### PR TITLE
[expo-sqlite] Export plugin

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Include the plugin under the `exports` in the package.json.
+
 ### 💡 Others
 
 ## 15.0.2 — 2024-11-07

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Include the plugin under the `exports` in the package.json.
+- Include the plugin under the `exports` in the package.json. ([#32780](https://github.com/expo/expo/pull/32780) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -14,7 +14,8 @@
     "./kv-store": {
       "default": "./kv-store.js",
       "types": "./kv-store.d.ts"
-    }
+    },
+    "./app.plugin.js": "./app.plugin.js"
   },
   "scripts": {
     "build": "expo-module build",


### PR DESCRIPTION
# Why
Closes  #32778

# How
The plugin was not included in the `exports` in the package.json. I've added it. 

# Test Plan
Tested by installing in a new project and building