### PR TITLE
[docs] Remove betaVersion references

### DIFF
--- a/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
@@ -1,9 +1,5 @@
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
 
-import packageJson from '~/package.json';
-
-const BETA_MAJOR_VERSION = packageJson.betaVersion.split('.')[0];
-
 export type VersionSelectorProps = {
   version?: string | undefined;
   setVersion: (version: string) => void;
@@ -24,9 +20,7 @@ export const VersionSelector = ({
         onChange={e => setVersion(e.target.value)}>
         {availableVersions.map(version => (
           <option key={version} value={version}>
-            {version === 'unversioned'
-              ? 'unversioned'
-              : `SDK ${version}${version === BETA_MAJOR_VERSION ? '  (beta)' : ''}`}
+            {version === 'unversioned' ? 'unversioned' : `SDK ${version}`}
           </option>
         ))}
       </select>

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 
 import { VersionSelector } from './VersionSelector';
 
-import packageJson from '~/package.json';
 import versions from '~/public/static/constants/versions.json';
 import diffInfo from '~/public/static/diffs/template-bare-minimum/diffInfo.json';
 import { DiffBlock } from '~/ui/components/Snippet';
@@ -13,7 +12,6 @@ import { RawH3, RawH4 } from '~/ui/components/Text';
 
 // versions used by SDK selector. This has "unversioned" removed on production versions. The diff selectors will match that.
 const { VERSIONS } = versions;
-const BETA_MAJOR_VERSION = packageJson.betaVersion.split('.')[0];
 
 export const TemplateBareMinimumDiffViewer = () => {
   const router = useRouter();
@@ -22,7 +20,7 @@ export const TemplateBareMinimumDiffViewer = () => {
 
   // default to from: last SDK, to: current SDK
   const lastTwoProductionVersions = bareDiffVersions
-    .filter((d: string) => d !== 'unversioned' && d !== BETA_MAJOR_VERSION)
+    .filter((d: string) => d !== 'unversioned')
     .slice(-2);
 
   const fromVersion = router?.query.fromSdk || lastTwoProductionVersions[0];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove betaVersion references from certain components.

![CleanShot 2024-11-12 at 22 59 21](https://github.com/user-attachments/assets/3ad9dcab-49b6-499f-aa3c-93fd2ff58c35)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove betaVersion references from certain components as mentioned above in the screenshot.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint` and it should pass.

![CleanShot 2024-11-12 at 23 00 00](https://github.com/user-attachments/assets/f6c2352e-8c71-435b-84b1-226636e19be5)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
