### PR TITLE
Update image-picker.mdx

### DIFF
--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -318,7 +318,7 @@ export default function Index() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       allowsEditing: true,
       quality: 1,
     });


### PR DESCRIPTION
Change mediaType from deprecated mediaTypes: ImagePicker.MediaTypeOptions.Images, to mediaTypes: ['images'], to match with previous code in tutorial

# Why
Change mediaType to match previous code

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
 Change from mediaTypes: ImagePicker.MediaTypeOptions.Images, to mediaTypes: ['images']

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
