### PR TITLE
[bare][Android] Remove `LinearGradient` from e2e tests

### DIFF
--- a/apps/bare-expo/e2e/TestSuite-test.native.js
+++ b/apps/bare-expo/e2e/TestSuite-test.native.js
@@ -8,7 +8,7 @@ export const TESTS = [
   // 'Font',
   'Permissions',
   // 'Blur',
-  'LinearGradient',
+  // 'LinearGradient',
   'Constants',
   // 'Contacts',
   'Crypto',


### PR DESCRIPTION
# Why

We have removed `LinearGradient` from our e2e tests that run on GitHub CI. We have observed many crashes during these tests due to unidentified GPU-related issues. While the code functions perfectly when run locally, it seems that the problems arise from the virtualization used by the CI runner.