### PR TITLE
[video][ios] Use a new DispatchQueue for setting audio session

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Fixed `generateThumbnailsAsync` not being available on Android in the types. ([#33491](https://github.com/expo/expo/pull/33491) by [@hirbod](https://github.com/hirbod))
+- Run VideoManager.setAppropriateAudioSessionOrWarn on a different queue for a lower load on the main thread. ([#33127](https://github.com/expo/expo/pull/33127) by [@behenate](https://github.com/behenate))
 
 ## 2.0.2 - 2024-11-29
 

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -10,15 +10,38 @@ import ExpoModulesCore
 class VideoManager {
   static var shared = VideoManager()
 
+  private var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
   private var videoViews = NSHashTable<VideoView>.weakObjects()
   private var videoPlayers = NSHashTable<VideoPlayer>.weakObjects()
 
-  func register(videoPlayer: VideoPlayer) {
-    videoPlayers.add(videoPlayer)
+  func register(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) {
+    let queue = queue ?? managerQueue
+    queue.async { [weak self, weak videoPlayer] in
+      guard let self = self, let videoPlayer = videoPlayer else {
+        return
+      }
+      self.videoPlayers.add(videoPlayer)
+    }
   }
 
-  func unregister(videoPlayer: VideoPlayer) {
-    videoPlayers.remove(videoPlayer)
+  func register(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) async {
+    let queue = queue ?? managerQueue
+    await queue.async { [weak self, weak videoPlayer] in
+      guard let self = self, let videoPlayer = videoPlayer else {
+        return
+      }
+      self.videoPlayers.add(videoPlayer)
+    }
+  }
+
+  func unregister(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) {
+    let queue = queue ?? managerQueue
+    queue.async { [weak self, weak videoPlayer] in
+      guard let self = self, let videoPlayer = videoPlayer else {
+        return
+      }
+      self.videoPlayers.remove(videoPlayer)
+    }
   }
 
   func register(videoView: VideoView) {
@@ -50,7 +73,16 @@ class VideoManager {
 
   // MARK: - Audio Session Management
 
-  internal func setAppropriateAudioSessionOrWarn() {
+  // This function usually takes less than 5ms to execute, but in some cases (initial setup) it takes up to 70ms
+  // Because of this we dispatch it on another queue to minimize the load on main queue.
+  internal func setAppropriateAudioSessionOrWarn(queue: DispatchQueue? = nil) {
+    let queue = queue ?? managerQueue
+    queue.async { [weak self] in
+      self?.setAudioSession()
+    }
+  }
+
+  private func setAudioSession() {
     let audioSession = AVAudioSession.sharedInstance()
     let audioMixingMode = findAudioMixingMode()
     var audioSessionCategoryOptions: AVAudioSession.CategoryOptions = audioSession.categoryOptions

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -10,13 +10,12 @@ import ExpoModulesCore
 class VideoManager {
   static var shared = VideoManager()
 
-  private var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
+  private static var managerQueue = DispatchQueue(label: "com.expo.video.manager.managerQueue")
   private var videoViews = NSHashTable<VideoView>.weakObjects()
   private var videoPlayers = NSHashTable<VideoPlayer>.weakObjects()
 
   func register(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) {
-    let queue = queue ?? managerQueue
-    queue.async { [weak self, weak videoPlayer] in
+    Self.managerQueue.async { [weak self, weak videoPlayer] in
       guard let self = self, let videoPlayer = videoPlayer else {
         return
       }
@@ -24,19 +23,8 @@ class VideoManager {
     }
   }
 
-  func register(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) async {
-    let queue = queue ?? managerQueue
-    await queue.async { [weak self, weak videoPlayer] in
-      guard let self = self, let videoPlayer = videoPlayer else {
-        return
-      }
-      self.videoPlayers.add(videoPlayer)
-    }
-  }
-
-  func unregister(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) {
-    let queue = queue ?? managerQueue
-    queue.async { [weak self, weak videoPlayer] in
+  func unregister(videoPlayer: VideoPlayer) {
+    Self.managerQueue.async { [weak self, weak videoPlayer] in
       guard let self = self, let videoPlayer = videoPlayer else {
         return
       }
@@ -75,9 +63,8 @@ class VideoManager {
 
   // This function usually takes less than 5ms to execute, but in some cases (initial setup) it takes up to 70ms
   // Because of this we dispatch it on another queue to minimize the load on main queue.
-  internal func setAppropriateAudioSessionOrWarn(queue: DispatchQueue? = nil) {
-    let queue = queue ?? managerQueue
-    queue.async { [weak self] in
+  internal func setAppropriateAudioSessionOrWarn() {
+    Self.managerQueue.async { [weak self] in
       self?.setAudioSession()
     }
   }

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -14,7 +14,7 @@ class VideoManager {
   private var videoViews = NSHashTable<VideoView>.weakObjects()
   private var videoPlayers = NSHashTable<VideoPlayer>.weakObjects()
 
-  func register(videoPlayer: VideoPlayer, queue: DispatchQueue? = nil) {
+  func register(videoPlayer: VideoPlayer) {
     Self.managerQueue.async { [weak self, weak videoPlayer] in
       guard let self = self, let videoPlayer = videoPlayer else {
         return


### PR DESCRIPTION
# Why

While profiling the TikTok example I've noticed that `setAppropriateAudioSessionOrWarn` can take a long time (up to 70ms when entering the screen on an iPhone 11), in other cases it would take around 5-10 ms. 

# How

Created a new dispatch queue for this function. Afaik there is no situation when we need to wait for the result of this function, so I didn't a completion block / async version of this.

# Test Plan

Tested in BareExpo on iOS 18 in the audio-session dependent screens