### PR TITLE
[ios][camera] Fix bounding box when barcode scanning

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Drop legacy `cameraview-aar` dependency. ([#32853](https://github.com/expo/expo/pull/32853) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Return the correct bounding box and corner points when scanning barcodes.
+- [iOS] Return the correct bounding box and corner points when scanning barcodes. ([#32871](https://github.com/expo/expo/pull/32871) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.0.4 — 2024-11-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Drop legacy `cameraview-aar` dependency. ([#32853](https://github.com/expo/expo/pull/32853) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Return the correct bounding box and corner points when scanning barcodes.
 
 ## 16.0.4 — 2024-11-13
 

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -22,7 +22,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   ]
   private var previewLayer: AVCaptureVideoPreviewLayer?
   private var zxingEnabled = true
-  private var delegate: MetatDataDelegate?
+  private var delegate: MetaDataDelegate?
 
   init(session: AVCaptureSession, sessionQueue: DispatchQueue) {
     self.session = session
@@ -111,7 +111,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     session.beginConfiguration()
     defer { session.commitConfiguration() }
 
-    delegate = MetatDataDelegate(
+    delegate = MetaDataDelegate(
       settings: settings,
       previewLayer: previewLayer,
       zxingBarcodeReaders: zxingBarcodeReaders,

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -14,7 +14,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   // MARK: - Properties
 
-  private lazy var barcodeScanner = createBarcodeScanner()
+  private var barcodeScanner: BarcodeScanner?
   private lazy var previewLayer = AVCaptureVideoPreviewLayer(session: self.session)
   private var isValidVideoOptions = true
   private var videoCodecType: AVVideoCodecType?
@@ -50,7 +50,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   var isScanningBarcodes = false {
     didSet {
       Task {
-        await barcodeScanner.setIsEnabled(isScanningBarcodes)
+        await barcodeScanner?.setIsEnabled(isScanningBarcodes)
       }
     }
   }
@@ -144,6 +144,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     #if !targetEnvironment(simulator)
     setupPreview()
     #endif
+    barcodeScanner = createBarcodeScanner()
     UIDevice.current.beginGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.addObserver(
       self,
@@ -268,7 +269,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     addErrorNotification()
     await changePreviewOrientation()
 
-    await barcodeScanner.maybeStartBarcodeScanning()
+    await barcodeScanner?.maybeStartBarcodeScanning()
     session.commitConfiguration()
     updateCameraIsActive()
     onCameraReady()
@@ -306,7 +307,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   func setBarcodeScannerSettings(settings: BarcodeSettings) {
     Task {
-      await barcodeScanner.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
+      await barcodeScanner?.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
     }
   }
 
@@ -757,7 +758,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     for output in session.outputs {
       session.removeOutput(output)
     }
-    await barcodeScanner.stopBarcodeScanning()
+    await barcodeScanner?.stopBarcodeScanning()
     session.commitConfiguration()
 
     motionManager.stopAccelerometerUpdates()

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -4,7 +4,7 @@ protocol BarcodeScanningResponseHandler {
   func onScanningResult(_ result: [String: Any]) async
 }
 
-class MetatDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
+class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
   private var settings: [String: [AVMetadataObject.ObjectType]]
   private var previewLayer: AVCaptureVideoPreviewLayer?
   private var zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader]


### PR DESCRIPTION
# Why
Closes #32867

Because the barcode scanner was a lazy property, it was possible for the metadata delegate to be created before the scanner. This led to the preview layer being nil and the wrong bounds and corner points being returned when scanning barcodes. Strangely enough this did not repro in bare expo

# How
Made the barcodeScanner optional and create it in the initializer. This ensure that it will always have the preview layer set correctly when the metadata delegate functions are called. 

# Test Plan
Used the provided repro. Bare-expo also works as before  
