### PR TITLE
[docs] Recommend installing specific react-native-view-shot version in Expo tutorial

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -24,7 +24,7 @@ In this chapter, we'll learn how to take a screenshot using a third-party librar
 
 To install `react-native-view-shot` and `expo-media-library`, run the following commands:
 
-<Terminal cmd={['$ npx expo install react-native-view-shot expo-media-library']} />
+<Terminal cmd={['$ npx expo install react-native-view-shot@3.7.0 expo-media-library']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feedback in [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1732036437701089)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the installation command to include 3.7.0 version of `react-native-view-shot` in Take a screenshot chapter of Expo tutorial

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
