### PR TITLE
[pod-install] better handled unknown opts

### DIFF
--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Do not treat unknown opts as possible project path. ([#32919](https://github.com/expo/expo/pull/32919) by [@Simek](https://github.com/Simek))
+
 ### 💡 Others
 
 ## 0.3.1 — 2024-11-14

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pod-install",
   "version": "0.3.1",
-  "description": "Ensure CocoaPods are installed in your project",
+  "description": "A fast, zero-dependency package for cutting down on common issues developers have when running pod install.",
   "main": "./build/index.js",
   "scripts": {
     "build": "ncc build ./src/index.ts -o build/",

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -87,7 +87,9 @@ const program = new Command(packageJSON.name)
   .version(packageJSON.version)
   .arguments('[project-directory]')
   .usage(`${chalk.green('[project-directory]')} [options]`)
-  .description('Install pods in your project')
+  .description(
+    'A fast, zero-dependency package for cutting down on common issues developers have when running pod install.'
+  )
   .option('--quiet', 'only print errors')
   .option('--non-interactive', 'disable interactive prompts')
   .allowUnknownOption()

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -19,7 +19,7 @@ function info(message: string) {
 
 async function runAsync(maybeProjectDirectory?: string): Promise<void> {
   if (process.platform !== 'darwin') {
-    info(chalk.yellow('CocoaPods is only supported on darwin machines'));
+    info(chalk.yellow('⚠️ CocoaPods is only supported on darwin machines'));
     process.exit(0);
   }
 
@@ -27,7 +27,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
   const possibleProjectRoot = resolve(hasProjectDirectory ? maybeProjectDirectory : process.cwd());
 
   if (!existsSync(possibleProjectRoot)) {
-    info(chalk.red(`\nTarget directory does not exist: ${possibleProjectRoot}\n`));
+    info(chalk.red(`\n💥 Target directory does not exist: ${possibleProjectRoot}\n`));
     process.exit(1);
   }
 
@@ -37,7 +37,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
     const packageJsonPath = join(possibleProjectRoot, 'package.json');
 
     if (!existsSync(packageJsonPath)) {
-      info(chalk.red(`\n'package.json' file does not exist: ${packageJsonPath}\n`));
+      info(chalk.red(`\n💥 'package.json' file does not exist: ${packageJsonPath}\n`));
       process.exit(1);
     }
 
@@ -47,7 +47,7 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
     if (hasExpoPackage) {
       info(
         chalk.yellow(
-          `No 'ios' directory found, skipping installing pods.`,
+          `⚠️ No 'ios' directory found, skipping installing pods.`,
           `\nPods will be automatically installed when the 'ios' directory is generated with 'npx expo prebuild' or 'npx expo run:ios'.`,
           learnMore('https://docs.expo.dev/workflow/prebuild/')
         )
@@ -56,14 +56,14 @@ async function runAsync(maybeProjectDirectory?: string): Promise<void> {
     }
 
     if (hasProjectDirectory) {
-      info(chalk.yellow(`CocoaPods is not supported in project at ${possibleProjectRoot}`));
+      info(chalk.yellow(`⚠️ CocoaPods is not supported in project at ${possibleProjectRoot}`));
     } else {
-      info(chalk.yellow('CocoaPods is not supported in this project'));
+      info(chalk.yellow('⚠️ CocoaPods is not supported in this project'));
     }
     process.exit(0);
   }
 
-  info('Scanning for pods...');
+  info('🔍️ Scanning for pods...');
 
   if (!(await CocoaPodsPackageManager.isCLIInstalledAsync())) {
     await CocoaPodsPackageManager.installCLIAsync({
@@ -88,8 +88,8 @@ const program = new Command(packageJSON.name)
   .arguments('[project-directory]')
   .usage(`${chalk.green('[project-directory]')} [options]`)
   .description('Install pods in your project')
-  .option('--quiet', 'Only print errors')
-  .option('--non-interactive', 'Disable interactive prompts')
+  .option('--quiet', 'only print errors')
+  .option('--non-interactive', 'disable interactive prompts')
   .allowUnknownOption()
   .parse(process.argv)
   .action(async (maybeProjectDirectory?: string) => {
@@ -104,7 +104,7 @@ const program = new Command(packageJSON.name)
         console.log(`  ${chalk.magenta(reason.command)} has failed.`);
       } else {
         console.log(
-          chalk.red`An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`
+          chalk.red`💥 An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`
         );
         console.log(reason);
       }

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -19,7 +19,28 @@ const program = new Command(packageJSON.name)
   .option('--quiet', 'Only print errors')
   .option('--non-interactive', 'Disable interactive prompts')
   .allowUnknownOption()
-  .parse(process.argv);
+  .parse(process.argv)
+  .action(async (projectDirectory?: string) => {
+    try {
+      await runAsync(projectDirectory);
+      if (!program.opts().quiet) {
+        await shouldUpdate();
+      }
+    } catch (reason: any) {
+      console.log('\nAborting run');
+      if (reason.command) {
+        console.log(`  ${chalk.magenta(reason.command)} has failed.`);
+      } else {
+        console.log(chalk.red`An unexpected error was encountered. Please report it as a bug:`);
+        console.log(reason);
+      }
+      console.log();
+      if (!program.opts().quiet) {
+        await shouldUpdate();
+      }
+      process.exit(1);
+    }
+  });
 
 function info(message: string) {
   if (!program.opts().quiet) {
@@ -27,13 +48,14 @@ function info(message: string) {
   }
 }
 
-async function runAsync(projectDirectory: string): Promise<void> {
+async function runAsync(projectDirectory?: string): Promise<void> {
   if (process.platform !== 'darwin') {
     info(chalk.red('\nCocoaPods is only supported on darwin machines\n'));
     process.exit(1);
   }
 
-  const possibleProjectRoot = resolve(projectDirectory ?? process.cwd());
+  const hasProjectDirectory = projectDirectory && !projectDirectory.startsWith('--');
+  const possibleProjectRoot = resolve(hasProjectDirectory ? projectDirectory : process.cwd());
 
   if (!existsSync(possibleProjectRoot)) {
     info(chalk.red(`\nTarget directory does not exist! (${possibleProjectRoot})\n`));
@@ -64,7 +86,7 @@ async function runAsync(projectDirectory: string): Promise<void> {
       process.exit(0);
     }
 
-    if (projectDirectory) {
+    if (hasProjectDirectory) {
       info(chalk.yellow(`CocoaPods is not supported in project at ${possibleProjectRoot}`));
     } else {
       info(chalk.yellow('CocoaPods is not supported in this project'));
@@ -93,24 +115,5 @@ async function runAsync(projectDirectory: string): Promise<void> {
 }
 
 (async () => {
-  program.parse(process.argv);
-  try {
-    await runAsync(program.args[0]);
-    if (!program.opts().quiet) {
-      await shouldUpdate();
-    }
-  } catch (reason: any) {
-    console.log('\nAborting run');
-    if (reason.command) {
-      console.log(`  ${chalk.magenta(reason.command)} has failed.`);
-    } else {
-      console.log(chalk.red`An unexpected error was encountered. Please report it as a bug:`);
-      console.log(reason);
-    }
-    console.log();
-    if (!program.opts().quiet) {
-      await shouldUpdate();
-    }
-    process.exit(1);
-  }
+  await program.parseAsync(process.argv);
 })();

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -31,7 +31,9 @@ const program = new Command(packageJSON.name)
       if (reason.command) {
         console.log(`  ${chalk.magenta(reason.command)} has failed.`);
       } else {
-        console.log(chalk.red`An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`);
+        console.log(
+          chalk.red`An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`
+        );
         console.log(reason);
       }
       console.log();

--- a/packages/pod-install/src/index.ts
+++ b/packages/pod-install/src/index.ts
@@ -31,7 +31,7 @@ const program = new Command(packageJSON.name)
       if (reason.command) {
         console.log(`  ${chalk.magenta(reason.command)} has failed.`);
       } else {
-        console.log(chalk.red`An unexpected error was encountered. Please report it as a bug:`);
+        console.log(chalk.red`An unexpected error was encountered. Report it on GitHub: https://github.com/expo/expo/issues`);
         console.log(reason);
       }
       console.log();


### PR DESCRIPTION
# Why

Refs #32914

# How

Better handle unknown opts, do not attempt to construct path using unsupported opts, see:
* https://github.com/tj/commander.js/tree/master?tab=readme-ov-file#parsing-configuration

Move code around to better match recommended approach to async action.

# Test Plan

Tested the CLI locally, on various Expo project and non-project directories. Made sure that unknown opts are not used.

# Preview

![Screenshot 2024-11-14 at 20 01 10](https://github.com/user-attachments/assets/4e0c65c2-05b0-4935-82f0-412dd89e8f48)
