### PR TITLE
[core] support kotlin 2.0.21 for kspVersion

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Use `findNodeHandle` with a native ref instead of a class component instance to avoid expensive calls to `findCurrentFiberUsingSlowPath`. ([#33016](https://github.com/expo/expo/pull/33016) by [@tsapeta](https://github.com/tsapeta))
 - Introduced `ReactNativeFeatureFlags` compat to fix React Native 0.77 breaking changes. ([#33077](https://github.com/expo/expo/pull/33077) by [@kudo](https://github.com/kudo))
+- Fixed compatibility for React Native 0.77. ([#33079](https://github.com/expo/expo/pull/33079) by [@kudo](https://github.com/kudo))
 
 ## 2.0.3 — 2024-11-14
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -26,7 +26,8 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
           "1.8.10": "1.8.10-1.0.9",
           "1.8.22": "1.8.22-1.0.11",
           "1.9.23": "1.9.23-1.0.20",
-          "1.9.24": "1.9.24-1.0.20"
+          "1.9.24": "1.9.24-1.0.20",
+          "2.0.21": "2.0.21-1.0.27"
         ]
 
         project.rootProject.ext.has("kspVersion")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
@@ -41,7 +41,7 @@ class FilteredReadableMap(
   private val backingMap: ReadableMap,
   private val filteredKeys: List<String>
 ) : ReadableMap by backingMap {
-  override val entryIterator: Iterator<Map.Entry<String, Any>> =
+  override val entryIterator =
     FilteredIterator(backingMap.entryIterator) {
       !filteredKeys.contains(it.key)
     }


### PR DESCRIPTION
# Why

fix nightly testing for react-native 0.77

# How

- add ksp version mappings for kotlin 2.0.21
- fixed breaking change from `ReadableMap.entryIterator` (from Any to Any?) https://github.com/facebook/react-native/commit/bcdf6ad1afae2a783ca077fc29906e370bf3f7a2

# Test Plan

ci passed on upstrack pr

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
