### PR TITLE
[core][Android] Support css properties by default

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Supported css properties (border, background and shadow) by default.
+
 ### 🐛 Bug fixes
 
 - Fixed type errors when using `ts-jest`. ([#32954](https://github.com/expo/expo/pull/32954) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Supported css properties (border, background and shadow) by default.
+- [Android] Supported css properties (border, background and shadow) by default. ([#33074](https://github.com/expo/expo/pull/33074) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -20,6 +20,7 @@ import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
+import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
 
@@ -65,6 +66,9 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified T : View> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
     require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
     val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }))
+
+    viewDefinitionBuilder.UseCSSProps()
+
     body.invoke(viewDefinitionBuilder)
     viewManagerDefinition = viewDefinitionBuilder.build()
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
@@ -1,8 +1,10 @@
 package expo.modules.kotlin.views
 
 import android.content.Context
+import android.graphics.Canvas
 import android.widget.LinearLayout
 import androidx.annotation.UiThread
+import com.facebook.react.uimanager.BackgroundStyleApplicator
 import expo.modules.kotlin.AppContext
 
 /**
@@ -45,5 +47,13 @@ abstract class ExpoView(
       // We need to force measure and layout, because React Native doesn't do it for us.
       post(Runnable { measureAndLayout() })
     }
+  }
+
+  override fun dispatchDraw(canvas: Canvas) {
+    // When the border radius is set, we need to clip the content to the padding box.
+    // This is because the border radius is applied to the background drawable, not the view itself.
+    // It is the same behavior as in React Native.
+    BackgroundStyleApplicator.clipToPaddingBox(this, canvas)
+    super.dispatchDraw(canvas)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
@@ -1,0 +1,174 @@
+@file:Suppress("FunctionName")
+
+package expo.modules.kotlin.views.decorators
+
+import android.view.View
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
+import com.facebook.react.uimanager.Spacing
+import com.facebook.react.uimanager.ViewProps
+import com.facebook.react.uimanager.style.BorderRadiusProp
+import com.facebook.react.uimanager.style.BorderStyle
+import com.facebook.react.uimanager.style.BoxShadow
+import com.facebook.react.uimanager.style.LogicalEdge
+import expo.modules.kotlin.types.enforceType
+import expo.modules.kotlin.views.ViewDefinitionBuilder
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBorderColorProps(crossinline body: (view: T, edge: LogicalEdge, color: Int?) -> Unit) {
+  PropGroup(
+    ViewProps.BORDER_COLOR to Spacing.ALL,
+    ViewProps.BORDER_LEFT_COLOR to Spacing.LEFT,
+    ViewProps.BORDER_RIGHT_COLOR to Spacing.RIGHT,
+    ViewProps.BORDER_TOP_COLOR to Spacing.TOP,
+    ViewProps.BORDER_BOTTOM_COLOR to Spacing.BOTTOM,
+    ViewProps.BORDER_START_COLOR to Spacing.START,
+    ViewProps.BORDER_END_COLOR to Spacing.END,
+    ViewProps.BORDER_BLOCK_COLOR to Spacing.BLOCK,
+    ViewProps.BORDER_BLOCK_END_COLOR to Spacing.BLOCK_END,
+    ViewProps.BORDER_BLOCK_START_COLOR to Spacing.BLOCK_START
+  ) { view: T, spacing: Int, color: Int? ->
+    body(view, LogicalEdge.fromSpacingType(spacing), color)
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBorderColorProps() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBorderColorProps { view: View, edge: LogicalEdge, color: Int? ->
+    BackgroundStyleApplicator.setBorderColor(
+      view,
+      edge,
+      color
+    )
+  }
+}
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBorderWidthProps(crossinline body: (view: T, edge: LogicalEdge, width: Float?) -> Unit) {
+  PropGroup(
+    ViewProps.BORDER_WIDTH,
+    ViewProps.BORDER_LEFT_WIDTH,
+    ViewProps.BORDER_RIGHT_WIDTH,
+    ViewProps.BORDER_TOP_WIDTH,
+    ViewProps.BORDER_BOTTOM_WIDTH,
+    ViewProps.BORDER_START_WIDTH,
+    ViewProps.BORDER_END_WIDTH
+  ) { view: T, index: Int, width: Float? ->
+    body(view, LogicalEdge.entries[index], width)
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBorderWidthProps() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBorderWidthProps { view, edge, width ->
+    BackgroundStyleApplicator.setBorderWidth(
+      view,
+      edge,
+      width ?: Float.NaN
+    )
+  }
+}
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBorderRadiusProps(crossinline body: (view: T, border: BorderRadiusProp, radius: LengthPercentage?) -> Unit) {
+  PropGroup(
+    ViewProps.BORDER_RADIUS,
+    ViewProps.BORDER_TOP_LEFT_RADIUS,
+    ViewProps.BORDER_TOP_RIGHT_RADIUS,
+    ViewProps.BORDER_BOTTOM_RIGHT_RADIUS,
+    ViewProps.BORDER_BOTTOM_LEFT_RADIUS,
+    ViewProps.BORDER_TOP_START_RADIUS,
+    ViewProps.BORDER_TOP_END_RADIUS,
+    ViewProps.BORDER_BOTTOM_START_RADIUS,
+    ViewProps.BORDER_BOTTOM_END_RADIUS,
+    ViewProps.BORDER_END_END_RADIUS,
+    ViewProps.BORDER_END_START_RADIUS,
+    ViewProps.BORDER_START_END_RADIUS,
+    ViewProps.BORDER_START_START_RADIUS
+  ) { view: T, index: Int, radius: Float? ->
+    body(
+      view,
+      BorderRadiusProp.entries[index],
+      radius?.let { LengthPercentage(it, LengthPercentageType.POINT) }
+    )
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBorderRadiusProps() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBorderRadiusProps { view, border, radius ->
+    BackgroundStyleApplicator.setBorderRadius(
+      view,
+      border,
+      radius
+    )
+  }
+}
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBorderStyleProp(crossinline body: (view: T, style: BorderStyle?) -> Unit) {
+  Prop("borderStyle") { view: T, style: String? ->
+    val parsedBorderStyle = style?.let { BorderStyle.fromString(style) }
+    body(view, parsedBorderStyle)
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBorderStyleProp() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBorderStyleProp { view, style ->
+    BackgroundStyleApplicator.setBorderStyle(
+      view,
+      style
+    )
+  }
+}
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBackgroundProp(crossinline body: (view: T, color: Int?) -> Unit) {
+  Prop(ViewProps.BACKGROUND_COLOR) { view: T, color: Int? ->
+    body(view, color)
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBackgroundProp() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBackgroundProp { view, color ->
+    BackgroundStyleApplicator.setBackgroundColor(view, color)
+  }
+}
+
+inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBoxShadowProp(crossinline body: (view: T, shadow: List<BoxShadow>) -> Unit) {
+  Prop(ViewProps.BOX_SHADOW) { view: T, shadows: ReadableArray? ->
+    if (shadows == null) {
+      body(view, emptyList())
+      return@Prop
+    }
+
+    val shadowStyle = mutableListOf<BoxShadow>()
+    for (i in 0..<shadows.size()) {
+      val shadow = BoxShadow.parse(shadows.getMap(i)) ?: continue
+      shadowStyle.add((shadow))
+    }
+    body(view, shadowStyle)
+  }
+}
+
+private fun <T : View> ViewDefinitionBuilder<T>.UseBoxShadowProp() {
+  enforceType<ViewDefinitionBuilder<View>>(this)
+  UseBoxShadowProp { view, shadows ->
+    BackgroundStyleApplicator.setBoxShadow(view, shadows)
+  }
+}
+
+/**
+ * Decorates the view definition builder with CSS props.
+ * This includes border, background, and box shadow properties.
+ */
+@PublishedApi
+internal fun <T : View> ViewDefinitionBuilder<T>.UseCSSProps() {
+  UseBorderColorProps()
+  UseBorderWidthProps()
+  UseBorderRadiusProps()
+  UseBorderStyleProp()
+
+  UseBackgroundProp()
+
+  UseBoxShadowProp()
+}


### PR DESCRIPTION
# Why

Supports css properties by default - includes border, background, and box shadow properties.

# How

Handled css properties inside of the expo modules core, you can still opt out by overriding those properties in your module. This PR introduces a new method for applying borders, background colors, and box shadows, which is currently utilized in React Native.

# Test Plan

- bare-expo ✅ 

|   |  |
| :---: | :---: |
|  ![Screenshot_20241119_151737](https://github.com/user-attachments/assets/8e4f6183-3aed-4574-825f-af56a6dcc03e) | ![Screenshot_20241119_151908](https://github.com/user-attachments/assets/a55b4612-6c1a-48d7-804f-0173c4ee6d6a) |
| ![Screenshot_20241119_152020](https://github.com/user-attachments/assets/40eb3a74-8957-4889-bc8e-5aee71071edd) | ![Screenshot_20241119_152045](https://github.com/user-attachments/assets/76f196ae-b48b-4954-8277-39905192e763) |
| ![Screenshot_20241119_152114](https://github.com/user-attachments/assets/8866efa2-e027-43c0-a410-284192346f21)
 | |
