### PR TITLE
[doctor] handle gitignore checks when git is unavailable

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Handle gitignore checks when git is unavailable. e.g. EAS Build. ([#32130](https://github.com/expo/expo/pull/32833) by [@betomoedano](https://github.com/betomoedano))
+
 ### 💡 Others
 
 ## 1.12.3 — 2024-11-05

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -17,7 +17,7 @@ export class ProjectSetupCheck implements DoctorCheck {
      * this check when running on an EAS Build worker, where we may or may not
      * have git. */
 
-    if (fs.existsSync(path.join(projectRoot, 'modules')) && !process.env.EAS_BUILD) {
+    if (fs.existsSync(path.join(projectRoot, 'modules'))) {
       // Glob returns matching files and `git check-ignore` checks files, as
       // well, but we want to check if the path is gitignored, so we pick vital
       // files to match off of (e.g., .podspec, build.gradle).


### PR DESCRIPTION
# Why

By default, EAS CLI will produce the archive by copying all files starting from the root of the git repository with the exception of .git, node_modules, and all files matched by rules from .gitignore (or .easignore if it exists). [See FYI](https://github.com/expo/fyi/blob/main/eas-build-archive.md)

This behavior means that in CI environments like EAS Build, Git is not accessible. As a result, some doctor checks fail when it attempts to run checks that require Git commands, such as `await spawnAsync('git', ['rev-parse', '--show-toplevel'])`.

[ENG-13860 Doctor gitignore nuance](https://linear.app/expo/issue/ENG-13860/doctor-gitignore-nuance)

# How

- Modified `isFileIgnoredAsync` to implement a fallback mechanism when git commands fail
- Added manual parsing of `.gitignore` files using the existing `isFileIgnoredByRules` function (already used for `.easignore`)
- Maintained the existing git command behavior when git is available for accuracy
- Added proper error handling to prevent crashes when git commands fail

# Test Plan

- Ran doctor locally
- Create a new project and remove `.git`
- Run `nexpo-doctor` and validate check is handled properly without `.git`
- Added test for git command fallback behavior

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
