### PR TITLE
Update platform-differences.mdx app/(tabs)/index.tsx to use mediaType…

### DIFF
--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -81,7 +81,7 @@ export default function Index() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
       allowsEditing: true,
       quality: 1,
     });


### PR DESCRIPTION
…s: ['images'

Replaced the deprecated` ImagePicker.MediaTypeOptions.Images` with `mediaTypes: ['images']` in `app/(tabs)/index.tsx` to align with the updated code examples in the tutorial.

# Why
Ensures consistency and compatibility with the previous code examples.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
`ImagePicker.MediaTypeOptions.Images` is deprecated. The [ImagePicker documentation](https://docs.expo.dev/versions/latest/sdk/imagepicker/) uses the `mediaTypes` array syntax in its examples, such as: `mediaTypes: ['images', 'videos']`

This PR updates the code in `app/(tabs)/index.tsx` to reflect this change, replacing `ImagePicker.MediaTypeOptions.Images` with `mediaTypes: ['images']`.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
