### PR TITLE
[docs] Remove unnecessary await in Splash Screen docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -72,7 +72,7 @@ export default function App() {
       // loading its initial state and rendering its first pixels. So instead,
       // we hide the splash screen once we know the root view has already
       // performed layout.
-      await SplashScreen.hide();
+      SplashScreen.hide();
     }
   }, [appIsReady]);
 


### PR DESCRIPTION
# Why

The await keyword is not needed here anymore.

# How

The async keyword was already removed in the useCallback. This also removes the await keyword. This function is not async anymore as can be seen at https://docs.expo.dev/versions/unversioned/sdk/splash-screen/#splashscreenhide

# Test Plan

-

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
