### PR TITLE
Update GitHub Actions runners to macOS 15

### DIFF
--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -80,7 +80,7 @@ jobs:
         run: ./gradlew assembleDebug
 
   ios:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 75
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         build-type: [debug, release]
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   ios-build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
   ios-test:
     needs: ios-build
     runs-on: macos-12
-    # runs-on: macos-14
+    # runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   ios-build:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
   ios-test:
     needs: ios-build
     runs-on: macos-12
-    # runs-on: macos-14
+    # runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Why

Due to this incomprehensible decision: https://github.com/actions/runner-images/issues/10703

# How

Updated workflows from macos-14 runners to macos-15

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
