### PR TITLE
Update expo-cli.mdx typo

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -229,7 +229,7 @@ Building from Xcode is useful because you can set native breakpoints and profile
 
 **iOS development signing**
 
-If you want to see how your app will run on your device, all you have to do is connect it, run `npx expo run:ios —-device`, and select your connected device.
+If you want to see how your app will run on your device, all you have to do is connect it, run `npx expo run:ios --device`, and select your connected device.
 
 Expo CLI will automatically sign the device for development, install the app, and launch it.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Wrong dash was used in docs command.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
