### PR TITLE
Enforce Ruby version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,5 @@
 PATH_add bin
 
-layout ruby
-
 export EXPO_ROOT_DIR=`pwd`
 
 # ANDROID_HOME should be replaced with ANDROID_SDK_ROOT as soon as RN stops using it for its buildscripts
@@ -33,6 +31,18 @@ install_git_hooks() {
   done
 }
 
+use_ruby() {
+  local required_version=$1
+
+  if ! ruby -v | grep -q "ruby $required_version"; then
+    log_error "Ruby $required_version is required. Please install it using your Ruby version manager like rbenv or rvm."
+    exit 1
+  fi
+
+  layout ruby
+}
+
 source_secrets secrets/expotools.env
 source_local
 install_git_hooks
+use_ruby "3.3"


### PR DESCRIPTION
# Why

@tsapeta and i were digging with the problem for unstable Podfile.lock. it has been overwritten by different people recently, specifically hermes-engine and Yoga hash are different. 

# How

after digging out, it could be ruby version difference. the [`Dir.glob`](https://github.com/facebook/react-native/blob/2944752a5de8eba3b240d699baedda83592b9504/packages/react-native/ReactCommon/yoga/Yoga.podspec#L64) returns sorted result in ruby 3.3 and unsorted result in ruby 2.7.

to this case, it's better to enforce our ruby version. rather than a `.ruby-version` which is quite strict. i would like to enforce only for major + minor version. and don't require rbenv, rvm or something. this pr tries to run `ruby --version` as a sanity check, which would be good enough. 

![Screenshot 2024-11-20 at 6 30 27 PM](https://github.com/user-attachments/assets/18850de7-814b-48b5-912b-917b890b53d5)

# Test Plan

i have rbenv installed and try
```sh
# without error
$ rbenv global 3.3.6
$ direnv allow

# should show error
$ rbenv global system
$ direnv allow 
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
