### PR TITLE
[ios][media-library] Fixed loading ph:// assets for new architecture

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### 🎉 New features
 
-### 🐛 Bug fixes
+### 🐛 Bug fixes 
+
+- [iOS] Add back image loader to handle `ph://` and `assets-library://` scheme for New Architecture. ([#30116](https://github.com/expo/expo/issues/30116)) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler) ([#33097](https://github.com/expo/expo/pull/33097) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-### 🐛 Bug fixes 
+### 🐛 Bug fixes
 
 - [iOS] Add back image loader to handle `ph://` and `assets-library://` scheme for New Architecture. ([#30116](https://github.com/expo/expo/issues/30116)) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler) ([#33097](https://github.com/expo/expo/pull/33097) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -43,5 +43,15 @@
   "peerDependencies": {
     "expo": "*",
     "react-native": "*"
+  },
+  "codegenConfig": {
+    "name": "expo-media-library",
+    "type": "modules",
+    "jsSrcsDir": "./src",
+    "ios": {
+      "modulesConformingToProtocol": {
+        "RCTImageURLLoader": "MediaLibraryImageLoader"
+      }
+    }
   }
 }


### PR DESCRIPTION
# Why

This PR closes https://github.com/expo/expo/issues/30116 - `ph://` and `assets-library` schemes are not showing up in the React Native `Image` component when returned by `expo-media-library` on the new architecture.

This is a follow up to https://github.com/expo/expo/pull/29747, which fixed [the issue on old architecture](https://github.com/expo/expo/issues/29741), but didn't seem to work on the new architecture based on [this reproduction](https://github.com/khushal87/expo-media-library-bug/tree/new-architecture). 

When digging through some of the React Native issues about `ph://`, like https://github.com/facebook/react-native/issues/36136, I found the PR in `react-native-cameraroll` that added the feature to the new architecture: https://github.com/react-native-cameraroll/react-native-cameraroll/pull/632 (looks like they actually reference the code in this module, haha).

The major change to get new arch compatibility was adding codegen configuration for `modulesConformingToProtocol`:

https://github.com/react-native-cameraroll/react-native-cameraroll/blob/447365b308f21d91f968bd60b114ee5875d67b08/package.json#L118-L126

# How

In the [reproducer app](https://github.com/khushal87/expo-media-library-bug/tree/new-architecture), I made the change to the local `node_modules` folder for `expo-media-library`, ran `npx expo prebuild`, and saw it working:

https://github.com/user-attachments/assets/9fc7474c-94a3-4249-9dc4-79d578acd47c

# Test Plan

Since this only changes the codegen configuration block in the `package.json` for `expo-media-library`, I think it's sufficient to see the reproducer app working.

I'd be happy to write some tests, but I fear I need a little guidance on that. In order to really see the difference, I think we'd need to write end-to-end tests that load from `expo-media-library` and render the images in React Native's `Image` component, and then do it for both old and new architecture.

I read the E2E testing docs in the contributing guides, but I'm still not sure how I'd write the correct test for this. Again, I'd be very happy to do so if someone can help me get started. But for a config change, maybe this is sufficient.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

I don't think any of these are applicable here :)

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
