### PR TITLE
[docs] Fixed syntax error in babel configuration for react-compiler

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -158,7 +158,7 @@ module.exports = function (api) {
             // Passed directly to the React Compiler Babel plugin.
             compilationMode: 'strict',
             panicThreshold: 'all_errors',
-          }
+          },
           web: {
             'react-compiler': {
               // Web-only settings...


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Updated a syntax error in the babel configuration code snippet related to react-compiler setup.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated the effect mdx file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified locally docs site still working, and verified code syntax is valid

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
