### PR TITLE
[video][ios] Fix safe area insets not updating for native controls

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Web] Fix `playbackRate` not being applied in the setup function.([#34182](https://github.com/expo/expo/pull/34182) by [@behenate](https://github.com/behenate))
 - [iOS] Fix `AVPlayer` not deallocating when the player is unmounted. ([#33922](https://github.com/expo/expo/pull/33922) by [@behenate](https://github.com/behenate))
+- Fix safe area insets not updating for native controls on iOS. ([#32864](https://github.com/expo/expo/pull/32864) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -200,7 +200,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   public override func safeAreaInsetsDidChange() {
     super.safeAreaInsetsDidChange()
-    // This is the only way that I (@behenate) to force re-calculation of the safe-area insets for native controls
+    // This is the only way that I (@behenate) found to force re-calculation of the safe-area insets for native controls
     playerViewController.view.removeFromSuperview()
     addSubview(playerViewController.view)
   }

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -197,4 +197,11 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     playerViewController.beginAppearanceTransition(self.window != nil, animated: true)
     #endif
   }
+
+  public override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    // This is the only way that I (@behenate) to force re-calculation of the safe-area insets for native controls
+    playerViewController.view.removeFromSuperview()
+    addSubview(playerViewController.view)
+  }
 }


### PR DESCRIPTION
# Why

Safe area insets for the native controls are not updating when view moves from underneath the notch.
Fixes https://github.com/expo/expo/issues/30722

# How

Forces re-update of the native controls when the insets for a view change. The solution is kinda ugly, but nothing else I've tried has worked.

# Test Plan

Tested in BareExpo and the repro app from the issue.