### PR TITLE
[video][ios] Dispatch `replaceCurrentItem` on main queue

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Dispatch current player item changes on main queue to fix KVO-related crashes. ([#33123](https://github.com/expo/expo/pull/33123) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 2.0.1 — 2024-11-19


### PR DESCRIPTION
# Why

While creating the TikTok example i was calling the `replace()` multiple times, it turns out that there is a similar issue to the crash issue when deiniting the player that we fixed a few months ago. Sometimes the KVO observers of the player item enter a race condition and cause a crash.

# How

Moved all replace operations onto the main queue.

# Test Plan

Tested in BareExpo on iOS 18 simulator
