### PR TITLE
[Android][core] Fix `no non-static method "SharedObject.getSharedObjectId()" when proguard is enabled

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed type errors when using `ts-jest`. ([#32954](https://github.com/expo/expo/pull/32954) by [@kudo](https://github.com/kudo))
-- [Android] Fixed `no non-static method "SharedObject.getSharedObjectId()" when proguard is enabled.
+- [Android] Fixed `no non-static method "SharedObject.getSharedObjectId()" when proguard is enabled. ([#33011](https://github.com/expo/expo/pull/33011) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed type errors when using `ts-jest`. ([#32954](https://github.com/expo/expo/pull/32954) by [@kudo](https://github.com/kudo))
+- [Android] Fixed `no non-static method "SharedObject.getSharedObjectId()" when proguard is enabled.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -20,6 +20,7 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
   internal var sharedObjectId: SharedObjectId = SharedObjectId(0)
 
   // Used by JNI
+  @DoNotStrip
   private fun getSharedObjectId(): Int {
     return sharedObjectId.value
   }


### PR DESCRIPTION
# Why

Fixed `no non-static method "SharedObject.getSharedObjectId()" when proguard is enabled
See https://github.com/expo/expo/pull/32943#pullrequestreview-2439329839.

# How

Added missing `DoNotStrip` annotation.  
# Test Plan

- run e2e locally ✅ 