### PR TITLE
[docs] - Update Sentry Global Scope for EAS Updates

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -256,24 +256,25 @@ Sentry.init({
   // dsn, release, dist, etc...
 });
 
-Sentry.configureScope(scope => {
-  scope.setTag('expo-update-id', Updates.updateId);
-  scope.setTag('expo-is-embedded-update', Updates.isEmbeddedLaunch);
+const scope = Sentry.getGlobalScope();
 
-  if (typeof updateGroup === 'string') {
-    scope.setTag('expo-update-group-id', updateGroup);
+scope.setTag('expo-update-id', Updates.updateId);
+scope.setTag('expo-is-embedded-update', Updates.isEmbeddedLaunch);
 
-    const owner = extra?.expoClient?.owner ?? '[account]';
-    const slug = extra?.expoClient?.slug ?? '[project]';
-    scope.setTag(
-      'expo-update-debug-url',
-      `https://expo.dev/accounts/${owner}/projects/${slug}/updates/${updateGroup}`
-    );
-  } else if (Updates.isEmbeddedLaunch) {
-    // This will be `true` if the update is the one embedded in the build, and not one downloaded from the updates server.
-    scope.setTag('expo-update-debug-url', 'not applicable for embedded updates');
-  }
-});
+if (typeof updateGroup === 'string') {
+  scope.setTag('expo-update-group-id', updateGroup);
+
+  const owner = extra?.expoClient?.owner ?? '[account]';
+  const slug = extra?.expoClient?.slug ?? '[project]';
+  scope.setTag(
+    'expo-update-debug-url',
+    `https://expo.dev/accounts/${owner}/projects/${slug}/updates/${updateGroup}`
+  );
+} else if (Updates.isEmbeddedLaunch) {
+  // This will be `true` if the update is the one embedded in the build, and not one downloaded from the updates server.
+  scope.setTag('expo-update-debug-url', 'not applicable for embedded updates');
+}
+
 ```
 
 Once configured, information about the associated update will show up in an error's tag section:

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -274,7 +274,6 @@ if (typeof updateGroup === 'string') {
   // This will be `true` if the update is the one embedded in the build, and not one downloaded from the updates server.
   scope.setTag('expo-update-debug-url', 'not applicable for embedded updates');
 }
-
 ```
 
 Once configured, information about the associated update will show up in an error's tag section:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Sentry's global scope is used slightly different now.

https://docs.sentry.io/platforms/react-native/enriching-events/scopes/#global-scope

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use latest sentry and expo packages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
