### PR TITLE
[docs] Adds Workflows documentation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -289,6 +289,13 @@ const general = [
     { expanded: false }
   ),
   makeSection('EAS', [makePage('eas/index.mdx'), makePage('eas/json.mdx')]),
+  makeSection('Workflows', [
+    makePage('workflows/get-started.mdx'),
+    makePage('workflows/triggers.mdx'),
+    makePage('workflows/jobs.mdx'),
+    makePage('workflows/control-flow.mdx'),
+    makePage('workflows/variables.mdx'),
+  ]),
   makeSection('EAS Build', [
     makePage('build/introduction.mdx'),
     makePage('build/setup.mdx'),

--- a/docs/pages/workflows/control-flow.mdx
+++ b/docs/pages/workflows/control-flow.mdx
@@ -1,0 +1,69 @@
+---
+title: Control flow
+description: Learn how to control the flow of Workflows with conditions that run certain jobs based on the result of previous jobs.
+---
+
+You can control the flow of your workflows with conditions that run certain jobs based on the result of previous jobs.
+
+## `needs`
+
+You can add an list of job names to the `needs` keyword on a job. If a job in the list fails, the job will be skipped.
+
+```yaml .eas/workflows/prerequisite.yaml
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+      profile: production
+  end-to-end-test:
+    # @info #
+    needs: [build]
+    # @end #
+    type: maestro
+    params:
+      build_id: ${{ jobs.build.outputs.build_id }}
+      flow_path: ['./e2e/flow.yaml']
+```
+
+## `after`
+
+You can add a list of job names to the `after` keyword on a job. The jobs in the list will run after the job completes no matter if it succeeded or failed.
+
+```yaml .eas/workflows/after.yaml
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+      profile: production
+  send_slack_notification:
+    after: [build]
+    steps:
+      - name: Send Slack notification
+        inputs:
+          message: 'Build completed.'
+          slack_hook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+## `if`
+
+You can add a condition to a job with the `if` keyword. If the condition evaluates to `true`, the job will run. Otherwise, it will be skipped.
+
+```yaml .eas/workflows/conditional.yaml
+on:
+	push: {} # runs on all branches
+
+jobs:
+  update:
+    type: update
+  build:
+    name: Build iOS
+    type: build
+    # @info #
+    if: ${{ github.ref == "refs/heads/main" }} # Will only run if on main.
+    # @end #
+    params:
+      profile: production
+      platform: ios
+```

--- a/docs/pages/workflows/control-flow.mdx
+++ b/docs/pages/workflows/control-flow.mdx
@@ -7,7 +7,7 @@ You can control the flow of your workflows with conditions that run certain jobs
 
 ## `needs`
 
-You can add an list of job names to the `needs` keyword on a job. If a job in the list fails, the job will be skipped.
+You can add a list of previous job names using the `needs` keyword on a job. If any job from that list fails, the current job will be skipped.
 
 ```yaml .eas/workflows/prerequisite.yaml
 jobs:
@@ -28,7 +28,7 @@ jobs:
 
 ## `after`
 
-You can add a list of job names to the `after` keyword on a job. The jobs in the list will run after the job completes no matter if it succeeded or failed.
+You can add a list of previous job names using the `after` keyword on a job. Any job in the list will run after the current job completes, no matter if it succeeded or failed.
 
 ```yaml .eas/workflows/after.yaml
 jobs:

--- a/docs/pages/workflows/get-started.mdx
+++ b/docs/pages/workflows/get-started.mdx
@@ -1,0 +1,143 @@
+---
+title: Get Started
+description: Learn how to use Workflows to automate your development and release processes.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Callout } from '~/ui/components/Callout';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+
+<Callout type="info">
+  Workflows are currently in preview. We may introduce breaking changes in the coming weeks. Got
+  feedback? Send us an email at workflows@expo.dev.
+</Callout>
+
+Builds, submissions, updates and more are all a part of delivering your app to users. Workflows consist of a sequence of jobs, which help you and your team get things done. You can do things like building your project, run end-to-end tests, submit that build to the app stores, then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate you and your team's release process.
+
+<Collapsible summary="How do workflows compare to other CI services?">
+
+Workflows on EAS are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that help you build, submit, update, run Maestro tests, and more. It all runs on EAS, so you'll only have to manage one set of YAML files, and all of the artifacts from your job runs will appear on expo.dev.
+
+Other CI services, like CircleCI and GitHub Actions, are more generalized and have the ability to do more than workflows. However, those services also require you to understand more about the implementation of each job. While that is necessary in some cases, workflows help you get common tasks done quickly by pre-packaging the most essential types of jobs for app developers. In addition, workflows are designed to provide you with the fastest possible cloud machine for the task at hand, and we're constantly updating those for you.
+
+Workflows are great for operations related to your Expo apps, while other CICD services will provide a better experience for other types of workflows.
+
+</Collapsible>
+
+## Set up your project
+
+If you haven't already, you'll need to create a project and sync it with EAS:
+
+<Collapsible summary="Create a project and sync it with EAS">
+  You can create a new project with the following command:
+
+{' '}
+
+<Terminal cmd={['$ npx create-expo-app@latest']} />
+
+Once you've created the project, login with your account:
+
+{' '}
+
+<Terminal cmd={['$ npx eas-cli@latest login']} />
+
+Finally, link the project you have locally with EAS:
+
+  <Terminal cmd={['$ npx eas-cli@latest init']} />
+</Collapsible>
+
+Then, create a directory named **.eas/workflows** at the root of your project with a **.yaml** file inside of it. For example: **.eas/workflows/hello-world.yaml**.
+
+## Write a workflow
+
+Each workflow consists of three top-level elements:
+
+- `name`: defines the name of the workflow. For example: “Hello World!”
+- `on`: defines when this workflow should be triggered. For example: when pushing a new commit to a GitHub branch.
+- `jobs`: a sequence of jobs which can depend on and pass data between each other. For example: a job that runs a unit test followed by a job that builds your project into an app.
+
+Here's an example of a workflow that prints “Hello world!”:
+
+```yaml .eas/workflows/hello-world.yaml
+name: Hello World
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  Hello World:
+    steps:
+      - run: echo "Hello, World"
+```
+
+Here's another example that creates and submits an iOS build of a project on every push to every branch. This is similar to running `eas build --platform ios --profile production --auto-submit`:
+
+```yaml .eas/workflows/ios-build-and-submit.yaml
+name: Release iOS app
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+      profile: production
+  submit:
+    needs: [build]
+    type: submit
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+```
+
+## Configure your project
+
+To enable workflows to run on events from GitHub, you'll need to install Expo's GitHub app and connect it to your project. Here's how:
+
+- Navigate to your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github)
+- Follow the UI to install the GitHub app. Then search for the GitHub repository that matches the Expo project and connect it.
+
+## Run your workflow
+
+Once you have a workflow file and your project is connected to Expo's GitHub app, you can trigger your workflow by pushing a commit to your GitHub repository. For the workflow to run, you'll need to make sure the trigger (defined with `on`) you defined in your workflow is met.
+
+Alternatively, you can trigger a workflow manually by running the following command:
+
+<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/<your-workflow-file>.yaml']} />
+
+Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
+
+## Next steps
+
+Learn more about the building blocks of workflows:
+
+<BoxLink
+  title="Triggers"
+  description="Learn how to trigger workflows."
+  href="/workflows/triggers"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="Jobs"
+  description="Learn which pre-packaged and custom jobs you can run with Workflows."
+  href="/workflows/jobs"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="Control flow"
+  description="Learn how to control the flow of your workflows with conditions that run certain jobs based on the result of previous jobs."
+  href="/workflows/control-flow"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="Variables"
+  description="Learn how to use variables in your workflows."
+  href="/workflows/variables"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/workflows/get-started.mdx
+++ b/docs/pages/workflows/get-started.mdx
@@ -55,11 +55,11 @@ Then, create a directory named **.eas/workflows** at the root of your project wi
 
 Each workflow consists of three top-level elements:
 
-- `name`: defines the name of the workflow. For example: “Hello World!”
+- `name`: defines the name of the workflow. For example: "Hello World!"
 - `on`: defines when this workflow should be triggered. For example: when pushing a new commit to a GitHub branch.
 - `jobs`: a sequence of jobs which can depend on and pass data between each other. For example: a job that runs a unit test followed by a job that builds your project into an app.
 
-Here's an example of a workflow that prints “Hello world!”:
+Here's an example of a workflow that prints "Hello world!":
 
 ```yaml .eas/workflows/hello-world.yaml
 name: Hello World

--- a/docs/pages/workflows/get-started.mdx
+++ b/docs/pages/workflows/get-started.mdx
@@ -15,11 +15,11 @@ import { Terminal } from '~/ui/components/Snippet';
   feedback? Send us an email at workflows@expo.dev.
 </Callout>
 
-Builds, submissions, updates and more are all a part of delivering your app to users. Workflows consist of a sequence of jobs, which help you and your team get things done. You can do things like building your project, run end-to-end tests, submit that build to the app stores, then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate you and your team's release process.
+Builds, submissions, updates, and more are all a part of delivering your app to users. Workflows consist of a sequence of jobs, which help you and your team get things done. With workflows, you can build your project, run end-to-end tests, submit that build to the app stores, and then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate your and your team's release process.
 
 <Collapsible summary="How do workflows compare to other CI services?">
 
-Workflows on EAS are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that help you build, submit, update, run Maestro tests, and more. It all runs on EAS, so you'll only have to manage one set of YAML files, and all of the artifacts from your job runs will appear on expo.dev.
+Workflows on EAS are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that can build, submit, update, run Maestro tests, and more. All job types run on EAS, so you'll only have to manage one set of YAML files, and all the artifacts from your job runs will appear on [expo.dev](https://expo.dev/).
 
 Other CI services, like CircleCI and GitHub Actions, are more generalized and have the ability to do more than workflows. However, those services also require you to understand more about the implementation of each job. While that is necessary in some cases, workflows help you get common tasks done quickly by pre-packaging the most essential types of jobs for app developers. In addition, workflows are designed to provide you with the fastest possible cloud machine for the task at hand, and we're constantly updating those for you.
 
@@ -55,11 +55,11 @@ Then, create a directory named **.eas/workflows** at the root of your project wi
 
 Each workflow consists of three top-level elements:
 
-- `name`: defines the name of the workflow. For example: "Hello World!"
-- `on`: defines when this workflow should be triggered. For example: when pushing a new commit to a GitHub branch.
+- `name`: defines the name of the workflow. For example: "Hello World"
+- `on`: defines when this workflow should be triggered. For example, when pushing a new commit to a GitHub branch.
 - `jobs`: a sequence of jobs which can depend on and pass data between each other. For example: a job that runs a unit test followed by a job that builds your project into an app.
 
-Here's an example of a workflow that prints "Hello world!":
+Here's an example of a workflow that prints "Hello, world":
 
 ```yaml .eas/workflows/hello-world.yaml
 name: Hello World
@@ -98,7 +98,7 @@ jobs:
 
 ## Configure your project
 
-To enable workflows to run on events from GitHub, you'll need to install Expo's GitHub app and connect it to your project. Here's how:
+To enable workflows to run on events from GitHub, you'll need to install Expo's GitHub app and connect it to your project:
 
 - Navigate to your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github)
 - Follow the UI to install the GitHub app. Then search for the GitHub repository that matches the Expo project and connect it.
@@ -113,7 +113,7 @@ Alternatively, you can trigger a workflow manually by running the following comm
 
 Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
 
-## Next steps
+## Building blocks
 
 Learn more about the building blocks of workflows:
 

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -5,9 +5,9 @@ description: Learn which pre-packaged and custom jobs you can run with Workflows
 
 Workflows sequence jobs together to automate your development and release processes. You can run two types of jobs: pre-packaged jobs and custom jobs.
 
-Pre-packaged jobs are provided by Expo and meet common use cases for developers, like building, submitting, and running end to end test. Since they are provided by Expo, they are continuously maintained and updated.
+Expo provides pre-packaged jobs that meet common use cases for developers, such as building, submitting, and running end-to-end tests. Since they are provided by Expo, they are continuously maintained and updated.
 
-Custom jobs are jobs that you write yourself. They are useful for any use case that isn't met by the pre-packaged jobs.
+Custom jobs are jobs that you write yourself. They are useful for any use case not met by the pre-packaged jobs.
 
 ## Build
 
@@ -55,7 +55,7 @@ jobs:
     type: update
 ```
 
-## End-to-end test with Maestro
+## End-to-end tests with Maestro
 
 This is a pre-packaged job that runs end-to-end tests with Maestro. Given a `build_id`, we'll choose the correct machine to run the tests on the correct platform.
 

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -1,0 +1,84 @@
+---
+title: Jobs
+description: Learn which pre-packaged and custom jobs you can run with Workflows.
+---
+
+Workflows sequence jobs together to automate your development and release processes. You can run two types of jobs: pre-packaged jobs and custom jobs.
+
+Pre-packaged jobs are provided by Expo and meet common use cases for developers, like building, submitting, and running end to end test. Since they are provided by Expo, they are continuously maintained and updated.
+
+Custom jobs are jobs that you write yourself. They are useful for any use case that isn't met by the pre-packaged jobs.
+
+## Build
+
+This is a pre-packaged job that creates a build from a project:
+
+```yaml .eas/workflows/build.yaml
+jobs:
+  build:
+    type: build
+    params:
+      platform: android | ios
+      profile: string # default: production
+```
+
+This job outputs the following variables:
+
+- `platform`: Either `android` or `ios`.
+- `build_id`: The ID of the build.
+
+## Submit
+
+This is a pre-packaged job that submits a build to an app store. Given a `build_id`, we'll choose the correct automation to submit the build to the correct store.
+
+```yaml .eas/workflows/submit.yaml
+jobs:
+  submit:
+    type: submit
+    params:
+      profile: string # default: production
+      build_id: string
+```
+
+This job outputs the following variables:
+
+- `platform`: Either `android` or `ios`.
+- `submission_id`: The ID of the submission.
+
+## Update
+
+This is a pre-packaged job that publishes an update:
+
+```yaml .eas/workflows/update.yaml
+jobs:
+  update:
+    type: update
+```
+
+## End-to-end test with Maestro
+
+This is a pre-packaged job that runs end-to-end tests with Maestro. Given a `build_id`, we'll choose the correct machine to run the tests on the correct platform.
+
+```yaml .eas/workflows/e2e-test.yaml
+jobs:
+  e2e-test:
+    type: maestro
+    params:
+      build_id: string
+      flow_path: string | string[] # string is a file path from the project root
+```
+
+## Custom jobs
+
+Custom jobs are jobs that you write yourself. They are useful for any use case that isn't met by the pre-packaged jobs.
+
+```yaml .eas/workflows/custom-job.yaml
+jobs:
+  custom-job:
+    type: custom # default: undefined
+    steps:
+      - name: Run a script
+        run: echo "Hello, world!"
+```
+
+Within custom jobs, you can use our [built-in functions](/custom-builds/schema/#built-in-eas-functions), like `eas/checkout`, `eas/use_npm_token` to interact with the project.

--- a/docs/pages/workflows/triggers.mdx
+++ b/docs/pages/workflows/triggers.mdx
@@ -1,0 +1,56 @@
+---
+title: Triggers
+description: Learn which triggers work with Workflows.
+---
+
+Triggers define when a workflow should kick off. When its conditions are met, the workflow will start.
+
+## On push
+
+You can trigger a workflow on a push to a GitHub branch with the `push` trigger.
+
+```yaml .eas/workflows/hello-world.yaml
+name: Hello World
+
+on:
+  push:
+	  branches:
+	    - 'main'
+	    - 'feature/**'
+	    # other branches names and globs
+
+jobs:
+  # ...
+```
+
+## On pull request
+
+You can trigger a workflow on a pull request with the `pull_request` trigger.
+
+```yaml .eas/workflows/hello-world.yaml
+name: Hello World
+
+on:
+  pull_request:
+	  branches:
+		  - 'main'
+		  # other branch names and globs
+
+jobs:
+  # ...
+```
+
+## More
+
+Workflows also support triggering on all branches, on both push and pull request events:
+
+```yaml .eas/workflows/hello-world.yaml
+name: Hello World
+
+on:
+	push: {} # this will default to `branches: ['*']`, meaning "run on all branches"
+	pull_request: {}
+
+jobs:
+  # ...
+```

--- a/docs/pages/workflows/triggers.mdx
+++ b/docs/pages/workflows/triggers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Triggers
-description: Learn which triggers work with Workflows.
+description: Learn which triggers are available to work with Workflows.
 ---
 
 Triggers define when a workflow should kick off. When its conditions are met, the workflow will start.

--- a/docs/pages/workflows/variables.mdx
+++ b/docs/pages/workflows/variables.mdx
@@ -16,20 +16,20 @@ jobs:
       # @end #
     steps:
       - name: Set fingerprint hash
-			id: fingerprint_step_id
-			run: |
-				FINGERPRINT_HASH=$(npx expo-updates fingerprint:generate --platform ios | jq '.hash')
-                # @info Sets the `fingerprint_hash` as a variable #
-				set-output fingerprint_hash $FINGERPRINT_HASH
-                # @end #
-                # @info Exposes the `fingerprint_hash` variable to other steps in this job #
-			outputs: [fingerprint_hash]
-                # @end #
+        id: fingerprint_step_id
+        # @info Exposes the `fingerprint_hash` variable to other steps in this job #
+        outputs: [fingerprint_hash]
+        # @end #
+        run: |
+          FINGERPRINT_HASH=$(npx expo-updates fingerprint:generate --platform ios | jq '.hash')
+          # @info Sets the `fingerprint_hash` as a variable #
+          set-output fingerprint_hash $FINGERPRINT_HASH
+          # @end #
       - name: Do something with the fingerprint hash
-			run: |
-                # @info Accesses the `fingerprint_hash` variable #
-				echo ${ steps.fingerprint_step_id.outputs.fingerprint_hash }
-                # @end #
+          run: |
+            # @info Accesses the `fingerprint_hash` variable #
+            echo ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
+            # @end #
     maybe_build:
       needs: [fingerprint]
       # @info Accesses the `fingerprint_hash_for_workflow` variable #

--- a/docs/pages/workflows/variables.mdx
+++ b/docs/pages/workflows/variables.mdx
@@ -1,0 +1,47 @@
+---
+title: Variables
+description: Learn how to use variables in Workflows.
+---
+
+You can use variables in your workflows to pass data between jobs or steps. Variables are useful for conditionals on subsequent jobs or afftecting the output of a workflow.
+
+You can set variables in the workflow file with the `set-output` function:
+
+```yaml .eas/workflows/variables.yaml
+jobs:
+  fingerprint:
+    outputs:
+      # @info Sets the `fingerprint_hash_for_workflow` as a variable #
+      fingerprint_hash_for_workflow: ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
+      # @end #
+    steps:
+      - name: Set fingerprint hash
+			id: fingerprint_step_id
+			run: |
+				FINGERPRINT_HASH=$(npx expo-updates fingerprint:generate --platform ios | jq '.hash')
+                # @info Sets the `fingerprint_hash` as a variable #
+				set-output fingerprint_hash $FINGERPRINT_HASH
+                # @end #
+                # @info Exposes the `fingerprint_hash` variable to other steps in this job #
+			outputs: [fingerprint_hash]
+                # @end #
+      - name: Do something with the fingerprint hash
+			run: |
+                # @info Accesses the `fingerprint_hash` variable #
+				echo ${ steps.fingerprint_step_id.outputs.fingerprint_hash }
+                # @end #
+    maybe_build:
+      needs: [fingerprint]
+      # @info Accesses the `fingerprint_hash_for_workflow` variable #
+      if: ${{ needs.fingerprint.outputs.fingerprint_hash_for_workflow != '1234' }}
+      # @end #
+      type: build
+      params:
+        platform: ios
+```
+
+In the example above, three things are happening:
+
+- The `set-output` function sets the `fingerprint_hash` variable.
+- The `outputs` keyword on the step inside the `fingerprint` job exposes the `fingerprint_hash` variable to other steps in `fingerprint` job. That variable is used in an `echo` statement later in the job.
+- The `outputs` keyword on the `fingerprint` job specifies that the whole workflow will have access to a variable called `fingerprint_hash_for_workflow`. That variable is later used in the `maybe_build` job to conditionally run the build job.

--- a/docs/pages/workflows/variables.mdx
+++ b/docs/pages/workflows/variables.mdx
@@ -26,10 +26,10 @@ jobs:
           set-output fingerprint_hash $FINGERPRINT_HASH
           # @end #
       - name: Do something with the fingerprint hash
-          run: |
-            # @info Accesses the `fingerprint_hash` variable #
-            echo ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
-            # @end #
+        run: |
+          # @info Accesses the `fingerprint_hash` variable #
+          echo ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
+          # @end #
     maybe_build:
       needs: [fingerprint]
       # @info Accesses the `fingerprint_hash_for_workflow` variable #

--- a/docs/pages/workflows/variables.mdx
+++ b/docs/pages/workflows/variables.mdx
@@ -1,9 +1,9 @@
 ---
 title: Variables
-description: Learn how to use variables in Workflows.
+description: Learn how to pass data between jobs or steps or set conditionals using variables in Workflows.
 ---
 
-You can use variables in your workflows to pass data between jobs or steps. Variables are useful for conditionals on subsequent jobs or afftecting the output of a workflow.
+Variables can be used in workflows to pass data between jobs or steps. They are useful for conditionals on subsequent jobs or affecting the output of a workflow.
 
 You can set variables in the workflow file with the `set-output` function:
 
@@ -11,28 +11,28 @@ You can set variables in the workflow file with the `set-output` function:
 jobs:
   fingerprint:
     outputs:
-      # @info Sets the `fingerprint_hash_for_workflow` as a variable #
+      # @info Sets the <CODE>fingerprint_hash_for_workflow</CODE> as a variable #
       fingerprint_hash_for_workflow: ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
       # @end #
     steps:
       - name: Set fingerprint hash
         id: fingerprint_step_id
-        # @info Exposes the `fingerprint_hash` variable to other steps in this job #
+        # @info Exposes the <CODE>fingerprint_hash</CODE> variable to other steps in this job #
         outputs: [fingerprint_hash]
         # @end #
+        # @info Sets the <CODE>fingerprint_hash</CODE> as a variable #
         run: |
           FINGERPRINT_HASH=$(npx expo-updates fingerprint:generate --platform ios | jq '.hash')
-          # @info Sets the `fingerprint_hash` as a variable #
           set-output fingerprint_hash $FINGERPRINT_HASH
-          # @end #
+        # @end #
       - name: Do something with the fingerprint hash
+        # @info Accesses the <CODE>fingerprint_hash</CODE variable #
         run: |
-          # @info Accesses the `fingerprint_hash` variable #
           echo ${{ steps.fingerprint_step_id.outputs.fingerprint_hash }}
-          # @end #
+        # @end #
     maybe_build:
       needs: [fingerprint]
-      # @info Accesses the `fingerprint_hash_for_workflow` variable #
+      # @info Accesses the <CODE>fingerprint_hash_for_workflow</CODE> variable #
       if: ${{ needs.fingerprint.outputs.fingerprint_hash_for_workflow != '1234' }}
       # @end #
       type: build


### PR DESCRIPTION
# Why

We are about to release a new product called Workflows. This PR details how to use Workflows with documentation.

# Test Plan

Read through the docs and make sure they make sense. You can read them in the following places:

- [/workflows/get-started](/workflows/get-started/)
- [/workflows/triggers](/workflows/triggers/)
- [/workflows/jobs](/workflows/jobs/)
- [/workflows/control-flow](/workflows/control-flow/)
- [/workflows/variables](/workflows/variables/)