### PR TITLE
Adding TTL clarification for iOS/APNs

### DIFF
--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -103,6 +103,10 @@ This is likely due to the `priority` level of the notifications you're sending. 
 
 And setting the priority to `high` gives your notification the greatest likelihood that the Android will display the notification.
 
+### Notifications sent whilst an iOS device is offline are not recevied when the device comes back online 
+
+This indicates that you have not set the [Time to Live / TTL](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format) as part of the message format. This defaults to zero for iOS/APNs, so redelivery is never attempted. Adjust this setting to account for devices being offline / out of network reception.
+
 ### Handle expired push notification credentials
 
 When your push notification credentials have expired, run `eas credentials`, choose iOS and a build profile, then remove your push notification key and generate a new one.

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -103,7 +103,7 @@ This is likely due to the `priority` level of the notifications you're sending. 
 
 And setting the priority to `high` gives your notification the greatest likelihood that the Android will display the notification.
 
-### Notifications sent whilst an iOS device is offline are not recevied when the device comes back online 
+### Notifications sent whilst an iOS device is offline are not recevied when the device comes back online
 
 This indicates that you have not set the [Time to Live / TTL](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format) as part of the message format. This defaults to zero for iOS/APNs, so redelivery is never attempted. Adjust this setting to account for devices being offline / out of network reception.
 


### PR DESCRIPTION
Clarifying the TTL setting as a lack of notification redelivery was an issue I was experiencing. This is not clear or highlighted in the current documentation.

# Why

This is not clear or highlighted in the current documentation. I was not able to receive notifications consistently until I discovered this setting.

# How

n/a

# Test Plan

n/a

# Checklist


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
