### PR TITLE
Revert "[template-default] Fix import in useThemeColor.ts"

### DIFF
--- a/templates/expo-template-default/hooks/useThemeColor.ts
+++ b/templates/expo-template-default/hooks/useThemeColor.ts
@@ -3,7 +3,7 @@
  * https://docs.expo.dev/guides/color-schemes/
  */
 
-import { useColorScheme } from './useColorScheme';
+import { useColorScheme } from 'react-native';
 
 import { Colors } from '@/constants/Colors';
 


### PR DESCRIPTION
Reverts expo/expo#32988

after some discussion, the change doesn't appear to be correct and the problem will be addressed differently