### PR TITLE
[image][Android] Fix `borderColor` is not applied

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixes Gif animations never stopping even when loop count is set to 1. ([#32944](https://github.com/expo/expo/pull/32944) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed `borderColor` is not applied.
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixes Gif animations never stopping even when loop count is set to 1. ([#32944](https://github.com/expo/expo/pull/32944) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed `borderColor` is not applied.
+- [Android] Fixed `borderColor` is not applied. ([#33026](https://github.com/expo/expo/pull/33026) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -267,11 +267,12 @@ class ExpoImageModule : Module() {
         ViewProps.BORDER_TOP_COLOR to Spacing.TOP,
         ViewProps.BORDER_BOTTOM_COLOR to Spacing.BOTTOM,
         ViewProps.BORDER_START_COLOR to Spacing.START,
-        ViewProps.BORDER_END_COLOR to Spacing.END
+        ViewProps.BORDER_END_COLOR to Spacing.END,
+        ViewProps.BORDER_BLOCK_COLOR to Spacing.BLOCK,
+        ViewProps.BORDER_BLOCK_END_COLOR to Spacing.BLOCK_END,
+        ViewProps.BORDER_BLOCK_START_COLOR to Spacing.BLOCK_START
       ) { view: ExpoImageViewWrapper, index: Int, color: Int? ->
-        val rgbComponent = if (color == null) YogaConstants.UNDEFINED.toInt() else (color and 0x00FFFFFF)
-        val alphaComponent = if (color == null) YogaConstants.UNDEFINED else (color ushr 24).toFloat()
-        view.setBorderColor(index, rgbComponent, alphaComponent)
+        view.setBorderColor(index, color)
       }
 
       Prop("borderStyle") { view: ExpoImageViewWrapper, borderStyle: String? ->

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -161,8 +161,8 @@ class ExpoImageView(
     borderDrawable.setBorderWidth(position, width)
   }
 
-  internal fun setBorderColor(position: Int, rgb: Int) {
-    borderDrawable.setBorderColor(position, rgb)
+  internal fun setBorderColor(position: Int, color: Int) {
+    borderDrawable.setBorderColor(position, color)
   }
 
   internal fun setBorderStyle(style: String?) {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -181,7 +181,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
   private var borderRadius = FloatArray(9) { YogaConstants.UNDEFINED }
   private var borderWidth = FloatArray(9) { YogaConstants.UNDEFINED }
-  private var borderColor = Array(9) { YogaConstants.UNDEFINED.toInt() to YogaConstants.UNDEFINED }
+  private var borderColor = Array<Int?>(12) { null }
 
   fun setBorderRadius(index: Int, radius: Float) {
     borderRadius[index] = radius
@@ -193,9 +193,11 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
     activeView.setBorderWidth(index, width)
   }
 
-  fun setBorderColor(index: Int, rgb: Int, alpha: Float) {
-    borderColor[index] = rgb to alpha
-    activeView.setBorderColor(index, rgb)
+  fun setBorderColor(index: Int, color: Int?) {
+    borderColor[index] = color
+    if (color != null) {
+      activeView.setBorderColor(index, color)
+    }
   }
 
   fun setIsAnimating(setAnimating: Boolean) {
@@ -242,8 +244,10 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
     view.setTintColor(tintColor)
     view.isFocusable = isFocusableProp
     view.contentDescription = accessibilityLabel
-    borderColor.forEachIndexed { index, (rgb, alpha) ->
-      view.setBorderColor(index, rgb)
+    borderColor.forEachIndexed { index, color ->
+      if (color != null) {
+        view.setBorderColor(index, color)
+      }
     }
     borderRadius.forEachIndexed { index, value ->
       view.setBorderRadius(index, value)


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/32814.

# How

The mapping between `ViewProps.BORDER_*_COLOR` to `Spacing.*` was changed. 

# Test Plan

- [freeboub/bug-expo-border-color](https://github.com/freeboub/bug-expo-border-color) ✅ 