### PR TITLE
[apple-auth] Add explicit return type

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `formatFullName` not specifying a return type.
+- Fix `formatFullName` not specifying a return type. ([#33068](https://github.com/expo/expo/pull/33068) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `formatFullName` not specifying a return type.
+
 ### 💡 Others
 
 ## 7.1.1 — 2024-11-15

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
@@ -33,7 +33,7 @@ public final class AppleAuthenticationModule: Module {
       }
     }
 
-    Function("formatFullName") { (fullName: FullName, formatStyle: FullNameFormatStyle?) in
+    Function("formatFullName") { (fullName: FullName, formatStyle: FullNameFormatStyle?) -> String in
       let formatStyle = formatStyle?.toFullNameFormatStyle() ?? .default
       var nameComponents = PersonNameComponents()
 


### PR DESCRIPTION
# Why
Closes #33046

# How
#32567 added a new function `formatFullName`. When running on Xcode 15 the closure requires an explicit return type to compile.

# Test Plan
I can't run xcode 15 but this shouldn't be a problem, the reporter tested this change and it resolved the issue

