### PR TITLE
[pod-install] fix path argument being required, improve logic

### DIFF
--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 ### 🐛 Bug fixes
 
-- Fix missing fallback to `process.cwd()` while no argument has been passed.
+- Fix missing fallback to `process.cwd()` while no argument has been passed. ([#32848](https://github.com/expo/expo/pull/32848) by [@Simek](https://github.com/Simek))
 
 ### 💡 Others
 
-- Improve console messages and errors.
+- Improve console messages and errors. ([#32848](https://github.com/expo/expo/pull/32848) by [@Simek](https://github.com/Simek))
 
 ## 0.3.0 — 2024-10-22
 

--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### 🐛 Bug fixes
 
+- Fix missing fallback to `process.cwd()` while no argument has been passed.
+
 ### 💡 Others
+
+- Improve console messages and errors.
 
 ## 0.3.0 — 2024-10-22
 

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -13,52 +13,66 @@ const packageJSON = require('../package.json');
 
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
-  .arguments('<project-directory>')
-  .usage(`${chalk.green('<project-directory>')} [options]`)
+  .arguments('[project-directory]')
+  .usage(`${chalk.green('[project-directory]')} [options]`)
   .description('Install pods in your project')
   .option('--quiet', 'Only print errors')
   .option('--non-interactive', 'Disable interactive prompts')
   .allowUnknownOption()
   .parse(process.argv);
 
-const info = (message: string) => {
+function info(message: string) {
   if (!program.opts().quiet) {
     console.log(message);
   }
-};
+}
 
-async function runAsync(): Promise<void> {
+async function runAsync(projectDirectory: string): Promise<void> {
   if (process.platform !== 'darwin') {
-    info(chalk.red('CocoaPods is only supported on darwin machines'));
-    return;
+    info(chalk.red('\nCocoaPods is only supported on darwin machines\n'));
+    process.exit(1);
   }
 
-  let projectRoot = resolve(process.cwd());
+  const possibleProjectRoot = resolve(projectDirectory ?? process.cwd());
 
-  const possibleProjectRoot = CocoaPodsPackageManager.getPodProjectRoot(projectRoot);
-  if (!possibleProjectRoot) {
-    const packageJsonPath = join(projectRoot, 'package.json');
+  if (!existsSync(possibleProjectRoot)) {
+    info(chalk.red(`\nTarget directory does not exist! (${possibleProjectRoot})\n`));
+    process.exit(1);
+  }
 
-    if (existsSync(packageJsonPath)) {
-      const jsonData = JSON.parse(readFileSync(packageJsonPath).toString());
-      const hasExpoPackage = jsonData.dependencies?.hasOwnProperty('expo');
+  const projectRoot = CocoaPodsPackageManager.getPodProjectRoot(possibleProjectRoot);
 
-      if (hasExpoPackage) {
-        info(
-          chalk.yellow(
-            `No 'ios' directory found, skipping installing pods. Pods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`,
-            learnMore('https://docs.expo.dev/workflow/prebuild/')
-          )
-        );
-        return;
-      }
+  if (!projectRoot) {
+    const packageJsonPath = join(possibleProjectRoot, 'package.json');
+
+    if (!existsSync(packageJsonPath)) {
+      info(chalk.red(`\n'package.json' file does not exist! (${packageJsonPath})\n`));
+      process.exit(1);
     }
 
-    info(chalk.yellow('CocoaPods is not supported in this project'));
-    return;
-  } else {
-    projectRoot = possibleProjectRoot;
+    const jsonData = JSON.parse(readFileSync(packageJsonPath).toString());
+    const hasExpoPackage = jsonData.dependencies?.hasOwnProperty('expo');
+
+    if (hasExpoPackage) {
+      info(
+        chalk.yellow(
+          `No 'ios' directory found, skipping installing pods.`,
+          `\nPods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`,
+          learnMore('https://docs.expo.dev/workflow/prebuild/')
+        )
+      );
+      process.exit(0);
+    }
+
+    if (projectDirectory) {
+      info(chalk.yellow(`CocoaPods is not supported in project at ${possibleProjectRoot}`));
+    } else {
+      info(chalk.yellow('CocoaPods is not supported in this project'));
+    }
+    process.exit(0);
   }
+
+  info('Scanning for pods...');
 
   if (!(await CocoaPodsPackageManager.isCLIInstalledAsync())) {
     await CocoaPodsPackageManager.installCLIAsync({
@@ -80,15 +94,13 @@ async function runAsync(): Promise<void> {
 
 (async () => {
   program.parse(process.argv);
-  info('Scanning for pods...');
   try {
-    await runAsync();
+    await runAsync(program.args[0]);
     if (!program.opts().quiet) {
       await shouldUpdate();
     }
   } catch (reason: any) {
-    console.log();
-    console.log('Aborting run');
+    console.log('\nAborting run');
     if (reason.command) {
       console.log(`  ${chalk.magenta(reason.command)} has failed.`);
     } else {


### PR DESCRIPTION
# Why

Fixes #32828
Fixes ENG-14160

# How

Add a default fallback for project directory argument and make it optional again.

Improve the logic to bail out earliest as possible, add and improve messages, always return code `1` on failures.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-11-13 at 09 27 13](https://github.com/user-attachments/assets/13bda4ff-1e96-4fbb-8134-f2fa114ec5f9)
