### PR TITLE
[docs] Revert react-native-view-shot pinned version in Expo tutorial

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -24,7 +24,7 @@ In this chapter, we'll learn how to take a screenshot using a third-party librar
 
 To install `react-native-view-shot` and `expo-media-library`, run the following commands:
 
-<Terminal cmd={['$ npx expo install react-native-view-shot@3.7.0 expo-media-library']} />
+<Terminal cmd={['$ npx expo install react-native-view-shot expo-media-library']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Thanks to @brentvatne, the issue on `Cannot read properties of undefined (reading 'getEnforcing')` in `react-native-view-shot` is fixed in version 4.0.2.

We can remove the pinned version for `react-native-view-shot` in the Expo tutorial.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the pinned version.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
