### PR TITLE
[expo-updates] fix detox debug build

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,11 +12,9 @@
 
 ### 🐛 Bug fixes
 
-
 - Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
-- fix E2E tests in debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
-
+- fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,8 +12,11 @@
 
 ### 🐛 Bug fixes
 
+
 - Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
+- fix E2E tests in debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
+
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -78,8 +78,11 @@ class UpdatesDevLauncherController(
   }
 
   @get:Synchronized
-  override val launchAssetFile: String
-    get() = throw Exception("IUpdatesController.launchAssetFile should not be called in dev client")
+  override val launchAssetFile: override val launchAssetFile: String?
+    get() {
+      logger.warn("IUpdatesController.launchAssetFile should not be called in dev client, except during Detox testing")
+      return null
+    }
 
   override val bundleAssetName: String
     get() = throw Exception("IUpdatesController.bundleAssetName should not be called in dev client")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -78,9 +78,9 @@ class UpdatesDevLauncherController(
   }
 
   @get:Synchronized
-  override val launchAssetFile: override val launchAssetFile: String?
+  override val launchAssetFile: String?
     get() {
-      logger.warn("IUpdatesController.launchAssetFile should not be called in dev client, except during Detox testing")
+      logger.warn("launchAssetFile should not be called from expo-dev-client build, except for Detox testing")
       return null
     }
 


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/28918

Debug build is using Dev Client and `launchAssetFile` [can't be called from Dev Client](https://github.com/expo/expo/blob/c1ab8d0551cf2f1b0604316a18daa563fd24c495/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt#L82), so it's not possible to run Detox E2E tests in debug mode, which makes the development of tests harder. 

# How

Simply do not try to preload updates if Dev Client is used.

# Test Plan

There is no user facing change. It only affects E2E tests development.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
