### PR TITLE
[core][Android] Fix sending ByteArray as event payload

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed requests from `expo/fetch` being stuck on iOS. ([#32894](https://github.com/expo/expo/pull/32894) by [@kudo](https://github.com/kudo))
+- [Android] Fixed sending event containing `ByteArray` from the Kotlin module results in string ID instead of `Uint8Array`.
 
 ## 2.0.2 — 2024-11-13
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed requests from `expo/fetch` being stuck on iOS. ([#32894](https://github.com/expo/expo/pull/32894) by [@kudo](https://github.com/kudo))
-- [Android] Fixed sending event containing `ByteArray` from the Kotlin module results in string ID instead of `Uint8Array`.
+- [Android] Fixed sending event containing `ByteArray` from the Kotlin module results in string ID instead of `Uint8Array`. ([#32945](https://github.com/expo/expo/pull/32945) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.0.2 — 2024-11-13
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
@@ -57,7 +57,7 @@ public:
     jni::alias_ref<JavaScriptModuleObject::javaobject> jsiThis,
     jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
     jni::alias_ref<jstring> eventName,
-    jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
+    jni::alias_ref<jni::JMap<jstring, jobject>> eventBody
   );
 
 private:

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReadableNativeMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.uimanager.UIManagerHelper
@@ -12,7 +11,7 @@ import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.jni.JNIUtils
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.JSTypeConverter
-import expo.modules.kotlin.types.toJSValue
+import expo.modules.kotlin.types.toJSValueExperimental
 import java.lang.ref.WeakReference
 
 /**
@@ -27,25 +26,25 @@ class KModuleEventEmitterWrapper(
 ) : KEventEmitterWrapper(legacyEventEmitter, reactContextHolder) {
   override fun emit(eventName: String, eventBody: Bundle?) {
     checkIfEventWasExported(eventName)
-    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
+    emitNative(eventName, eventBody?.toJSValueExperimental())
   }
 
   override fun emit(eventName: String, eventBody: WritableMap?) {
     checkIfEventWasExported(eventName)
-    emitNative(eventName, eventBody as? ReadableNativeMap)
+    emitNative(eventName, eventBody?.toHashMap())
   }
 
   override fun emit(eventName: String, eventBody: Record?) {
     checkIfEventWasExported(eventName)
-    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
+    emitNative(eventName, eventBody?.toJSValueExperimental())
   }
 
   override fun emit(eventName: String, eventBody: Map<*, *>?) {
     checkIfEventWasExported(eventName)
-    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
+    emitNative(eventName, eventBody?.toJSValueExperimental())
   }
 
-  private fun emitNative(eventName: String, eventBody: ReadableNativeMap?) {
+  private fun emitNative(eventName: String, eventBody: Map<String, Any?>?) {
     val runtimeContext = moduleHolder.module.runtimeContext
     val jsObject = moduleHolder.safeJSObject ?: return
     try {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIUtils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIUtils.kt
@@ -1,7 +1,5 @@
 package expo.modules.kotlin.jni
 
-import com.facebook.react.bridge.ReadableNativeMap
-
 @Suppress("KotlinJniMissingFunction")
 class JNIUtils {
   companion object {
@@ -26,7 +24,7 @@ class JNIUtils {
       jsiThis: JavaScriptModuleObject,
       jsiContext: JSIContext,
       eventName: String,
-      eventBody: ReadableNativeMap?
+      eventBody: Map<String, Any?>?
     )
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/29566.

# How

I changed the converters used for emitting new events from the module. Previously, we relied on legacy converters built on top of `WritableMap`. Now, we are using Java maps directly. While this change may seem significant, we are already using the new converters for passing and receiving data from the native functions, and they have been thoroughly tested.

# Test Plan

- unit tests ✅ 
- [OzymandiasTheGreat/expo-passing-buffers](https://github.com/OzymandiasTheGreat/expo-passing-buffers) ✅ 