### PR TITLE
[docs] Add latest in the compatible version array for `APISectionPlatformTags`

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6295,13 +6295,6 @@ exports[`APISection expo-pedometer 1`] = `
         class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
         data-text="true"
       >
-        <span
-          class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
-          data-text="true"
-        >
-          Only for:
-           
-        </span>
         <div
           class="select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
         >
@@ -6328,7 +6321,6 @@ exports[`APISection expo-pedometer 1`] = `
             iOS
           </span>
         </div>
-        <br />
       </span>
     </div>
     <h3

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -24,7 +24,7 @@ export const APISectionPlatformTags = ({
   const { platforms: defaultPlatforms } = usePageMetadata();
   const { version } = usePageApiVersion();
 
-  const isCompatibleVersion = ['unversioned', 'v52.0.0'].includes(version);
+  const isCompatibleVersion = ['unversioned', 'latest', 'v52.0.0'].includes(version);
   const platformsData = platforms || getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -20,13 +20,6 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
-      <span
-        class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
-        data-text="true"
-      >
-        Only for:
-         
-      </span>
       <div
         class="select-none inline-flex bg-element py-1 px-2 mr-2 rounded-full items-center gap-1 border border-default [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-green3 !text-palette-green12 !border-palette-green4"
       >
@@ -53,7 +46,6 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           Android
         </span>
       </div>
-      <br />
     </span>
   </div>
   <p


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/3243 and SDK 52 release

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding `latest` to the `isCompatibleVersion`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Go to a library's reference page and check for latest and SDK 52 version to see platform tags are showing:

![CleanShot 2024-11-12 at 23 30 03](https://github.com/user-attachments/assets/cbe9f6f5-c0da-47c7-95c0-6b7822e6b8ca)

![CleanShot 2024-11-12 at 23 29 57](https://github.com/user-attachments/assets/32de1a6c-d2fb-4806-8fb6-080b2a6150f2)


Also run `yarn run test -u` to update snapshots.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
