### PR TITLE
Add example on built-in functions

### DIFF
--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -90,6 +90,13 @@ jobs:
     steps:
       - uses: eas/checkout
 
-      - name: Install modules
-        run: yarn install
+      - uses: eas/install_node_modules
+      
+      - name: Say hello!
+        run: echo "Hello world!"
+        
+      - name: Multiline script
+        run: |
+          CURRENT_DATE=$(date)
+          echo "It is $CURRENT_DATE"
 ```

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -91,10 +91,10 @@ jobs:
       - uses: eas/checkout
 
       - uses: eas/install_node_modules
-      
+
       - name: Say hello!
         run: echo "Hello world!"
-        
+
       - name: Multiline script
         run: |
           CURRENT_DATE=$(date)

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -81,4 +81,15 @@ jobs:
         run: echo "Hello, world!"
 ```
 
-Within custom jobs, you can use our [built-in functions](/custom-builds/schema/#built-in-eas-functions), like `eas/checkout`, `eas/use_npm_token` to interact with the project.
+Within custom jobs, you can use our [built-in functions](/custom-builds/schema/#built-in-eas-functions), like `eas/checkout`, `eas/use_npm_token` to interact with the project. These need to be prefixed with the `uses:` keyword.
+
+```yaml .eas/workflows/custom-job.yaml
+jobs:
+  custom-job:
+    type: custom
+    steps:
+      - uses: eas/checkout
+
+      - name: Install modules
+        run: yarn install
+```


### PR DESCRIPTION
# Why

It was not clear to me how to use built-in functions, so I had to ask this on Discord.

# How

This PR adds an example on how to use built-in functions, as this was not obvious from the existing examples.

Kudos to @sjchmiela who explained this to me (see: https://discord.com/channels/695411232856997968/1308879787561062441/1308897739328720958)

# Test Plan

Read the updated documentation and try it.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
