### PR TITLE
[DOCS] Compatibility issue of multiple targets with use_frameworks

### DIFF
--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -273,6 +273,8 @@ abstract_target 'common' do
 end
 ```
 
+> **Note**: Using use_frameworks might break linking expo modules correctly on the newly added targets.
+
 Open project in Xcode, click on the project name in the navigation panel, right click on the existing target, and click "Duplicate":
 
 <ContentSpotlight


### PR DESCRIPTION
# Why

Took me a day to figure out that using react-native-firebase and its use_frameworks were causing issues but just with newly added targets.
Feel free to adjust wording as you see fit

# How

-

# Test Plan

-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
