### PR TITLE
fix(cli): add temporary fix for Windows SSR

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix windows SSR.
+
 ### 💡 Others
 
 ## 0.21.3 — 2024-11-14

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- fix windows SSR.
+- fix windows SSR. ([#32923](https://github.com/expo/expo/pull/32923) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -329,6 +329,11 @@ export function withExtendedResolver(
           );
         }
 
+        // TODO: Windows doesn't support externals somehow.
+        if (process.platform === 'win32') {
+          return /^(source-map-support(\/.*)?)$/.test(moduleName);
+        }
+
         // Extern these modules in standard Node.js environments in development to prevent API routes side-effects
         // from leaking into the dev server process.
         return /^(source-map-support(\/.*)?|react|react-native-helmet-async|@radix-ui\/.+|@babel\/runtime\/.+|react-dom(\/.+)?|debug|acorn-loose|acorn|css-in-js-utils\/lib\/.+|hyphenate-style-name|color|color-string|color-convert|color-name|fontfaceobserver|fast-deep-equal|query-string|escape-string-regexp|invariant|postcss-value-parser|memoize-one|nullthrows|strict-uri-encode|decode-uri-component|split-on-first|filter-obj|warn-once|simple-swizzle|is-arrayish|inline-style-prefixer\/.+)$/.test(


### PR DESCRIPTION
# Why

- Create temporary workaround for windows users https://github.com/expo/expo/issues/32843


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- When running on windows, disable all externals in bundling. Unclear why these don't work, but disabling the externals appears to unblock starting the process.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Ran with @marklawlor 