### PR TITLE
[docs] Fix expo-audio GitHub link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -1,7 +1,7 @@
 ---
 title: Audio (expo-audio)
 description: A library that provides an API to implement audio playback and recording in apps.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-audio'
 packageName: 'expo-audio'
 iconUrl: '/static/images/packages/expo-av.png'
 platforms: ['android', 'ios', 'web']


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #32932

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the link in `sourceCodeUrl` metadata field to https://github.com/expo/expo/tree/main/packages/expo-audio.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
