### PR TITLE
feat: export config plugin types

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 11.0.1 — 2024-11-10
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 11.0.1 — 2024-11-10
 
 ### 🐛 Bug fixes

--- a/packages/expo-asset/plugin/build/withAssets.d.ts
+++ b/packages/expo-asset/plugin/build/withAssets.d.ts
@@ -1,6 +1,10 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
-export type AssetProps = {
+export type WithAssetProps = {
     assets?: string[];
 };
-declare const _default: ConfigPlugin<AssetProps | null>;
+/**
+ * @deprecated Use `WithAssetProps` instead.
+ */
+export type AssetProps = WithAssetProps;
+declare const _default: ConfigPlugin<void | WithAssetProps>;
 export default _default;

--- a/packages/expo-asset/plugin/src/withAssets.ts
+++ b/packages/expo-asset/plugin/src/withAssets.ts
@@ -5,11 +5,16 @@ import { withAssetsIos } from './withAssetsIos';
 
 const pkg = require('expo-asset/package.json');
 
-export type AssetProps = {
+export type WithAssetProps = {
   assets?: string[];
 };
 
-const withAssets: ConfigPlugin<AssetProps | null> = (config, props) => {
+/**
+ * @deprecated Use `WithAssetProps` instead.
+ */
+export type AssetProps = WithAssetProps;
+
+const withAssets: ConfigPlugin<WithAssetProps | void> = (config, props) => {
   if (!props) {
     return config;
   }

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 0.2.3 — 2024-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 0.2.3 — 2024-10-28
 

--- a/packages/expo-audio/plugin/build/withAudio.d.ts
+++ b/packages/expo-audio/plugin/build/withAudio.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    microphonePermission?: string | false | undefined;
-}>;
+export type WithAudioProps = {
+    microphonePermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithAudioProps>;
 export default _default;

--- a/packages/expo-audio/plugin/src/withAudio.ts
+++ b/packages/expo-audio/plugin/src/withAudio.ts
@@ -4,10 +4,11 @@ const pkg = require('expo-audio/package.json');
 
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 
-const withAudio: ConfigPlugin<{ microphonePermission?: string | false } | void> = (
-  config,
-  { microphonePermission } = {}
-) => {
+export type WithAudioProps = {
+  microphonePermission?: string | false;
+};
+
+const withAudio: ConfigPlugin<WithAudioProps | void> = (config, { microphonePermission } = {}) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSMicrophoneUsageDescription: MICROPHONE_USAGE,
   })(config, {

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 15.0.1 — 2024-10-24
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 15.0.1 — 2024-10-24
 
 ### 💡 Others

--- a/packages/expo-av/plugin/build/withAV.d.ts
+++ b/packages/expo-av/plugin/build/withAV.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    microphonePermission?: string | false | undefined;
-}>;
+export type WithAVProps = {
+    microphonePermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithAVProps>;
 export default _default;

--- a/packages/expo-av/plugin/src/withAV.ts
+++ b/packages/expo-av/plugin/src/withAV.ts
@@ -4,10 +4,11 @@ const pkg = require('expo-av/package.json');
 
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 
-const withAV: ConfigPlugin<{ microphonePermission?: string | false } | void> = (
-  config,
-  { microphonePermission } = {}
-) => {
+export type WithAVProps = {
+  microphonePermission?: string | false;
+};
+
+const withAV: ConfigPlugin<WithAVProps | void> = (config, { microphonePermission } = {}) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSMicrophoneUsageDescription: MICROPHONE_USAGE,
   })(config, {

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 14.0.2 — 2024-10-24
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 14.0.2 — 2024-10-24
 

--- a/packages/expo-calendar/plugin/build/withCalendar.d.ts
+++ b/packages/expo-calendar/plugin/build/withCalendar.d.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    calendarPermission?: string | false | undefined;
-    remindersPermission?: string | false | undefined;
-}>;
+export type WithCalendarProps = {
+    calendarPermission?: string | false;
+    remindersPermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithCalendarProps>;
 export default _default;

--- a/packages/expo-calendar/plugin/src/withCalendar.ts
+++ b/packages/expo-calendar/plugin/src/withCalendar.ts
@@ -5,12 +5,15 @@ const pkg = require('expo-calendar/package.json');
 const CALENDARS_USAGE = 'Allow $(PRODUCT_NAME) to access your calendars';
 const REMINDERS_USAGE = 'Allow $(PRODUCT_NAME) to access your reminders';
 
-const withCalendar: ConfigPlugin<
-  {
-    calendarPermission?: string | false;
-    remindersPermission?: string | false;
-  } | void
-> = (config, { calendarPermission, remindersPermission } = {}) => {
+export type WithCalendarProps = {
+  calendarPermission?: string | false;
+  remindersPermission?: string | false;
+};
+
+const withCalendar: ConfigPlugin<WithCalendarProps | void> = (
+  config,
+  { calendarPermission, remindersPermission } = {}
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSCalendarsUsageDescription: CALENDARS_USAGE,
     NSRemindersUsageDescription: REMINDERS_USAGE,

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 16.0.3 — 2024-10-28
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 16.0.3 — 2024-10-28
 
 ### 🐛 Bug fixes

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -1,7 +1,8 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    cameraPermission?: string | false | undefined;
-    microphonePermission?: string | false | undefined;
-    recordAudioAndroid?: boolean | undefined;
-}>;
+export type WithCameraProps = {
+    cameraPermission?: string | false;
+    microphonePermission?: string | false;
+    recordAudioAndroid?: boolean;
+};
+declare const _default: ConfigPlugin<void | WithCameraProps>;
 export default _default;

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -10,13 +10,16 @@ const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 
-const withCamera: ConfigPlugin<
-  {
-    cameraPermission?: string | false;
-    microphonePermission?: string | false;
-    recordAudioAndroid?: boolean;
-  } | void
-> = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
+export type WithCameraProps = {
+  cameraPermission?: string | false;
+  microphonePermission?: string | false;
+  recordAudioAndroid?: boolean;
+};
+
+const withCamera: ConfigPlugin<WithCameraProps | void> = (
+  config,
+  { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSCameraUsageDescription: CAMERA_USAGE,
     NSMicrophoneUsageDescription: MICROPHONE_USAGE,

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 14.0.2 — 2024-11-07
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 14.0.2 — 2024-11-07
 
 ### 🐛 Bug fixes

--- a/packages/expo-contacts/plugin/build/withContacts.d.ts
+++ b/packages/expo-contacts/plugin/build/withContacts.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    contactsPermission?: string | undefined;
-}>;
+export type WithContactProps = {
+    contactsPermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithContactProps>;
 export default _default;

--- a/packages/expo-contacts/plugin/src/withContacts.ts
+++ b/packages/expo-contacts/plugin/src/withContacts.ts
@@ -4,7 +4,11 @@ const pkg = require('expo-contacts/package.json');
 
 const CONTACTS_USAGE = 'Allow $(PRODUCT_NAME) to access your contacts';
 
-const withContacts: ConfigPlugin<{ contactsPermission?: string } | void> = (
+export type WithContactProps = {
+  contactsPermission?: string | false;
+};
+
+const withContacts: ConfigPlugin<WithContactProps | void> = (
   config,
   { contactsPermission } = {}
 ) => {

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 13.0.1 — 2024-11-05
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 13.0.1 — 2024-11-05
 
 ### 💡 Others

--- a/packages/expo-font/plugin/build/withFonts.d.ts
+++ b/packages/expo-font/plugin/build/withFonts.d.ts
@@ -1,5 +1,5 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
-export type FontProps = {
+export type WithFontProps = {
     fonts?: string[];
     android?: {
         fonts?: string[];
@@ -8,5 +8,9 @@ export type FontProps = {
         fonts?: string[];
     };
 };
-declare const _default: ConfigPlugin<FontProps>;
+/**
+ * @deprecated Use `WithFontProps` instead.
+ */
+export type FontProps = WithFontProps;
+declare const _default: ConfigPlugin<void | WithFontProps>;
 export default _default;

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -5,7 +5,7 @@ import { withFontsIos } from './withFontsIos';
 
 const pkg = require('expo-font/package.json');
 
-export type FontProps = {
+export type WithFontProps = {
   fonts?: string[];
   android?: {
     fonts?: string[];
@@ -15,7 +15,12 @@ export type FontProps = {
   };
 };
 
-const withFonts: ConfigPlugin<FontProps> = (config, props) => {
+/**
+ * @deprecated Use `WithFontProps` instead.
+ */
+export type FontProps = WithFontProps;
+
+const withFonts: ConfigPlugin<WithFontProps | void> = (config, props) => {
   if (!props) {
     return config;
   }

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 16.0.1 — 2024-11-04
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 16.0.1 — 2024-11-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/plugin/build/withImagePicker.d.ts
+++ b/packages/expo-image-picker/plugin/build/withImagePicker.d.ts
@@ -1,9 +1,9 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
-type Props = {
+export type WithImagePickerProps = {
     photosPermission?: string | false;
     cameraPermission?: string | false;
     microphonePermission?: string | false;
 };
-export declare const withAndroidImagePickerPermissions: ConfigPlugin<Props | void>;
-declare const _default: ConfigPlugin<void | Props>;
+export declare const withAndroidImagePickerPermissions: ConfigPlugin<WithImagePickerProps | void>;
+declare const _default: ConfigPlugin<void | WithImagePickerProps>;
 export default _default;

--- a/packages/expo-image-picker/plugin/src/withImagePicker.ts
+++ b/packages/expo-image-picker/plugin/src/withImagePicker.ts
@@ -11,13 +11,13 @@ const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 const READ_PHOTOS_USAGE = 'Allow $(PRODUCT_NAME) to access your photos';
 
-type Props = {
+export type WithImagePickerProps = {
   photosPermission?: string | false;
   cameraPermission?: string | false;
   microphonePermission?: string | false;
 };
 
-export const withAndroidImagePickerPermissions: ConfigPlugin<Props | void> = (
+export const withAndroidImagePickerPermissions: ConfigPlugin<WithImagePickerProps | void> = (
   config,
   { cameraPermission, microphonePermission } = {}
 ) => {
@@ -41,7 +41,7 @@ export const withAndroidImagePickerPermissions: ConfigPlugin<Props | void> = (
   return config;
 };
 
-const withImagePicker: ConfigPlugin<Props | void> = (
+const withImagePicker: ConfigPlugin<WithImagePickerProps | void> = (
   config,
   { photosPermission, cameraPermission, microphonePermission } = {}
 ) => {

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 15.0.1 — 2024-10-22
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 15.0.1 — 2024-10-22
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-local-authentication/plugin/build/withLocalAuthentication.d.ts
+++ b/packages/expo-local-authentication/plugin/build/withLocalAuthentication.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    faceIDPermission?: string | false | undefined;
-}>;
+export type WithLocalAuthenticationProps = {
+    faceIDPermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithLocalAuthenticationProps>;
 export default _default;

--- a/packages/expo-local-authentication/plugin/src/withLocalAuthentication.ts
+++ b/packages/expo-local-authentication/plugin/src/withLocalAuthentication.ts
@@ -3,7 +3,11 @@ import { AndroidConfig, ConfigPlugin, IOSConfig, createRunOncePlugin } from 'exp
 const pkg = require('expo-local-authentication/package.json');
 const FACE_ID_USAGE = 'Allow $(PRODUCT_NAME) to use Face ID';
 
-const withLocalAuthentication: ConfigPlugin<{ faceIDPermission?: string | false } | void> = (
+export type WithLocalAuthenticationProps = {
+  faceIDPermission?: string | false;
+};
+
+const withLocalAuthentication: ConfigPlugin<WithLocalAuthenticationProps | void> = (
   config,
   { faceIDPermission } = {}
 ) => {

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 16.0.0 — 2024-10-22
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 16.0.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
@@ -1,5 +1,5 @@
 import type { ExpoConfig } from 'expo/config';
-export type WithExpoLocalization = {
+export type WithExpoLocalizationProps = {
     supportsRTL?: boolean;
     forcesRTL?: boolean;
     allowDynamicLocaleChangesAndroid?: boolean;
@@ -7,6 +7,6 @@ export type WithExpoLocalization = {
 /**
  * @deprecated use `WithExpoLocalization` instead
  */
-export type ConfigPluginProps = WithExpoLocalization;
-declare function withExpoLocalization(config: ExpoConfig, data?: WithExpoLocalization): ExpoConfig;
+export type ConfigPluginProps = WithExpoLocalizationProps;
+declare function withExpoLocalization(config: ExpoConfig, data?: WithExpoLocalizationProps): ExpoConfig;
 export default withExpoLocalization;

--- a/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
@@ -1,8 +1,12 @@
 import type { ExpoConfig } from 'expo/config';
-type ConfigPluginProps = {
+export type WithExpoLocalization = {
     supportsRTL?: boolean;
     forcesRTL?: boolean;
     allowDynamicLocaleChangesAndroid?: boolean;
 };
-declare function withExpoLocalization(config: ExpoConfig, data?: ConfigPluginProps): ExpoConfig;
+/**
+ * @deprecated use `WithExpoLocalization` instead
+ */
+export type ConfigPluginProps = WithExpoLocalization;
+declare function withExpoLocalization(config: ExpoConfig, data?: WithExpoLocalization): ExpoConfig;
 export default withExpoLocalization;

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -6,7 +6,7 @@ import {
   withStringsXml,
 } from 'expo/config-plugins';
 
-export type WithExpoLocalization = {
+export type WithExpoLocalizationProps = {
   supportsRTL?: boolean;
   forcesRTL?: boolean;
   allowDynamicLocaleChangesAndroid?: boolean;
@@ -15,9 +15,9 @@ export type WithExpoLocalization = {
 /**
  * @deprecated use `WithExpoLocalization` instead
  */
-export type ConfigPluginProps = WithExpoLocalization;
+export type ConfigPluginProps = WithExpoLocalizationProps;
 
-function withExpoLocalizationIos(config: ExpoConfig, data: WithExpoLocalization) {
+function withExpoLocalizationIos(config: ExpoConfig, data: WithExpoLocalizationProps) {
   const mergedConfig = { ...config.extra, ...data };
   if (mergedConfig?.supportsRTL == null && mergedConfig?.forcesRTL == null) return config;
   if (!config.ios) config.ios = {};
@@ -31,7 +31,7 @@ function withExpoLocalizationIos(config: ExpoConfig, data: WithExpoLocalization)
   return config;
 }
 
-function withExpoLocalizationAndroid(config: ExpoConfig, data: WithExpoLocalization) {
+function withExpoLocalizationAndroid(config: ExpoConfig, data: WithExpoLocalizationProps) {
   if (data.allowDynamicLocaleChangesAndroid) {
     config = withAndroidManifest(config, (config) => {
       const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
@@ -74,7 +74,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: WithExpoLocalizat
 
 function withExpoLocalization(
   config: ExpoConfig,
-  data: WithExpoLocalization = {
+  data: WithExpoLocalizationProps = {
     allowDynamicLocaleChangesAndroid: true,
   }
 ) {

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -6,13 +6,18 @@ import {
   withStringsXml,
 } from 'expo/config-plugins';
 
-type ConfigPluginProps = {
+export type WithExpoLocalization = {
   supportsRTL?: boolean;
   forcesRTL?: boolean;
   allowDynamicLocaleChangesAndroid?: boolean;
 };
 
-function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
+/**
+ * @deprecated use `WithExpoLocalization` instead
+ */
+export type ConfigPluginProps = WithExpoLocalization;
+
+function withExpoLocalizationIos(config: ExpoConfig, data: WithExpoLocalization) {
   const mergedConfig = { ...config.extra, ...data };
   if (mergedConfig?.supportsRTL == null && mergedConfig?.forcesRTL == null) return config;
   if (!config.ios) config.ios = {};
@@ -26,7 +31,7 @@ function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
   return config;
 }
 
-function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps) {
+function withExpoLocalizationAndroid(config: ExpoConfig, data: WithExpoLocalization) {
   if (data.allowDynamicLocaleChangesAndroid) {
     config = withAndroidManifest(config, (config) => {
       const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
@@ -69,7 +74,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
 
 function withExpoLocalization(
   config: ExpoConfig,
-  data: ConfigPluginProps = {
+  data: WithExpoLocalization = {
     allowDynamicLocaleChangesAndroid: true,
   }
 ) {

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 18.0.1 — 2024-10-22
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 18.0.1 — 2024-10-22
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-location/plugin/build/withLocation.d.ts
+++ b/packages/expo-location/plugin/build/withLocation.d.ts
@@ -1,10 +1,11 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    locationAlwaysAndWhenInUsePermission?: string | false | undefined;
-    locationAlwaysPermission?: string | false | undefined;
-    locationWhenInUsePermission?: string | false | undefined;
-    isIosBackgroundLocationEnabled?: boolean | undefined;
-    isAndroidBackgroundLocationEnabled?: boolean | undefined;
-    isAndroidForegroundServiceEnabled?: boolean | undefined;
-}>;
+export type WithLocationProps = {
+    locationAlwaysAndWhenInUsePermission?: string | false;
+    locationAlwaysPermission?: string | false;
+    locationWhenInUsePermission?: string | false;
+    isIosBackgroundLocationEnabled?: boolean;
+    isAndroidBackgroundLocationEnabled?: boolean;
+    isAndroidForegroundServiceEnabled?: boolean;
+};
+declare const _default: ConfigPlugin<void | WithLocationProps>;
 export default _default;

--- a/packages/expo-location/plugin/src/withLocation.ts
+++ b/packages/expo-location/plugin/src/withLocation.ts
@@ -9,6 +9,15 @@ import {
 const pkg = require('expo-location/package.json');
 const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
 
+export type WithLocationProps = {
+  locationAlwaysAndWhenInUsePermission?: string | false;
+  locationAlwaysPermission?: string | false;
+  locationWhenInUsePermission?: string | false;
+  isIosBackgroundLocationEnabled?: boolean;
+  isAndroidBackgroundLocationEnabled?: boolean;
+  isAndroidForegroundServiceEnabled?: boolean;
+};
+
 const withBackgroundLocation: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
     if (!Array.isArray(config.modResults.UIBackgroundModes)) {
@@ -21,16 +30,7 @@ const withBackgroundLocation: ConfigPlugin = (config) => {
   });
 };
 
-const withLocation: ConfigPlugin<
-  {
-    locationAlwaysAndWhenInUsePermission?: string | false;
-    locationAlwaysPermission?: string | false;
-    locationWhenInUsePermission?: string | false;
-    isIosBackgroundLocationEnabled?: boolean;
-    isAndroidBackgroundLocationEnabled?: boolean;
-    isAndroidForegroundServiceEnabled?: boolean;
-  } | void
-> = (
+const withLocation: ConfigPlugin<WithLocationProps | void> = (
   config,
   {
     locationAlwaysAndWhenInUsePermission,

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 17.0.2 — 2024-11-05
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 17.0.2 — 2024-11-05
 

--- a/packages/expo-media-library/plugin/build/withMediaLibrary.d.ts
+++ b/packages/expo-media-library/plugin/build/withMediaLibrary.d.ts
@@ -1,8 +1,9 @@
 import { ConfigPlugin, AndroidConfig } from 'expo/config-plugins';
+export type WithMediaLibraryProps = {
+    photosPermission?: string | false;
+    savePhotosPermission?: string | false;
+    isAccessMediaLocationEnabled?: boolean;
+};
 export declare function modifyAndroidManifest(manifest: AndroidConfig.Manifest.AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
-declare const _default: ConfigPlugin<void | {
-    photosPermission?: string | false | undefined;
-    savePhotosPermission?: string | false | undefined;
-    isAccessMediaLocationEnabled?: boolean | undefined;
-}>;
+declare const _default: ConfigPlugin<void | WithMediaLibraryProps>;
 export default _default;

--- a/packages/expo-media-library/plugin/src/withMediaLibrary.ts
+++ b/packages/expo-media-library/plugin/src/withMediaLibrary.ts
@@ -8,6 +8,12 @@ import {
 
 const pkg = require('expo-media-library/package.json');
 
+export type WithMediaLibraryProps = {
+  photosPermission?: string | false;
+  savePhotosPermission?: string | false;
+  isAccessMediaLocationEnabled?: boolean;
+};
+
 export function modifyAndroidManifest(
   manifest: AndroidConfig.Manifest.AndroidManifest
 ): AndroidConfig.Manifest.AndroidManifest {
@@ -26,13 +32,10 @@ const withMediaLibraryExternalStorage: ConfigPlugin = (config) => {
   });
 };
 
-const withMediaLibrary: ConfigPlugin<
-  {
-    photosPermission?: string | false;
-    savePhotosPermission?: string | false;
-    isAccessMediaLocationEnabled?: boolean;
-  } | void
-> = (config, { photosPermission, savePhotosPermission, isAccessMediaLocationEnabled } = {}) => {
+const withMediaLibrary: ConfigPlugin<WithMediaLibraryProps | void> = (
+  config,
+  { photosPermission, savePhotosPermission, isAccessMediaLocationEnabled } = {}
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSPhotoLibraryUsageDescription: 'Allow $(PRODUCT_NAME) to access your photos',
     NSPhotoLibraryAddUsageDescription: 'Allow $(PRODUCT_NAME) to save photos',

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 4.0.2 — 2024-10-29
 

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 4.0.2 — 2024-10-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-navigation-bar/plugin/build/withNavigationBar.d.ts
+++ b/packages/expo-navigation-bar/plugin/build/withNavigationBar.d.ts
@@ -1,7 +1,7 @@
 import { ExpoConfig } from 'expo/config';
 import { ConfigPlugin, AndroidConfig } from 'expo/config-plugins';
 import { NavigationBarVisibility, NavigationBarBehavior, NavigationBarPosition, NavigationBarButtonStyle } from 'expo-navigation-bar';
-export type Props = {
+export type WithNavigationBarProps = {
     borderColor?: string;
     backgroundColor?: string | null;
     barStyle?: NavigationBarButtonStyle | null;
@@ -10,14 +10,18 @@ export type Props = {
     position?: NavigationBarPosition;
     legacyVisible?: NonNullable<NonNullable<ExpoConfig['androidNavigationBar']>['visible']>;
 };
-export declare function resolveProps(config: Pick<ExpoConfig, 'androidNavigationBar'>, _props: Props | void): Props;
+/**
+ * @deprecated Use `WithNavigationBarProps` instead.
+ */
+export type Props = WithNavigationBarProps;
+export declare function resolveProps(config: Pick<ExpoConfig, 'androidNavigationBar'>, _props: WithNavigationBarProps | void): WithNavigationBarProps;
 /**
  * Ensure the Expo Go manifest is updated when the project is using config plugin properties instead
  * of the static values that Expo Go reads from (`androidNavigationBar`).
  */
-export declare const withAndroidNavigationBarExpoGoManifest: ConfigPlugin<Props>;
-export declare function setStrings(strings: AndroidConfig.Resources.ResourceXML, { borderColor, visibility, position, behavior, legacyVisible, }: Omit<Props, 'backgroundColor' | 'barStyle'>): AndroidConfig.Resources.ResourceXML;
-export declare function setNavigationBarColors({ backgroundColor }: Pick<Props, 'backgroundColor'>, colors: AndroidConfig.Resources.ResourceXML): AndroidConfig.Resources.ResourceXML;
-export declare function setNavigationBarStyles({ backgroundColor, barStyle }: Pick<Props, 'backgroundColor' | 'barStyle'>, styles: AndroidConfig.Resources.ResourceXML): AndroidConfig.Resources.ResourceXML;
-declare const _default: ConfigPlugin<void | Props>;
+export declare const withAndroidNavigationBarExpoGoManifest: ConfigPlugin<WithNavigationBarProps>;
+export declare function setStrings(strings: AndroidConfig.Resources.ResourceXML, { borderColor, visibility, position, behavior, legacyVisible, }: Omit<WithNavigationBarProps, 'backgroundColor' | 'barStyle'>): AndroidConfig.Resources.ResourceXML;
+export declare function setNavigationBarColors({ backgroundColor }: Pick<WithNavigationBarProps, 'backgroundColor'>, colors: AndroidConfig.Resources.ResourceXML): AndroidConfig.Resources.ResourceXML;
+export declare function setNavigationBarStyles({ backgroundColor, barStyle }: Pick<WithNavigationBarProps, 'backgroundColor' | 'barStyle'>, styles: AndroidConfig.Resources.ResourceXML): AndroidConfig.Resources.ResourceXML;
+declare const _default: ConfigPlugin<void | WithNavigationBarProps>;
 export default _default;

--- a/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
+++ b/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
@@ -23,7 +23,7 @@ const debug = Debug('expo:system-navigation-bar:plugin');
 
 const pkg = require('expo-navigation-bar/package.json');
 
-export type Props = {
+export type WithNavigationBarProps = {
   borderColor?: string;
   backgroundColor?: string | null;
   barStyle?: NavigationBarButtonStyle | null;
@@ -32,6 +32,11 @@ export type Props = {
   position?: NavigationBarPosition;
   legacyVisible?: NonNullable<NonNullable<ExpoConfig['androidNavigationBar']>['visible']>;
 };
+
+/**
+ * @deprecated Use `WithNavigationBarProps` instead.
+ */
+export type Props = WithNavigationBarProps;
 
 // strings.xml keys, this should not change.
 const BORDER_COLOR_KEY = 'expo_navigation_bar_border_color';
@@ -68,9 +73,9 @@ function convertColorAndroid(input: string): number {
 
 export function resolveProps(
   config: Pick<ExpoConfig, 'androidNavigationBar'>,
-  _props: Props | void
-): Props {
-  let props: Props;
+  _props: WithNavigationBarProps | void
+): WithNavigationBarProps {
+  let props: WithNavigationBarProps;
   if (!_props) {
     props = {
       backgroundColor: config.androidNavigationBar?.backgroundColor,
@@ -102,7 +107,10 @@ export function resolveProps(
  * Ensure the Expo Go manifest is updated when the project is using config plugin properties instead
  * of the static values that Expo Go reads from (`androidNavigationBar`).
  */
-export const withAndroidNavigationBarExpoGoManifest: ConfigPlugin<Props> = (config, props) => {
+export const withAndroidNavigationBarExpoGoManifest: ConfigPlugin<WithNavigationBarProps> = (
+  config,
+  props
+) => {
   if (!config.androidNavigationBar) {
     // Remap the config plugin props so Expo Go knows how to apply them.
     config.androidNavigationBar = {
@@ -116,7 +124,7 @@ export const withAndroidNavigationBarExpoGoManifest: ConfigPlugin<Props> = (conf
   return config;
 };
 
-const withNavigationBar: ConfigPlugin<Props | void> = (config, _props) => {
+const withNavigationBar: ConfigPlugin<WithNavigationBarProps | void> = (config, _props) => {
   const props = resolveProps(config, _props);
 
   config = withAndroidNavigationBarExpoGoManifest(config, props);
@@ -148,7 +156,7 @@ export function setStrings(
     position,
     behavior,
     legacyVisible,
-  }: Omit<Props, 'backgroundColor' | 'barStyle'>
+  }: Omit<WithNavigationBarProps, 'backgroundColor' | 'barStyle'>
 ): AndroidConfig.Resources.ResourceXML {
   const pairs = [
     [BORDER_COLOR_KEY, borderColor ? convertColorAndroid(borderColor) : null],
@@ -177,17 +185,19 @@ export function setStrings(
   return AndroidConfig.Strings.setStringItem(stringItems, strings);
 }
 
-const withNavigationBarColors: ConfigPlugin<Pick<Props, 'backgroundColor'>> = (config, props) => {
+const withNavigationBarColors: ConfigPlugin<Pick<WithNavigationBarProps, 'backgroundColor'>> = (
+  config,
+  props
+) => {
   return withAndroidColors(config, (config) => {
     config.modResults = setNavigationBarColors(props, config.modResults);
     return config;
   });
 };
 
-const withNavigationBarStyles: ConfigPlugin<Pick<Props, 'backgroundColor' | 'barStyle'>> = (
-  config,
-  props
-) => {
+const withNavigationBarStyles: ConfigPlugin<
+  Pick<WithNavigationBarProps, 'backgroundColor' | 'barStyle'>
+> = (config, props) => {
   return withAndroidStyles(config, (config) => {
     config.modResults = setNavigationBarStyles(props, config.modResults);
     return config;
@@ -195,7 +205,7 @@ const withNavigationBarStyles: ConfigPlugin<Pick<Props, 'backgroundColor' | 'bar
 };
 
 export function setNavigationBarColors(
-  { backgroundColor }: Pick<Props, 'backgroundColor'>,
+  { backgroundColor }: Pick<WithNavigationBarProps, 'backgroundColor'>,
   colors: AndroidConfig.Resources.ResourceXML
 ): AndroidConfig.Resources.ResourceXML {
   if (backgroundColor) {
@@ -211,7 +221,7 @@ export function setNavigationBarColors(
 }
 
 export function setNavigationBarStyles(
-  { backgroundColor, barStyle }: Pick<Props, 'backgroundColor' | 'barStyle'>,
+  { backgroundColor, barStyle }: Pick<WithNavigationBarProps, 'backgroundColor' | 'barStyle'>,
   styles: AndroidConfig.Resources.ResourceXML
 ): AndroidConfig.Resources.ResourceXML {
   styles = AndroidConfig.Styles.assignStylesValue(styles, {

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
+
 ## 4.0.2 — 2024-11-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-router/plugin/build/index.d.ts
+++ b/packages/expo-router/plugin/build/index.d.ts
@@ -1,5 +1,5 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const withRouter: ConfigPlugin<{
+export type WithRouterProps = {
     /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
     origin?: string;
     /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
@@ -17,5 +17,6 @@ declare const withRouter: ConfigPlugin<{
     sitemap?: boolean;
     /** Generate partial typed routes */
     partialTypedGroups?: boolean;
-} | void>;
+};
+declare const withRouter: ConfigPlugin<WithRouterProps | void>;
 export default withRouter;

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -3,6 +3,21 @@ import { validate } from 'schema-utils';
 
 const schema = require('../options.json');
 
+export type WithRouterProps = {
+  /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
+  origin?: string;
+  /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
+  headOrigin?: string;
+  /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
+  root?: string;
+  /** Should Async Routes be enabled, currently only `development` is supported. */
+  asyncRoutes?: string | { android?: string; ios?: string; web?: string; default?: string };
+  /** Should the sitemap be generated. Defaults to `true` */
+  sitemap?: boolean;
+  /** Generate partial typed routes */
+  partialTypedGroups?: boolean;
+};
+
 const withExpoHeadIos: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
     // TODO: Add a way to enable this...
@@ -23,22 +38,7 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
   });
 };
 
-const withRouter: ConfigPlugin<
-  {
-    /** Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production, development origin is inferred using the Expo CLI development server. */
-    origin?: string;
-    /** A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`. */
-    headOrigin?: string;
-    /** Should Async Routes be enabled. `production` is currently web-only and will be disabled on native. */
-    root?: string;
-    /** Should Async Routes be enabled, currently only `development` is supported. */
-    asyncRoutes?: string | { android?: string; ios?: string; web?: string; default?: string };
-    /** Should the sitemap be generated. Defaults to `true` */
-    sitemap?: boolean;
-    /** Generate partial typed routes */
-    partialTypedGroups?: boolean;
-  } | void
-> = (config, _props) => {
+const withRouter: ConfigPlugin<WithRouterProps | void> = (config, _props) => {
   const props = _props || {};
   validate(schema, props);
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 14.0.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 14.0.0 — 2024-10-22
 

--- a/packages/expo-secure-store/plugin/build/withSecureStore.d.ts
+++ b/packages/expo-secure-store/plugin/build/withSecureStore.d.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    faceIDPermission?: string | false | undefined;
-    configureAndroidBackup?: boolean | undefined;
-}>;
+export type WithSecureStoreProps = {
+    faceIDPermission?: string | false;
+    configureAndroidBackup?: boolean;
+};
+declare const _default: ConfigPlugin<void | WithSecureStoreProps>;
 export default _default;

--- a/packages/expo-secure-store/plugin/src/withSecureStore.ts
+++ b/packages/expo-secure-store/plugin/src/withSecureStore.ts
@@ -12,12 +12,15 @@ const BACKUP_RULES_PATH = '@xml/secure_store_backup_rules';
 const EXTRACTION_RULES_PATH = '@xml/secure_store_data_extraction_rules';
 const FACEID_USAGE = 'Allow $(PRODUCT_NAME) to access your Face ID biometric data.';
 
-const withSecureStore: ConfigPlugin<
-  {
-    faceIDPermission?: string | false;
-    configureAndroidBackup?: boolean;
-  } | void
-> = (config, { faceIDPermission, configureAndroidBackup = true } = {}) => {
+export type WithSecureStoreProps = {
+  faceIDPermission?: string | false;
+  configureAndroidBackup?: boolean;
+};
+
+const withSecureStore: ConfigPlugin<WithSecureStoreProps | void> = (
+  config,
+  { faceIDPermission, configureAndroidBackup = true } = {}
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSFaceIDUsageDescription: FACEID_USAGE,
   })(config, {

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 14.0.1 — 2024-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 14.0.1 — 2024-10-28
 

--- a/packages/expo-sensors/plugin/build/withSensors.d.ts
+++ b/packages/expo-sensors/plugin/build/withSensors.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
-    motionPermission?: string | false | undefined;
-}>;
+export type WithSensorsProps = {
+    motionPermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithSensorsProps>;
 export default _default;

--- a/packages/expo-sensors/plugin/src/withSensors.ts
+++ b/packages/expo-sensors/plugin/src/withSensors.ts
@@ -8,10 +8,11 @@ import {
 const pkg = require('expo-sensors/package.json');
 const MOTION_USAGE = 'Allow $(PRODUCT_NAME) to access your device motion';
 
-const withSensors: ConfigPlugin<{ motionPermission?: string | false } | void> = (
-  config,
-  { motionPermission } = {}
-) => {
+export type WithSensorsProps = {
+  motionPermission?: string | false;
+};
+
+const withSensors: ConfigPlugin<WithSensorsProps | void> = (config, { motionPermission } = {}) => {
   if (motionPermission === false) {
     config = withPodfileProperties(config, (config) => {
       config.modResults.MOTION_PERMISSION = 'false';

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 0.29.6 — 2024-11-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 0.29.6 — 2024-11-11
 

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
@@ -1,7 +1,7 @@
 import { AndroidSplashConfig } from '@expo/prebuild-config/build/plugins/unversioned/expo-splash-screen/getAndroidSplashConfig';
 import { IOSSplashConfig } from '@expo/prebuild-config/build/plugins/unversioned/expo-splash-screen/getIosSplashConfig';
 import { ConfigPlugin } from 'expo/config-plugins';
-type PluginConfig = {
+export type WithSplashScreenProps = {
     backgroundColor: string;
     imageWidth?: number;
     enableFullScreenImage_legacy?: boolean;
@@ -13,5 +13,5 @@ type PluginConfig = {
     android?: AndroidSplashConfig;
     ios?: IOSSplashConfig;
 };
-declare const _default: ConfigPlugin<PluginConfig>;
+declare const _default: ConfigPlugin<void | WithSplashScreenProps>;
 export default _default;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.js
@@ -5,6 +5,9 @@ const withIosSplashScreen_1 = require("@expo/prebuild-config/build/plugins/unver
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-splash-screen/package.json');
 const withSplashScreen = (config, props) => {
+    if (!props) {
+        return config;
+    }
     const android = {
         ...props,
         ...props?.android,

--- a/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
@@ -6,7 +6,7 @@ import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
 const pkg = require('expo-splash-screen/package.json');
 
-type PluginConfig = {
+export type WithSplashScreenProps = {
   backgroundColor: string;
   imageWidth?: number;
   enableFullScreenImage_legacy?: boolean;
@@ -19,7 +19,11 @@ type PluginConfig = {
   ios?: IOSSplashConfig;
 };
 
-const withSplashScreen: ConfigPlugin<PluginConfig> = (config, props) => {
+const withSplashScreen: ConfigPlugin<WithSplashScreenProps | void> = (config, props) => {
+  if (!props) {
+    return config;
+  }
+
   const android: AndroidSplashConfig = {
     ...props,
     ...props?.android,

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 15.0.2 — 2024-11-07
 
 ### 💡 Others

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 15.0.2 — 2024-11-07
 

--- a/packages/expo-sqlite/plugin/build/withSQLite.d.ts
+++ b/packages/expo-sqlite/plugin/build/withSQLite.d.ts
@@ -1,5 +1,5 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-interface Props {
+export type WithSQLiteProps = {
     customBuildFlags?: string;
     enableFTS?: boolean;
     useSQLCipher?: boolean;
@@ -13,6 +13,6 @@ interface Props {
         enableFTS?: boolean;
         useSQLCipher?: boolean;
     };
-}
-declare const _default: ConfigPlugin<Props>;
+};
+declare const _default: ConfigPlugin<void | WithSQLiteProps>;
 export default _default;

--- a/packages/expo-sqlite/plugin/build/withSQLite.js
+++ b/packages/expo-sqlite/plugin/build/withSQLite.js
@@ -3,6 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-sqlite/package.json');
 const withSQLite = (config, props) => {
+    if (!props) {
+        return config;
+    }
     config = withSQLiteAndroidProps(config, props);
     config = withSQLiteIOSProps(config, props);
     return config;

--- a/packages/expo-sqlite/plugin/src/withSQLite.ts
+++ b/packages/expo-sqlite/plugin/src/withSQLite.ts
@@ -8,7 +8,7 @@ import {
 
 const pkg = require('expo-sqlite/package.json');
 
-interface Props {
+export type WithSQLiteProps = {
   customBuildFlags?: string;
   enableFTS?: boolean;
   useSQLCipher?: boolean;
@@ -22,15 +22,19 @@ interface Props {
     enableFTS?: boolean;
     useSQLCipher?: boolean;
   };
-}
+};
 
-const withSQLite: ConfigPlugin<Props> = (config, props) => {
+const withSQLite: ConfigPlugin<WithSQLiteProps | void> = (config, props) => {
+  if (!props) {
+    return config;
+  }
+
   config = withSQLiteAndroidProps(config, props);
   config = withSQLiteIOSProps(config, props);
   return config;
 };
 
-const withSQLiteAndroidProps: ConfigPlugin<Props> = (config, props) => {
+const withSQLiteAndroidProps: ConfigPlugin<WithSQLiteProps> = (config, props) => {
   return withGradleProperties(config, (config) => {
     const customBuildFlags = props?.android?.customBuildFlags ?? props?.customBuildFlags;
     const enableFTS = props?.android?.enableFTS ?? props?.enableFTS;
@@ -55,7 +59,7 @@ const withSQLiteAndroidProps: ConfigPlugin<Props> = (config, props) => {
   });
 };
 
-const withSQLiteIOSProps: ConfigPlugin<Props> = (config, props) => {
+const withSQLiteIOSProps: ConfigPlugin<WithSQLiteProps> = (config, props) => {
   return withPodfileProperties(config, (config) => {
     const customBuildFlags = props?.ios?.customBuildFlags ?? props?.customBuildFlags;
     const enableFTS = props?.ios?.enableFTS ?? props?.enableFTS;

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 5.0.0 — 2024-10-22
 

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 5.0.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-tracking-transparency/plugin/build/withTrackingTransparency.d.ts
+++ b/packages/expo-tracking-transparency/plugin/build/withTrackingTransparency.d.ts
@@ -1,11 +1,12 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void | {
+export type WithTrackingTransparencyProps = {
     /**
      * Sets the iOS `NSUserTrackingUsageDescription` permission message in `Info.plist`. Omitting a
      * description will result in using the default permission message.
      * @default 'Allow this app to collect app-related data that can be used for tracking you or your
      * device.'
      */
-    userTrackingPermission?: string | false | undefined;
-}>;
+    userTrackingPermission?: string | false;
+};
+declare const _default: ConfigPlugin<void | WithTrackingTransparencyProps>;
 export default _default;

--- a/packages/expo-tracking-transparency/plugin/src/withTrackingTransparency.ts
+++ b/packages/expo-tracking-transparency/plugin/src/withTrackingTransparency.ts
@@ -5,17 +5,20 @@ const pkg = require('expo-tracking-transparency/package.json');
 const DEFAULT_NSUserTrackingUsageDescription =
   'Allow this app to collect app-related data that can be used for tracking you or your device.';
 
-const withTrackingTransparency: ConfigPlugin<
-  {
-    /**
-     * Sets the iOS `NSUserTrackingUsageDescription` permission message in `Info.plist`. Omitting a
-     * description will result in using the default permission message.
-     * @default 'Allow this app to collect app-related data that can be used for tracking you or your
-     * device.'
-     */
-    userTrackingPermission?: string | false;
-  } | void
-> = (config, props) => {
+export type WithTrackingTransparencyProps = {
+  /**
+   * Sets the iOS `NSUserTrackingUsageDescription` permission message in `Info.plist`. Omitting a
+   * description will result in using the default permission message.
+   * @default 'Allow this app to collect app-related data that can be used for tracking you or your
+   * device.'
+   */
+  userTrackingPermission?: string | false;
+};
+
+const withTrackingTransparency: ConfigPlugin<WithTrackingTransparencyProps | void> = (
+  config,
+  props
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSUserTrackingUsageDescription: DEFAULT_NSUserTrackingUsageDescription,
   })(config, {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- export config plugin types
+
 ## 2.0.0 — 2024-11-11
 
 ### 💡 Others

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- export config plugin types
+- export config plugin types ([#32786](https://github.com/expo/expo/pull/32786) by [@leonhh](https://github.com/leonhh))
 
 ## 2.0.0 — 2024-11-11
 

--- a/packages/expo-video/plugin/build/withExpoVideo.d.ts
+++ b/packages/expo-video/plugin/build/withExpoVideo.d.ts
@@ -1,7 +1,7 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
-type WithExpoVideoOptions = {
+export type WithExpoVideoProps = {
     supportsBackgroundPlayback?: boolean;
     supportsPictureInPicture?: boolean;
 };
-declare const withExpoVideo: ConfigPlugin<WithExpoVideoOptions>;
+declare const withExpoVideo: ConfigPlugin<WithExpoVideoProps | void>;
 export default withExpoVideo;

--- a/packages/expo-video/plugin/src/withExpoVideo.ts
+++ b/packages/expo-video/plugin/src/withExpoVideo.ts
@@ -5,12 +5,12 @@ import {
   withAndroidManifest,
 } from 'expo/config-plugins';
 
-type WithExpoVideoOptions = {
+export type WithExpoVideoProps = {
   supportsBackgroundPlayback?: boolean;
   supportsPictureInPicture?: boolean;
 };
 
-const withExpoVideo: ConfigPlugin<WithExpoVideoOptions> = (
+const withExpoVideo: ConfigPlugin<WithExpoVideoProps | void> = (
   config,
   { supportsBackgroundPlayback, supportsPictureInPicture } = {}
 ) => {


### PR DESCRIPTION
# Why

To allow type checking/hints in `app.config.ts` files like this:

```ts
import { ConfigContext, ExpoConfig } from 'expo/config';
import { WithCameraProps } from 'expo-camera/plugin/build/withCamera';

export default ({ config }: ConfigContext): ExpoConfig => ({
  ...config,
  slug: 'my-app',
  name: 'My App',
  plugins: [
    [
      'expo-camera',
      {
        cameraPermission: 'Allow $(PRODUCT_NAME) to access your camera',
      } satisfies WithCameraProps,
    ],
  ],
});
```

# How

Export the types from config plugins that can be used in the `plugins` array. 

I did not document this yet as this might not be a recommended approach.

# Test Plan

See above example

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
