### PR TITLE
[docs] migrate to the latest version of styleguide packages

### DIFF
--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -11,12 +11,11 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       data-text="true"
     >
       <svg
-        class="text-icon-default icon-sm"
+        class="text-icon-default translate-z icon-sm"
         fill="none"
         role="img"
         stroke="currentColor"
         viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
       >
         <g
           id="layout-alt-03-outline-icon"
@@ -40,12 +39,11 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
         >
           <svg
             aria-label="Scroll to top"
-            class="icon-sm text-icon-secondary"
+            class="translate-z icon-sm text-icon-secondary"
             fill="none"
             role="img"
             stroke="currentColor"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="arrow-circle-up-outline-icon"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -232,11 +232,10 @@ not appear on the screen.
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -1063,12 +1062,11 @@ properties.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -1257,11 +1255,10 @@ This should come from the user field of an
         class="select-none [table_&]:mt-0.5 mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -1303,12 +1300,11 @@ This should come from the user field of an
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -1451,12 +1447,11 @@ value depending on the state of the credential.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -1681,12 +1676,11 @@ Calling this method will show the sign in modal before actually refreshing the u
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -1970,12 +1964,11 @@ the user, since this remains the same for apps released by the same developer.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -2246,12 +2239,11 @@ from using
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -2495,12 +2487,11 @@ sign-out operation.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -2674,11 +2665,10 @@ which contains all of the pertinent user and credential information.
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -3554,11 +3544,10 @@ may be
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -3717,11 +3706,10 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -4028,11 +4016,10 @@ None of these options are required.
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -4356,11 +4343,10 @@ You must include the ID string of the user to sign out.
         class="mt-1 select-none [table_&]:mt-0.5"
       >
         <svg
-          class="icon-sm text-icon-default"
+          class="translate-z icon-sm text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="info-circle-solid-icon"
@@ -5181,14 +5167,13 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
+            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
           >
             <svg
-              class="icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <g
                 id="apple-custom-icon"
@@ -5345,11 +5330,10 @@ After calling this function, the listener will no longer receive any events from
           class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -5993,11 +5977,10 @@ for more details.
           class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -6035,11 +6018,10 @@ You will still need to handle null values for any fields you request.
           class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -6269,11 +6251,10 @@ for more details.
           class="mt-1 select-none [table_&]:mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -6617,12 +6598,11 @@ exports[`APISection expo-pedometer 1`] = `
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -6692,14 +6672,13 @@ exports[`APISection expo-pedometer 1`] = `
         data-text="true"
       >
         <div
-          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-blue3 !text-palette-blue12 !border-palette-blue4"
+          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
         >
           <svg
-            class="icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+            class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="apple-custom-icon"
@@ -6893,12 +6872,11 @@ exports[`APISection expo-pedometer 1`] = `
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -7004,11 +6982,10 @@ exports[`APISection expo-pedometer 1`] = `
           class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -7101,12 +7078,11 @@ a start date that is more than seven days in the past returns only the available
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -7239,12 +7215,11 @@ available on this device.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -7450,12 +7425,11 @@ provided with a single argument that is
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"
@@ -7527,11 +7501,10 @@ provided with a single argument that is
           class="select-none [table_&]:mt-0.5 mt-0.5"
         >
           <svg
-            class="icon-sm text-icon-default"
+            class="translate-z icon-sm text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
           >
             <g
               id="info-circle-solid-icon"
@@ -8150,12 +8123,11 @@ in order to enable/disable the permission.
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="icon-sm inline-block text-icon-secondary"
+          class="translate-z icon-sm inline-block text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="corner-down-right-outline-icon"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -21,14 +21,13 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       data-text="true"
     >
       <div
-        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 !bg-palette-green3 !text-palette-green12 !border-palette-green4"
+        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
       >
         <svg
-          class="icon-xs mt-[-0.5px] text-palette-green12 opacity-80"
+          class="translate-z icon-xs mt-[-0.5px] text-palette-green12 opacity-80"
           fill="none"
           role="img"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="android-custom-icon"
@@ -81,12 +80,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
         data-text="true"
       >
         <svg
-          class="icon-sm text-icon-secondary"
+          class="translate-z icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
           viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <g
             id="code-square-01-outline-icon"

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,10 +23,10 @@
     "postinstall": "node --async-stack-traces --unhandled-rejections=strict ./scripts/copy-latest.js && yarn generate-static-resources"
   },
   "dependencies": {
-    "@expo/styleguide": "^8.3.0",
-    "@expo/styleguide-base": "^1.0.1",
-    "@expo/styleguide-icons": "^2.0.3",
-    "@expo/styleguide-search-ui": "^2.1.2",
+    "@expo/styleguide": "^9.0.1",
+    "@expo/styleguide-base": "^2.0.1",
+    "@expo/styleguide-icons": "^2.1.1",
+    "@expo/styleguide-search-ui": "^2.2.4",
     "@mdx-js/loader": "^2.2.1",
     "@mdx-js/mdx": "^2.2.1",
     "@mdx-js/react": "^2.2.1",

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -44,7 +44,7 @@ code {
 
 ::selection {
   @apply text-default;
-  background-color: rgb(from var(--blue5) r g b / 80%);
+  background-color: rgb(from var(--blue-5) r g b / 80%);
 }
 
 ::-moz-selection {
@@ -123,9 +123,8 @@ div.tippy-box {
 }
 
 .tippy-box[data-theme~='expo'] .tippy-content {
-  @apply text-sm text-palette-white rounded-md py-3 px-4;
+  @apply text-sm text-palette-white bg-palette-black rounded-md py-3 px-4;
   line-height: 1.525;
-  background: #000;
 }
 
 .tippy-box[data-state='visible'] {
@@ -202,10 +201,10 @@ div.tippy-box {
   transition: 200ms ease all;
   transition-property: text-shadow, opacity;
   text-shadow:
-    var(--yellow7) 0 0 10px,
-    var(--yellow7) 0 0 10px,
-    var(--yellow7) 0 0 10px,
-    var(--yellow7) 0 0 10px;
+    var(--yellow-7) 0 0 10px,
+    var(--yellow-7) 0 0 10px,
+    var(--yellow-7) 0 0 10px,
+    var(--yellow-7) 0 0 10px;
 }
 
 .code-annotation.with-tooltip:hover {
@@ -254,7 +253,7 @@ div.tippy-box {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  @apply text-palette-red11;
+  @apply text-palette-red10;
 }
 
 .token.selector,
@@ -278,7 +277,7 @@ div.tippy-box {
 .token.atrule,
 .token.attr-value,
 .token.function {
-  @apply text-palette-purple11;
+  @apply text-palette-purple10 dark:text-palette-purple11;
 }
 
 .token.class-name,

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -27,6 +27,9 @@ module.exports = {
         'launch-party-blue': '#006CFF',
         'launch-party-yellow': '#F3AD0D',
       },
+      borderColor: {
+        'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
+      },
       backgroundImage: () => ({
         'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
         'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -80,11 +80,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <g
                 id="triangle-down-custom-icon"
@@ -224,11 +223,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <g
                 id="triangle-down-custom-icon"
@@ -301,11 +299,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <g
                 id="triangle-down-custom-icon"
@@ -453,11 +450,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="ml-1.5 mr-2 mt-[5px] self-baseline"
             >
               <svg
-                class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+                class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
               >
                 <g
                   id="triangle-down-custom-icon"
@@ -764,11 +760,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <g
                 id="triangle-down-custom-icon"

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -86,18 +86,21 @@ function getCalloutColor(type: CalloutType) {
     case 'warning':
       return mergeClasses(
         'border-warning bg-warning',
-        `[&_code]:border-palette-yellow6 [&_code]:bg-palette-yellow4`,
-        `dark:[&_code]:border-palette-yellow7 dark:[&_code]:bg-palette-yellow5`
+        `[&_code]:border-palette-yellow5 [&_code]:bg-palette-yellow4`,
+        `selection:bg-palette-yellow5 dark:selection:bg-palette-yellow6`,
+        `dark:[&_code]:border-palette-yellow6 dark:[&_code]:bg-palette-yellow5`
       );
     case 'error':
       return mergeClasses(
         'border-danger bg-danger',
-        `[&_code]:border-palette-red7 [&_code]:bg-palette-red5`
+        `[&_code]:border-palette-red6 [&_code]:bg-palette-red5`,
+        `selection:bg-palette-red5 dark:selection:bg-palette-red6`
       );
     case 'info':
       return mergeClasses(
         'border-info bg-info',
-        `[&_code]:border-palette-blue6 [&_code]:bg-palette-blue4`
+        `[&_code]:border-palette-blue5 [&_code]:bg-palette-blue4`,
+        `dark:selection:bg-palette-yellow6`
       );
     default:
       return null;

--- a/docs/ui/components/Header/Logo.tsx
+++ b/docs/ui/components/Header/Logo.tsx
@@ -13,7 +13,7 @@ export const Logo = ({ subgroup }: Props) => (
       className="flex select-none flex-row items-center gap-2 decoration-0 outline-offset-1"
       href="https://expo.dev">
       <WordMarkLogo
-        className={mergeClasses('my-1 mt-px h-5 w-[72px] text-default', 'max-md-gutters:hidden')}
+        className={mergeClasses('mt-px h-5 w-[72px] text-default', 'max-md-gutters:hidden')}
         title="Expo"
       />
       <LogoIcon

--- a/docs/ui/components/Home/resources/WhyImage.tsx
+++ b/docs/ui/components/Home/resources/WhyImage.tsx
@@ -1,5 +1,3 @@
-import { theme } from '@expo/styleguide';
-
 export const WhyImage = () => (
   <svg
     className="absolute bottom-5 right-5"
@@ -11,30 +9,29 @@ export const WhyImage = () => (
     <path
       opacity="0.4"
       d="M40.7406 74.6911C59.4909 74.6911 74.6911 59.4909 74.6911 40.7406C74.6911 21.9903 59.4909 6.7901 40.7406 6.7901C21.9903 6.7901 6.7901 21.9903 6.7901 40.7406C6.7901 59.4909 21.9903 74.6911 40.7406 74.6911Z"
-      fill={theme.palette.green5}
-      stroke={theme.palette.green9}
+      className="fill-palette-green5 stroke-palette-green9"
       strokeWidth="6.7901"
       strokeLinecap="round"
     />
     <path
       d="M30.861 30.5555C31.6592 28.2865 33.2346 26.3732 35.3084 25.1545C37.3821 23.9357 39.8202 23.4902 42.1909 23.8969C44.5616 24.3035 46.7119 25.536 48.2609 27.3762C49.8099 29.2163 50.6577 31.5453 50.6541 33.9506C50.6541 40.7407 40.469 44.1357 40.469 44.1357M40.7406 57.7159H40.7745"
-      stroke={theme.palette.green9}
+      className="stroke-palette-green9"
       strokeWidth="6.7901"
       strokeLinecap="round"
     />
     <path
       d="M102.389 74.6911C121.139 74.6911 136.339 59.4909 136.339 40.7406C136.339 21.9903 121.139 6.7901 102.389 6.7901C83.6385 6.7901 68.4383 21.9903 68.4383 40.7406C68.4383 59.4909 83.6385 74.6911 102.389 74.6911Z"
-      fill={theme.palette.green5}
+      className="fill-palette-green5"
     />
     <path
       d="M102.451 74.6911C121.201 74.6911 136.401 59.4909 136.401 40.7406C136.401 21.9903 121.201 6.7901 102.451 6.7901C83.7002 6.7901 68.5 21.9903 68.5 40.7406C68.5 59.4909 83.7002 74.6911 102.451 74.6911Z"
-      stroke={theme.palette.green7}
+      className="stroke-palette-green7"
       strokeWidth="6.7901"
       strokeLinecap="round"
     />
     <path
       d="M87 40.6664L97.1852 50.8515L117.555 30.4812"
-      stroke={theme.palette.green10}
+      className="stroke-palette-green10"
       strokeWidth="6.7901"
       strokeLinecap="round"
     />

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { DiscordIcon } from '@expo/styleguide-icons/custom/DiscordIcon';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
@@ -14,14 +15,21 @@ export function DiscoverMore() {
         Try out Expo in minutes and learn how to get the most out of Expo.
       </HeaderDescription>
       <GridContainer>
-        <GridCell className="border-palette-orange6 bg-palette-orange3 selection:bg-palette-orange5">
+        <GridCell
+          className={mergeClasses(
+            'border-palette-orange6 bg-palette-orange3 selection:bg-palette-orange5',
+            'dark:border-palette-orange7 dark:bg-palette-orange4 dark:selection:bg-palette-orange6'
+          )}>
           <SnackImage />
           <RawH3 className="!font-bold !text-palette-orange11">Try Expo in your browser</RawH3>
           <P className="max-w-[24ch] !text-xs !text-palette-orange11">
             Expo’s Snack lets you try Expo with zero local setup.
           </P>
           <HomeButton
-            className="border-palette-orange11 bg-palette-orange11 text-palette-orange3 hocus:bg-palette-orange11"
+            className={mergeClasses(
+              'border-palette-orange11 bg-palette-orange11 text-palette-orange3 hocus:bg-palette-orange11',
+              'dark:border-palette-orange10 dark:bg-palette-orange10'
+            )}
             href="https://snack.expo.dev/"
             target="_blank"
             rightSlot={<ArrowUpRightIcon className="icon-md text-palette-orange3" />}>
@@ -41,7 +49,11 @@ export function DiscoverMore() {
             Read FAQ
           </HomeButton>
         </GridCell>
-        <GridCell className="border-palette-yellow7 bg-palette-yellow3 selection:bg-palette-yellow5 dark:border-palette-yellow6">
+        <GridCell
+          className={mergeClasses(
+            'border-palette-yellow6 bg-palette-yellow3 selection:bg-palette-yellow5',
+            'dark:border-palette-yellow7 dark:bg-palette-yellow4'
+          )}>
           <OfficeHoursImage />
           <RawH3 className="!font-bold !text-palette-yellow11">Join us for Office Hours</RawH3>
           <P className="max-w-[28ch] !text-xs !text-palette-yellow11">

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -13,19 +13,19 @@ export function getPlatformName(text: string): PlatformName {
 export function getTagClasses(type: string) {
   switch (type) {
     case 'android':
-      return '!bg-palette-green3 !text-palette-green12 !border-palette-green4';
+      return 'bg-palette-green3 text-palette-green12 border-palette-green4';
     case 'ios':
-      return '!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4';
+      return 'bg-palette-blue3 text-palette-blue12 border-palette-blue4';
     case 'web':
-      return '!bg-palette-orange3 !text-palette-orange12 !border-palette-orange4';
+      return 'bg-palette-orange3 text-palette-orange12 border-palette-orange3.5 dark:bg-palette-orange4 dark:border-palette-orange5';
     case 'macos':
-      return '!bg-palette-purple3 !text-palette-purple12 !border-palette-purple4';
+      return 'bg-palette-purple3 text-palette-purple12 border-palette-purple4';
     case 'tvos':
-      return '!bg-palette-pink3 !text-palette-pink12 !border-palette-pink4';
+      return 'bg-palette-pink3 text-palette-pink12 border-palette-pink4';
     case 'deprecated':
-      return '!bg-palette-yellow2 !text-palette-yellow12 !border-palette-yellow4';
+      return 'bg-palette-yellow2 text-palette-yellow12 border-palette-yellow4';
     case 'experimental':
-      return '!bg-palette-pink3 !text-palette-pink12 !border-palette-pink4';
+      return 'bg-palette-pink3 text-palette-pink12 border-palette-pink4';
     default:
       return undefined;
   }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -387,38 +387,38 @@
   dependencies:
     cross-spawn "^7.0.3"
 
-"@expo/styleguide-base@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-1.0.1.tgz#c05b64370fc1754ed7e3c627fd2d788582445cd2"
-  integrity sha512-Iu52/esfpMXB5cOT3oyTvcSdkwok9re9Wtu4Tz7cmeumjh+81kTIB1GHZn8W1RFhSx9dys0NXr3UqPD8MkngtQ==
+"@expo/styleguide-base@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-2.0.1.tgz#9fc3488ab81c846f3097733cc340feb38b7985db"
+  integrity sha512-zC0xawqLBcO32V+I1LB+pktBGablZsJVQaIYCY+elQ2Lo8ZBx385tS+oofh9uNjoT3U5DnQoRkxqXL5GIZ398A==
   dependencies:
-    "@radix-ui/colors" "^0.1.8"
+    "@radix-ui/colors" "^3.0.0"
 
-"@expo/styleguide-icons@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-2.0.3.tgz#234f741cab325cff5d0533626e61347faca1121b"
-  integrity sha512-7cZxGXclDYk9aghP6yTnZzLjYQxbTesCSG4Cau46bHmjzMVi8J1A2l5IflZCCWsQMsk051Ms3ketX3gcuTfXRQ==
+"@expo/styleguide-icons@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-2.1.1.tgz#7a46fb578b1f301511f33d122b92ca370edb6548"
+  integrity sha512-q8V5WQsAH8sWjWUM5wYUFRJMJ3aI29ha6yPo4PK8sHVEbaOtVcxCVzHs7tDI1B0NRH4wwRNoPa0XB296d8DoHQ==
   dependencies:
     tailwind-merge "^2.5.4"
 
-"@expo/styleguide-search-ui@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-2.1.2.tgz#065bc7a7f9a310a269f81159ceb95dd834e34e61"
-  integrity sha512-oDE6IvGaIJjlS9n7rmwG8LvS6SUi5C6C2gAGcV1LKZ2IlwRZEyYpTnbed+bPhmQXwfrgkZC6HW9T4gWi+C8drg==
+"@expo/styleguide-search-ui@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-search-ui/-/styleguide-search-ui-2.2.4.tgz#23f139fb23c9076cea2ae66d51ddb35094155c66"
+  integrity sha512-0oXhvjgedmntNz0pZRLm7EAuT7P4doDC6Hu+J7qTLPaP18qPWHfIC4qGWVPEwTHwqKHE2QSK63iMonRtJGndew==
   dependencies:
-    "@expo/styleguide" "^8.3.0"
-    "@expo/styleguide-icons" "^2.0.3"
+    "@expo/styleguide" "^9.0.1"
+    "@expo/styleguide-icons" "^2.1.1"
     "@sanity/client" "^6.21.3"
     "@sanity/image-url" "^1.0.2"
     cmdk "^0.2.1"
     lodash.groupby "^4.6.0"
 
-"@expo/styleguide@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.3.0.tgz#28909a076eff138c34a02e6bdb4e29c1ce264d0f"
-  integrity sha512-VCMoM2ayHyWnzaza2JR7tv3ZBbgv1o32BUzOFDPCzg3vN0Bigp/Uk5Pq33vhyLM9UrTrfDnFSDx0srOwcIfD8Q==
+"@expo/styleguide@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-9.0.1.tgz#fe189e0d34c2d07468179d859d4d91cfad9c69ea"
+  integrity sha512-qaSI0xCMWSvb2vnq3vxRsCa+HO4W4QoKN6JBmvXOOe/Io59ZK1CA7mUZfV3YGnJbjuOPfqW31x3ST2UdFrQZow==
   dependencies:
-    "@expo/styleguide-base" "^1.0.1"
+    "@expo/styleguide-base" "^2.0.1"
     tailwind-merge "^2.5.4"
 
 "@floating-ui/core@^0.7.3":
@@ -1013,10 +1013,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@radix-ui/colors@^0.1.8":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@radix-ui/colors/-/colors-0.1.9.tgz#aad732ecc4ce1018adcb3aedd3ce3c573c2256cc"
-  integrity sha512-Vxq944ErPJsdVepjEUhOLO9ApUVOocA63knc+V2TkJ09D/AVOjiMIgkca/7VoYgODcla0qbSIBjje0SMfZMbAw==
+"@radix-ui/colors@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/colors/-/colors-3.0.0.tgz#e8a591a303c44e503bd1212cacf40a09511165e0"
+  integrity sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==
 
 "@radix-ui/primitive@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
# Why

It's time to upgrade docs to be based on the latest version of styleguide packages.

# How

Migrate to the latest version of styleguide packages, which includes updated colors palette. The changes would be mostly visible in the dark mode, but still the light theme appearance also will alter slightly.

In the process I have also updated the Callouts and PlatformTag themes, and tweaked shades here and there.

There are also some changes coming from the other styleguide packages, worth mentioning are improved icons rendering (especially on Safari) and batch of few visual fixes for the search UI.

# Test Plan

The changes have been reviewed by running docs app locally. All lnt checks and tests are passing.

# Preview

![Screenshot 2024-11-19 at 22 37 05](https://github.com/user-attachments/assets/1c534984-ecf9-4145-85a2-6dbb7f088347)
![Screenshot 2024-11-19 at 22 36 49](https://github.com/user-attachments/assets/ae14800c-333e-4210-9c10-258dc6990a10)

