### PR TITLE
[docs] Refactor code to accept optional betaVersion parameter

### DIFF
--- a/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
@@ -1,10 +1,17 @@
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
 
+import packageJson from '~/package.json';
+
 export type VersionSelectorProps = {
   version?: string | undefined;
   setVersion: (version: string) => void;
   availableVersions: string[];
 };
+
+export const BETA_MAJOR_VERSION =
+  'betaVersion' in packageJson && typeof packageJson.betaVersion === 'string'
+    ? packageJson.betaVersion.split('.')[0]
+    : undefined;
 
 export const VersionSelector = ({
   version,
@@ -20,7 +27,9 @@ export const VersionSelector = ({
         onChange={e => setVersion(e.target.value)}>
         {availableVersions.map(version => (
           <option key={version} value={version}>
-            {version === 'unversioned' ? 'unversioned' : `SDK ${version}`}
+            {version === 'unversioned'
+              ? 'unversioned'
+              : `SDK ${version}${version === BETA_MAJOR_VERSION ? '  (beta)' : ''}`}
           </option>
         ))}
       </select>

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -2,7 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { useRouter } from 'next/compat/router';
 import { useEffect } from 'react';
 
-import { VersionSelector } from './VersionSelector';
+import { VersionSelector, BETA_MAJOR_VERSION } from './VersionSelector';
 
 import versions from '~/public/static/constants/versions.json';
 import diffInfo from '~/public/static/diffs/template-bare-minimum/diffInfo.json';
@@ -20,7 +20,7 @@ export const TemplateBareMinimumDiffViewer = () => {
 
   // default to from: last SDK, to: current SDK
   const lastTwoProductionVersions = bareDiffVersions
-    .filter((d: string) => d !== 'unversioned')
+    .filter((d: string) => d !== 'unversioned' && d !== BETA_MAJOR_VERSION)
     .slice(-2);
 
   const fromVersion = router?.query.fromSdk || lastTwoProductionVersions[0];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14155

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding `BETA_MAJOR_VERSION` as optional parameter to **TemplateBareMinimumDiffViewer.tsx** (thanks to @Simek on suggestions about adding this optional type!)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint`:

![CleanShot 2024-11-13 at 01 10 27](https://github.com/user-attachments/assets/fcb906e4-f0ea-4f35-9747-21b0e4e22e50)

Run `yarn run test`:

![CleanShot 2024-11-13 at 01 10 48](https://github.com/user-attachments/assets/37f7cbe2-7f75-46f7-8171-2bd7a9e1399e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
