### PR TITLE
[expo-gl] Fix GL layer transparency on iOS

### DIFF
--- a/packages/expo-gl/ios/GLView.swift
+++ b/packages/expo-gl/ios/GLView.swift
@@ -48,9 +48,9 @@ internal final class GLView: ExpoView, EXGLContextDelegate {
 
     // Initialize properties of our backing CAEAGLLayer
     if let eaglLayer = layer as? CAEAGLLayer {
-      eaglLayer.isOpaque = true
+      eaglLayer.isOpaque = false
       eaglLayer.drawableProperties = [
-        kEAGLDrawablePropertyRetainedBacking: true,
+        kEAGLDrawablePropertyRetainedBacking: false,
         kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8
       ]
     }


### PR DESCRIPTION
# Why

A recent regression in migrating the iOS implementation of expo-gl to Swift, introduced a regression that causes the GLView to always have a black background.

![IMG_1483](https://github.com/user-attachments/assets/86f03067-9bff-4342-8a36-2339758feda4)

# How

Though the logic did not change in this migration, I believe it surfaced an existing bug in which we do not properly set the transparency of the backing CAEAGLLayer correctly.

# Test Plan

Validated that after this change, the GLView transparency matches Android and SDK 51.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
