### PR TITLE
[docs] Add warning callout on Splash Screen guide for Android 12+ behavior of full screen splash image

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -20,6 +20,8 @@ A splash screen and an app icon are fundamental elements of a mobile app. They p
 
 ## Splash screen
 
+> **warning** This section uses the `splash` property from the app config. **Starting SDK 52**, using `expo-splash-screen` config plugin is recommended because using a full screen splash image on Android 12+ will not work. See [`expo-splash-screen` reference](/versions/v52.0.0/sdk/splash-screen/#configuration) on how to use the config plugin.
+
 A splash screen, also known as a launch screen, is the first screen a user sees when they open your app. It stays visible while the app is loading. You can also control the behavior of when a splash screen disappears by using the native [SplashScreen API](/versions/latest/sdk/splash-screen).
 
 The default splash screen in an Expo project is a blank white screen. It can be customized using the [`splash`](/versions/latest/config/app/#splash) property in the project's [app config](/workflow/configuration) using the steps below.

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -20,7 +20,7 @@ A splash screen and an app icon are fundamental elements of a mobile app. They p
 
 ## Splash screen
 
-> **warning** This section uses the `splash` property from the app config. **Starting SDK 52**, using `expo-splash-screen` config plugin is recommended because using a full screen splash image on Android 12+ will not work. See [`expo-splash-screen` reference](/versions/v52.0.0/sdk/splash-screen/#configuration) on how to use the config plugin.
+> **warning** This section uses the `splash` property from the app config. **Starting SDK 52**, using `expo-splash-screen` config plugin is recommended because using a full screen splash image on Android 12+ will not work so the following information for Android is outdated. See [`expo-splash-screen` reference](/versions/v52.0.0/sdk/splash-screen/#configuration) on how to use the config plugin and for up-to-date information.
 
 A splash screen, also known as a launch screen, is the first screen a user sees when they open your app. It stays visible while the app is loading. You can also control the behavior of when a splash screen disappears by using the native [SplashScreen API](/versions/latest/sdk/splash-screen).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Check [Improvements and Known Limitations for `expo-splash-screen`](https://github.com/expo/universe/pull/17396/files#diff-65da414558cae26fac4cbd830183e14316e8142db94f4c975ad43d6e0eb4dd7bR107) section from the upcoming SDK 52 release notes.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a warning callout the briefly explains that using full screen splash image doesn't work with Android 12+ and link to `expo-splash-screen` config plugin example in Splash Screen section of the guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-12 at 18 27 06](https://github.com/user-attachments/assets/9bf22bf1-693b-4299-a7c0-9868b63b88d2)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
