### PR TITLE
[android][audio] Improve handling of audio Visualizer

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Imporve handling of `Visulaizer`.
+
 ## 0.2.3 — 2024-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [Android] Imporve handling of `Visulaizer`.
+- [Android] Imporve handling of `Visulaizer`. ([#33018](https://github.com/expo/expo/pull/33018) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.2.3 — 2024-10-28
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -157,6 +157,7 @@ class AudioPlayer(
       }
     }
 
+    // It must only be created once, otherwise the app will crash
     if (visualizer == null) {
       visualizer = Visualizer(player.audioSessionId).apply {
         captureSize = Visualizer.getCaptureSizeRange()[1]

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.media.audiofx.Visualizer
-import android.telephony.VisualVoicemailService
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.AudioAttributes

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -172,8 +172,7 @@ class AudioPlayer(
               }
             }
 
-            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) {
-            }
+            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) = Unit
           },
           Visualizer.getMaxCaptureRate() / 2,
           true,


### PR DESCRIPTION
# Why
We shouldn't create the `Visualizer` as a property of the class because it's not always the case that the user wants it. Instead, we'll create it on demand whenever audio sampling is enabled and release it when it's disabled

# How
Add a function to create the `Visualizer` when necessary.

# Test Plan
Bare-expo

