### PR TITLE
[image] migrate ImageView to CSSBackgroundDrawable

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] migrate ImageView to CSSBackgroundDrawable ([#33024](https://github.com/expo/expo/pull/33024) by [@vonovak](https://github.com/vonovak))
+
 ## 2.0.0 — 2024-11-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -12,13 +12,19 @@ import android.util.Log
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.graphics.transform
 import androidx.core.view.isVisible
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.modules.i18nmanager.I18nUtil
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.views.view.ReactViewBackgroundDrawable
+import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
+import com.facebook.react.uimanager.style.BorderRadiusProp
 import expo.modules.image.drawing.OutlineProvider
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.records.ContentPosition
 
+@OptIn(UnstableReactNativeAPI::class)
 @SuppressLint("ViewConstructor")
 class ExpoImageView(
   context: Context
@@ -45,17 +51,27 @@ class ExpoImageView(
   private var transformationMatrixChanged = false
 
   private val borderDrawableLazyHolder = lazy {
-    ReactViewBackgroundDrawable(context).apply {
+    CSSBackgroundDrawable(context).apply {
       callback = this@ExpoImageView
 
       outlineProvider.borderRadiiConfig
         .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
         .withIndex()
         .forEach { (i, radius) ->
+          val appliedRadius =
+            if (radius.isNaN()) {
+              null
+            } else {
+              LengthPercentage(radius, LengthPercentageType.POINT)
+            }
           if (i == 0) {
-            setRadius(radius)
+            BackgroundStyleApplicator.setBorderRadius(
+              this@ExpoImageView,
+              BorderRadiusProp.BORDER_RADIUS,
+              appliedRadius
+            )
           } else {
-            setRadius(radius, i - 1)
+            BackgroundStyleApplicator.setBorderRadius(this@ExpoImageView, BorderRadiusProp.entries[i - 1], appliedRadius)
           }
         }
     }
@@ -148,10 +164,20 @@ class ExpoImageView(
     if (borderDrawableLazyHolder.isInitialized()) {
       val radius = borderRadius.ifYogaDefinedUse(PixelUtil::toPixelFromDIP)
       borderDrawableLazyHolder.value.apply {
+        val appliedRadius =
+          if (radius.isNaN()) {
+            null
+          } else {
+            LengthPercentage(radius, LengthPercentageType.POINT)
+          }
         if (position == 0) {
-          setRadius(radius)
+          BackgroundStyleApplicator.setBorderRadius(
+            this@ExpoImageView,
+            BorderRadiusProp.BORDER_RADIUS,
+            appliedRadius
+          )
         } else {
-          setRadius(radius, position - 1)
+          BackgroundStyleApplicator.setBorderRadius(this@ExpoImageView, BorderRadiusProp.entries[position - 1], appliedRadius)
         }
       }
     }


### PR DESCRIPTION
# Why

`ReactViewBackgroundDrawable` is removed in 0.77 (deprecated since 75). This changes its use to `CSSBackgroundDrawable` which stayed in core.

context: https://github.com/facebook/react-native/pull/46166

# How

replaced `ReactViewBackgroundDrawable` with `CSSBackgroundDrawable` and used `BackgroundStyleApplicator`

# Test Plan

bare expo "Comparison with original image" looks okay

![Screenshot_1731948395.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jedBphTC4kiypS6zFnpk/88bd119a-11b9-4789-8299-a923d9b0e1f6.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
