### PR TITLE
Update image-picker.mdx

### DIFF
--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -52,6 +52,7 @@ export default function Index() {
   const pickImageAsync = async () => {
     /* @tutinfo Pass image picker options to <CODE>launchImageLibraryAsync()</CODE> */
     let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
       allowsEditing: true,
       quality: 1,
     });
@@ -165,7 +166,7 @@ const PlaceholderImage = require('@/assets/images/background-image.png');
 export default function Index() {
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       allowsEditing: true,
       quality: 1,
     });


### PR DESCRIPTION
Change deprecated mediaTypes: ImagePicker.MediaTypeOptions.Images to mediaTypes: ["images"]

# Why
I'm learning from docs, in this section in tutorial is used deprecated mediaTypes

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
https://docs.expo.dev/versions/latest/sdk/imagepicker/ provided up to date mediaTypes

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
