### PR TITLE
[docs] Remove `await` in SplashScreen reference example

### DIFF
--- a/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
@@ -72,7 +72,7 @@ export default function App() {
       // loading its initial state and rendering its first pixels. So instead,
       // we hide the splash screen once we know the root view has already
       // performed layout.
-      await SplashScreen.hide();
+      SplashScreen.hide();
     }
   }, [appIsReady]);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up changes [32815](https://github.com/expo/expo/pull/32815) to remove unwanted `await` under Usage example in SplashScreen SDK 52 API reference.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
