### PR TITLE
[video] Add `FlatList` and `FlashList` examples

### DIFF
--- a/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
@@ -1,0 +1,110 @@
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { FlashList } from '@shopify/flash-list';
+import { VideoView, VideoSource, useVideoPlayer } from 'expo-video';
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+
+import { styles, ViewSize } from './VideoFlatListScreen';
+import { localVideoSource } from './videoSources';
+
+const videoSources = Array(100).fill(localVideoSource);
+
+type RenderItemProps = {
+  item: VideoSource;
+  index: number;
+  viewSize: ViewSize;
+  visibleIndex: number;
+};
+
+function RenderItem({ item, index, viewSize, visibleIndex }: RenderItemProps) {
+  const [heart, setHeart] = useState(false);
+  // We don't pass the item directly into the player, when the item changes in the argument
+  // the video player is re-created, which is slow
+  const player = useVideoPlayer(null, (player) => {
+    player.bufferOptions = {
+      preferredForwardBufferDuration: 5,
+    };
+    player.loop = true;
+    player.pause();
+  });
+
+  // Instead, we use the replace function
+  useEffect(() => {
+    player.replace(item);
+  }, [index]);
+
+  useEffect(() => {
+    if (visibleIndex === index) {
+      player.play();
+    } else {
+      player.pause();
+    }
+  }, [visibleIndex]);
+
+  return (
+    <View style={viewSize}>
+      <VideoView
+        player={player}
+        style={styles.videoView}
+        nativeControls={false}
+        contentFit="fill"
+        allowsVideoFrameAnalysis={false}
+      />
+      <View style={styles.overlayContainer}>
+        <View style={styles.controlsContainer}>
+          <AntDesign
+            name={heart ? 'heart' : 'hearto'}
+            size={50}
+            color="white"
+            onPress={() => {
+              setHeart(!heart);
+            }}
+          />
+          <AntDesign name="message1" size={50} color="white" />
+          <AntDesign name="cloudupload" size={50} color="white" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function VideoFlatListScreen() {
+  const [viewSize, setViewSize] = useState<ViewSize | null>(null);
+  const [visibleIndex, setVisibleIndex] = useState(0);
+
+  return (
+    <View
+      style={styles.contentContainer}
+      onLayout={(e) => {
+        setViewSize(e.nativeEvent.layout);
+      }}>
+      {viewSize && (
+        <FlashList
+          data={videoSources}
+          snapToInterval={viewSize.height}
+          snapToAlignment="center"
+          disableIntervalMomentum
+          onViewableItemsChanged={({ viewableItems, changed }) => {
+            const visible = viewableItems[0];
+            const index = visible?.index;
+            if (index != null) {
+              setVisibleIndex(index);
+            }
+          }}
+          viewabilityConfig={{
+            itemVisiblePercentThreshold: 50,
+            waitForInteraction: false,
+          }}
+          renderItem={({ item, index, extraData }) => (
+            <RenderItem item={item} index={index} viewSize={viewSize} visibleIndex={extraData} />
+          )}
+          extraData={visibleIndex}
+          decelerationRate={0.8}
+          showsVerticalScrollIndicator={false}
+          estimatedItemSize={viewSize.height}
+          drawDistance={viewSize.height * 2}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
@@ -1,0 +1,156 @@
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { VideoView, VideoPlayer, createVideoPlayer, VideoSource } from 'expo-video';
+import { useEffect, useRef, useState } from 'react';
+import { FlatList, StyleSheet, View } from 'react-native';
+
+import { localVideoSource } from './videoSources';
+
+const videoSources = Array(100).fill(localVideoSource);
+
+export type ViewSize = {
+  width: number;
+  height: number;
+};
+
+type RenderItemProps = {
+  item: VideoSource;
+  index: number;
+  playerPool: VideoPlayer[];
+  viewSize: ViewSize;
+};
+
+function createPlayerPool(size: number, setup?: (player: VideoPlayer) => void): VideoPlayer[] {
+  return Array.from({ length: size }, () => {
+    const player = createVideoPlayer(null);
+    setup?.(player);
+    return player;
+  });
+}
+
+function RenderItem({ item, index, playerPool, viewSize }: RenderItemProps) {
+  const player = playerPool[index % playerPool.length];
+  const [heart, setHeart] = useState(false);
+
+  useEffect(() => {
+    player.replace(item);
+  }, [playerPool]);
+
+  return (
+    <View style={viewSize}>
+      <VideoView
+        player={player}
+        style={styles.videoView}
+        nativeControls={false}
+        contentFit="fill"
+        allowsVideoFrameAnalysis={false}
+      />
+      <View style={styles.overlayContainer}>
+        <View style={styles.controlsContainer}>
+          <AntDesign
+            name={heart ? 'heart' : 'hearto'}
+            size={50}
+            color="white"
+            onPress={() => {
+              setHeart(!heart);
+            }}
+          />
+          <AntDesign name="message1" size={50} color="white" />
+          <AntDesign name="cloudupload" size={50} color="white" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function VideoFlatListScreen() {
+  const [viewSize, setViewSize] = useState<ViewSize | null>(null);
+  const playerPool = useRef<VideoPlayer[]>([]);
+
+  useEffect(() => {
+    playerPool.current = createPlayerPool(10, (player) => {
+      player.bufferOptions = {
+        preferredForwardBufferDuration: 5,
+      };
+      player.loop = true;
+    });
+
+    return () => {
+      playerPool.current.forEach((player) => player.release());
+      playerPool.current = [];
+    };
+  }, []);
+
+  return (
+    <View
+      style={styles.contentContainer}
+      onLayout={(e) => {
+        setViewSize(e.nativeEvent.layout);
+      }}>
+      {viewSize && (
+        <FlatList
+          data={videoSources}
+          snapToInterval={viewSize.height}
+          snapToAlignment="center"
+          disableIntervalMomentum
+          onViewableItemsChanged={({ viewableItems, changed }) => {
+            const visible = viewableItems[0];
+            const index = visible?.index;
+            if (index == null) {
+              return;
+            }
+
+            const visiblePlayer = playerPool.current[index % playerPool.current.length];
+            for (const player of playerPool.current) {
+              if (visiblePlayer !== player && player.playing) {
+                player.pause();
+              }
+            }
+
+            visiblePlayer.play();
+          }}
+          viewabilityConfig={{
+            itemVisiblePercentThreshold: 50,
+            waitForInteraction: false,
+          }}
+          renderItem={({ item, index }) => (
+            <RenderItem
+              item={item}
+              index={index}
+              playerPool={playerPool.current}
+              viewSize={viewSize}
+            />
+          )}
+          removeClippedSubviews={false}
+          decelerationRate={0.8}
+          initialNumToRender={1}
+          maxToRenderPerBatch={1}
+          windowSize={10}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}
+
+export const styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    alignSelf: 'stretch',
+  },
+  controlsContainer: {
+    marginBottom: 50,
+    marginRight: 25,
+    justifyContent: 'space-around',
+    height: 200,
+  },
+  videoView: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+  },
+  overlayContainer: {
+    flex: 1,
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+  },
+});

--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -78,6 +78,22 @@ export const VideoScreens = [
     },
   },
   {
+    name: 'FlatList of videos',
+    route: 'video/flat-list',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./VideoFlatListScreen'));
+    },
+  },
+  {
+    name: 'FlashList of videos',
+    route: 'video/flash-list',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./VideoFlashListScreen'));
+    },
+  },
+  {
     name: 'Generating video thumbnails',
     route: 'video/thumbnails',
     options: {},

--- a/apps/native-component-list/src/screens/Video/videoSources.ts
+++ b/apps/native-component-list/src/screens/Video/videoSources.ts
@@ -75,6 +75,7 @@ export {
   bigBuckBunnySource,
   forBiggerBlazesSource,
   elephantsDreamSource,
+  localVideoSource,
   androidDrmSource,
   videoLabels,
   videoSources,


### PR DESCRIPTION
# Why

A lot of people are trying to do TikTok/reels-like apps with `expo-video` and failing, because they create too many players or create a new player every time the source changes.
The aim of the screens is to showcase how to implement this in the most performant way possible. If you have any suggestions please share!

# How

Added two screens - one based on a FlatList and another based on FlashList. Both work good, FlashList is slightly smoother  though. On iOS it's very good, on Android there is a small hiccup (Edit: source of the hiccup seems to be a slight corruption of the `ace.mp4` file) when the player starts playing, I'm still working on the source of it.


# Test Plan

Tested in BareExpo on a Pixel 8 and iPhone 11

https://github.com/user-attachments/assets/848dcb3d-8905-4890-a7a3-571e6b98b355

