### PR TITLE
improve tailwind docs

### DIFF
--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -244,26 +244,13 @@ Then, configure Tailwind according to the [Tailwind PostCSS docs](https://tailwi
 
 Install `tailwindcss` and its peer dependencies, and create a **tailwind.config.js** file:
 
-<Terminal cmd={['$ yarn add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init']} />
+<Terminal
+  cmd={['$ npx expo add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init -p']}
+/>
 
 </Step>
 
 <Step label="2">
-
-Add `tailwindcss` and `autoprefixer` to your **postcss.config.js** file:
-
-```js postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-```
-
-</Step>
-
-<Step label="3">
 
 Add the paths to all of your template files in your **tailwind.config.js** file:
 
@@ -287,7 +274,7 @@ module.exports = {
 
 </Step>
 
-<Step label="4">
+<Step label="3">
 
 Create **global.css** in your project and add directives for each of Tailwind's layers:
 
@@ -304,15 +291,17 @@ Ensure you import this file in your root-most JavaScript file:
 import './global.css';
 ```
 
+If you're using [DOM Components](/guides/dom-components), ensure you import this file in each module marked with `"use dom"` as they don't share globals.
+
 > When using Expo Router, you can use **./index.js** or **./app/\_layout.js**. They both work the same.
 
 </Step>
 
-<Step label="5">
+<Step label="4">
 
-Start your project by clearing the transform cache for good measure:
+Start your project:
 
-<Terminal cmd={['$ npx expo --clear']} />
+<Terminal cmd={['$ npx expo']} />
 
 </Step>
 
@@ -340,6 +329,27 @@ export default function Page() {
     <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
       <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
     </View>
+  );
+}
+```
+
+#### Tailwind for native
+
+Tailwind does not support native platforms directly but you can use the compatibility library [nativewind](https://www.nativewind.dev/) for universal support.
+
+Alternatively, you can use [DOM Components](/guides/dom-components) to render your Tailwind web code in a WebView on native.
+
+```tsx app/index.tsx
+'use dom';
+
+// Remember to import the global.css file in each DOM component.
+import '../global.css';
+
+export default function Page() {
+  return (
+    <div className="bg-slate-100 rounded-xl">
+      <p className="text-lg font-medium">Welcome to Tailwind</p>
+    </div>
   );
 }
 ```

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -244,26 +244,13 @@ Then, configure Tailwind according to the [Tailwind PostCSS docs](https://tailwi
 
 Install `tailwindcss` and its peer dependencies, and create a **tailwind.config.js** file:
 
-<Terminal cmd={['$ yarn add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init']} />
+<Terminal
+  cmd={['$ npx expo add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init -p']}
+/>
 
 </Step>
 
 <Step label="2">
-
-Add `tailwindcss` and `autoprefixer` to your **postcss.config.js** file:
-
-```js postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-```
-
-</Step>
-
-<Step label="3">
 
 Add the paths to all of your template files in your **tailwind.config.js** file:
 
@@ -287,7 +274,7 @@ module.exports = {
 
 </Step>
 
-<Step label="4">
+<Step label="3">
 
 Create **global.css** in your project and add directives for each of Tailwind's layers:
 
@@ -304,15 +291,17 @@ Ensure you import this file in your root-most JavaScript file:
 import './global.css';
 ```
 
+If you're using [DOM Components](/guides/dom-components), ensure you import this file in each module marked with `"use dom"` as they don't share globals.
+
 > When using Expo Router, you can use **./index.js** or **./app/\_layout.js**. They both work the same.
 
 </Step>
 
-<Step label="5">
+<Step label="4">
 
-Start your project by clearing the transform cache for good measure:
+Start your project:
 
-<Terminal cmd={['$ npx expo --clear']} />
+<Terminal cmd={['$ npx expo']} />
 
 </Step>
 
@@ -340,6 +329,27 @@ export default function Page() {
     <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
       <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
     </View>
+  );
+}
+```
+
+#### Tailwind for native
+
+Tailwind does not support native platforms directly but you can use the compatibility library [nativewind](https://www.nativewind.dev/) for universal support.
+
+Alternatively, you can use [DOM Components](/guides/dom-components) to render your Tailwind web code in a WebView on native.
+
+```tsx app/index.tsx
+'use dom';
+
+// Remember to import the global.css file in each DOM component.
+import '../global.css';
+
+export default function Page() {
+  return (
+    <div className="bg-slate-100 rounded-xl">
+      <p className="text-lg font-medium">Welcome to Tailwind</p>
+    </div>
   );
 }
 ```


### PR DESCRIPTION
# Why

- Tailwind made postcss setup a little bit easier.
- Add info about DOM components.
- `--clear` flag is no longer needed.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
