### PR TITLE
[core] Add `@DoNotStrip` annotation to `Either` types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] At `@DoNotStrip` annotation to new `Either` types.
+
 ### 💡 Others
 
 ## 2.0.0 — 2024-11-10

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] At `@DoNotStrip` annotation to new `Either` types. ([#32783](https://github.com/expo/expo/pull/32783) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Added `@DoNotStrip` annotation to new `Either` types. ([#32783](https://github.com/expo/expo/pull/32783) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] At `@DoNotStrip` annotation to new `Either` types.
+- [Android] At `@DoNotStrip` annotation to new `Either` types. ([#32783](https://github.com/expo/expo/pull/32783) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -107,6 +107,7 @@ open class Either<FirstType : Any, SecondType : Any>(
 }
 
 @EitherType
+@DoNotStrip
 open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   bareValue: Any,
   deferredValue: MutableList<DeferredValue>,
@@ -122,6 +123,7 @@ open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
 }
 
 @EitherType
+@DoNotStrip
 class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   bareValue: Any,
   deferredValue: MutableList<DeferredValue>,


### PR DESCRIPTION
# Why
Closes #32739

# How
The new `Either` types need to have the `@DoNotStrip` annotation added.

# Test Plan
Tested running the default template in release mode

![Screenshot_1731339183](https://github.com/user-attachments/assets/9580a40a-06c8-4e12-b72c-7b8f15a0d87b)

