### PR TITLE
[ios][camera] Fix shutter animation

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix shutter animation not running.
+- [iOS] Fix shutter animation not running. ([#32820](https://github.com/expo/expo/pull/32820) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix shutter animation not running.
+
 ### 💡 Others
 
 ## 16.0.3 — 2024-10-28

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -391,9 +391,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
       return
     }
     Task { @MainActor in
-      self.previewLayer.opacity = 0
+      self.layer.opacity = 0
       UIView.animate(withDuration: 0.25) {
-        self.previewLayer.opacity = 1
+        self.layer.opacity = 1
       }
     }
   }


### PR DESCRIPTION
# Why
Closes #32819

# How
Because of the changes to how layers are handled on ios, we should not animate the previewLayer but the layer of the view itself.

# Test Plan
bare-expo. The animation works correctly

