### PR TITLE
[docs] Adds workflows to /guides

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -289,6 +289,13 @@ const general = [
     { expanded: false }
   ),
   makeSection('EAS', [makePage('eas/index.mdx'), makePage('eas/json.mdx')]),
+  makeSection('Workflows', [
+    makePage('workflows/get-started.mdx'),
+    makePage('workflows/triggers.mdx'),
+    makePage('workflows/jobs.mdx'),
+    makePage('workflows/control-flow.mdx'),
+    makePage('workflows/variables.mdx'),
+  ]),
   makeSection('EAS Build', [
     makePage('build/introduction.mdx'),
     makePage('build/setup.mdx'),


### PR DESCRIPTION
# Why

This adds links to workflows docs under /guides, in the EAS and above EAS Build. I chose this spot since workflows create builds, submissions, updates, etc.

# Screenshot

<img width="328" alt="Screenshot 2024-11-17 at 11 56 11 AM" src="https://github.com/user-attachments/assets/eae8f4ad-c896-4381-ab35-e1954a060601">


# Test Plan

Make sure that the workflows docs show up under the /guides section in the docs.