### PR TITLE
[docs] a11y fixes, sidebar DOM optimizations

### DIFF
--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -95,7 +95,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
               !this.state.showScrollTop && 'pointer-events-none opacity-0'
             )}
             onClick={e => this.handleTopClick(e)}>
-            <ArrowCircleUpIcon className="icon-sm text-icon-secondary" />
+            <ArrowCircleUpIcon className="icon-sm text-icon-secondary" aria-label="Scroll to top" />
           </Button>
         </CALLOUT>
         {displayedHeadings.map(heading => {

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
           class="flex self-center text-inherit leading-none"
         >
           <svg
+            aria-label="Scroll to top"
             class="icon-sm text-icon-secondary"
             fill="none"
             role="img"

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -11,7 +11,10 @@ import { LaunchPartyBanner } from '~/ui/components/LaunchPartyBanner';
 
 function Home() {
   return (
-    <DocumentationPage hideTOC hideFromSearch>
+    <DocumentationPage
+      hideTOC
+      hideFromSearch
+      description="Build one JavaScript/TypeScript project that runs natively on all your users' devices.">
       <div className="h-0">
         <DevicesImageMasks />
       </div>

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -44,7 +44,7 @@ export type NavigationRoute = {
   weight?: number;
   isNew?: boolean;
   isDeprecated?: boolean;
-  children?: NavigationRoute[];
+  children?: NavigationRouteWithSection[];
 };
 
 export type NavigationRouteWithSection = NavigationRoute & { section?: string };

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             Bare Workflow
           </span>
           <a
+            aria-label="Permalink"
             class="ml-auto inline"
             href="#bare-workflow"
           >
@@ -247,6 +248,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             ExpoKit
           </span>
           <a
+            aria-label="Permalink"
             class="ml-auto inline"
             href="#expokit"
           >
@@ -323,6 +325,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             Bare Workflow
           </span>
           <a
+            aria-label="Permalink"
             class="ml-auto inline"
             href="#bare-workflow-1"
           >
@@ -474,6 +477,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               ExpoKit
             </span>
             <a
+              aria-label="Permalink"
               class="ml-auto inline"
               href="#expokit-1"
             >
@@ -784,6 +788,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             Bare Workflow
           </span>
           <a
+            aria-label="Permalink"
             class="ml-auto inline"
             href="#bare-workflow-2"
           >

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -110,7 +110,8 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           <LinkBase
             href={'#' + heading.current.slug}
             ref={heading.current.ref}
-            className="ml-auto inline">
+            className="ml-auto inline"
+            aria-label="Permalink">
             <PermalinkIcon className="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible" />
           </LinkBase>
           <div />

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -17,7 +17,7 @@ export const PageTitle = ({ title, description, packageName, iconUrl, sourceCode
     <>
       <div
         className={mergeClasses(
-          'my-2 flex items-start justify-between gap-4',
+          'mt-2 flex items-start justify-between gap-4',
           'max-xl-gutters:flex-col max-xl-gutters:items-start'
         )}>
         <H1 className="!my-0">

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -16,71 +16,42 @@ import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
 import { TerminalBrowserIcon } from '@expo/styleguide-icons/outline/TerminalBrowserIcon';
 
 import { SidebarNodeProps } from './Sidebar';
-import { SidebarTitle, SidebarLink, SidebarSection } from './index';
+import { SidebarLink, SidebarSection, SidebarTitle } from './index';
 
 import { reportEasTutorialCompleted } from '~/providers/Analytics';
 import { useTutorialChapterCompletion } from '~/providers/TutorialChapterCompletionProvider';
 import { NavigationRoute } from '~/types/common';
 import { HandWaveIcon } from '~/ui/components/CustomIcons/HandWaveIcon';
 import { CircularProgressBar } from '~/ui/components/ProgressTracker/CircularProgressBar';
-import { Chapter } from '~/ui/components/ProgressTracker/TutorialData';
 
 export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
-  const title = route.sidebarTitle ?? route.name;
-  const Icon = getIconElement(title);
   const { chapters, setChapters, getStartedChapters, setGetStartedChapters } =
     useTutorialChapterCompletion();
 
-  const allChaptersCompleted = chapters.every((chapter: Chapter) => chapter.completed);
-  const completedChaptersCount = chapters.filter((chapter: Chapter) => chapter.completed).length;
-  const isChapterCompleted = (childSlug: string) => {
-    const isCompleted = chapters.some(
-      (chapter: Chapter) => chapter.slug === childSlug && chapter.completed
-    );
-    return isCompleted;
-  };
-  const totalChapters = chapters.length;
-  const progressPercentage = (completedChaptersCount / totalChapters) * 100;
+  const title = route.sidebarTitle ?? route.name;
+  const Icon = getIconElement(title);
 
-  if (allChaptersCompleted) {
-    reportEasTutorialCompleted();
-  }
-
-  const resetTutorial = () => {
-    if (allChaptersCompleted) {
-      const resetChapters = chapters.map((chapter: Chapter) => ({ ...chapter, completed: false }));
-      setChapters(resetChapters);
-    }
-  };
-
-  const allGetStartedChaptersCompleted = getStartedChapters.every(
-    (chapter: Chapter) => chapter.completed
-  );
-  const completedGetStartedChaptersCount = getStartedChapters.filter(
-    (chapter: Chapter) => chapter.completed
-  ).length;
-  const isGetStartedChapterCompleted = (childSlug: string) => {
-    const isCompleted = getStartedChapters.some(
-      (chapter: Chapter) => chapter.slug === childSlug && chapter.completed
-    );
-    return isCompleted;
-  };
-  const totalGetStartedChapters = getStartedChapters.length;
-  const progressPercentageForGetStarted =
-    (completedGetStartedChaptersCount / totalGetStartedChapters) * 100;
-
-  const resetGetStartedTutorial = () => {
-    if (allGetStartedChaptersCompleted) {
-      const resetChapters = getStartedChapters.map((chapter: Chapter) => ({
-        ...chapter,
-        completed: false,
-      }));
-      setGetStartedChapters(resetChapters);
-    }
-  };
-
-  // @ts-ignore
   if (route.children?.[0]?.section === 'EAS tutorial') {
+    const allChaptersCompleted = chapters.every(chapter => chapter.completed);
+    const completedChaptersCount = chapters.filter(chapter => chapter.completed).length;
+    const totalChapters = chapters.length;
+    const progressPercentage = (completedChaptersCount / totalChapters) * 100;
+
+    if (allChaptersCompleted) {
+      reportEasTutorialCompleted();
+    }
+
+    const isChapterCompleted = (childSlug: string) => {
+      return chapters.some(chapter => chapter.slug === childSlug && chapter.completed);
+    };
+
+    const resetTutorial = () => {
+      if (allChaptersCompleted) {
+        const resetChapters = chapters.map(chapter => ({ ...chapter, completed: false }));
+        setChapters(resetChapters);
+      }
+    };
+
     return (
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
@@ -92,17 +63,15 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </div>
           </div>
         )}
-        {(route.children || []).map(child => {
+        {route.children.map(child => {
           const childSlug = child.href;
           const completed = isChapterCompleted(childSlug);
 
           return (
-            <div className="flex items-center justify-between" key={`${route.name}-${child.name}`}>
-              <div className="flex-1">
-                <SidebarLink info={child}>{child.sidebarTitle || child.name}</SidebarLink>
-              </div>
-              {completed && <CheckIcon className="size-4" />}
-            </div>
+            <SidebarLink info={child} className="flex flex-1">
+              {child.sidebarTitle ?? child.name}
+              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+            </SidebarLink>
           );
         })}
         {allChaptersCompleted && (
@@ -118,8 +87,29 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
     );
   }
 
-  // @ts-ignore
   if (route.children?.[0]?.section === 'Expo tutorial') {
+    const allGetStartedChaptersCompleted = getStartedChapters.every(chapter => chapter.completed);
+    const completedGetStartedChaptersCount = getStartedChapters.filter(
+      chapter => chapter.completed
+    ).length;
+    const totalGetStartedChapters = getStartedChapters.length;
+    const progressPercentageForGetStarted =
+      (completedGetStartedChaptersCount / totalGetStartedChapters) * 100;
+
+    const isGetStartedChapterCompleted = (childSlug: string) => {
+      return getStartedChapters.some(chapter => chapter.slug === childSlug && chapter.completed);
+    };
+
+    const resetGetStartedTutorial = () => {
+      if (allGetStartedChaptersCompleted) {
+        const resetChapters = getStartedChapters.map(chapter => ({
+          ...chapter,
+          completed: false,
+        }));
+        setGetStartedChapters(resetChapters);
+      }
+    };
+
     return (
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
@@ -131,17 +121,15 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </div>
           </div>
         )}
-        {(route.children || []).map(child => {
+        {route.children.map(child => {
           const childSlug = child.href;
           const completed = isGetStartedChapterCompleted(childSlug);
 
           return (
-            <div className="flex items-center justify-between" key={`${route.name}-${child.name}`}>
-              <div className="flex-1">
-                <SidebarLink info={child}>{child.sidebarTitle || child.name}</SidebarLink>
-              </div>
-              {completed && <CheckIcon className="size-4" />}
-            </div>
+            <SidebarLink info={child} className="flex flex-1">
+              {child.sidebarTitle ?? child.name}
+              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+            </SidebarLink>
           );
         })}
         {allGetStartedChaptersCompleted && (

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -8,6 +8,7 @@ import { NavigationRoute } from '~/types/common';
 
 type SidebarLinkProps = PropsWithChildren<{
   info: NavigationRoute;
+  className?: string;
 }>;
 
 const HEAD_NAV_HEIGHT = 160;
@@ -22,7 +23,7 @@ const isLinkInViewport = (element: HTMLAnchorElement) => {
   );
 };
 
-export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
+export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => {
   const router = useRouter();
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -44,39 +45,38 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
   const isExternal = info.href.startsWith('http');
 
   return (
-    <div className="flex min-h-8 items-center p-1 pr-0">
-      <LinkBase
-        href={info.href as string}
-        ref={ref}
+    <LinkBase
+      href={info.href as string}
+      ref={ref}
+      className={mergeClasses(
+        'group -ml-2.5 flex w-full scroll-m-[60px] items-center p-1 pr-0 text-xs text-secondary decoration-0',
+        'hocus:text-link [&_svg]:hocus:text-icon-info',
+        isSelected && 'text-link [&_svg]:text-icon-info',
+        info.isDeprecated && 'line-through',
+        className
+      )}
+      {...customDataAttributes}>
+      <div
         className={mergeClasses(
-          'group -ml-2.5 flex w-full scroll-m-[60px] items-center text-xs text-secondary decoration-0',
-          'hocus:text-link hocus:[&_svg]:text-icon-tertiary',
-          isSelected && 'text-link',
-          info.isDeprecated && 'line-through'
+          'mx-1.5 my-2 size-1.5 shrink-0 self-start rounded-full',
+          isSelected && 'bg-palette-blue11'
         )}
-        {...customDataAttributes}>
+      />
+      {children}
+      {info.isNew && (
         <div
           className={mergeClasses(
-            'mx-1.5 my-2 size-1.5 shrink-0 self-start rounded-full',
-            isSelected && 'bg-palette-blue11'
-          )}
-        />
-        {children}
-        {info.isNew && (
-          <div
-            className={mergeClasses(
-              '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[11px] font-semibold leading-none text-palette-white',
-              isSelected
-                ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
-                : 'border-palette-blue10 bg-none text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
-            )}>
-            NEW
-          </div>
-        )}
-        {isExternal && (
-          <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
-        )}
-      </LinkBase>
-    </div>
+            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[11px] font-semibold leading-none text-palette-white',
+            isSelected
+              ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
+              : 'border-palette-blue10 bg-none text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
+          )}>
+          NEW
+        </div>
+      )}
+      {isExternal && (
+        <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
+      )}
+    </LinkBase>
   );
 };

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -20,6 +20,7 @@ export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
       leftSlot={<ClipboardIcon className="icon-sm text-icon-default" />}
       onClick={onCopyClick}
       disabled={copyDone}
+      aria-label="Copy content"
       {...rest}>
       {copyDone ? 'Copied!' : 'Copy'}
     </SnippetAction>

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -29,6 +29,7 @@ export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
         <div>
           <SnippetAction
             className="min-w-[44px] px-3"
+            aria-label="Show settings"
             leftSlot={<DotsVerticalIcon className="icon-md shrink-0 text-icon-secondary" />}
             {...rest}
           />


### PR DESCRIPTION
# Why

Few tweaks and fixes based on the Lighthouse checks, including improved a11y and DOM simplification.

# How

Short summary of changes:
* add missing home page description
* add missing labels for icons-only interactables
* simplify DOM of Sidebar elements
* correct `NavigationRoute` child routes type
* reduce the spacing between sidebar links slightly
* place tutorial check at top of link, colorize hen link is hovered

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-11-17 at 21 31 27](https://github.com/user-attachments/assets/84bda687-c5ca-43d8-b6f5-2fb0cae6eb9f)
