### PR TITLE
[create-expo-nightly] fix running error

### DIFF
--- a/packages/create-expo-nightly/package.json
+++ b/packages/create-expo-nightly/package.json
@@ -41,10 +41,10 @@
     "@tsconfig/node20": "^20.1.2",
     "@vercel/ncc": "^0.38.0",
     "chalk": "^5.3.0",
-    "commander": "^11.1.0",
+    "commander": "^12.1.0",
     "expo-module-scripts": "^4.0.0",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.10",
-    "zx": "^7.2.3"
+    "zx": "^8.2.0"
   }
 }

--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -1,9 +1,12 @@
-import JsonFile from '@expo/json-file';
 import fs from 'fs-extra';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages';
-import { runAsync } from './Processes';
+import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages.js';
+import { runAsync } from './Processes.js';
+
+const require = createRequire(import.meta.url);
+const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
 
 /**
  * Clone the expo/expo repository and install dependencies.

--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -11,8 +11,15 @@ const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo
 /**
  * Clone the expo/expo repository and install dependencies.
  */
-export async function setupExpoRepoAsync(expoRepoPath: string, nightlyVersion: string) {
-  if (!(await fs.pathExists(expoRepoPath))) {
+export async function setupExpoRepoAsync(
+  projectRoot: string,
+  useExpoRepoPath: string | undefined,
+  nightlyVersion: string
+): Promise<string> {
+  let expoRepoPath: string;
+  const useExistingRepo = useExpoRepoPath && (await fs.pathExists(useExpoRepoPath));
+  if (!useExistingRepo) {
+    expoRepoPath = path.join(projectRoot, 'expo');
     console.log(`Cloning expo repository to ${expoRepoPath}`);
     console.time('Cloned expo repository');
     await runAsync(
@@ -24,7 +31,7 @@ export async function setupExpoRepoAsync(expoRepoPath: string, nightlyVersion: s
     );
     console.timeEnd('Cloned expo repository');
   } else {
-    console.log(`Updating expo repository at ${expoRepoPath}`);
+    expoRepoPath = useExpoRepoPath;
   }
 
   console.log(`Running \`yarn install\` in ${expoRepoPath}`);
@@ -32,6 +39,8 @@ export async function setupExpoRepoAsync(expoRepoPath: string, nightlyVersion: s
   await setupDependenciesAsync(expoRepoPath, nightlyVersion);
   await runAsync('yarn', ['install'], { cwd: expoRepoPath });
   console.timeEnd('Installed dependencies in expo repository');
+
+  return expoRepoPath;
 }
 
 /**
@@ -41,6 +50,7 @@ export async function packExpoBareTemplateTarballAsync(
   expoRepoPath: string,
   outputRoot: string
 ): Promise<string> {
+  await fs.ensureDir(outputRoot);
   const { stdout } = await runAsync('npm', ['pack', '--json', '--pack-destination', outputRoot], {
     cwd: path.join(expoRepoPath, 'templates', 'expo-template-bare-minimum'),
   });

--- a/packages/create-expo-nightly/src/Npm.ts
+++ b/packages/create-expo-nightly/src/Npm.ts
@@ -1,4 +1,4 @@
-import { runAsync } from './Processes';
+import { runAsync } from './Processes.js';
 
 /**
  * Get the version of a package's dist-tag from npm.

--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -1,9 +1,12 @@
-import JsonFile from '@expo/json-file';
-import fs from 'fs/promises';
 import { glob } from 'glob';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import { runAsync } from './Processes';
+import { runAsync } from './Processes.js';
+
+const require = createRequire(import.meta.url);
+const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
 
 let cachedPackages: Package[] | null = null;
 

--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -25,6 +25,12 @@ const EXCLUDE_PACKAGES = [
   'install-expo-modules',
   'pod-install',
   'uri-scheme',
+  'patch-project',
+  'create-expo-module',
+  'create-expo-nightly',
+  '@react-native-community/cli-platform-android', // mock modules inside expo-modules-autolinkin
+  'react', // canary react inside @expo/cli
+  'react-dom', // canary react inside @expo/cli
 ];
 
 export const REACT_NATIVE_TRANSITIVE_DEPENDENCIES = [
@@ -37,26 +43,18 @@ export const REACT_NATIVE_TRANSITIVE_DEPENDENCIES = [
 
 interface Package {
   name: string;
-  version: string;
   path: string;
 }
 
 /**
- * Register linkable package in the expo repo for bun linking.
+ * Add given workspace packages to the project.
  */
-export async function registerPackageLinkingAsync(expoRepoPath: string, pkg: Package) {
-  await runAsync('bun', ['link'], { cwd: pkg.path });
-}
-
-/**
- * Add given linkable packages to the project.
- */
-export async function addLinkablePackagesToAppAsync(projectRoot: string, packages: Package[]) {
+export async function addWorkspacePackagesToAppAsync(projectRoot: string, packages: Package[]) {
   const packageJson = await JsonFile.readAsync(path.join(projectRoot, 'package.json'));
   const dependencies: Record<string, string> =
     (packageJson.dependencies as Record<string, string>) ?? {};
   for (const pkg of packages) {
-    dependencies[pkg.name] = `link:${pkg.name}`;
+    dependencies[pkg.name] = 'workspace:*';
   }
   await JsonFile.mergeAsync(path.join(projectRoot, 'package.json'), { dependencies });
 }
@@ -70,7 +68,7 @@ export async function reinstallPackagesAsync(projectRoot: string) {
     fs.rm(path.join(projectRoot, 'bun.lockb'), { force: true }),
     fs.rm(path.join(projectRoot, 'yarn.lock'), { force: true }),
   ]);
-  await runAsync('bun', ['install'], { cwd: projectRoot });
+  await runAsync('bun', ['install', '--ignore-scripts'], { cwd: projectRoot });
 }
 
 /**
@@ -90,23 +88,17 @@ export async function getExpoPackagesAsync(expoRepoPath: string): Promise<Packag
       '**/__mocks__/**',
       '**/__fixtures__/**',
       '**/e2e/**',
+      '**/build/**',
     ],
   });
-  const packages = await Promise.all(
-    paths
-      .filter((pkgPath) => {
-        for (const exclude of EXCLUDE_PACKAGES) {
-          if (pkgPath.startsWith(exclude)) {
-            return false;
-          }
-        }
-        return true;
-      })
-      .flatMap(async (packageJsonName) => {
+  const packages = (
+    await Promise.all(
+      paths.map(async (packageJsonName) => {
         const packageRoot = path.join(expoRepoPath, 'packages', path.dirname(packageJsonName));
         return await createPackageAsync(packageRoot);
       })
-  );
+    )
+  ).filter((pkg) => pkg != null) as Package[];
 
   cachedPackages = packages.sort((a, b) => a.name.localeCompare(b.name));
   return cachedPackages;
@@ -121,21 +113,22 @@ export async function getReactNativeTransitivePackagesAsync(
   const packages = await Promise.all(
     REACT_NATIVE_TRANSITIVE_DEPENDENCIES.map((name) => {
       const packageRoot = path.join(expoRepoPath, 'node_modules', name);
-      return createPackageAsync(packageRoot);
+      return Promise.resolve({ name, path: packageRoot });
     })
   );
   return packages;
 }
 
-async function createPackageAsync(packageRoot: string): Promise<Package> {
+async function createPackageAsync(packageRoot: string): Promise<Package | null> {
   const packageJsonPath = path.join(packageRoot, 'package.json');
   const packagePath = path.dirname(packageJsonPath);
   const packageJson = await JsonFile.readAsync(packageJsonPath);
   const name = packageJson.name as string;
-  const version = packageJson.version as string;
+  if (EXCLUDE_PACKAGES.includes(name)) {
+    return null;
+  }
   return {
     name,
     path: packagePath,
-    version,
   };
 }

--- a/packages/create-expo-nightly/src/Processes.ts
+++ b/packages/create-expo-nightly/src/Processes.ts
@@ -1,4 +1,7 @@
-import { $, cd } from 'zx';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { $, cd } = require('zx') as typeof import('zx');
 
 let defaultVerbose = false;
 

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -1,9 +1,13 @@
-import JsonFile, { JSONArray, JSONObject, JSONValue } from '@expo/json-file';
+import type { JSONArray, JSONObject, JSONValue } from '@expo/json-file';
 import fs from 'fs-extra';
 import assert from 'node:assert';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import { runAsync } from './Processes';
+import { runAsync } from './Processes.js';
+
+const require = createRequire(import.meta.url);
+const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
 
 export interface ProjectProperties {
   /** The Android applicationId and iOS bundleIdentifier. */

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -4,6 +4,8 @@ import assert from 'node:assert';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+import { setupExpoRepoAsync } from './ExpoRepo.js';
+import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages.js';
 import { runAsync } from './Processes.js';
 
 const require = createRequire(import.meta.url);
@@ -16,8 +18,17 @@ export interface ProjectProperties {
   /** Enable the New Architecture mode. */
   newArchEnabled: boolean;
 
+  /** react-native nightly version */
+  nightlyVersion: string;
+
   /** The template to use when creating the project. @default "blank-typescript" */
   template?: string;
+
+  /** The template version on npm. @default "canary" */
+  templateVersion?: string;
+
+  /** Whether to use local expo/expo repository rather than clone a new one */
+  useExpoRepoPath: string | undefined;
 }
 
 /**
@@ -25,50 +36,81 @@ export interface ProjectProperties {
  */
 export async function createExpoApp(
   projectRoot: string,
-  expoRepoPath: string,
   props: ProjectProperties
-) {
+): Promise<string> {
   const template = props.template ?? 'blank-typescript';
+  const templateVersion = props.templateVersion ?? 'canary';
   if (await fs.pathExists(projectRoot)) {
     throw new Error(`Project already exists at ${projectRoot}`);
   }
-  await runAsync('bunx', ['create-expo-app', projectRoot, '--no-install', `--template`, template]);
-  await setupDependenciesAsync(projectRoot);
-  await setupEntryAsync(projectRoot);
+  await runAsync('bunx', [
+    'create-expo-app',
+    projectRoot,
+    '--no-install',
+    `--template`,
+    `${template}@${templateVersion}`,
+  ]);
+
+  const expoRepoPath = await setupExpoRepoAsync(
+    projectRoot,
+    props.useExpoRepoPath,
+    props.nightlyVersion
+  );
+
+  await setupProjectPackageJsonAsync(projectRoot, expoRepoPath, props.nightlyVersion);
   await setupMetroConfigAsync(projectRoot, expoRepoPath);
   await setupAppJsonAsync(projectRoot, {
     appId: props.appId,
     newArchEnabled: props.newArchEnabled,
   });
+
+  return expoRepoPath;
 }
 
 /**
- * Purge dependencies and will setup later.
+ * Setup package.json in the project for resolutions, workspaces and so on.
  */
-async function setupDependenciesAsync(projectRoot: string) {
-  await JsonFile.mergeAsync(path.join(projectRoot, 'package.json'), {
-    dependencies: {},
+async function setupProjectPackageJsonAsync(
+  projectRoot: string,
+  expoRepoPath: string,
+  nightlyVersion: string
+) {
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  const packageJson = await JsonFile.readAsync(packageJsonPath);
+
+  const scripts: Record<string, string> = (packageJson.scripts as Record<string, string>) ?? {};
+  scripts['postinstall'] = 'bun --cwd expo postinstall';
+
+  let workspacePrefix: string;
+  const relativePath = path.relative(projectRoot, expoRepoPath);
+  if (relativePath.startsWith('..')) {
+    workspacePrefix = expoRepoPath;
+  } else {
+    workspacePrefix = relativePath;
+  }
+
+  const resolutions: Record<string, string> =
+    (packageJson.resolutions as Record<string, string>) ?? {};
+  for (const name of REACT_NATIVE_TRANSITIVE_DEPENDENCIES) {
+    resolutions[name] = `${nightlyVersion}`;
+  }
+  await JsonFile.mergeAsync(packageJsonPath, {
+    // Add workspaces
+    workspaces: [`${workspacePrefix}/packages/*`, `${workspacePrefix}/packages/@expo/*`],
+
+    // Exclude templates from autolinking
+    expo: {
+      autolinking: {
+        exclude: ['expo-face-detector', 'expo-module-template', 'expo-module-template-local'],
+      },
+    },
+
+    // Pin the versions of transitive dependencies
+    resolutions,
+
+    // Add postinstall script
+    scripts,
   });
-}
-
-/**
- * Setup the entry point for monorepo.
- */
-async function setupEntryAsync(projectRoot: string) {
-  await fs.writeFile(
-    path.join(projectRoot, 'index.js'),
-    `\
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
-`
-  );
-  await JsonFile.deleteKeyAsync(path.join(projectRoot, 'package.json'), 'main');
 }
 
 /**
@@ -129,19 +171,17 @@ async function setupAppJsonAsync(
   sectionAndroid.package = appId;
   sectionIos.bundleIdentifier = appId;
 
-  // Add expo-build-properties plugin
   const plugins = exp.plugins ?? [];
   assert(isJSONArray(plugins));
-  plugins.push(['expo-build-properties', { android: { newArchEnabled }, ios: { newArchEnabled } }]);
+  // Push plugins if any
 
   // Add updates config
-  exp.runtimeVersion = {
-    policy: 'appVersion',
-  };
+  exp.runtimeVersion = '1.0.0';
 
   exp.android = sectionAndroid;
   exp.ios = sectionIos;
   exp.plugins = plugins;
+  exp.newArchEnabled = newArchEnabled;
   await JsonFile.writeAsync(appJsonPath, appJson);
 }
 

--- a/packages/create-expo-nightly/src/SanityChecks.ts
+++ b/packages/create-expo-nightly/src/SanityChecks.ts
@@ -1,4 +1,7 @@
-import { which } from 'zx';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { which } = require('zx') as typeof import('zx');
 
 /**
  * Check whether the current environment has the required tools available.

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -1,30 +1,29 @@
 #!/usr/bin/env node
 
-import './Preclude.fx';
+import './Preclude.fx.js';
 
 import chalk from 'chalk';
 import { Command } from 'commander';
 import path from 'node:path';
 
-import { packExpoBareTemplateTarballAsync, setupExpoRepoAsync } from './ExpoRepo';
-import { getNpmVersionAsync } from './Npm';
+import { packExpoBareTemplateTarballAsync, setupExpoRepoAsync } from './ExpoRepo.js';
+import { getNpmVersionAsync } from './Npm.js';
 import {
   addLinkablePackagesToAppAsync,
   getExpoPackagesAsync,
   getReactNativeTransitivePackagesAsync,
   registerPackageLinkingAsync,
   reinstallPackagesAsync,
-} from './Packages';
-import { setDefaultVerbose } from './Processes';
+} from './Packages.js';
+import { setDefaultVerbose } from './Processes.js';
 import {
   type ProjectProperties,
   createExpoApp,
   installCocoaPodsAsync,
   prebuildAppAsync,
-} from './Project';
-import { checkRequiredToolsAsync } from './SanityChecks';
-
-const packageJSON = require('../package.json');
+} from './Project.js';
+import { checkRequiredToolsAsync } from './SanityChecks.js';
+import packageJSON from '../package.json' assert { type: 'json' };
 
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)

--- a/packages/create-expo-nightly/src/types.d.ts
+++ b/packages/create-expo-nightly/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module '*.json';

--- a/packages/create-expo-nightly/tsconfig.json
+++ b/packages/create-expo-nightly/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "declaration": true,
     "strictNullChecks": true,
@@ -15,8 +15,8 @@
     "downlevelIteration": true,
 
     "outDir": "build",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4067,7 +4067,7 @@
   dependencies:
     form-data "*"
 
-"@types/fs-extra@^11.0.1":
+"@types/fs-extra@>=11":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.4.tgz#e16a863bb8843fba8c5004362b5a73e17becca45"
   integrity sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==
@@ -4274,7 +4274,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/minimist@^1.2.0", "@types/minimist@^1.2.2":
+"@types/minimist@^1.2.0":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
   integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
@@ -4306,14 +4306,14 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.5.7":
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=20", "@types/node@^20.5.7":
   version "20.12.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
   integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.16.3", "@types/node@^18.19.34":
+"@types/node@^18.19.34":
   version "18.19.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.34.tgz#c3fae2bbbdb94b4a52fe2d229d0dccce02ef3d27"
   integrity sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==
@@ -4384,11 +4384,6 @@
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
-
-"@types/ps-tree@^1.1.2":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.6.tgz#fbb22dabe3d64b79295f37ce0afb7320a26ac9a6"
-  integrity sha512-PtrlVaOaI44/3pl3cvnlK+GxOM3re2526TJvPvh7W+keHIXdV4TE0ylpPBAcvFQCbGitaTXwL9u+RF7qtVeazQ==
 
 "@types/qs@*":
   version "6.9.7"
@@ -4573,11 +4568,6 @@
     "@types/webpack-sources" "*"
     anymatch "^3.0.0"
     source-map "^0.6.0"
-
-"@types/which@^3.0.0":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/which/-/which-3.0.3.tgz#41142ed5a4743128f1bc0b69c46890f0453ddb89"
-  integrity sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==
 
 "@types/wrap-ansi@^8.0.1":
   version "8.0.1"
@@ -6090,7 +6080,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.2.0, chalk@^5.3.0:
+chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -6473,11 +6463,6 @@ commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
-
-commander@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
-  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^12.0.0, commander@^12.1.0:
   version "12.1.0"
@@ -7400,11 +7385,6 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
-  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
-
 duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -8009,19 +7989,6 @@ event-emitter@^0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-event-stream@=3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  integrity sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==
-  dependencies:
-    duplexer "~0.1.1"
-    from "~0"
-    map-stream "~0.1.0"
-    pause-stream "0.0.11"
-    split "0.3"
-    stream-combiner "~0.0.4"
-    through "~2.3.1"
 
 event-target-shim@^5.0.0, event-target-shim@^5.0.1:
   version "5.0.1"
@@ -8767,11 +8734,6 @@ from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-from@~0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
-  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
-
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
@@ -8796,7 +8758,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.1, fs-extra@^11.2.0:
+fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
@@ -8890,11 +8852,6 @@ fuse.js@^6.4.6:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.5.3.tgz#7446c0acbc4ab0ab36fa602e97499bdb69452b93"
   integrity sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg==
-
-fx@*:
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/fx/-/fx-31.0.0.tgz#f013b367d711f25daa7d117af0b10ea7148c4993"
-  integrity sha512-OoeYSPKqNKmfnH4s+rGYI0c8OZmqqOOXsUtqy0YyHqQQoQSDiDs3m3M9uXKx5OQR+jDx7/FhYqpO3kl/As/xgg==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -9108,17 +9065,6 @@ globby@^11.0.1, globby@^11.0.3:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-globby@^13.1.4:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
-  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.3.0"
-    ignore "^5.2.4"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -9563,7 +9509,7 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.1, ignore@^5.3.2:
+ignore@^5.1.1, ignore@^5.2.0, ignore@^5.3.1, ignore@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -11509,11 +11455,6 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-map-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-  integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
-
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -12326,15 +12267,6 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
-  integrity sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
-
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -13060,13 +12992,6 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
-pause-stream@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
-  dependencies:
-    through "~2.3"
-
 peek-stream@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
@@ -13447,13 +13372,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-ps-tree@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
-  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
-  dependencies:
-    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -14984,11 +14902,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slash@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
-  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
-
 slash@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-5.0.0.tgz#8c18a871096b71ee0e002976a4fe3374991c3074"
@@ -15191,13 +15104,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split@0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
-  dependencies:
-    through "2"
-
 split@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -15299,13 +15205,6 @@ stream-chain@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
   integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
-
-stream-combiner@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
-  dependencies:
-    duplexer "~0.1.1"
 
 stream-json@^1.8.0:
   version "1.8.0"
@@ -15856,7 +15755,7 @@ through2@^2.0.1, through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
+through@2, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -17007,11 +16906,6 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-webpod@^0:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/webpod/-/webpod-0.0.2.tgz#b577c93604fd23596488735887168b3236e3adae"
-  integrity sha512-cSwwQIeg8v4i3p4ajHhwgR7N6VyxAf+KYSSsY6Pd3aETE+xEU4vbitz7qQkB0I321xnhDdgtxuiSfk5r/FVtjg==
-
 websocket-driver@>=0.5.1:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
@@ -17139,13 +17033,6 @@ which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-3.0.1.tgz#89f1cd0c23f629a8105ffe69b8172791c87b4be1"
-  integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
 
@@ -17484,23 +17371,10 @@ zod@^3.22.4:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
-zx@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/zx/-/zx-7.2.3.tgz#d9fef6bd084f7e21994080de09fb20e441074c39"
-  integrity sha512-QODu38nLlYXg/B/Gw7ZKiZrvPkEsjPN3LQ5JFXM7h0JvwhEdPNNl+4Ao1y4+o3CLNiDUNcwzQYZ4/Ko7kKzCMA==
-  dependencies:
-    "@types/fs-extra" "^11.0.1"
-    "@types/minimist" "^1.2.2"
-    "@types/node" "^18.16.3"
-    "@types/ps-tree" "^1.1.2"
-    "@types/which" "^3.0.0"
-    chalk "^5.2.0"
-    fs-extra "^11.1.1"
-    fx "*"
-    globby "^13.1.4"
-    minimist "^1.2.8"
-    node-fetch "3.3.1"
-    ps-tree "^1.2.0"
-    webpod "^0"
-    which "^3.0.0"
-    yaml "^2.2.2"
+zx@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/zx/-/zx-8.2.0.tgz#46e8594bf2fe8c6bc15d6e571108e525da3c22b1"
+  integrity sha512-ec7Z1Ki9h4CsKqbMjZ8H7G1PbbZYErscxT314LF66Ljx1YRENisqa5m9IN2VjbYgOKxdv5t0MbVd3Hf+II3e7w==
+  optionalDependencies:
+    "@types/fs-extra" ">=11"
+    "@types/node" ">=20"


### PR DESCRIPTION
# Why

fix ESM running error as well as refactoring

# How

- well support ESM that to fix the error when running `npx create-expo-nightly@latest`
  ```
  ReferenceError: require is not defined in ES module scope, you can use import instead
  ```
- replace the package installation from bun link to bun workspace. 

# Test Plan

- at least ios nightly test should pass https://github.com/expo/expo/actions/runs/11832018336. android has react-native breaking changes and will follow up later

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
