### PR TITLE
Edit document to avoid error `NOT_FOUND` when deploy to Vercel

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -411,7 +411,7 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/api/index.ts"
+      "destination": "/api/index"
     }
   ]
 }


### PR DESCRIPTION
# Why

Using the recommended config of `vercel.json` v3 causes Vercel to be unable to show the website, Vercel simple shows the error `NOT_FOUND`.
<img width="515" alt="image" src="https://github.com/user-attachments/assets/de8f4656-d782-44f9-97e9-2236fe2ee938">

Using the newer version  of `vercel.json` somehow make Vercel not build `functions/api/index.ts.func` (as of using version 2) but instead builds `functions/api/index.func`.
- `vercel/output` tree when using v2 config:
![photo_2024-11-18_16-31-05](https://github.com/user-attachments/assets/469e436d-278d-4b11-bfd1-56bb03c3ae94)
- When using v3 config:
![image](https://github.com/user-attachments/assets/bc7ba534-e7fe-4e6d-b991-9fcd0630687a)

When rewrite to `/api/index.ts`, Vercel cannot find the function `api/index.ts`. 

# How
Simply changing the rewrie to `/api/index` fixes the issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- Start with `pnpx create-expo-app@latest my-project`
- Reset the project using `pnpm reset-project`
- Follow [instruction](https://docs.expo.dev/router/reference/api-routes/) to add api routes
   - Change `web`/`output` to `"server"` in `app.json`
   - Create a simple api route 
```.ts
// app/hello+api
export function GET(request: Request) {
  return Response.json({ hello: 'world' });
}
```
   - Add `api/index.ts` as Vercel server entry file
```ts
// api/index.ts
const { createRequestHandler } = require('@expo/server/adapter/vercel');

module.exports = createRequestHandler({
  build: require('path').join(__dirname, '../dist/server'),
});
```
   - Use recommended v3 of `vercel.json`
```json
{
  "buildCommand": "expo export -p web",
  "outputDirectory": "dist/client",
  "functions": {
    "api/index.ts": {
      "runtime": "@vercel/node@3.0.11",
      "includeFiles": "dist/server/**"
    }
  },
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "/api/index.ts"
    }
  ]
}
```
- Create a Vercel build, the build will be successful, however when navigate to the preview website or the api `/hello`, Vercel will show `NOT_FOUND` error
<img width="515" alt="image" src="https://github.com/user-attachments/assets/de8f4656-d782-44f9-97e9-2236fe2ee938">

- Simply change `rewrites`/`destination` to `"/api/index"` (remove `".ts"`) and rebuild solves the problem (The index page and the api route works as intended).

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
