### PR TITLE
fix(cli): detect and enable offline mode after DNS is resolved without network access

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Detect and enable offline mode after DNS is resolved, but network isn't accessible.
+
 ### 💡 Others
 
 ## 0.21.6 — 2024-11-19

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Detect and enable offline mode after DNS is resolved, but network isn't accessible.
+- Detect and enable offline mode after DNS is resolved, but network isn't accessible. ([#33084](https://github.com/expo/expo/pull/33084) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -190,18 +190,36 @@ it('switches to offline mode when node-fetch network errors are thrown', async (
   expect(disableNetwork).toHaveBeenCalled();
 });
 
-it('switches to offline mode when undici network errors are thrown', async () => {
-  const undiciNetworkError = new Error('fetch failed');
-  const undiciNetworkCause = new Error('getaddrinfo ENOTFOUND api.expo.dev');
+describe('switches to offline mode when undici network errors are thrown', () => {
+  it('detects when ENOTFOUND is thrown', async () => {
+    const undiciNetworkError = new Error('fetch failed');
+    const undiciNetworkCause = new Error('getaddrinfo ENOTFOUND api.expo.dev');
 
-  Object.defineProperty(undiciNetworkError, 'cause', { value: undiciNetworkCause });
-  Object.defineProperty(undiciNetworkCause, 'code', { value: 'ENOTFOUND' });
+    Object.defineProperty(undiciNetworkError, 'cause', { value: undiciNetworkCause });
+    Object.defineProperty(undiciNetworkCause, 'code', { value: 'ENOTFOUND' });
 
-  jest.mocked(fetch).mockRejectedValueOnce(undiciNetworkError);
+    jest.mocked(fetch).mockRejectedValueOnce(undiciNetworkError);
 
-  await expect(fetchAsync('https://api.expo.dev')).rejects.toThrow(
-    'Network connection is unreliable. Try again with the environment variable `EXPO_OFFLINE=1` to skip network requests'
-  );
+    await expect(fetchAsync('https://api.expo.dev')).rejects.toThrow(
+      'Network connection is unreliable. Try again with the environment variable `EXPO_OFFLINE=1` to skip network requests'
+    );
 
-  expect(disableNetwork).toHaveBeenCalled();
+    expect(disableNetwork).toHaveBeenCalled();
+  });
+
+  it('detects when UND_ERR_CONNECT_TIMEOUT is thrown', async () => {
+    const undiciNetworkError = new Error('fetch failed');
+    const undiciNetworkCause = new Error('getaddrinfo UND_ERR_CONNECT_TIMEOUT api.expo.dev');
+
+    Object.defineProperty(undiciNetworkError, 'cause', { value: undiciNetworkCause });
+    Object.defineProperty(undiciNetworkCause, 'code', { value: 'UND_ERR_CONNECT_TIMEOUT' });
+
+    jest.mocked(fetch).mockRejectedValueOnce(undiciNetworkError);
+
+    await expect(fetchAsync('https://api.expo.dev')).rejects.toThrow(
+      'Network connection is unreliable. Try again with the environment variable `EXPO_OFFLINE=1` to skip network requests'
+    );
+
+    expect(disableNetwork).toHaveBeenCalled();
+  });
 });

--- a/packages/@expo/cli/src/api/user/UserSettings.ts
+++ b/packages/@expo/cli/src/api/user/UserSettings.ts
@@ -55,6 +55,15 @@ export async function setSessionAsync(sessionData?: SessionData) {
 }
 
 /**
+ * Check if there are credentials available, without fetching the user information.
+ * This can be used as a faster check to see if users are authenticated.
+ * Note, this isn't checking the validity of the credentials.
+ */
+export function hasCredentials() {
+  return !!getAccessToken() || !!getSession();
+}
+
+/**
  * Get an anonymous and randomly generated identifier.
  * This is used to group telemetry event by unknown actor,
  * and cannot be used to identify a single user.

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -4,15 +4,11 @@ import {
   closeDevelopmentSessionAsync,
   updateDevelopmentSessionAsync,
 } from '../../api/updateDevelopmentSession';
-import { getUserAsync } from '../../api/user/user';
+import { hasCredentials } from '../../api/user/UserSettings';
 import { env } from '../../utils/env';
 import * as ProjectDevices from '../project/devices';
 
 const debug = require('debug')('expo:start:server:developmentSession') as typeof console.log;
-
-async function isAuthenticatedAsync(): Promise<boolean> {
-  return !!(await getUserAsync().catch(() => null));
-}
 
 export class DevelopmentSession {
   /** If the `startAsync` was successfully called */
@@ -52,7 +48,7 @@ export class DevelopmentSession {
 
       const deviceIds = await this.getDeviceInstallationIdsAsync();
 
-      if (!(await isAuthenticatedAsync()) && !deviceIds?.length) {
+      if (!hasCredentials() && !deviceIds?.length) {
         debug(
           'Development session will not ping because the user is not authenticated and there are no devices.'
         );
@@ -93,7 +89,7 @@ export class DevelopmentSession {
     try {
       const deviceIds = await this.getDeviceInstallationIdsAsync();
 
-      if (!(await isAuthenticatedAsync()) && !deviceIds?.length) {
+      if (!hasCredentials() && !deviceIds?.length) {
         return false;
       }
 


### PR DESCRIPTION
# Why

This adds a missing error code to the offline detection / handler when making requests. If the DNS is resolved, undici will throw `UND_ERR_CONNECT_TIMEOUT` after trying to connect without an actual internet connection.

# How

- Added `UND_ERR_CONNECT_TIMEOUT` as error code to check for when enabling offline mode
- Avoid running `getUserAsync` when validating if development session should be created
  - This causes two separate calls for development sessions, which block each other -- making the offline detection having to time out twice before its enabling offline mode

# Test Plan

See test.

- Create and start a project
- Close the project
- Disable wifi
- Open project again
  - The DNS cache should still be warm, but the development session call should cause offline mode to be enabled.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
