### PR TITLE
[apple-auth] Move struct definition

### DIFF
--- a/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
@@ -3,21 +3,6 @@ import ExpoModulesCore
 
 let credentialRevokedEventName = "Expo.appleIdCredentialRevoked"
 
-struct FullName: Record {
-  @Field
-  var namePrefix: String?
-  @Field
-  var nameSuffix: String?
-  @Field
-  var givenName: String?
-  @Field
-  var middleName: String?
-  @Field
-  var familyName: String?
-  @Field
-  var nickname: String?
-}
-
 public final class AppleAuthenticationModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoAppleAuthentication")

--- a/packages/expo-apple-authentication/ios/FullNameFormatStyle.swift
+++ b/packages/expo-apple-authentication/ios/FullNameFormatStyle.swift
@@ -1,6 +1,21 @@
 import AuthenticationServices
 import ExpoModulesCore
 
+struct FullName: Record {
+  @Field
+  var namePrefix: String?
+  @Field
+  var nameSuffix: String?
+  @Field
+  var givenName: String?
+  @Field
+  var middleName: String?
+  @Field
+  var familyName: String?
+  @Field
+  var nickname: String?
+}
+
 enum FullNameFormatStyle: String, Enumerable {
   case `default`
   case short


### PR DESCRIPTION
# Why
#32567 added a new record in the module file. 

# How
Moving it to the same place the enum it added was defined.

# Test Plan
n/a

