### PR TITLE
[docs] AppConfig: improvements for schema renderer

### DIFF
--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -19,8 +19,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-              data-text="true"
+              class="font-medium"
             >
               name
             </code>
@@ -51,18 +50,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </svg>
         </a>
       </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+      <div
+        class="my-3"
         data-text="true"
       >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        <span
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
           data-text="true"
         >
-          string
-        </code>
-      </p>
+          Type: 
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            data-text="true"
+          >
+            string
+          </code>
+        </span>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -163,8 +167,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-              data-text="true"
+              class="font-medium"
             >
               androidNavigationBar
             </code>
@@ -195,18 +198,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </svg>
         </a>
       </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+      <div
+        class="my-3"
         data-text="true"
       >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        <span
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
           data-text="true"
         >
-          object
-        </code>
-      </p>
+          Type: 
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            data-text="true"
+          >
+            object
+          </code>
+        </span>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -383,8 +391,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
+                class="font-medium"
               >
                 visible
               </code>
@@ -415,27 +422,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </a>
         </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+        <div
+          class="my-3"
           data-text="true"
         >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
             data-text="true"
           >
-            enum
-          </code>
-           • Path:
-           
-          <code
-            class="break-words px-1 text-secondary"
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              enum
+            </code>
+          </span>
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+            data-text="true"
           >
-            androidNavigationBar
-            .
-            visible
-          </code>
-        </p>
+             • Path:
+             
+            <code
+              class="break-words px-1 text-secondary"
+            >
+              androidNavigationBar
+              .
+              visible
+            </code>
+          </span>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -535,8 +552,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                  data-text="true"
+                  class="font-medium"
                 >
                   always
                 </code>
@@ -567,27 +583,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </a>
           </p>
-          <p
-            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+          <div
+            class="my-3"
             data-text="true"
           >
-            Type: 
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            <span
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
               data-text="true"
             >
-              boolean
-            </code>
-             • Path:
-             
-            <code
-              class="break-words px-1 text-secondary"
+              Type: 
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                data-text="true"
+              >
+                boolean
+              </code>
+            </span>
+            <span
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+              data-text="true"
             >
-              androidNavigationBar.visible
-              .
-              always
-            </code>
-          </p>
+               • Path:
+               
+              <code
+                class="break-words px-1 text-secondary"
+              >
+                androidNavigationBar.visible
+                .
+                always
+              </code>
+            </span>
+          </div>
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
             data-text="true"
@@ -612,8 +638,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
+                class="font-medium"
               >
                 backgroundColor
               </code>
@@ -644,27 +669,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </a>
         </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+        <div
+          class="my-3"
           data-text="true"
         >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
             data-text="true"
           >
-            string
-          </code>
-           • Path:
-           
-          <code
-            class="break-words px-1 text-secondary"
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              string
+            </code>
+          </span>
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+            data-text="true"
           >
-            androidNavigationBar
-            .
-            backgroundColor
-          </code>
-        </p>
+             • Path:
+             
+            <code
+              class="break-words px-1 text-secondary"
+            >
+              androidNavigationBar
+              .
+              backgroundColor
+            </code>
+          </span>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -703,8 +738,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="inline"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-              data-text="true"
+              class="font-medium"
             >
               intentFilters
             </code>
@@ -735,18 +769,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </svg>
         </a>
       </p>
-      <p
-        class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+      <div
+        class="my-3"
         data-text="true"
       >
-        Type: 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        <span
+          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
           data-text="true"
         >
-          array
-        </code>
-      </p>
+          Type: 
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            data-text="true"
+          >
+            array
+          </code>
+        </span>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -874,8 +913,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
+                class="font-medium"
               >
                 autoVerify
               </code>
@@ -906,27 +944,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </a>
         </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+        <div
+          class="my-3"
           data-text="true"
         >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
             data-text="true"
           >
-            boolean
-          </code>
-           • Path:
-           
-          <code
-            class="break-words px-1 text-secondary"
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              boolean
+            </code>
+          </span>
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+            data-text="true"
           >
-            intentFilters
-            .
-            autoVerify
-          </code>
-        </p>
+             • Path:
+             
+            <code
+              class="break-words px-1 text-secondary"
+            >
+              intentFilters
+              .
+              autoVerify
+            </code>
+          </span>
+        </div>
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
           data-text="true"
@@ -950,8 +998,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="inline"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                data-text="true"
+                class="font-medium"
               >
                 data
               </code>
@@ -982,27 +1029,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </a>
         </p>
-        <p
-          class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+        <div
+          class="my-3"
           data-text="true"
         >
-          Type: 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
             data-text="true"
           >
-            array || object
-          </code>
-           • Path:
-           
-          <code
-            class="break-words px-1 text-secondary"
+            Type: 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
+            >
+              array || object
+            </code>
+          </span>
+          <span
+            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+            data-text="true"
           >
-            intentFilters
-            .
-            data
-          </code>
-        </p>
+             • Path:
+             
+            <code
+              class="break-words px-1 text-secondary"
+            >
+              intentFilters
+              .
+              data
+            </code>
+          </span>
+        </div>
         <div
           class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
@@ -1019,8 +1076,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="inline"
               >
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !px-1.5 !text-sm"
-                  data-text="true"
+                  class="font-medium"
                 >
                   host
                 </code>
@@ -1051,27 +1107,37 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </a>
           </p>
-          <p
-            class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary my-3"
+          <div
+            class="my-3"
             data-text="true"
           >
-            Type: 
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            <span
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
               data-text="true"
             >
-              string
-            </code>
-             • Path:
-             
-            <code
-              class="break-words px-1 text-secondary"
+              Type: 
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                data-text="true"
+              >
+                string
+              </code>
+            </span>
+            <span
+              class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"
+              data-text="true"
             >
-              intentFilters.data
-              .
-              host
-            </code>
-          </p>
+               • Path:
+               
+              <code
+                class="break-words px-1 text-secondary"
+              >
+                intentFilters.data
+                .
+                host
+              </code>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/ui/components/AppConfigSchemaTable/index.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/index.tsx
@@ -9,7 +9,7 @@ import { CodeBlock } from '~/components/base/code';
 import { APIBox } from '~/components/plugins/APIBox';
 import { mdComponents } from '~/components/plugins/api/APISectionUtils';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { P, CALLOUT, CODE, createPermalinkedComponent } from '~/ui/components/Text';
+import { P, CALLOUT, CODE, createPermalinkedComponent, LI, UL } from '~/ui/components/Text';
 
 export type AppConfigSchemaProps = {
   schema: Record<string, Property>;
@@ -41,7 +41,7 @@ const Anchor = createPermalinkedComponent(P, {
 function PropertyName({ name, nestingLevel }: PropertyNameProps) {
   return (
     <Anchor level={nestingLevel} data-testid={name} data-heading="true">
-      <CODE className="!px-1.5 !text-sm">{name}</CODE>
+      <code className="font-medium">{name}</code>
     </Anchor>
   );
 }
@@ -57,6 +57,7 @@ function AppConfigProperty({
   subproperties,
   parent,
 }: FormattedProperty & { nestingLevel: number }) {
+  const canHaveMultipleValues = Array.isArray(type);
   return (
     <APIBox
       className={mergeClasses(
@@ -65,30 +66,87 @@ function AppConfigProperty({
         '[&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default'
       )}>
       <PropertyName name={name} nestingLevel={nestingLevel} />
-      <CALLOUT theme="secondary" data-text="true" className="my-3">
-        {Array.isArray(type) ? (
-          <span className="mb-2 grid grid-cols-1 gap-2">
-            One of types:{' '}
-            {type.map((oneOfType, index) => (
-              <CodeBlock className="!text-balance !text-secondary" inline key={`${name}-${index}`}>
-                {oneOfType}
-              </CodeBlock>
-            ))}
-          </span>
+      <div className="my-3" data-text="true">
+        {canHaveMultipleValues ? (
+          <div className="mb-2 grid grid-cols-1">
+            <CALLOUT theme="secondary" tag="span">
+              One of types:
+            </CALLOUT>
+            <UL className="[&>li]:leading-loose">
+              {type.map((oneOfType, index) => {
+                const typeData = JSON.parse(oneOfType);
+
+                if (typeData.type === 'string') {
+                  return (
+                    <LI theme="secondary" className="text-sm" key={`${name}-string-${index}`}>
+                      {typeData.pattern ? (
+                        <>
+                          <CODE>string</CODE> matching the following pattern:{' '}
+                          <code className="text-sm text-default">{typeData.pattern}</code>
+                        </>
+                      ) : (
+                        <CODE>string</CODE>
+                      )}
+                    </LI>
+                  );
+                } else if (typeData.type === 'object' && typeData.properties) {
+                  return (
+                    <LI theme="secondary" className="text-sm" key={`${name}-object-${index}`}>
+                      <span className="mb-2 block">
+                        An <CODE>object</CODE> with the following properties:
+                      </span>
+                      {Object.keys(typeData.properties).map((key: string) => {
+                        const subTypeData = typeData.properties[key];
+                        return (
+                          <AppConfigProperty
+                            description={
+                              subTypeData.enum
+                                ? [
+                                    subTypeData.description,
+                                    `Valid values: ${subTypeData.enum.map((value: string) => `\`${value}\``).join(', ')}.`,
+                                  ]
+                                    .filter(Boolean)
+                                    .join('')
+                                : subTypeData.description
+                            }
+                            type={subTypeData.enum ? 'enum' : subTypeData.type}
+                            parent={parent ? `${parent}.${name}` : name}
+                            name={key}
+                            key={`${key}-${name}-${index}`}
+                            subproperties={[]}
+                            nestingLevel={nestingLevel + 1}
+                          />
+                        );
+                      })}
+                    </LI>
+                  );
+                } else {
+                  return (
+                    <CodeBlock
+                      className="text-balance text-secondary"
+                      inline
+                      key={`${name}-${index}`}>
+                      {oneOfType}
+                    </CodeBlock>
+                  );
+                }
+              })}
+            </UL>
+          </div>
         ) : (
-          <>
+          <CALLOUT theme="secondary" tag="span">
             Type: <CODE>{type ?? 'undefined'}</CODE>
-          </>
+          </CALLOUT>
         )}
-        {nestingLevel > 0 && (
-          <>
+        {!canHaveMultipleValues && nestingLevel > 0 && (
+          <CALLOUT theme="secondary" tag="span">
             &emsp;&bull;&emsp;Path:{' '}
             <code className="break-words px-1 text-secondary">
               {parent}.{name}
             </code>
-          </>
+          </CALLOUT>
         )}
-      </CALLOUT>
+      </div>
       <ReactMarkdown components={mdComponents}>{description}</ReactMarkdown>
       {expoKit && (
         <Collapsible summary="ExpoKit">
@@ -108,11 +166,12 @@ function AppConfigProperty({
           <CodeBlock inline>{JSON.stringify(example, null, 2)}</CodeBlock>
         </span>
       )}
-      {subproperties.length > 0 &&
+      {subproperties &&
+        subproperties.length > 0 &&
         subproperties.map((formattedProperty, index) => (
           <AppConfigProperty
             {...formattedProperty}
-            key={`${name}-${index}`}
+            key={`${name}-${formattedProperty.name}-${index}`}
             nestingLevel={nestingLevel + 1}
           />
         ))}

--- a/docs/ui/components/AppConfigSchemaTable/types.ts
+++ b/docs/ui/components/AppConfigSchemaTable/types.ts
@@ -33,4 +33,5 @@ export type FormattedProperty = {
   bareWorkflow?: string;
   subproperties: FormattedProperty[];
   parent?: string;
+  enum?: string[];
 };


### PR DESCRIPTION
# Why

Fixes ENG-13908
Fixes #32959

# How

Improvements for schema renderer, especially when it comes to the fields with multiple possible types, fix warnings.

However, there is still a lot to do on the schema side tho, which would improve even further the clarity of the content on that page.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-11-19 at 15 38 55](https://github.com/user-attachments/assets/e1231da6-734d-4f90-b98a-ca0d9329161d)
![Screenshot 2024-11-19 at 15 30 58](https://github.com/user-attachments/assets/6fa490f6-37e3-4e8e-aeb7-8b12f0df083e)
