### PR TITLE
[ci] refactor Test React Native nightly build

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ruby-version: 3.2.2
       - name: 💎 Install Ruby gems
-        run: gem install 'cocoapods:1.14.3' xcpretty
+        run: gem install cocoapods xcpretty
       - name: ♻️ Restore workspace node modules
         # Use restore only cache here because we don't want to nightly react-native version saving back to the cache
         uses: actions/cache/restore@v3
@@ -54,8 +54,8 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.workspace-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: ⭐️ Create test-nightlies Project
-        run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }}
+      - name: ⭐️ Create test-nightlies Project (New Architecture)
+        run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly
       - name: 🍏 Query available simulator device ID
         run: |
@@ -63,7 +63,7 @@ jobs:
           xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.value | length > 0)'
           DEVICE_ID=$(defaults read com.apple.iphonesimulator CurrentDeviceUDID || xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.value | length > 0) | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS")) | .value[] | select(.isAvailable == true) | .udid' | head -n 1)
           echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
-      - name: 🍏 Build iOS Project
+      - name: 🍏 Build iOS Project (New Architecture)
         run: |
           pod install --project-directory=ios
           xcodebuild -workspace ios/testnightlies.xcworkspace -scheme testnightlies -configuration $CONFIGURATION -sdk iphonesimulator -destination "id=$DEVICE_ID" -derivedDataPath "ios/build" | xcpretty
@@ -78,12 +78,12 @@ jobs:
         with:
           name: ios-builds-oldArch-${{ matrix.build-type }}
           path: ${{ runner.temp }}/test-nightlies/ios/build/**/testnightlies.app/
-      - name: 🍏 Build iOS Project (New Architecture)
+      - name: 🍏 Build iOS Project (Old Architecture)
         run: |
-          jq '.expo.plugins[] |= (if (type == "array" and .[0] == "expo-build-properties") then .[1].ios.newArchEnabled = true else . end)' app.json > app.json.tmp
+          jq '.expo.newArchEnabled = false' app.json > app.json.tmp
           mv -f app.json.tmp app.json
           cat app.json
-          npx expo prebuild -p ios --no-install --template expo-template-bare-minimum-*.tgz
+          npx expo prebuild -p ios --no-install --clean --template .expo/expo-template-bare-minimum-*.tgz
           pod install --project-directory=ios
           xcodebuild -workspace ios/testnightlies.xcworkspace -scheme testnightlies -configuration $CONFIGURATION -sdk iphonesimulator -destination "id=$DEVICE_ID" -derivedDataPath "ios/build" | xcpretty
         shell: bash
@@ -146,10 +146,10 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.workspace-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: ⭐️ Create test-nightlies Project
-        run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }}
+      - name: ⭐️ Create test-nightlies Project (New Architecture)
+        run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly
-      - name: 🤖 Build Android project
+      - name: 🤖 Build Android project (New Architecture)
         run: |
           cd android && ./gradlew ":app:assemble$VARIANT"
         shell: bash
@@ -163,12 +163,12 @@ jobs:
         with:
           name: android-builds-oldArch-${{ matrix.build-type }}
           path: ${{ runner.temp }}/test-nightlies/android/app/build/outputs/apk/
-      - name: 🤖 Build Android project (New Architecture)
+      - name: 🤖 Build Android project (Old Architecture)
         run: |
-          jq '.expo.plugins[] |= (if (type == "array" and .[0] == "expo-build-properties") then .[1].android.newArchEnabled = true else . end)' app.json > app.json.tmp
+          jq '.expo.newArchEnabled = false' app.json > app.json.tmp
           mv -f app.json.tmp app.json
           cat app.json
-          npx expo prebuild -p ios --no-install --template expo-template-bare-minimum-*.tgz
+          npx expo prebuild -p android --no-install --clean --template .expo/expo-template-bare-minimum-*.tgz
           cd android && ./gradlew ":app:assemble$VARIANT"
         shell: bash
         working-directory: ${{ runner.temp }}/test-nightlies

--- a/packages/create-expo-nightly/src/index.ts
+++ b/packages/create-expo-nightly/src/index.ts
@@ -39,7 +39,11 @@ const program = new Command(packageJSON.name)
     'dev.expo.testnightlies'
   )
   .option('--no-install', 'Skip installing CocoaPods.')
-  .option('--enable-new-architecture', 'Enable the New Architecture mode.')
+  .option(
+    '--enable-new-architecture <boolean>',
+    'Enable / disable the New Architecture mode (default: new arch enabled).',
+    'true'
+  )
   .parse(process.argv);
 
 async function runAsync(programName: string) {
@@ -52,7 +56,7 @@ async function runAsync(programName: string) {
   const nightlyVersion = await getNpmVersionAsync('react-native', 'nightly');
   const projectProps: ProjectProperties = {
     appId: programOpts.appId,
-    newArchEnabled: !!programOpts.enableNewArchitecture,
+    newArchEnabled: programOpts.enableNewArchitecture !== 'false',
     nightlyVersion,
     useExpoRepoPath: programOpts.expoRepo,
   };
@@ -72,11 +76,12 @@ async function runAsync(programName: string) {
   console.log(chalk.cyan(`Reinstalling packages`));
   await reinstallPackagesAsync(projectRoot);
 
-  console.log(chalk.cyan(`Running prebuild`));
+  console.log(chalk.cyan(`Creating expo-template-bare-minimum tarball`));
   const tarballPath = await packExpoBareTemplateTarballAsync(
     expoRepoPath,
     path.join(projectRoot, '.expo')
   );
+  console.log(chalk.cyan(`Running prebuild`));
   await prebuildAppAsync(projectRoot, tarballPath);
 
   if (programOpts.install) {


### PR DESCRIPTION
# Why

Nightlies used `expo.newArchEnabled=true` (the default for new projects) for old architecture (so old arch script actually tested new arch, I believe), and then used `expo-build-properties` to enable new arch in the `Build Android/ios project (New Architecture)` steps . I made it so that both new and old arch is tested using the root field `expo.newArchEnabled`.


# How

updated the CI job and `packages/create-expo-nightly/src/index.ts`

# Test Plan

CI should not fail as soon as it does in https://github.com/expo/expo/runs/32962747933

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
