### PR TITLE
[docs] Add babel.config.js reference

### DIFF
--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -10,7 +10,7 @@ Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) i
 
 Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 
-## Customize babel.config.js
+## Create babel.config.js
 
 If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
 

--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -6,7 +6,7 @@ isNew: true
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
+Babel is used as the JavaScript compiler to transform modern JavaScript (ES6+) into a version compatible with the JavaScript engine on mobile devices.
 
 Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 

--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -8,9 +8,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
 
-Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset.
+Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 
-## Add babel.config.js file
+## Customize babel.config.js
 
 If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
 

--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -1,0 +1,36 @@
+---
+title: babel.config.js
+description: A reference for Babel configuration file.
+isNew: true
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
+
+Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset.
+
+## Add babel.config.js file
+
+If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
+
+1. Navigate to the root of your project, run the following command inside a terminal:
+
+<Terminal cmd={['$ npx expo customize']} />
+
+2. This command will prompt generating different config files. Select **babel.config.js**.
+
+3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
+
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};
+```
+
+## babel-preset-expo
+
+[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds supports for decorators, tree-shaking web libraries, and loading font icons.

--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -12,13 +12,13 @@ Each new Expo project created using `npx create-expo-app` configures Babel autom
 
 ## Create babel.config.js
 
-If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
+If your project requires a custom Babel configuration, you need to create the **babel.config.js** file in your project by following the steps below:
 
 1. Navigate to the root of your project, run the following command inside a terminal:
 
 <Terminal cmd={['$ npx expo customize']} />
 
-2. This command will prompt generating different config files. Select **babel.config.js**.
+2. This command prompts generating different config files. Select **babel.config.js**.
 
 3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
 
@@ -33,4 +33,4 @@ module.exports = function (api) {
 
 ## babel-preset-expo
 
-[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds supports for decorators, tree-shaking web libraries, and loading font icons.
+[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds support for decorators, tree-shaking web libraries, and loading font icons.

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -10,7 +10,7 @@ Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) i
 
 Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 
-## Customize babel.config.js
+## Create babel.config.js
 
 If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
 

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -6,7 +6,7 @@ isNew: true
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
+Babel is used as the JavaScript compiler to transform modern JavaScript (ES6+) into a version compatible with the JavaScript engine on mobile devices.
 
 Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -8,9 +8,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
 
-Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset.
+Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 
-## Add babel.config.js file
+## Customize babel.config.js
 
 If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
 

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -1,0 +1,36 @@
+---
+title: babel.config.js
+description: A reference for Babel configuration file.
+isNew: true
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+Babel is used as the JavaScript compiler to transform modern JavaScript (Es6+) into a version compatible with the JavaScript engine on mobile devices.
+
+Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset.
+
+## Add babel.config.js file
+
+If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
+
+1. Navigate to the root of your project, run the following command inside a terminal:
+
+<Terminal cmd={['$ npx expo customize']} />
+
+2. This command will prompt generating different config files. Select **babel.config.js**.
+
+3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
+
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};
+```
+
+## babel-preset-expo
+
+[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds supports for decorators, tree-shaking web libraries, and loading font icons.

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -12,13 +12,13 @@ Each new Expo project created using `npx create-expo-app` configures Babel autom
 
 ## Create babel.config.js
 
-If your project requires custom Babel configuration, you need to create the **babel.config.js** file in your project.
+If your project requires a custom Babel configuration, you need to create the **babel.config.js** file in your project by following the steps below:
 
 1. Navigate to the root of your project, run the following command inside a terminal:
 
 <Terminal cmd={['$ npx expo customize']} />
 
-2. This command will prompt generating different config files. Select **babel.config.js**.
+2. This command prompts generating different config files. Select **babel.config.js**.
 
 3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
 
@@ -33,4 +33,4 @@ module.exports = function (api) {
 
 ## babel-preset-expo
 
-[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds supports for decorators, tree-shaking web libraries, and loading font icons.
+[`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds support for decorators, tree-shaking web libraries, and loading font icons.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As per discussion with @brentvatne, we need a reference document to explain how to create `babel.config.js` file. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a **babel.config.js** reference doc under Reference > Configuration files section
- Inside the reference doc, add instructions creating babel.config.js
- Changes applied to unversioned and SDK 52

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-12 at 19 12 28](https://github.com/user-attachments/assets/324d2d14-b303-4ee8-91f5-2ea7e384c118)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
