### PR TITLE
[template-default] Fix import in useThemeColor.ts

### DIFF
--- a/templates/expo-template-default/hooks/useThemeColor.ts
+++ b/templates/expo-template-default/hooks/useThemeColor.ts
@@ -3,7 +3,7 @@
  * https://docs.expo.dev/guides/color-schemes/
  */
 
-import { useColorScheme } from 'react-native';
+import { useColorScheme } from './useColorScheme';
 
 import { Colors } from '@/constants/Colors';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
There is a bug because importing from 'react-native' prevents the useColorScheme.web.ts to be imported, making the web using the dark scheme instead of the light on some browsers.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I simply changed the import to actually use the local useColorScheme files that were previously bypassed by the import from react-native

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

For me I simply create a new project with this template, open the web project and check that the ThemedText renders with the proper theme. On my Chrome browser I used to get a mixture of white background and black background, after this fix everything is properly themed.

Note: for some reason this doesn't happen with the default template code, but very quickly with custom projects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
