### PR TITLE
[splashscreen] Restore setTheme workaround

### DIFF
--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -1,9 +1,11 @@
 package expo.modules.splashscreen
 
 import android.app.Activity
+import android.os.Build
 import android.view.View
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.view.animation.AccelerateInterpolator
+import android.window.SplashScreenView
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.facebook.react.bridge.ReactMarker
@@ -32,13 +34,19 @@ object SplashScreenManager {
     val duration = options.duration
 
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
-      splashScreenViewProvider.view
+      val splashScreenView = splashScreenViewProvider.view
+      splashScreenView
         .animate()
         .setDuration(duration)
         .alpha(0.0f)
         .setInterpolator(AccelerateInterpolator())
         .withEndAction {
-          splashScreenViewProvider.remove()
+          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            splashScreenViewProvider.remove();
+          } else {
+            // Avoid calling applyThemesSystemBarAppearance
+            (splashScreenView as SplashScreenView).remove();
+          }
         }.start()
     }
   }


### PR DESCRIPTION
# Why
This workaround was in place for most of the development of the new splashscreen and was left out during a refactor. It avoids `applyThemesSystemBarAppearance` being called on the main window causing the users `StatusBar` defined choice.

# How
Add back the check when removing the splashscreen

# Test Plan
bare-expo

cc @zoontek 
