### PR TITLE
[camera] Add `expo-gl` integration to new module

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bring back `expo-gl' integration.
+
 ## 16.0.5 — 2024-11-13
 
 ### 💡 Others

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Bring back `expo-gl' integration. ([#33027](https://github.com/expo/expo/pull/33027) by [@alanjhughes](https://github.com/alanjhughes))
+- Bring back `expo-gl` integration. ([#33027](https://github.com/expo/expo/pull/33027) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.0.5 — 2024-11-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Bring back `expo-gl' integration.
+- Bring back `expo-gl' integration. ([#33027](https://github.com/expo/expo/pull/33027) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.0.5 — 2024-11-13
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -125,6 +125,7 @@ class ExpoCameraView(
   private var imageAnalysisUseCase: ImageAnalysis? = null
   private var recorder: Recorder? = null
   private var barcodeFormats: List<BarcodeType> = emptyList()
+  private var glSurface: SurfaceTexture? = null
 
   private var previewView = PreviewView(context).apply {
     elevation = 0f
@@ -366,6 +367,15 @@ class ExpoCameraView(
           .also {
             it.surfaceProvider = previewView.surfaceProvider
           }
+
+        glSurface?.let {
+          preview.setSurfaceProvider { request ->
+            val surface = Surface(it)
+            request.provideSurface(surface, ContextCompat.getMainExecutor(context)) {
+              surface.release()
+            }
+          }
+        }
 
         val cameraSelector = CameraSelector.Builder()
           .requireLensFacing(lensFacing.mapToCharacteristic())
@@ -619,7 +629,11 @@ class ExpoCameraView(
     }
   }
 
-  override fun setPreviewTexture(surfaceTexture: SurfaceTexture?) = Unit
+  override fun setPreviewTexture(surfaceTexture: SurfaceTexture?) {
+    glSurface = surfaceTexture
+    shouldCreateCamera = true
+    createCamera()
+  }
 
   override fun getPreviewSizeAsArray() = intArrayOf(previewView.width, previewView.height)
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -3,7 +3,7 @@ import ExpoModulesCore
 import CoreMotion
 
 public class CameraView: ExpoView, EXAppLifecycleListener,
-  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate, CameraEvent {
+  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate, EXCameraInterface, CameraEvent {
   public var session = AVCaptureSession()
   public var sessionQueue = DispatchQueue(label: "captureSessionQueue")
 


### PR DESCRIPTION
# Why
Brings back the `expo-gl` integration with the camera.

# How
iOS
- Just conform to `EXCameraInterface`

Android
- Create a `surfaceProvider` and provide the texture from gl if it is present.

# Test Plan
|Android|iOS|
|-----|------|
|![ios](https://github.com/user-attachments/assets/d2c1074f-85aa-4df3-b60b-e7734ba41fb6)|![android](https://github.com/user-attachments/assets/bcd85dfc-d9c3-42d4-b4e9-06ba8067296b)|

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
