### PR TITLE
[core] fix fetch stuck issue

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed requests from `expo/fetch` being stuck on iOS. ([#32894](https://github.com/expo/expo/pull/32894) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.0.2 — 2024-11-13

--- a/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
@@ -89,12 +89,15 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
     didReceive challenge: URLAuthenticationChallenge,
     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
   ) {
-    if let delegate = getDelegate(task: task) {
+    if let delegate = getDelegate(task: task),
+      delegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:))) {
       delegate.urlSession?(
         session,
         task: task,
         didReceive: challenge,
         completionHandler: completionHandler)
+    } else {
+      completionHandler(.performDefaultHandling, nil)
     }
   }
 }


### PR DESCRIPTION
# Why

fix expo/fetch stuck
reported from https://github.com/expo/expo/discussions/21710#discussioncomment-11243263

# How

it's a regression from #32670. the delegate proxy also being used for expo/fetch. the delegate does not implement the `URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:)` method. so completionHandler does not be called and get stuck.

this pr checks whether the delegate method is implemented, otherwise uses the default impelmentatiion

# Test Plan

test repro from https://github.com/fukuli053/expo52-fetch-issue

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
