### PR TITLE
[jest-expo] fix error if no babel config in project

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed error when `babel.config.js` is not existed. ([#32942](https://github.com/expo/expo/pull/32942) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 52.0.1 — 2024-11-14

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -6,6 +6,7 @@ const isEqual = require('lodash/isEqual');
 const jestPreset = cloneDeep(require('react-native/jest-preset'));
 
 const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
+const { resolveBabelConfig } = require('./src/resolveBabelConfig');
 
 // Emulate the alias behavior of Expo's Metro resolver.
 jestPreset.moduleNameMapper = {
@@ -22,10 +23,14 @@ if (upstreamBabelJest) {
 }
 
 // transform
-jestPreset.transform['\\.[jt]sx?$'] = [
-  'babel-jest',
-  { caller: { name: 'metro', bundler: 'metro', platform: 'ios' } },
-];
+const babelOpts = {
+  caller: { name: 'metro', bundler: 'metro', platform: 'ios' },
+};
+const babelConfigFile = resolveBabelConfig(process.cwd());
+if (babelConfigFile) {
+  babelOpts.configFile = babelConfigFile;
+}
+jestPreset.transform['\\.[jt]sx?$'] = ['babel-jest', babelOpts];
 
 /* Update this when metro changes their default extensions */
 const defaultMetroAssetExts = [

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -1,0 +1,30 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Resolve the babel `configFile` option.
+ */
+function resolveBabelConfig(projectRoot) {
+  // TODO(EvanBacon): We might want to disable babelrc lookup when the user specifies `enableBabelRCLookup: false`.
+  const possibleBabelRCPaths = ['.babelrc', '.babelrc.js', 'babel.config.js'];
+  const foundBabelRCPath = possibleBabelRCPaths.find((configFileName) =>
+    fs.existsSync(path.resolve(process.cwd(), configFileName))
+  );
+  if (foundBabelRCPath) {
+    // If the user has a babel config file, we should return null and use the default configFile resolution from babel.
+    return null;
+  }
+
+  try {
+    return require.resolve('babel-preset-expo');
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+module.exports = {
+  resolveBabelConfig,
+};


### PR DESCRIPTION
# Why

fixes jest test error when no `babel.config.js` in project.
fixes #32883

# How

since #31928, the babel.config.js has been removed and use the default resolution from [our metro config](https://github.com/expo/expo/blob/4cb6f580e07deacd3a8e736305121294e6141ab4/packages/%40expo/metro-config/src/loadBabelConfig.ts#L28-L46). if no babel.config.js is not there, it directly uses babel-preset-expo. we did not have similar logic for jest. this pr tries to implement similar to jest.

# Test Plan

```sh
$ bunx create-expo-app -t default@sdk-52 sdk52
$ cd sdk52
$ bun run test
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
