### PR TITLE
[docs] Add a section about disabling New Architecture

### DIFF
--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -164,22 +164,9 @@ Now you can tap around your app and test it out. For most non-trivial apps, you'
 
 ## Disable the New Architecture in an existing project
 
-To disable New Architecture in your project, set `newArchEnabled` to `false` in your app config. You can also selectively disable it for a single platform by setting, for example, `"android": { "newArchEnabled": false }`.
+Starting SDK 52, Expo Go will only support the New Architecture since all Expo libraries and third-party libraries included in Expo Go support the New Architecture.
 
-```json app.json
-{
-  "expo": {
-    "newArchEnabled": false
-  }
-}
-```
-
-<Collapsible summary="Are you disabling the New Architecture in a bare React Native app?">
-
-- **Android**: Set `newArchEnabled=false` in the **gradle.properties** file.
-- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"false"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
-
-</Collapsible>
+If you want to opt out of using the New Architecture, whether you are using Expo Go or a development build, remove the `newArchEnabled` property from app config and create a [development build](/develop/development-builds/introduction/).
 
 ## Troubleshooting
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -158,13 +158,13 @@ Now you can tap around your app and test it out. For most non-trivial apps, you'
 <Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
 
 - **Android**: Set `newArchEnabled=true` in the **gradle.properties** file.
-- **iOS**: If your project has a **Podfile.properties.json** file (it was created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
+- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
 
 </Collapsible>
 
 ## Disable the New Architecture in an existing project
 
-If you encounter issues with the New Architecture, you can disable it by setting `newArchEnabled` to `false` in your app config:
+To disable New Architecture in your project, set `newArchEnabled` to `false` in your app config. You can also selectively disable it for a single platform by setting, for example, `"android": { "newArchEnabled": false }`.
 
 ```json app.json
 {
@@ -174,7 +174,12 @@ If you encounter issues with the New Architecture, you can disable it by setting
 }
 ```
 
-You can also selectively disable it for a single platform by setting, for example, `"android": { "newArchEnabled": false }`.
+<Collapsible summary="Are you disabling the New Architecture in a bare React Native app?">
+
+- **Android**: Set `newArchEnabled=false` in the **gradle.properties** file.
+- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"false"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
+
+</Collapsible>
 
 ## Troubleshooting
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -164,7 +164,7 @@ Now you can tap around your app and test it out. For most non-trivial apps, you'
 
 ## Disable the New Architecture in an existing project
 
-Starting SDK 52, Expo Go only supports the New Architecture since all Expo libraries and third-party libraries included in Expo Go support the New Architecture.
+Starting SDK 52, Expo Go only supports the New Architecture since all Expo libraries and third-party libraries included in Expo Go support the New Architecture. Note that [the Go app is not intended to be used as a development environment for real-world apps](https://expo.fyi/expo-go-usage).
 
 If you want to opt out of using the New Architecture, whether you are using Expo Go or a development build, remove the `newArchEnabled` property from app config and create a [development build](/develop/development-builds/introduction/).
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -124,7 +124,7 @@ Set `newArchEnabled` on target platforms:
 
 <Step label="2">
 
-Create a new build.
+Create a new build:
 
 <Tabs tabs={['Android', 'iOS']}>
   <Tab>
@@ -161,6 +161,20 @@ Now you can tap around your app and test it out. For most non-trivial apps, you'
 - **iOS**: If your project has a **Podfile.properties.json** file (it was created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
 
 </Collapsible>
+
+## Disable the New Architecture in an existing project
+
+If you encounter issues with the New Architecture, you can disable it by setting `newArchEnabled` to `false` in your app config:
+
+```json app.json
+{
+  "expo": {
+    "newArchEnabled": false
+  }
+}
+```
+
+You can also selectively disable it for a single platform by setting, for example, `"android": { "newArchEnabled": false }`.
 
 ## Troubleshooting
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -164,7 +164,7 @@ Now you can tap around your app and test it out. For most non-trivial apps, you'
 
 ## Disable the New Architecture in an existing project
 
-Starting SDK 52, Expo Go will only support the New Architecture since all Expo libraries and third-party libraries included in Expo Go support the New Architecture.
+Starting SDK 52, Expo Go only supports the New Architecture since all Expo libraries and third-party libraries included in Expo Go support the New Architecture.
 
 If you want to opt out of using the New Architecture, whether you are using Expo Go or a development build, remove the `newArchEnabled` property from app config and create a [development build](/develop/development-builds/introduction/).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feedback in [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1731710182975079) .

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add info based on [changelog release post](https://expo.dev/changelog/2024/11-12-sdk-52#what-the-rollout-will-look-like) about removing the `newArchEnabled` and creating a development build to disable it. Also added info about Expo Go that disabling it is not an option.
- Fix a typo in Step 2 under Enable the New Architecture in an existing project

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-27 at 17 30 52](https://github.com/user-attachments/assets/dc543c3c-23cb-4cb3-9dba-fd018a696e99)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
