### PR TITLE
[image][Android] Fix Gifs animation never stops even when loop count is set to 1

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed Gifs animation never stops even when loop count is set to 1.
+- [Android] Fixes Gif animations never stopping even when loop count is set to 1. ([#32944](https://github.com/expo/expo/pull/32944) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed Gifs animation never stops even when loop count is set to 1.
+
 ### 💡 Others
 
 ## 2.0.0 — 2024-11-11

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
   api 'com.caverock:androidsvg-aar:1.4'
 
-  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.1"
+  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.2"
   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
 
   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/30858.
See https://github.com/penfeizhou/APNG4Android/pull/229 for more information.

# Test Plan

- https://snack.expo.dev/@desquinazirbi/expo-image-gifs-issue ✅ 