### PR TITLE
[ci] Downgrade Android emulator version to 33.1.24

### DIFF
--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'A custom working directory - e.g. `./android` if your root Gradle project is under the `./android` sub-directory within your repository'
     required: false
     default: './'
+  emulator-build:
+    description: 'build number of a specific version of the emulator binary to use - e.g. `11237101` for emulator v33.1.24'
+    required: false
 
 outputs:
   avd-hit:
@@ -44,6 +47,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        emulator-build: ${{ inputs.emulator-build }}
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready
@@ -68,6 +72,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        emulator-build: ${{ inputs.emulator-build }}
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready
@@ -92,6 +97,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        emulator-build: ${{ inputs.emulator-build }}
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -236,6 +236,10 @@ jobs:
           avd-name: avd-${{ matrix.api-level }}
           script: ./scripts/start-android-e2e-test.sh
           working-directory: ./apps/bare-expo
+          # We use an older version of the simulator due to this issue:
+          # https://github.com/facebook/react-native/issues/43320
+          # This build number is for version 33.1.24 which matches the API level that we test against.
+          emulator-build: 11237101
       - name: 📸 Store images of test failures
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Why

Fixes CI failures in test suite E2E tests for Android, e.g. https://github.com/expo/expo/runs/33013889209
It seems to be failing with this message:
```
dev.expo.payments.BareExpoTestSuite:.........E1114 22:13:38.189801    2275 FrameBuffer.cpp:3628] Failed to find ColorBuffer:382
...E1114 22:13:45.820218    2275 FrameBuffer.cpp:3628] Failed to find ColorBuffer:460
INSTRUMENTATION_RESULT: shortMsg=Process crashed.
INSTRUMENTATION_CODE: 0
```

# How

I've found that issue in React Native repo: https://github.com/facebook/react-native/issues/43320 and it seems that the solution is to downgrade the emulator to version 33.1.24 which is the latest stable version for the API level that we test against. Its build number is `11237101`.

# Test Plan

CI job should pass