### PR TITLE
[ci] Use Android API level 34 for testing

### DIFF
--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -5,7 +5,7 @@ inputs:
   avd-api:
     description: 'API version used in AVD'
     required: false
-    default: '33'
+    default: '34'
   avd-name:
     description: 'Created AVD name'
     required: true

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -43,7 +43,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [34]
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [34]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [34]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [34]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [34]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Why

Our `targetSdkVersion` is now 34, so we should update the emulator to 34 as well

# How

Updated the Android API level used in our workflows 

# Test Plan

CI checks are passing