### PR TITLE
[tools] fix building tools on Windows

### DIFF
--- a/tools/bin/expotools.js
+++ b/tools/bin/expotools.js
@@ -5,6 +5,7 @@
 // and TypeScript files are compiled. To make it work even when node_modules are empty,
 // we shouldn't eagerly require any dependency - we have to run yarn first.
 
+const spawnAsync = require('@expo/spawn-async');
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -49,7 +50,12 @@ async function maybeRebuildAndRun() {
   // If `yarn.lock` checksum changed, reinstall expotools dependencies.
   if (!state.dependenciesChecksum || state.dependenciesChecksum !== dependenciesChecksum) {
     console.log(' 🧶 Yarning...');
-    await spawnAsync('yarn', ['install']);
+    try {
+      await spawnAsync('yarn', ['install'], { cwd: ROOT_PATH });
+    } catch (error) {
+      console.error(LogModifiers.error(` 💥 Yarning failed: ${error.stack}`));
+      process.exit(1);
+    }
   }
 
   // If checksum of source files changed, rebuild TypeScript files.
@@ -58,7 +64,7 @@ async function maybeRebuildAndRun() {
 
     try {
       // Compile TypeScript files into build folder.
-      await spawnAsync('yarn', ['run', 'build']);
+      await spawnAsync('yarn', ['run', 'build'], { cwd: ROOT_PATH });
       state.schema = await getCommandsSchemaAsync();
     } catch (error) {
       console.error(LogModifiers.error(` 💥 Rebuilding failed: ${error.stack}`));
@@ -188,29 +194,6 @@ function readState() {
 function saveState(state) {
   fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
   fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
-}
-
-function spawnAsync(command, args, options) {
-  return new Promise((resolve, reject) => {
-    const child = child_process.spawn(
-      command,
-      args,
-      options || {
-        stdio: ['pipe', 'ignore', 'pipe'],
-        ignoreStdio: true,
-        cwd: ROOT_PATH,
-      }
-    );
-
-    child.on('exit', (code) => {
-      child.removeAllListeners();
-      resolve({ code });
-    });
-    child.on('error', (error) => {
-      child.removeAllListeners();
-      reject(error);
-    });
-  });
 }
 
 function canRequire(packageName) {

--- a/tools/bin/expotools.js
+++ b/tools/bin/expotools.js
@@ -6,7 +6,6 @@
 // we shouldn't eagerly require any dependency - we have to run yarn first.
 
 const spawnAsync = require('@expo/spawn-async');
-const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
# Why

![Screenshot 2024-11-12 012856](https://github.com/user-attachments/assets/5893af1d-8858-4ebb-a99a-23e52d9c7740)

# How

Replace direct Node child process call with `@expo/spawn-async`, wrap yarning step with try-catch, so on error the exist code is correct.

# Test Plan

Tested running `et` on various directories in the monorepo, on both - Win and macOS.

