### PR TITLE
[cli] fix: expo install --fix does not handle prerelease versions correctly

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix Expo Router root path on Windows. ([#32792](https://github.com/expo/expo/pull/32792) by [@marklawlor](https://github.com/marklawlor))
+- Fix handling of prerelease versions in dependency version checks. ([#32875](https://github.com/expo/expo/pull/32875) by [@betomoedano](https://github.com/betomoedano))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -4,6 +4,7 @@ import resolveFrom from 'resolve-from';
 
 import * as Log from '../../../../log';
 import {
+  isDependencyVersionIncorrect,
   logIncorrectDependencies,
   validateDependenciesVersionsAsync,
 } from '../validateDependenciesVersions';
@@ -290,5 +291,40 @@ describe(validateDependenciesVersionsAsync, () => {
     await expect(
       validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)
     ).resolves.toBeNull();
+  });
+});
+
+describe(isDependencyVersionIncorrect, () => {
+  const testCases = [
+    ['3.9.0-rc.1', '~3.9.0-rc.1', false, 'prerelease with tilde range'],
+    ['3.9.0-rc.1', '~3.9.1', true, 'different prerelease with tilde range'],
+    ['3.9.0-rc.1', '^3.9.0-rc.1', false, 'prerelease with caret range'],
+    ['3.9.0-rc.1', '3.9.0-rc.1', false, 'exact prerelease match'],
+    ['3.9.0', '^3.9.0', false, 'regular version with caret range'],
+    ['3.9.0', '~3.9.1', true, 'different regular version with tilde range'],
+    ['3.9.0', '~3.9.0', false, 'same regular version with tilde range'],
+    ['3.9.0', '>=3.9.0', false, 'same version with greater than or equal range'],
+    ['3.9.0', '>=4.0.0', true, 'version less than minimum'],
+    ['3.9.3', '>=3.9.0 <4.0.0', false, 'version within range'],
+    ['3.8.3', '>=3.9.0 <4.0.0', true, 'version outside range'],
+    ['4.0.0', '>=3.9.0 <=4.0.0', false, 'version equal to maximum'],
+    ['3.9.0-rc.1', '>=4.0.0-rc.1', true, 'prerelease less than minimum'],
+    ['4.0.0-preview.1', '>=4.0.0-preview.1', false, 'prerelease version equal to maximum'],
+    ['3.9.0-rc.1', '3.9.0', true, 'prerelease should be updated to stable version'],
+    ['1.2.3-rc.1', '^1.2.3', true, 'prerelease should not satisfy stable range'],
+    ['2.0.0', '>=2.0.0-beta.1 <2.0.0-beta.5', true, 'stable should not satisfy prerelease range'],
+    ['2.0.x', '>=1.0.0 <3.0.0', true, 'invalid version string'],
+  ];
+
+  testCases.forEach(([actual, expected, result, description]) => {
+    it(`returns ${result} evaluating ${actual} against ${expected} - ${description}`, () => {
+      expect(
+        isDependencyVersionIncorrect(
+          'react-native-reanimated',
+          actual as string,
+          expected as string
+        )
+      ).toBe(result);
+    });
   });
 });

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -233,7 +233,7 @@ function findIncorrectDependencies(
   return incorrectDeps;
 }
 
-function isDependencyVersionIncorrect(
+export function isDependencyVersionIncorrect(
   packageName: string,
   actualVersion: string,
   expectedVersionOrRange?: string
@@ -247,8 +247,12 @@ function isDependencyVersionIncorrect(
     return semver.ltr(actualVersion, expectedVersionOrRange);
   }
 
-  // all other packages: version range is based on Expo SDK version, so we always want to match range
-  return !semver.intersects(expectedVersionOrRange, actualVersion);
+  // For all other packages, check if the actual version satisfies the expected range
+  const satisfies = semver.satisfies(actualVersion, expectedVersionOrRange, {
+    includePrerelease: true,
+  });
+
+  return !satisfies;
 }
 
 function findDependencyType(


### PR DESCRIPTION
# Why

[ENG-14162 `expo install --fix` does not handle prerelease versions correctly.](https://linear.app/expo/issue/ENG-14162/expo-install-fix-does-not-handle-prerelease-versions-correctly)

# How

Use `semver.satisfies` instead of `semver.intersects`. The semver.satisfies function is designed to check if a specific version satisfies a given range, which aligns with our use case. Additionally, by passing the { includePrerelease: true } option (which I didn't know about), we ensure that prerelease versions are correctly considered during the comparison.

# Test Plan

Added new test cases to verify that the updated function behaves correctly in various scenarios involving prerelease and stable versions:

```
['3.9.0-rc.1', '3.9.0', true, 'prerelease should be updated to stable version'],
['1.2.3-rc.1', '^1.2.3', true, 'prerelease should not satisfy stable range'],
['2.0.0', '>=2.0.0-beta.1 <2.0.0-beta.5', true, 'stable should not satisfy prerelease range'],
['2.0.x', '>=1.0.0 <3.0.0', true, 'invalid version string'],
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
