### PR TITLE
[Blocked] Add RNDateTimePickerPackage compatibility for Expo SDK 52

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -134,7 +134,7 @@ class ExponentPackage : ReactPackage {
         nativeModules.add(NetInfoModule(reactContext))
         nativeModules.addAll(SvgPackage().getNativeModuleIterator(reactContext).map { it.module })
         nativeModules.addAll(MapsPackage().createNativeModules(reactContext))
-        nativeModules.addAll(RNDateTimePickerPackage().getReactModuleInfoProvider().getReactModuleInfos().map { RNDateTimePickerPackage().getModule(it.value.name(), reactContext)!! })
+        nativeModules.addAll(dateTimePickerPackage.createNativeModules(reactContext))
         nativeModules.addAll(stripePackage.createNativeModules(reactContext))
         nativeModules.addAll(skiaPackage.createNativeModules(reactContext))
 
@@ -173,7 +173,7 @@ class ExponentPackage : ReactPackage {
         RNGestureHandlerPackage(),
         RNScreensPackage(),
         RNCWebViewPackage(),
-        RNDateTimePickerPackage(),
+        dateTimePickerPackage,
         RNCMaskedViewPackage(),
         RNCPickerPackage(),
         ReactSliderPackage(),
@@ -215,6 +215,7 @@ class ExponentPackage : ReactPackage {
     // Need to avoid initializing duplicated packages
     private val stripePackage = StripeSdkPackage()
     private val skiaPackage = RNSkiaPackage()
+    private val dateTimePickerPackage = RNDateTimePickerPackage()
 
     fun kernelExponentPackage(
       context: Context,


### PR DESCRIPTION

# Why

https://github.com/react-native-datetimepicker/datetimepicker/issues/939
https://github.com/expo/expo/issues/32525
https://github.com/expo/expo/pull/32591

Date Time Picker PR: [link](https://github.com/react-native-datetimepicker/datetimepicker/pull/940)

# How

Updated RNDateTimePickerPackage to:
- Adjust getReactModuleInfoProvider and createNativeModules to align with Expo’s native module compatibility.
- Implement createViewManagers, returning an empty list to meet TurboReactPackage requirements.

# Test Plan

1. Build and run the Expo app using SDK 52.
2. Confirm that the `RNDateTimePicker` functionality works as expected on both iOS and Android devices.
3. Validate that there are no issues with native module loading or registration.

### Expected Results
- `RNDateTimePicker` should function correctly, with no errors during module registration or usage.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
