### PR TITLE
[cli] TypeScript should be a dev dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Install TypeScript as a dev dependency
+
 ### 💡 Others
 
 ## 0.21.5 — 2024-11-14

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Install TypeScript as a dev dependency
+- Install TypeScript as a dev dependency ([#33055](https://github.com/expo/expo/pull/33055) by [@kadikraman](https://github.com/kadikraman))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -113,8 +113,8 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite<boolean> 
         requiredPackages: [
           // use typescript/package.json to skip node module cache issues when the user installs
           // the package and attempts to resolve the module in the same process.
-          { file: 'typescript/package.json', pkg: 'typescript' },
-          { file: '@types/react/package.json', pkg: '@types/react' },
+          { file: 'typescript/package.json', pkg: 'typescript', dev: true },
+          { file: '@types/react/package.json', pkg: '@types/react', dev: true },
         ],
       });
     } catch (error) {


### PR DESCRIPTION
# Why

Then TypeScript is automatically installed on the CLI, it is added as a _dependency_, instead of a dev dependency. It is a dev dependency in all our TypeScript templates, and furthermore, you'll get a "No metadata available: typescript" warning when running expo doctor on the project later.

To repro, 
```sh
bunx create-expo-app@latest test-js-to-ts -t blank
cd test-js-to-ts
mv -i App.js App.tsx
npx expo start
# say yes to installing typescript
npx expo-doctor
```

<img width="892" alt="Screenshot 2024-11-19 at 09 17 39" src="https://github.com/user-attachments/assets/94f24e8e-941e-4b5b-9bd8-9be1271dcadb">

Thanks @wodin for reporting this issue.

# How

Update the required packages in the cli to install TypeScript as a dev dependency.

# Test Plan

Tested locally using the repro steps.

<img width="403" alt="Screenshot 2024-11-19 at 09 21 07" src="https://github.com/user-attachments/assets/a34f5577-32a8-4115-ba6b-d3bb2b603ec4">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
