### PR TITLE
[image][Android] Fix `border` related props

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fixes Gif animations never stopping even when loop count is set to 1. ([#32944](https://github.com/expo/expo/pull/32944) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `borderColor` is not applied. ([#33026](https://github.com/expo/expo/pull/33026) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed `border` related props weren't applied correctly.
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Fixes Gif animations never stopping even when loop count is set to 1. ([#32944](https://github.com/expo/expo/pull/32944) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `borderColor` is not applied. ([#33026](https://github.com/expo/expo/pull/33026) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed `border` related props weren't applied correctly.
+- [Android] Fixed `border` related props weren't applied correctly. ([#33078](https://github.com/expo/expo/pull/33078) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -16,10 +16,6 @@ import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.load.model.LazyHeaders
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
-import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.uimanager.Spacing
-import com.facebook.react.uimanager.ViewProps
-import com.facebook.yoga.YogaConstants
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import com.github.penfeizhou.animation.gif.GifDrawable
 import com.github.penfeizhou.animation.webp.WebPDrawable
@@ -229,58 +225,6 @@ class ExpoImageModule : Module() {
 
       Prop("transition") { view: ExpoImageViewWrapper, transition: ImageTransition? ->
         view.transition = transition
-      }
-
-      PropGroup(
-        ViewProps.BORDER_RADIUS to 0,
-        ViewProps.BORDER_TOP_LEFT_RADIUS to 1,
-        ViewProps.BORDER_TOP_RIGHT_RADIUS to 2,
-        ViewProps.BORDER_BOTTOM_RIGHT_RADIUS to 3,
-        ViewProps.BORDER_BOTTOM_LEFT_RADIUS to 4,
-        ViewProps.BORDER_TOP_START_RADIUS to 5,
-        ViewProps.BORDER_TOP_END_RADIUS to 6,
-        ViewProps.BORDER_BOTTOM_START_RADIUS to 7,
-        ViewProps.BORDER_BOTTOM_END_RADIUS to 8
-      ) { view: ExpoImageViewWrapper, index: Int, borderRadius: Float? ->
-        val radius = makeYogaUndefinedIfNegative(borderRadius ?: YogaConstants.UNDEFINED)
-        view.setBorderRadius(index, radius)
-      }
-
-      PropGroup(
-        ViewProps.BORDER_WIDTH to Spacing.ALL,
-        ViewProps.BORDER_LEFT_WIDTH to Spacing.LEFT,
-        ViewProps.BORDER_RIGHT_WIDTH to Spacing.RIGHT,
-        ViewProps.BORDER_TOP_WIDTH to Spacing.TOP,
-        ViewProps.BORDER_BOTTOM_WIDTH to Spacing.BOTTOM,
-        ViewProps.BORDER_START_WIDTH to Spacing.START,
-        ViewProps.BORDER_END_WIDTH to Spacing.END
-      ) { view: ExpoImageViewWrapper, index: Int, width: Float? ->
-        val pixelWidth = makeYogaUndefinedIfNegative(width ?: YogaConstants.UNDEFINED)
-          .ifYogaDefinedUse(PixelUtil::toPixelFromDIP)
-        view.setBorderWidth(index, pixelWidth)
-      }
-
-      PropGroup(
-        ViewProps.BORDER_COLOR to Spacing.ALL,
-        ViewProps.BORDER_LEFT_COLOR to Spacing.LEFT,
-        ViewProps.BORDER_RIGHT_COLOR to Spacing.RIGHT,
-        ViewProps.BORDER_TOP_COLOR to Spacing.TOP,
-        ViewProps.BORDER_BOTTOM_COLOR to Spacing.BOTTOM,
-        ViewProps.BORDER_START_COLOR to Spacing.START,
-        ViewProps.BORDER_END_COLOR to Spacing.END,
-        ViewProps.BORDER_BLOCK_COLOR to Spacing.BLOCK,
-        ViewProps.BORDER_BLOCK_END_COLOR to Spacing.BLOCK_END,
-        ViewProps.BORDER_BLOCK_START_COLOR to Spacing.BLOCK_START
-      ) { view: ExpoImageViewWrapper, index: Int, color: Int? ->
-        view.setBorderColor(index, color)
-      }
-
-      Prop("borderStyle") { view: ExpoImageViewWrapper, borderStyle: String? ->
-        view.borderStyle = borderStyle
-      }
-
-      Prop("backgroundColor") { view: ExpoImageViewWrapper, color: Int? ->
-        view.backgroundColor = color
       }
 
       Prop("tintColor") { view: ExpoImageViewWrapper, color: Int? ->

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -18,7 +18,6 @@ import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.RequestOptions
-import com.facebook.yoga.YogaConstants
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.enums.Priority
 import expo.modules.image.events.GlideRequestListener
@@ -115,18 +114,6 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
       transformationMatrixChanged = true
     }
 
-  internal var borderStyle: String? = null
-    set(value) {
-      field = value
-      activeView.setBorderStyle(value)
-    }
-
-  internal var backgroundColor: Int? = null
-    set(value) {
-      field = value
-      activeView.setBackgroundColor(value)
-    }
-
   internal var tintColor: Int? = null
     set(value) {
       field = value
@@ -179,27 +166,6 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
   internal var priority: Priority = Priority.NORMAL
   internal var cachePolicy: CachePolicy = CachePolicy.DISK
 
-  private var borderRadius = FloatArray(9) { YogaConstants.UNDEFINED }
-  private var borderWidth = FloatArray(9) { YogaConstants.UNDEFINED }
-  private var borderColor = Array<Int?>(12) { null }
-
-  fun setBorderRadius(index: Int, radius: Float) {
-    borderRadius[index] = radius
-    activeView.setBorderRadius(index, radius)
-  }
-
-  fun setBorderWidth(index: Int, width: Float) {
-    borderWidth[index] = width
-    activeView.setBorderWidth(index, width)
-  }
-
-  fun setBorderColor(index: Int, color: Int?) {
-    borderColor[index] = color
-    if (color != null) {
-      activeView.setBorderColor(index, color)
-    }
-  }
-
   fun setIsAnimating(setAnimating: Boolean) {
     val resource = activeView.drawable
 
@@ -239,22 +205,9 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
   private fun copyProps(view: ExpoImageView) {
     view.contentFit = contentFit
     view.contentPosition = contentPosition
-    view.setBorderStyle(borderStyle)
-    view.setBackgroundColor(backgroundColor)
     view.setTintColor(tintColor)
     view.isFocusable = isFocusableProp
     view.contentDescription = accessibilityLabel
-    borderColor.forEachIndexed { index, color ->
-      if (color != null) {
-        view.setBorderColor(index, color)
-      }
-    }
-    borderRadius.forEachIndexed { index, value ->
-      view.setBorderRadius(index, value)
-    }
-    borderWidth.forEachIndexed { index, value ->
-      view.setBorderWidth(index, value)
-    }
     setIsScreenReaderFocusable(view, accessible)
   }
 


### PR DESCRIPTION
# Why

A follow up to the https://github.com/expo/expo/pull/33074
A better fix than https://github.com/expo/expo/pull/33026
Fixes https://github.com/expo/expo/issues/31215

# How

The handling of border radius was changed in React Native version 0.76. We are able to patch this in the image package, but I believe it is better to adopt a standardized method for applying these properties.

Removed the code responsible for handling border related props. 

# Test Plan

- see https://github.com/expo/expo/pull/33074 ✅ 
