### PR TITLE
[create-expo-nightly] fix missing packages

### DIFF
--- a/packages/create-expo-nightly/package.json
+++ b/packages/create-expo-nightly/package.json
@@ -36,15 +36,17 @@
     "url": "git+https://github.com/expo/expo.git",
     "directory": "packages/create-expo-nightly"
   },
-  "devDependencies": {
+  "dependencies": {
     "@expo/json-file": "^9.0.0",
+    "zx": "^8.2.0"
+  },
+  "devDependencies": {
     "@tsconfig/node20": "^20.1.2",
     "@vercel/ncc": "^0.38.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "expo-module-scripts": "^4.0.0",
     "fs-extra": "^11.2.0",
-    "glob": "^10.3.10",
-    "zx": "^8.2.0"
+    "glob": "^10.3.10"
   }
 }


### PR DESCRIPTION
# Why

fixed missing `zx` and `@expo/json-file` packages when running `npx create-expo-nightly`

# How

it turns out ncc cannot include dependencies from `createRequire`. let's add these two packages to deps 

# Test Plan

publish and try later

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
