### PR TITLE
[expo-go] Adjust splashscreen to account for plugin

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
@@ -66,6 +66,16 @@ class ManagedAppSplashScreenConfiguration private constructor() {
      * - generic splash imageUrl
      */
     private fun parseImageUrl(manifest: Manifest): String? {
+      val pluginInfo = manifest.getPluginProperties("expo-splash-screen")
+      pluginInfo?.let { info ->
+        val url = manifest.getIconUrl()?.split("./")?.get(0)
+        val pluginUrl = info["image"] as String?
+        url?.let {
+          return "$it$pluginUrl"
+        }
+        return info["image"] as String?
+      }
+
       val androidSplash = manifest.getAndroidSplashInfo()
       if (androidSplash != null) {
         val dpiRelatedImageUrl = getStringFromJSONObject(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenConfiguration.kt
@@ -66,14 +66,10 @@ class ManagedAppSplashScreenConfiguration private constructor() {
      * - generic splash imageUrl
      */
     private fun parseImageUrl(manifest: Manifest): String? {
-      val pluginInfo = manifest.getPluginProperties("expo-splash-screen")
-      pluginInfo?.let { info ->
-        val url = manifest.getIconUrl()?.split("./")?.get(0)
-        val pluginUrl = info["image"] as String?
-        url?.let {
-          return "$it$pluginUrl"
-        }
-        return info["image"] as String?
+      // Because of the changes to splashscreen we are going to default to the app icon in expo go
+      val iconUrl = manifest.getIconUrl()
+      if (iconUrl != null) {
+        return iconUrl
       }
 
       val androidSplash = manifest.getAndroidSplashInfo()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
@@ -15,10 +15,16 @@ class SplashScreenView(
   context: Context
 ) : RelativeLayout(context) {
   val imageView: ImageView = ImageView(context).also { view ->
-    view.layoutParams = LayoutParams(
-      LayoutParams.MATCH_PARENT,
-      LayoutParams.MATCH_PARENT
-    )
+    val width = 200
+    val height = 200
+
+    val density = context.resources.displayMetrics.density
+    val pixelWidth = (width * density).toInt()
+    val pixelHeight = (height * density).toInt()
+
+    val layoutParams = LayoutParams(pixelWidth, pixelHeight)
+    layoutParams.addRule(CENTER_IN_PARENT)
+    view.layoutParams = layoutParams
   }
 
   init {

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
@@ -41,14 +41,8 @@ static const NSString *kImageResizeModeCover = @"cover";
 
 + (NSString * _Nullable)parseImageUrl:(EXManifestsManifest *)manifest
 {
-  NSDictionary *plugin = [manifest getPluginPropertiesWithPackageName:@"expo-splash-screen"];
-  NSString *image = [plugin valueForKey:@"image"];
-  if (image) {
-    NSURL *url = [NSURL URLWithString:manifest.bundleUrl];
-    NSString *origin = [NSString stringWithFormat:@"%@://%@:%@", url.scheme, url.host, url.port];
-    return [NSString stringWithFormat:@"%@/assets/%@", origin, image];
-  }
-  return manifest.iosSplashImageUrl;
+  // Because of the changes to splashscreen, we now default to the app icon in expo go
+  return manifest.iosAppIconUrl;
 }
 
 + (EXSplashScreenImageResizeMode)parseImageResizeMode:(EXManifestsManifest *)manifest

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
@@ -41,6 +41,14 @@ static const NSString *kImageResizeModeCover = @"cover";
 
 + (NSString * _Nullable)parseImageUrl:(EXManifestsManifest *)manifest
 {
+  NSDictionary *plugin = [manifest getPluginPropertiesWithPackageName:@"expo-splash-screen"];
+  NSString *image = [plugin valueForKey:@"image"];
+  if (image) {
+    NSURL *url = [NSURL URLWithString:manifest.bundleUrl];
+    NSString *schemeAndHost = [NSString stringWithFormat:@"%@://%@:%@", url.scheme, url.host, url.port];
+    NSString *result = [NSString stringWithFormat:@"%@/assets/%@", schemeAndHost, image];
+    return result;
+  }
   return manifest.iosSplashImageUrl;
 }
 

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXManagedAppSplashScreenConfigurationBuilder.m
@@ -45,9 +45,8 @@ static const NSString *kImageResizeModeCover = @"cover";
   NSString *image = [plugin valueForKey:@"image"];
   if (image) {
     NSURL *url = [NSURL URLWithString:manifest.bundleUrl];
-    NSString *schemeAndHost = [NSString stringWithFormat:@"%@://%@:%@", url.scheme, url.host, url.port];
-    NSString *result = [NSString stringWithFormat:@"%@/assets/%@", schemeAndHost, image];
-    return result;
+    NSString *origin = [NSString stringWithFormat:@"%@://%@:%@", url.scheme, url.host, url.port];
+    return [NSString stringWithFormat:@"%@/assets/%@", origin, image];
   }
   return manifest.iosSplashImageUrl;
 }

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -266,7 +266,7 @@ public class Manifest: NSObject {
       ])
     }
   }
-  
+
   public func iosAppIconUrl() -> String? {
     return expoClientConfigRootObject().let { it in
       Manifest.string(fromManifest: it, atPath: ["iconUrl"])

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -266,6 +266,12 @@ public class Manifest: NSObject {
       ])
     }
   }
+  
+  public func iosAppIconUrl() -> String? {
+    return expoClientConfigRootObject().let { it in
+      Manifest.string(fromManifest: it, atPath: ["iconUrl"])
+    }
+  }
 
   public func iosSplashImageUrl() -> String? {
     return expoClientConfigRootObject().let { it in


### PR DESCRIPTION
# Why
Closes ENG-14182
We need to account for the plugin being the default method of defining the splashscreen. When parsing the manifest we need to check for the plugin first and use the image it defines if present. Otherwise we fall back to the older configuration methods. Also, I adjusted the size of the image on Android to match the changes made on ios in #32687

# How
Get the plugin configuration from the manifest and provide that image if it is present. I had to generate the image URL myself and am unsure how to get this correctly. cc @wschurman 

# Test Plan
expo-go ios and Android both display the splash icon correctly

| Android | iOS |
| ---- | ----- |
|![android](https://github.com/user-attachments/assets/844a4a45-5419-4735-b784-9644aad05abe)|![ios](https://github.com/user-attachments/assets/619914f9-a903-4254-a14b-82ec7b021903)|

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
