### PR TITLE
[template] fix useColorScheme hook for web

### DIFF
--- a/templates/expo-template-default/components/Collapsible.tsx
+++ b/templates/expo-template-default/components/Collapsible.tsx
@@ -1,10 +1,11 @@
 import { PropsWithChildren, useState } from 'react';
-import { StyleSheet, TouchableOpacity, useColorScheme } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/templates/expo-template-default/components/ParallaxScrollView.tsx
+++ b/templates/expo-template-default/components/ParallaxScrollView.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren, ReactElement } from 'react';
-import { StyleSheet, useColorScheme } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, {
   interpolate,
   useAnimatedRef,
@@ -9,6 +9,7 @@ import Animated, {
 
 import { ThemedView } from '@/components/ThemedView';
 import { useBottomTabOverflow } from '@/components/ui/TabBarBackground';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 const HEADER_HEIGHT = 250;
 

--- a/templates/expo-template-default/hooks/useColorScheme.web.ts
+++ b/templates/expo-template-default/hooks/useColorScheme.web.ts
@@ -1,8 +1,21 @@
-// NOTE: The default React Native styling doesn't support server rendering.
-// Server rendered styles should not change between the first render of the HTML
-// and the first render on the client. Typically, web developers will use CSS media queries
-// to render different styles on the client and server, these aren't directly supported in React Native
-// but can be achieved using a styling library like Nativewind.
+import { useEffect, useState } from 'react';
+import { useColorScheme as useRNColorScheme } from 'react-native';
+
+/**
+ * To support static rendering, this value needs to be re-calculated on the client side for web
+ */
 export function useColorScheme() {
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
+
+  const colorScheme = useRNColorScheme();
+
+  if (hasHydrated) {
+    return colorScheme;
+  }
+
   return 'light';
 }

--- a/templates/expo-template-default/hooks/useThemeColor.ts
+++ b/templates/expo-template-default/hooks/useThemeColor.ts
@@ -3,9 +3,8 @@
  * https://docs.expo.dev/guides/color-schemes/
  */
 
-import { useColorScheme } from 'react-native';
-
 import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function useThemeColor(
   props: { light?: string; dark?: string },


### PR DESCRIPTION
# Why

When deploying a project using with static rendering, the color scheme is calculated when the static files are generated, so not taking the user's color scheme into account (impossible since it is not known at this time) and falling back to defaults.

So as a workaround, the web `useColorScheme` was set to default to `light`, but this import wasn't consistently used across the codebase.

# How

Basically, as a combination of these two PRs - thanks both for looking into it, I've added you as co-authors for this PR 🙏 
- https://github.com/expo/expo/pull/32988 by @sergehuber - always import `useColorScheme` hook from utils
- https://github.com/expo/expo/pull/30674 by @ashuvssut - calculate color scheme on client for web

# Test Plan

See the deployed demo using these changes: https://router-dark-mode-example.kadikraman.com/ 

| Before    | After |
| -------- | ------- |
| <img width="1166" alt="Screenshot 2024-11-19 at 12 52 35" src="https://github.com/user-attachments/assets/a4ca6b54-eb3b-4232-8776-4dbe2e1e7055">  | <img width="1166" alt="Screenshot 2024-11-19 at 12 55 13" src="https://github.com/user-attachments/assets/f7171a0c-950d-4df7-8129-fb2fcc7e65ee">  |




# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
