### PR TITLE
[docs] Remove SDK 49 references/callouts

### DIFF
--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -11,8 +11,6 @@ import { CODE } from '~/ui/components/Text';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server.
-
 SDK 50 added the experimental **asset selection feature**, which allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
 
 SDK 52 launched this feature to general availability.

--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -79,7 +79,7 @@ This can also be used for EAS Updates run from your [development build](/develop
 
 ## Using variables in app.config.js
 
-[Expo environment variables](/guides/environment-variables) are only available in SDK 49 or higher. In previous versions, it was common to set variables to be used in updates in **app.config.js** under the `expo.extra` property:
+In previous versions, it was common to set variables to be used in updates in **app.config.js** under the `expo.extra` property:
 
 ```js app.config.js
 export default () => ({
@@ -98,4 +98,4 @@ Then, to set the `API_URL` environment variable during development, you can prep
 
 The command sets the `API_URL` to `"http://localhost:3000"`. Then, the [`expo-constants`](/versions/latest/sdk/constants/#installation) library provides the `Constants.expoConfig.extra.API_URL` property to access it inside a project.
 
-Variables `expo.extra` are still accessible in SDK 49 and higher, but it is recommended to use the `EXPO_PUBLIC_` prefix and **.env** files instead to reference variables directly in your application code.
+Variables `expo.extra` are still accessible but it is recommended to use the `EXPO_PUBLIC_` prefix and **.env** files instead to reference variables directly in your application code.

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -100,9 +100,7 @@ TV also works with [react-navigation](https://reactnavigation.org/), [react-nati
 
 ## Integration with an existing Expo project
 
-If you have an existing Expo project using SDK 50 or later, the following walkthrough describes the steps required to modify an Expo project for TV.
-
-> **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
+The following walkthrough describes the steps required to modify an Expo project for TV.
 
 <Step label="1">
 

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -175,8 +175,6 @@ In the future, this will work universally across platforms with EAS Update hosti
 
 ## TypeScript
 
-> Available in SDK 49 and higher.
-
 Expo's Metro config supports the `compilerOptions.paths` and `compilerOptions.baseUrl` fields in the project's **tsconfig.json** (or **jsconfig.json**) file. This enables absolute imports and aliases in the project. See [TypeScript](/guides/typescript) guide for more information.
 
 This feature requires additional setup in bare projects. See the [Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -11,8 +11,6 @@ Environment variables are key-value pairs configured outside your source code th
 
 The Expo CLI will automatically load environment variables with an `EXPO_PUBLIC_` prefix from **.env** files for use within your JavaScript code whenever you use the Expo CLI, such as when running `npx expo start` to start your app in local development mode.
 
-> Available in SDK 49 and higher.
-
 ## Reading environment variables from .env files
 
 Create a **.env** file in the root of your project directory and add environment-specific variables on new lines in the form of `EXPO_PUBLIC_[NAME]=VALUE`:

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -40,60 +40,6 @@ console.log('Hello on iOS');
 
 This optimization is production only and runs on a per-file basis. If you re-export `Platform.OS` from a different module, it will not be removed from the production bundle.
 
-<Collapsible summary="Enable platform shaking (SDK 49 and lower)">
-
-> Platform shaking is enabled by default in Expo SDK 50 and greater.
-
-To remove code based on the `Platform` module from `react-native`, add the following to **metro.config.js**:
-
-```js metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
-
-const config = getDefaultConfig(__dirname);
-
-config.transformer.getTransformOptions = async () => ({
-  transform: {
-    /* @info This feature is experimental and may cause other issues. */
-    experimentalImportSupport: true,
-    /* @end */
-  },
-});
-
-module.exports = config;
-```
-
-Then, configure **babel.config.js** to preserve `import/export` syntax:
-
-```js babel.config.js
-module.exports = function (api) {
-  api.cache(true);
-  /* @info */
-  const disableImportExportTransform = true;
-  /* @end */
-  return {
-    presets: [
-      [
-        'babel-preset-expo',
-        {
-          native: {
-            /* @info */
-            disableImportExportTransform,
-            /* @end */
-          },
-          web: {
-            /* @info */
-            disableImportExportTransform,
-            /* @end */
-          },
-        },
-      ],
-    ],
-  };
-};
-```
-
-</Collapsible>
-
 Starting in SDK 51, `process.env.EXPO_OS` can be used to detect the platform that the JavaScript was bundled for (cannot change at runtime). This value does not support platform shaking imports due to how Metro minifies code after dependency resolution.
 
 ## Remove development-only code

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -5,7 +5,6 @@ description: Learn about how Expo CLI optimizes production JavaScript bundles.
 platforms: ['android', 'ios', 'web', 'tvos']
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -106,22 +106,6 @@ For example, to import `Button` component from **src/components/Button.tsx** usi
 }
 ```
 
-<Collapsible summary="Required configuration to enable path aliases for SDK 49">
-
-Set `tsconfigPaths` to `true` to enable path aliases in the project's [app config](/workflow/configuration/):
-
-```json app.json
-{
-  "expo": {
-    "experiments": {
-      "tsconfigPaths": true
-    }
-  }
-}
-```
-
-</Collapsible>
-
 <Collapsible summary="Disable path aliases for SDK 50 and above">
 
 `tsconfigPaths` is enabled by default which allows you to set path aliases. You can disable it by setting `tsconfigPaths` to `false` in the project's [app config](/workflow/configuration/):
@@ -169,22 +153,6 @@ For example, setting the above configuration allows importing `Button` component
 ```tsx
 import Button from 'src/components/Button';
 ```
-
-<Collapsible summary="Required configuration to enable absolute imports for SDK 49">
-
-Set `tsconfigPaths` to `true` to enable absolute imports in the project's [app config](/workflow/configuration/):
-
-```json app.json
-{
-  "expo": {
-    "experiments": {
-      "tsconfigPaths": true
-    }
-  }
-}
-```
-
-</Collapsible>
 
 #### Considerations
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -254,7 +254,7 @@ The following options are provided:
 - `--output-dir <dir>`: The directory to export the static files to. **Default: dist**
 - `--max-workers <number>`: Maximum number of tasks to allow the bundler to spawn. Setting this to `0` will run all transpilation on the same process, meaning you can easily debug Babel transpilation.
 - `-c, --clear`: Clear the bundler cache before exporting.
-- `--no-minify`: Skip minifying JavaScript and CSS assets (SDK 49 and above).
+- `--no-minify`: Skip minifying JavaScript and CSS assets.
 - `--no-bytecode`: Skip generating Hermes bytecode for native platforms (SDK 50 and above). Only use this for analyzing bundle sizes and never ship UTF-8 bundles to native platforms as this will lead to drastically longer startup times.
 
 #### Hosting with sub-paths
@@ -407,8 +407,6 @@ The command `npx expo install expo-camera` and `npx expo install expo-camera --f
 <Terminal cmd={['$ npx expo install --fix']} />
 
 ### Configuring dependency validation
-
-> Available in SDK 49 and above.
 
 There may be circumstances where you want to use a version of a package is different from the version recommended by `npx expo install`.
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -12,11 +12,11 @@ See more information about **metro.config.js** in the [customizing Metro guide](
 
 ## Environment variables
 
-In SDK 49 and higher, the Expo CLI can load environment variables from **.env** files. Learn more about how to use environment variables in Expo CLI in the [environment variables guide](/guides/environment-variables/).
+Expo CLI can load environment variables from **.env** files. Learn more about how to use environment variables in Expo CLI in the [environment variables guide](/guides/environment-variables/).
 
 EAS CLI uses a different mechanism for environment variables, except when it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](/build-reference/variables/).
 
-If you are migrating an older project to SDK 49 or above, then you should ignore local env files by adding the following to your **.gitignore**:
+If you are migrating an older project, then you should ignore local env files by adding the following to your **.gitignore**:
 
 ```sh .gitignore
 # local env files

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -12,11 +12,11 @@ See more information about **metro.config.js** in the [customizing Metro guide](
 
 ## Environment variables
 
-In SDK 49 and higher, the Expo CLI can load environment variables from **.env** files. Learn more about how to use environment variables in Expo CLI in the [environment variables guide](/guides/environment-variables/).
+Expo CLI can load environment variables from **.env** files. Learn more about how to use environment variables in Expo CLI in the [environment variables guide](/guides/environment-variables/).
 
 EAS CLI uses a different mechanism for environment variables, except when it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](/build-reference/variables/).
 
-If you are migrating an older project to SDK 49 or above, then you should ignore local env files by adding the following to your **.gitignore**:
+If you are migrating an older project, then you should ignore local env files by adding the following to your **.gitignore**:
 
 ```sh .gitignore
 # local env files


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-13927

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove SDK 49 references manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
