### PR TITLE
[video][Android] Fix `border` related props

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `border` related props weren't applied correctly.
+- [Android] Fixed `border` related props weren't applied correctly. ([#33075](https://github.com/expo/expo/pull/33075) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `border` related props weren't applied correctly.
+
 ### 💡 Others
 
 ## 2.0.0 — 2024-11-11

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -7,10 +7,6 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.uimanager.Spacing
-import com.facebook.react.uimanager.ViewProps
-import com.facebook.yoga.YogaConstants
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
@@ -22,8 +18,6 @@ import expo.modules.video.player.VideoPlayer
 import expo.modules.video.records.BufferOptions
 import expo.modules.video.records.SubtitleTrack
 import expo.modules.video.records.VideoSource
-import expo.modules.video.utils.ifYogaDefinedUse
-import expo.modules.video.utils.makeYogaUndefinedIfNegative
 import expo.modules.video.utils.runWithPiPMisconfigurationSoftHandling
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -78,55 +72,6 @@ class VideoModule : Module() {
         val linearPlayback = requiresLinearPlayback ?: false
         view.playerView.applyRequiresLinearPlayback(linearPlayback)
         view.videoPlayer?.requiresLinearPlayback = linearPlayback
-      }
-
-      PropGroup(
-        ViewProps.BORDER_RADIUS to 0,
-        ViewProps.BORDER_TOP_LEFT_RADIUS to 1,
-        ViewProps.BORDER_TOP_RIGHT_RADIUS to 2,
-        ViewProps.BORDER_BOTTOM_RIGHT_RADIUS to 3,
-        ViewProps.BORDER_BOTTOM_LEFT_RADIUS to 4,
-        ViewProps.BORDER_TOP_START_RADIUS to 5,
-        ViewProps.BORDER_TOP_END_RADIUS to 6,
-        ViewProps.BORDER_BOTTOM_START_RADIUS to 7,
-        ViewProps.BORDER_BOTTOM_END_RADIUS to 8
-      ) { view: VideoView, index: Int, borderRadius: Float? ->
-        val radius = makeYogaUndefinedIfNegative(borderRadius ?: YogaConstants.UNDEFINED)
-        view.setBorderRadius(index, radius)
-      }
-
-      PropGroup(
-        ViewProps.BORDER_WIDTH to Spacing.ALL,
-        ViewProps.BORDER_LEFT_WIDTH to Spacing.LEFT,
-        ViewProps.BORDER_RIGHT_WIDTH to Spacing.RIGHT,
-        ViewProps.BORDER_TOP_WIDTH to Spacing.TOP,
-        ViewProps.BORDER_BOTTOM_WIDTH to Spacing.BOTTOM,
-        ViewProps.BORDER_START_WIDTH to Spacing.START,
-        ViewProps.BORDER_END_WIDTH to Spacing.END
-      ) { view: VideoView, index: Int, width: Float? ->
-        val pixelWidth = makeYogaUndefinedIfNegative(width ?: YogaConstants.UNDEFINED)
-          .ifYogaDefinedUse(PixelUtil::toPixelFromDIP)
-        view.setBorderWidth(index, pixelWidth)
-      }
-
-      PropGroup(
-        ViewProps.BORDER_COLOR to Spacing.ALL,
-        ViewProps.BORDER_LEFT_COLOR to Spacing.LEFT,
-        ViewProps.BORDER_RIGHT_COLOR to Spacing.RIGHT,
-        ViewProps.BORDER_TOP_COLOR to Spacing.TOP,
-        ViewProps.BORDER_BOTTOM_COLOR to Spacing.BOTTOM,
-        ViewProps.BORDER_START_COLOR to Spacing.START,
-        ViewProps.BORDER_END_COLOR to Spacing.END
-      ) { view: VideoView, index: Int, color: Int ->
-        view.setBorderColor(index, color)
-      }
-
-      Prop("borderStyle") { view: VideoView, borderStyle: String? ->
-        view.setBorderStyle(borderStyle)
-      }
-
-      OnViewDidUpdateProps { view: VideoView ->
-        view.didUpdateProps()
       }
 
       AsyncFunction("enterFullscreen") { view: VideoView ->

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
-import android.graphics.Canvas
 import android.os.Build
 import android.util.Rational
 import android.view.View
@@ -14,27 +13,16 @@ import android.widget.ImageButton
 import androidx.fragment.app.FragmentActivity
 import androidx.media3.common.Tracks
 import androidx.media3.ui.PlayerView
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.modules.i18nmanager.I18nUtil
-import com.facebook.react.uimanager.LengthPercentage
-import com.facebook.react.uimanager.LengthPercentageType
-import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.uimanager.Spacing
-import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable
-import com.facebook.react.uimanager.style.BorderRadiusProp
-import com.facebook.yoga.YogaConstants
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import expo.modules.video.delegates.IgnoreSameSet
-import expo.modules.video.drawing.OutlineProvider
 import expo.modules.video.enums.ContentFit
 import expo.modules.video.player.VideoPlayer
 import expo.modules.video.player.VideoPlayerListener
 import expo.modules.video.utils.applyAutoEnterPiP
 import expo.modules.video.utils.applyRectHint
 import expo.modules.video.utils.calculateRectHint
-import expo.modules.video.utils.ifYogaDefinedUse
 import java.util.UUID
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
@@ -63,32 +51,6 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
 
   private val rootViewChildrenOriginalVisibility: ArrayList<Int> = arrayListOf()
   private var pictureInPictureHelperTag: String? = null
-
-  private var shouldInvalided = false
-
-  private val outlineProvider = OutlineProvider(context)
-
-  @UnstableReactNativeAPI
-  private val borderDrawableLazyHolder = lazy {
-    CSSBackgroundDrawable(context).apply {
-      callback = this@VideoView
-
-      outlineProvider.borderRadiiConfig
-        .map { it.ifYogaDefinedUse(PixelUtil::toPixelFromDIP) }
-        .withIndex()
-        .forEach { (i, radius) ->
-          if (i == 0) {
-            setBorderRadius(BorderRadiusProp.BORDER_RADIUS, LengthPercentage(radius, LengthPercentageType.POINT))
-          } else {
-            setBorderRadius(BorderRadiusProp.entries[i - 1], LengthPercentage(radius, LengthPercentageType.POINT))
-          }
-        }
-    }
-  }
-
-  @UnstableReactNativeAPI
-  private val borderDrawable
-    get() = borderDrawableLazyHolder.value
 
   var autoEnterPiP: Boolean by IgnoreSameSet(false) { new, _ ->
     applyAutoEnterPiP(currentActivity, new)
@@ -277,31 +239,6 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     applyRectHint(currentActivity, calculateRectHint(playerView))
   }
 
-  @UnstableReactNativeAPI
-  override fun draw(canvas: Canvas) {
-    // When the border-radii are not all the same, a convex-path
-    // is used for the Outline. Unfortunately clipping is not supported
-    // for convex-paths and we fallback to Canvas clipping.
-    outlineProvider.clipCanvasIfNeeded(canvas, this)
-
-    super.draw(canvas)
-
-    // Draw borders on top of the video
-    if (borderDrawableLazyHolder.isInitialized()) {
-      val newLayoutDirection = if (I18nUtil.instance.isRTL(context)) {
-        LAYOUT_DIRECTION_RTL
-      } else {
-        LAYOUT_DIRECTION_LTR
-      }
-
-      borderDrawable.apply {
-        layoutDirection = newLayoutDirection
-        setBounds(0, 0, width, height)
-        draw(canvas)
-      }
-    }
-  }
-
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     (currentActivity as? FragmentActivity)?.let {
@@ -324,78 +261,6 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
         .commitAllowingStateLoss()
     }
     applyAutoEnterPiP(currentActivity, false)
-  }
-
-  @UnstableReactNativeAPI
-  internal fun setBorderRadius(position: Int, borderRadius: Float) {
-    val isInvalidated = outlineProvider.setBorderRadius(borderRadius, position)
-    if (isInvalidated) {
-      invalidateOutline()
-      if (!outlineProvider.hasEqualCorners()) {
-        shouldInvalided = true
-      }
-    }
-
-    // Setting the border-radius doesn't necessarily mean that a border
-    // should to be drawn. Only update the border-drawable when needed.
-    if (borderDrawableLazyHolder.isInitialized()) {
-      shouldInvalided = true
-      val radius = borderRadius.ifYogaDefinedUse(PixelUtil::toPixelFromDIP)
-      borderDrawableLazyHolder.value.apply {
-        if (position == 0) {
-          setBorderRadius(BorderRadiusProp.BORDER_RADIUS, LengthPercentage(radius, LengthPercentageType.POINT))
-        } else {
-          setBorderRadius(BorderRadiusProp.entries[position - 1], LengthPercentage(radius, LengthPercentageType.POINT))
-        }
-      }
-    }
-  }
-
-  @UnstableReactNativeAPI
-  internal fun setBorderWidth(position: Int, width: Float) {
-    borderDrawable.setBorderWidth(position, width)
-    shouldInvalided = true
-  }
-
-  @UnstableReactNativeAPI
-  internal fun setBorderColor(position: Int, rgb: Int) {
-    borderDrawable.setBorderColor(position, rgb)
-    shouldInvalided = true
-  }
-
-  @UnstableReactNativeAPI
-  internal fun setBorderStyle(style: String?) {
-    borderDrawable.setBorderStyle(style)
-    shouldInvalided = true
-  }
-
-  @UnstableReactNativeAPI
-  fun didUpdateProps() {
-    val hasBorder = if (borderDrawableLazyHolder.isInitialized()) {
-      val spacings = listOf(
-        Spacing.ALL,
-        Spacing.LEFT,
-        Spacing.RIGHT,
-        Spacing.TOP,
-        Spacing.BOTTOM,
-        Spacing.START,
-        Spacing.END
-      )
-      spacings
-        .any {
-          val boarderWidth = borderDrawable.getBorderWidthOrDefaultTo(YogaConstants.UNDEFINED, it)
-          boarderWidth != YogaConstants.UNDEFINED && boarderWidth > 0f
-        }
-    } else {
-      false
-    }
-
-    // We need to enable drawing on the view to draw the border or background
-    setWillNotDraw(!isOpaque && !hasBorder)
-    if (shouldInvalided) {
-      shouldInvalided = false
-      invalidate()
-    }
   }
 
   companion object {


### PR DESCRIPTION
# Why

Fixes `border` related props.
A follow up to the https://github.com/expo/expo/pull/33074

# How

The handling of border color and radius was changed in React Native version 0.76. We are able to patch this in the video package, but I believe it is better to adopt a standardized method for applying these properties.

Removed the code responsible for handling border related props. 

# Test Plan

- bare-expo ✅ 
