### PR TITLE
[android][background-fetch] Fix so that we run tasks correctly when backgrounded or killed

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -13,6 +13,10 @@ try {
 
 Splashscreen.setOptions({ fade: true });
 
+// Require the `BackgroundFetchScreen` component from `native-component-list` if it's available
+// so that we load the module and register its background task on startup.
+optionalRequire(() => require('native-component-list/src/screens/BackgroundFetchScreen'));
+
 const loadAssetsAsync =
   optionalRequire(() => require('native-component-list/src/utilities/loadAssetsAsync')) ??
   (async () => null);

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Android: Fixed so that background fetch will run when app is killed or in the background.
+
 ### 💡 Others
 
 ## 13.0.2 — 2024-11-10

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Android: Fixed so that background fetch will run when app is killed or in the background.
+- Android: Fixed so that background fetch will run when app is killed or in the background. ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
+++ b/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
@@ -80,7 +80,7 @@ public class BackgroundFetchTaskConsumer extends TaskConsumer implements TaskCon
       TaskManagerUtilsInterface taskManagerUtils = getTaskManagerUtils();
 
       if (context != null) {
-        taskManagerUtils.scheduleJob(context, mTask, null);
+        taskManagerUtils.executeTask(context, mTask, null);
       }
     }
   }

--- a/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
+++ b/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
@@ -80,7 +80,7 @@ public class BackgroundFetchTaskConsumer extends TaskConsumer implements TaskCon
       TaskManagerUtilsInterface taskManagerUtils = getTaskManagerUtils();
 
       if (context != null) {
-        taskManagerUtils.executeTask(context, mTask, null);
+        taskManagerUtils.executeTask(mTask, null);
       }
     }
   }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Added `exeuteTask` method to `TaskManagerUtilsInterface` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Added `executeTask` method to `TaskManagerUtilsInterface` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
 
 ## 2.0.1 — 2024-11-12
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Added `exeuteTask` method to `TaskManagerUtilsInterface` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
+
 ## 2.0.1 — 2024-11-12
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/taskManager/TaskManagerUtilsInterface.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/taskManager/TaskManagerUtilsInterface.java
@@ -27,7 +27,7 @@ public interface TaskManagerUtilsInterface {
   /**
    * Executes a task directly
    */
-  void executeTask(Context context, TaskInterface task, Bundle data);
+  void executeTask(TaskInterface task, Bundle data);
 
   /**
    * Cancels scheduled job with given identifier.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/taskManager/TaskManagerUtilsInterface.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/taskManager/TaskManagerUtilsInterface.java
@@ -3,6 +3,7 @@ package expo.modules.interfaces.taskManager;
 import android.app.PendingIntent;
 import android.app.job.JobParameters;
 import android.content.Context;
+import android.os.Bundle;
 import android.os.PersistableBundle;
 
 import java.util.List;
@@ -22,6 +23,11 @@ public interface TaskManagerUtilsInterface {
    * Schedules a job for given task and with given list of extra data.
    */
   void scheduleJob(Context context, TaskInterface task, List<PersistableBundle> data);
+
+  /**
+   * Executes a task directly
+   */
+  void executeTask(Context context, TaskInterface task, Bundle data);
 
   /**
    * Cancels scheduled job with given identifier.

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Added implementation of `exeuteTask` method in `TaskManagerUtils` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
+
 ## 12.0.2 — 2024-11-05
 
 ### 💡 Others

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Added implementation of `exeuteTask` method in `TaskManagerUtils` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Added implementation of `executeTask` method in `TaskManagerUtils` ([#32849](https://github.com/expo/expo/pull/32849) by [@chrfalch](https://github.com/chrfalch))
 
 ## 12.0.2 — 2024-11-05
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -66,7 +66,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
   }
 
   @Override
-  public void executeTask(Context context, TaskInterface task, Bundle data) {
+  public void executeTask(TaskInterface task, Bundle data) {
     if (task == null) {
       Log.e(TAG, "Trying to execute a null task!");
     } else {

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -66,6 +66,15 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
   }
 
   @Override
+  public void executeTask(Context context, TaskInterface task, Bundle data) {
+    if (task == null) {
+      Log.e(TAG, "Trying to execute a null task!");
+    } else {
+      task.execute(data, null);
+    }
+  }
+
+  @Override
   public void cancelScheduledJob(Context context, int jobId) {
     JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
 


### PR DESCRIPTION
# Why

On Android, the `expo-background-fetch` library starts an alarm when the app is paused to be able to perform a background-task when the app has been backgrounded for a period of time.

If the app was killed after this, the app would've been started in the background in headless mode (without an activity). Instead of executing the defined task in response to being started by the alarm, the old code just scheduled (using the `JobScheduler` API) - resulting in nothing happening until the app was started by the user and the activity becoming active.

# How

This commit fixes this by doing the right thing - executing the task directly when getting notified by the alarm. This will result in the task being run immediately and if we're in headless mode the app will be loaded by `expo-task-manager` and the `RNHeadlessAppLoader` class.

Here are the details:

**App.tsx**: Added explicitly import of the `BackgroundFetchScreen` to make sure the task is registered also when the screen is not loaded

**BackgroundFetchTaskConsumer.java**: Instead of scheduling the job we're now executing it directly.

**TaskManagerUtilsInterface.java**: Added additional method for executing a task directly

**TaskManagerUtils**: Added implementation of executeTask

# Test Plan

Test in BareExpo:
- Run BareExpo (clean install to avoid any async storage data)
- Open API tab
- Open Background Fetch
- Confirm that background fetch has not been run and is not registered
- Click "Register background task"
- Go to home screen (putting app in background will start the background fetch)
- Test running in the background:
  - Wait approximately 2 minutes 
  - Open app and check the BackgroundFetch screen - we should see that it was called ("Last background fetch....")
- Test running from killed state
  - Kill app using task switcher 
  - Wait approximately 2 minutes 
  - Open app and check the BackgroundFetch screen - we should see that it was called ("Last background fetch....")
 
# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
