### PR TITLE
add fixes for RSC in new projects

### DIFF
--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -73,6 +73,8 @@ export default async function renderInfo({ name }) {
 
 The views return value of the Server Function is a React Server Component payload that will be streamed to the client.
 
+> `web.output` must be "single" in the `app.json` during the developer preview. Support for more output modes is coming soon.
+
 ## Server Components
 
 Server Components run in the server, meaning they can access server APIs and Node.js built-ins (when running locally). They can also use async components.

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -73,7 +73,7 @@ export default async function renderInfo({ name }) {
 
 The views return value of the Server Function is a React Server Component payload that will be streamed to the client.
 
-> `web.output` must be "single" in the `app.json` during the developer preview. Support for more output modes is coming soon.
+> `web.output` must be `single` in the app config during the developer preview. Support for more output modes is coming soon.
 
 ## Server Components
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add support for `TSInterfaceDeclaration` in server component plugin.
+- Add support for `TSInterfaceDeclaration` in server component plugin. ([#33121](https://github.com/expo/expo/pull/33121) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add support for `TSInterfaceDeclaration` in server component plugin.
+
 ### 💡 Others
 
 ## 12.0.1 — 2024-11-14

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -62,7 +62,12 @@ function reactClientReferencesPlugin(api) {
                                         callback(exportName);
                                     }
                                 }
-                                else if (!['InterfaceDeclaration', 'TSTypeAliasDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)) {
+                                else if (![
+                                    'InterfaceDeclaration',
+                                    'TSInterfaceDeclaration',
+                                    'TSTypeAliasDeclaration',
+                                    'TypeAlias',
+                                ].includes(exportPath.node.declaration.type)) {
                                     // TODO: What is this type?
                                     console.warn(`[babel-preset-expo] Unsupported export specifier for "use ${type}":`, exportPath.node.declaration.type);
                                 }

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -70,9 +70,12 @@ export function reactClientReferencesPlugin(api: ConfigAPI): babel.PluginObj {
                     callback(exportName);
                   }
                 } else if (
-                  !['InterfaceDeclaration', 'TSTypeAliasDeclaration', 'TypeAlias'].includes(
-                    exportPath.node.declaration.type
-                  )
+                  ![
+                    'InterfaceDeclaration',
+                    'TSInterfaceDeclaration',
+                    'TSTypeAliasDeclaration',
+                    'TypeAlias',
+                  ].includes(exportPath.node.declaration.type)
                 ) {
                   // TODO: What is this type?
                   console.warn(

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Add missing dependency for React Server environments.
 - Fix Typed Routes incorrectly collapsing group index routes ([#32890](https://github.com/expo/expo/pull/32890) by [@marklawlor](https://github.com/marklawlor))
 - Fix relative Hrefs not including search params ([#32931](https://github.com/expo/expo/pull/32931) by [@marklawlor](https://github.com/marklawlor))
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing dependency for React Server environments.
+- Add missing dependency for React Server environments. ([#33121](https://github.com/expo/expo/pull/33121) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Typed Routes incorrectly collapsing group index routes ([#32890](https://github.com/expo/expo/pull/32890) by [@marklawlor](https://github.com/marklawlor))
 - Fix relative Hrefs not including search params ([#32931](https://github.com/expo/expo/pull/32931) by [@marklawlor](https://github.com/marklawlor))
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -115,6 +115,7 @@
     "react-native-is-edge-to-edge": "^1.1.6",
     "schema-utils": "^4.0.1",
     "semver": "~7.6.3",
-    "server-only": "^0.0.1"
+    "server-only": "^0.0.1",
+    "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610"
   }
 }


### PR DESCRIPTION
# Why

- Document that not all output modes are supported yet.
- Add missing React dependency.
- Add support for TypeScript exports in client modules.
