### PR TITLE
using-eslint prettier command error fixed

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -142,7 +142,7 @@ To install Prettier in your project:
 <Terminal
   cmd={[
     '# For other package managers',
-    '$ npx expo install -- --save-dev prettier eslint-config-prettier eslint-plugin-prettier',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier',
     '',
     '# For yarn only',
     '$ yarn add -D prettier eslint-config-prettier eslint-plugin-prettier',


### PR DESCRIPTION
# Why

The `npx expo install` command fails when `-- --save-dev` is appended, resulting in `CommandError: Unexpected: --save-dev`. This PR resolves the issue by removing the unsupported `-- --save-dev` flag from the command.

# How

- Removed `-- --save-dev` from the command in the affected documentation and examples.
- Clarified usage in the documentation to indicate that `expo install` is only for Expo-compatible dependencies and that dev dependencies should be installed with `npm` or `yarn`.

# Test Plan

- Verified the corrected command runs successfully:
  ```bash
  npx expo install prettier eslint-config-prettier eslint-plugin-prettier
  ```
- Confirmed that no `CommandError` is raised after removing `-- --save-dev`.
- Checked documentation for accuracy regarding installation instructions for dev dependencies.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).