### PR TITLE
[linking][iOS] Fix AppDelegateSubscriber deep link propagation

### DIFF
--- a/apps/native-component-list/src/screens/LinkingScreen.tsx
+++ b/apps/native-component-list/src/screens/LinkingScreen.tsx
@@ -65,13 +65,17 @@ function TextInputButton({ text }: { text: string }) {
 }
 
 export default function LinkingScreen() {
-  const url = Linking.useURL();
+  const useURL = Linking.useURL();
+  const useLinkingURL = Linking.useLinkingURL();
+  const [eventListenerURL, setEventListenerURL] = React.useState<string>();
 
   React.useEffect(() => {
-    if (url) {
-      alert(`Linking url event: ${url}`);
-    }
-  });
+    const listener = Linking.addEventListener('url', ({ url }) => {
+      setEventListenerURL(url);
+    });
+
+    return listener.remove;
+  }, []);
 
   return (
     <ScrollView style={styles.container}>
@@ -81,7 +85,18 @@ export default function LinkingScreen() {
           Linking.openSettings();
         }}
       />
-      {url && <TextInputButton text={Linking.createURL('deep-link')} />}
+      {useURL && <TextInputButton text={Linking.createURL('deep-link')} />}
+      <View>
+        <MonoText containerStyle={styles.itemText}>Linking.useURL: {useURL}</MonoText>
+      </View>
+      <View>
+        <MonoText containerStyle={styles.itemText}>Linking.useLinkingURL: {useLinkingURL}</MonoText>
+      </View>
+      <View>
+        <MonoText containerStyle={styles.itemText}>
+          Linking.addEventListener: {eventListenerURL}
+        </MonoText>
+      </View>
       <TextInputButton text="https://github.com/search?q=Expo" />
       <TextInputButton text="https://www.expo.dev" />
       <TextInputButton text="http://www.expo.dev" />

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `addEventListener` and `useURL` hook. ([#33076](https://github.com/expo/expo/pull/33076) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 7.0.2 — 2024-10-25

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -4,6 +4,6 @@ public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     ExpoLinkingRegistry.shared.initialURL = url
     NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
-    return true
+    return false
   }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/33031

# How

- Update LinkingAppDelegateSubscriber to return `false` on the `openUrl`, that way allowing the deep link to be properly propagated to the other subscribers and the react-native-core `RCTLinkingManager`
- Update Linking Screen test cases to check for all variation of `useLinkingURL`

# Test Plan

BareExpo NCL on iOS

<img width="341" alt="image" src="https://github.com/user-attachments/assets/7a02ab5a-9338-4b94-9045-d9634ccfb5dc">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
