### PR TITLE
refactor: drop usage of `strip-ansi` in favor of `node:util`

### DIFF
--- a/packages/@expo/cli/e2e/utils/command-instance.ts
+++ b/packages/@expo/cli/e2e/utils/command-instance.ts
@@ -5,11 +5,11 @@ import {
   parseMultipartMixedResponseAsync,
 } from '@expo/multipart-body-parser';
 import assert from 'assert';
-import spawn from 'cross-spawn';
 import { ChildProcess } from 'child_process';
+import spawn from 'cross-spawn';
 import { once } from 'events';
 import { EventEmitter } from 'fbemitter';
-import stripAnsi from 'strip-ansi';
+import util from 'node:util';
 import treeKill from 'tree-kill';
 
 export const bin = require.resolve('../../build/bin/cli');
@@ -111,7 +111,7 @@ export class ExpoStartCommand extends EventEmitter {
       ) {
         const errorObject = JSON.parse(text);
 
-        throw new Error(stripAnsi(errorObject.message) ?? errorObject.message);
+        throw new Error(util.stripVTControlCharacters(errorObject.message) ?? errorObject.message);
       }
       throw new Error(`[${res.status}]: ${res.statusText}\n${text}`);
     }
@@ -174,7 +174,7 @@ export class ExpoStartCommand extends EventEmitter {
             resolve();
           };
 
-          for (const rawStr of stripAnsi(message)) {
+          for (const rawStr of util.stripVTControlCharacters(message)) {
             const tag = '[__EXPO_E2E_TEST:server]';
             if (rawStr.includes(tag)) {
               const matchedLine = rawStr
@@ -332,7 +332,7 @@ export abstract class ServeAbstractCommand extends EventEmitter {
 export class ServeStaticCommand extends ServeAbstractCommand {
   isReadyCallback(message: string): boolean {
     const tag = 'Accepting connections at ';
-    for (const rawStr of stripAnsi(message)) {
+    for (const rawStr of util.stripVTControlCharacters(message)) {
       if (rawStr.includes(tag)) {
         const matchedLine = rawStr
           .split('\n')
@@ -358,7 +358,7 @@ export class ServeStaticCommand extends ServeAbstractCommand {
 export class ExpoServeLocalCommand extends ServeAbstractCommand {
   isReadyCallback(message: string): boolean {
     const tag = 'Server running at ';
-    for (const rawStr of stripAnsi(message)) {
+    for (const rawStr of util.stripVTControlCharacters(message)) {
       if (rawStr.includes(tag)) {
         const matchedLine = rawStr
           .split('\n')

--- a/packages/@expo/package-manager/src/ios/__tests__/CocoaPodsPackageManager-test.ts
+++ b/packages/@expo/package-manager/src/ios/__tests__/CocoaPodsPackageManager-test.ts
@@ -1,8 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
+import util from 'node:util';
 import os from 'os';
 import path from 'path';
-import stripAnsi from 'strip-ansi';
 
 import { mockSpawnPromise } from '../../__tests__/spawn-utils';
 import {
@@ -109,7 +109,7 @@ describe(getPodUpdateMessage, () => {
 describe(getPodRepoUpdateMessage, () => {
   it(`formats pod repo update message`, () => {
     expect(
-      stripAnsi(
+      util.stripVTControlCharacters(
         getPodRepoUpdateMessage(
           '[!] Unable to find a specification for `expo-dev-menu-interface` depended upon by `expo-dev-launcher`'
         ).message
@@ -120,7 +120,7 @@ describe(getPodRepoUpdateMessage, () => {
   });
   it(`formats pod update message`, () => {
     expect(
-      stripAnsi(
+      util.stripVTControlCharacters(
         getPodRepoUpdateMessage(
           "You should run `pod update EXFileSystem` to apply changes you've made."
         ).message

--- a/tools/package.json
+++ b/tools/package.json
@@ -71,7 +71,6 @@
     "recursive-omit-by": "^2.0.0",
     "semver": "^7.6.3",
     "sharp": "^0.33.5",
-    "strip-ansi": "^6.0.0",
     "terminal-link": "^2.1.1",
     "typedoc": "0.26.7",
     "uuid": "^9.0.0",

--- a/tools/src/android-update-native-dependencies/prompts.ts
+++ b/tools/src/android-update-native-dependencies/prompts.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import stripAnsi from 'strip-ansi';
+import util from 'node:util';
 
 import {
   AndroidProjectDependenciesUpdates,
@@ -74,7 +74,7 @@ async function promptForDependenciesVersions(
         group: dependency.group,
         fullName: dependency.fullName,
         oldVersion: dependency.currentVersion,
-        newVersion: stripAnsi(version),
+        newVersion: util.stripVTControlCharacters(version),
       });
     }
   }

--- a/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
+import util from 'node:util';
 import readline from 'readline';
-import stripAnsi from 'strip-ansi';
 
 import { findPackagesToPromote } from './findPackagesToPromote';
 import logger from '../../Logger';
@@ -69,7 +69,7 @@ async function promptForPackagesToPromoteAsync(parcels: Parcel[]): Promise<strin
   // If possible, we clear everything that has been printed after the prompt.
   if (process.stdout.columns) {
     const bufferLength = choices.reduce(
-      (acc, choice) => acc + stripAnsi(choice.name).length + 2,
+      (acc, choice) => acc + util.stripVTControlCharacters(choice.name).length + 2,
       0
     );
     readline.moveCursor(process.stdout, 0, -Math.ceil(bufferLength / process.stdout.columns));


### PR DESCRIPTION
# Why

This drops `expo/expo`-wide usage of `strip-ansi` in favor of Node's built in `util.stripVTControlCharacters`.

See https://github.com/facebook/metro/commit/0f8cabdf9d79c8fe6245276d8c73f8e401189168#diff-db9ae0866f1a1c4ec08fa483d2298b72c478453e15935b9df6539a98c1ad5c4bR185

> [!IMPORTANT]
> This doesn't fully get rid of `strip-ansi`, it's often used as nested dependency.

# How

- Dropped `strip-ansi` in favor of `node:utils`.

# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
