### PR TITLE
fix(cli): throw error when importing native module on web.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- throw error when importing native module on web.
+- throw error when importing native module on web. ([#32790](https://github.com/expo/expo/pull/32790) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- throw error when importing native module on web.
+
 ### 💡 Others
 
 ## 0.20.4 — 2024-11-10

--- a/packages/@expo/cli/src/start/server/metro/metroErrors.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrors.ts
@@ -36,5 +36,10 @@ export function isFailedToResolveNameError(error: any): error is FailedToResolve
 }
 
 export function isFailedToResolvePathError(error: any): error is FailedToResolvePathError {
-  return !!error && 'candidates' in error && error.constructor.name === 'FailedToResolvePathError';
+  return (
+    !!error &&
+    'candidates' in error &&
+    error.constructor.name === 'FailedToResolvePathError' &&
+    !error.message.includes('Importing native-only module')
+  );
 }


### PR DESCRIPTION
# Why

Add quick hack to ensure the `react-native/Libraries/Utilities/codegenNativeCommands` import fails instantly on web.
