### PR TITLE
[expo-go] Remove vendored view shot

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -68,7 +68,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
-    "react-native-view-shot": "~4.0.2",
+    "react-native-view-shot": "4.0.2",
     "react-native-webview": "13.12.4",
     "test-suite": "*"
   },

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -28,6 +28,7 @@ import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
 import expo.modules.kotlin.ModulesProvider
 import expo.modules.manifests.core.Manifest
+import fr.greweb.reactnativeviewshot.RNViewShotModule
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.kernel.ExponentKernelModuleProvider
@@ -41,7 +42,6 @@ import versioned.host.exp.exponent.modules.api.ScreenOrientationModule
 import versioned.host.exp.exponent.modules.api.URLHandlerModule
 import versioned.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule
 import versioned.host.exp.exponent.modules.api.notifications.NotificationsModule
-import versioned.host.exp.exponent.modules.api.viewshot.RNViewShotModule
 import versioned.host.exp.exponent.modules.internal.DevMenuModule
 import versioned.host.exp.exponent.modules.internal.ExponentAsyncStorageModule
 import versioned.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule
@@ -124,7 +124,7 @@ class ExponentPackage : ReactPackage {
         val experienceKey = ExperienceKey.fromManifest(manifest)
         val scopedContext = ScopedContext(reactContext, experienceKey)
         nativeModules.add(NotificationsModule(reactContext, experienceKey, manifest.getStableLegacyID(), manifest.getEASProjectID()))
-        nativeModules.add(RNViewShotModule(reactContext, scopedContext))
+        nativeModules.add(RNViewShotModule(reactContext, scopedContext.cacheDir, scopedContext.externalCacheDir))
         nativeModules.add(ExponentTestNativeModule(reactContext))
         nativeModules.add(PedometerModule(reactContext))
         nativeModules.add(ScreenOrientationModule(reactContext))

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -119,7 +119,6 @@
 		B5FB74A11FF6DADC001C764B /* EXConstantsBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73791FF6DADB001C764B /* EXConstantsBinding.m */; };
 		B5FB74AC1FF6DADC001C764B /* EXImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB738F1FF6DADB001C764B /* EXImageUtils.m */; };
 		B5FB74B51FF6DADC001C764B /* EXUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A11FF6DADB001C764B /* EXUtil.m */; };
-		B5FB74B61FF6DADC001C764B /* RNViewShot.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A31FF6DADB001C764B /* RNViewShot.m */; };
 		B5FB74DE1FF6DADC001C764B /* EXVersionManagerObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.mm */; };
 		B5FB74DF1FF6DADC001C764B /* EXDevSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74001FF6DADB001C764B /* EXDevSettings.m */; };
 		B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74021FF6DADB001C764B /* EXDevSettingsDataSource.m */; };
@@ -416,8 +415,6 @@
 		B5FB738F1FF6DADB001C764B /* EXImageUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXImageUtils.m; sourceTree = "<group>"; };
 		B5FB73A01FF6DADB001C764B /* EXUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXUtil.h; sourceTree = "<group>"; };
 		B5FB73A11FF6DADB001C764B /* EXUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXUtil.m; sourceTree = "<group>"; };
-		B5FB73A21FF6DADB001C764B /* RNViewShot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNViewShot.h; sourceTree = "<group>"; };
-		B5FB73A31FF6DADB001C764B /* RNViewShot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNViewShot.m; sourceTree = "<group>"; };
 		B5FB73FA1FF6DADB001C764B /* EXUnversioned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXUnversioned.h; sourceTree = "<group>"; };
 		B5FB73FB1FF6DADB001C764B /* EXVersionManagerObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXVersionManagerObjC.h; sourceTree = "<group>"; };
 		B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EXVersionManagerObjC.mm; sourceTree = "<group>"; };
@@ -583,15 +580,6 @@
 				B248B8832AD8888C003C9C10 /* UpdatesBinding.swift */,
 			);
 			path = UniversalModules;
-			sourceTree = "<group>";
-		};
-		31F25C9123717B08009AD55F /* ViewShot */ = {
-			isa = PBXGroup;
-			children = (
-				B5FB73A21FF6DADB001C764B /* RNViewShot.h */,
-				B5FB73A31FF6DADB001C764B /* RNViewShot.m */,
-			);
-			path = ViewShot;
 			sourceTree = "<group>";
 		};
 		40CB1D742CD2A0C200CB3717 /* EXSplashScreen */ = {
@@ -1104,7 +1092,6 @@
 		B5FB72711FF6DADB001C764B /* Api */ = {
 			isa = PBXGroup;
 			children = (
-				31F25C9123717B08009AD55F /* ViewShot */,
 				BBD0318A200011C9009F0434 /* Cognito */,
 				B5FB738E1FF6DADB001C764B /* EXImageUtils.h */,
 				B5FB738F1FF6DADB001C764B /* EXImageUtils.m */,
@@ -1840,7 +1827,6 @@
 				B5FB74A11FF6DADC001C764B /* EXConstantsBinding.m in Sources */,
 				B526B5081E6A543500606CAB /* ExpoKit.m in Sources */,
 				B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */,
-				B5FB74B61FF6DADC001C764B /* RNViewShot.m in Sources */,
 				314791F02551CF2A00A81BA1 /* EXScopedServerRegistrationModule.m in Sources */,
 				F1D6AF61244714C100AC1C74 /* EXDevMenuGestureRecognizer.m in Sources */,
 				78D8252A204F826700CBD9D9 /* EXApiV2Result.m in Sources */,

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Api/ViewShot/RNViewShot.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Api/ViewShot/RNViewShot.h
@@ -1,7 +1,0 @@
-
-#import <React/RCTBridgeModule.h>
-
-@interface RNViewShot : NSObject <RCTBridgeModule>
-
-@end
-  

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1822,6 +1822,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-view-shot (4.0.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-webview (13.12.4):
     - DoubleConversion
     - glog
@@ -2595,6 +2616,7 @@ DEPENDENCIES:
   - "react-native-segmented-control (from `../../../node_modules/@react-native-segmented-control/segmented-control`)"
   - "react-native-skia (from `../../../node_modules/@shopify/react-native-skia`)"
   - "react-native-slider (from `../../../node_modules/@react-native-community/slider`)"
+  - react-native-view-shot (from `../modules/react-native-view-shot`)
   - react-native-webview (from `../modules/react-native-webview`)
   - React-nativeconfig (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -2889,6 +2911,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/@shopify/react-native-skia"
   react-native-slider:
     :path: "../../../node_modules/@react-native-community/slider"
+  react-native-view-shot:
+    :path: "../modules/react-native-view-shot"
   react-native-webview:
     :path: "../modules/react-native-webview"
   React-nativeconfig:
@@ -3099,6 +3123,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-skia: 425a5610939828363e0681b8b3e994dd4f18b711
   react-native-slider: 124ce99f9cd2d04c79f020da6dee9f8d38a6b8c7
+  react-native-view-shot: f0b94997decfc338383ba9dc0748985b02934b8c
   react-native-webview: 0bd56be54d01756f20eb942dad37a2cd22a6def2
   React-nativeconfig: 470fce6d871c02dc5eff250a362d56391b7f52d6
   React-NativeModulesApple: 6297fc3136c1fd42884795c51d7207de6312b606
@@ -3151,7 +3176,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: c24f990b03a68a7f6fe704b15dd487e7bb6b603e
   StripeUICore: f2d514e900c37436dc5427fdf2c29d68ab1c2935
   UMAppLoader: bda51f73f8599e336a778b23e0956130d1e244d5
-  Yoga: c5b0e913b5b3b4cde588227c1402e747797061f3
+  Yoga: 96872ee462cfc43866ad013c8160d4ff6b85709b
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 640a6a74acfd58d09119af8207a10b6297b9048b

--- a/apps/expo-go/modules/react-native-view-shot/LICENSE
+++ b/apps/expo-go/modules/react-native-view-shot/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Gaëtan Renaudeau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/expo-go/modules/react-native-view-shot/README.md
+++ b/apps/expo-go/modules/react-native-view-shot/README.md
@@ -1,0 +1,342 @@
+# react-native-view-shot ![](https://img.shields.io/npm/v/react-native-view-shot.svg) ![](https://img.shields.io/badge/react--native-%2040+-05F561.svg)
+
+Capture a React Native view to an image.
+
+<img src="./.readme/recursive.gif" width=300 />
+
+## Install
+
+```bash
+yarn add react-native-view-shot
+
+# In Expo
+
+expo install react-native-view-shot
+```
+
+Make sure `react-native-view-shot` is correctly linked in Xcode (might require a manual installation, refer to [React Native doc](https://reactnative.dev/docs/linking-libraries-ios.html)).
+
+**Before React Native 0.60.x you would have to:**
+
+```bash
+react-native link react-native-view-shot
+```
+
+**Since 0.60.x, [autolink](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) should just work**, on iOS, you'll need to ensure the CocoaPods are installed with:
+
+```bash
+npx pod-install
+```
+
+## High Level API
+
+```js
+import ViewShot from "react-native-view-shot";
+
+function ExampleCaptureOnMountManually {
+  const ref = useRef();
+
+  useEffect(() => {
+    // on mount
+    ref.current.capture().then(uri => {
+      console.log("do something with ", uri);
+    });
+  }, []);
+
+  return (
+    <ViewShot ref={ref} options={{ fileName: "Your-File-Name", format: "jpg", quality: 0.9 }}>
+      <Text>...Something to rasterize...</Text>
+    </ViewShot>
+  );
+}
+
+// alternative
+function ExampleCaptureOnMountSimpler {
+  const ref = useRef();
+
+  const onCapture = useCallback(uri => {
+    console.log("do something with ", uri);
+  }, []);
+
+  return (
+    <ViewShot onCapture={onCapture} captureMode="mount">
+      <Text>...Something to rasterize...</Text>
+    </ViewShot>
+  );
+}
+
+// waiting an image
+
+function ExampleWaitingCapture {
+  const ref = useRef();
+
+  const onImageLoad = useCallback(() => {
+    ref.current.capture().then(uri => {
+      console.log("do something with ", uri);
+    })
+  }, []);
+
+  return (
+    <ViewShot ref={ref}>
+      <Text>...Something to rasterize...</Text>
+      <Image ... onLoad={onImageLoad} />
+    </ViewShot>
+  );
+}
+
+// capture ScrollView content
+// NB: you may need to go the "imperative way" to use snapshotContentContainer with the scrollview ref instead
+function ExampleCaptureOnMountSimpler {
+  const ref = useRef();
+
+  const onCapture = useCallback(uri => {
+    console.log("do something with ", uri);
+  }, []);
+
+  return (
+    <ScrollView>
+      <ViewShot onCapture={onCapture} captureMode="mount">
+        <Text>...The Scroll View Content Goes Here...</Text>
+      </ViewShot>
+    </ScrollView>
+  );
+}
+```
+
+**Props:**
+
+- **`children`**: the actual content to rasterize.
+- **`options`**: the same options as in `captureRef` method.
+- **`captureMode`** (string):
+  - if not defined (default). the capture is not automatic and you need to use the ref and call `capture()` yourself.
+  - `"mount"`. Capture the view once at mount. (It is important to understand image loading won't be waited, in such case you want to use `"none"` with `viewShotRef.capture()` after `Image#onLoad`.)
+  - `"continuous"` EXPERIMENTAL, this will capture A LOT of images continuously. For very specific use-cases.
+  - `"update"` EXPERIMENTAL, this will capture images each time React redraw (on did update). For very specific use-cases.
+- **`onCapture`**: when a `captureMode` is defined, this callback will be called with the capture result.
+- **`onCaptureFailure`**: when a `captureMode` is defined, this callback will be called when a capture fails.
+
+## `captureRef(view, options)` lower level imperative API
+
+```js
+import { captureRef } from "react-native-view-shot";
+
+captureRef(viewRef, {
+  format: "jpg",
+  quality: 0.8,
+}).then(
+  (uri) => console.log("Image saved to", uri),
+  (error) => console.error("Oops, snapshot failed", error)
+);
+```
+
+Returns a Promise of the image URI.
+
+- **`view`** is a reference to a React Native component.
+- **`options`** may include:
+  - **`fileName`** _(string)_: (Android only) the file name of the file. Must be at least 3 characters long.
+  - **`width`** / **`height`** _(number)_: the width and height of the final image (resized from the View bound. don't provide it if you want the original pixel size).
+  - **`format`** _(string)_: either `png` or `jpg` or `webm` (Android). Defaults to `png`.
+  - **`quality`** _(number)_: the quality. 0.0 - 1.0 (default). (only available on lossy formats like jpg)
+  - **`result`** _(string)_, the method you want to use to save the snapshot, one of:
+    - `"tmpfile"` (default): save to a temporary file _(that will only exist for as long as the app is running)_.
+    - `"base64"`: encode as base64 and returns the raw string. Use only with small images as this may result of lags (the string is sent over the bridge). _N.B. This is not a data uri, use `data-uri` instead_.
+    - `"data-uri"`: same as `base64` but also includes the [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) header.
+  - **`snapshotContentContainer`** _(bool)_: if true and when view is a ScrollView, the "content container" height will be evaluated instead of the container height.
+  - [iOS] **`useRenderInContext`** _(bool)_: change the iOS snapshot strategy to use method `renderInContext` instead of `drawViewHierarchyInRect` which may help for some use cases.
+
+## `releaseCapture(uri)`
+
+This method release a previously captured `uri`. For tmpfile it will clean them out, for other result types it just won't do anything.
+
+NB: the tmpfile captures are automatically cleaned out after the app closes, so you might not have to worry about this unless advanced usecases. The `ViewShot` component will use it each time you capture more than once (useful for continuous capture to not leak files).
+
+## `captureScreen()` Android and iOS Only
+
+```js
+import { captureScreen } from "react-native-view-shot";
+
+captureScreen({
+  format: "jpg",
+  quality: 0.8,
+}).then(
+  (uri) => console.log("Image saved to", uri),
+  (error) => console.error("Oops, snapshot failed", error)
+);
+```
+
+This method will capture the contents of the currently displayed screen as a native hardware screenshot. It does not require a ref input, as it does not work at the view level. This means that ScrollViews will not be captured in their entirety - only the portions currently visible to the user.
+
+Returns a Promise of the image URI.
+
+- **`options`**: the same options as in `captureRef` method.
+
+### Advanced Examples
+
+[Checkout react-native-view-shot-example](example)
+
+## Interoperability Table
+
+> Snapshots are not guaranteed to be pixel perfect. It also depends on the platform. Here is some difference we have noticed and how to workaround.
+
+Model tested: iPhone 6 (iOS), Nexus 5 (Android).
+
+| System                | iOS              | Android           | Windows                |
+| --------------------- | ---------------- | ----------------- | ---------------------- |
+| View,Text,Image,..    | YES              | YES               | YES                    |
+| WebView               | YES              | YES<sup>1</sup>   | YES                    |
+| gl-react v2           | YES              | NO<sup>2</sup>    | NO<sup>3</sup>         |
+| react-native-video    | NO               | NO                | NO                     |
+| react-native-maps     | YES              | NO<sup>4</sup>    | NO<sup>3</sup>         |
+| react-native-svg      | YES              | YES               | maybe?                 |
+| react-native-camera   | NO               | YES               | NO <sup>3</sup>        |
+
+>
+
+1. Only supported by wrapping a `<View collapsable={false}>` parent and snapshotting it.
+2. It returns an empty image (not a failure Promise).
+3. Component itself lacks platform support.
+4. But you can just use the react-native-maps snapshot function: https://github.com/airbnb/react-native-maps#take-snapshot-of-map
+
+## Performance Optimization
+
+During profiling captured several things that influence on performance:
+
+1. (de-)allocation of memory for bitmap
+2. (de-)allocation of memory for Base64 output buffer
+3. compression of bitmap to different image formats: PNG, JPG
+
+To solve that in code introduced several new approaches:
+
+- reusable images, that reduce load on GC;
+- reusable arrays/buffers that also reduce load on GC;
+- RAW image format for avoiding expensive compression;
+- ZIP deflate compression for RAW data, that works faster in compare to `Bitmap.compress`
+
+more details and code snippet are below.
+
+### RAW Images
+
+Introduced a new image format RAW. it correspond a ARGB array of pixels.
+
+Advantages:
+
+- no compression, so its supper quick. Screenshot taking is less than 16ms;
+
+RAW format supported for `zip-base64`, `base64` and `tmpfile` result types.
+
+RAW file on disk saved in format: `${width}:${height}|${base64}` string.
+
+### zip-base64
+
+In compare to BASE64 result string this format fast try to apply zip/deflate compression on screenshot results
+and only after that convert results to base64 string. In combination zip-base64 + raw we got a super fast
+approach for capturing screen views and deliver them to the react side.
+
+### How to work with zip-base64 and RAW format?
+
+```js
+const fs = require("fs");
+const zlib = require("zlib");
+const PNG = require("pngjs").PNG;
+const Buffer = require("buffer").Buffer;
+
+const format = Platform.OS === "android" ? "raw" : "png";
+const result = Platform.OS === "android" ? "zip-base64" : "base64";
+
+captureRef(this.ref, { result, format }).then((data) => {
+  // expected pattern 'width:height|', example: '1080:1731|'
+  const resolution = /^(\d+):(\d+)\|/g.exec(data);
+  const width = (resolution || ["", 0, 0])[1];
+  const height = (resolution || ["", 0, 0])[2];
+  const base64 = data.substr((resolution || [""])[0].length || 0);
+
+  // convert from base64 to Buffer
+  const buffer = Buffer.from(base64, "base64");
+  // un-compress data
+  const inflated = zlib.inflateSync(buffer);
+  // compose PNG
+  const png = new PNG({ width, height });
+  png.data = inflated;
+  const pngData = PNG.sync.write(png);
+  // save composed PNG
+  fs.writeFileSync(output, pngData);
+});
+```
+
+Keep in mind that packaging PNG data is a CPU consuming operation as a `zlib.inflate`.
+
+Hint: use `process.fork()` approach for converting raw data into PNGs.
+
+> Note: code is tested in large commercial project.
+
+> Note #2: Don't forget to add packages into your project:
+>
+> ```js
+> yarn add pngjs
+> yarn add zlib
+> ```
+
+## Troubleshooting / FAQ
+
+### Saving to a file?
+
+- If you want to save the snapshotted image result to the CameraRoll, just use https://github.com/react-native-cameraroll/react-native-cameraroll
+- If you want to save it to an arbitrary file path, use something like https://github.com/itinance/react-native-fs
+- For any more advanced needs, you can write your own (or find another) native module that would solve your use-case.
+
+### The snapshot is rejected with an error?
+
+- Support of special components like Video / GL views is not guaranteed to work. In case of failure, the `captureRef` promise gets rejected (the library won't crash).
+
+### get a black or blank result or still have an error with simple views?
+
+Check the **Interoperability Table** above. Some special components are unfortunately not supported. If you have a View that contains one of an unsupported component, the whole snapshot might be compromised as well.
+
+### black background instead of transparency / weird border appear around texts?
+
+- It's preferable to **use a background color on the view you rasterize** to avoid transparent pixels and potential weirdness that some border appear around texts.
+
+### on Android, getting "Trying to resolve view with tag '{tagID}' which doesn't exist"
+
+> you need to make sure `collapsable` is set to `false` if you want to snapshot a **View**. Some content might even need to be wrapped into such `<View collapsable={false}>` to actually make them snapshotable! Otherwise that view won't reflect any UI View. ([found by @gaguirre](https://github.com/gre/react-native-view-shot/issues/7#issuecomment-245302844))
+
+Alternatively, you can use the `ViewShot` component that will have `collapsable={false}` set to solve this problem.
+
+### Getting "The content size must not be zero or negative."
+
+> Make sure you don't snapshot instantly, you need to wait at least there is a first `onLayout` event, or after a timeout, otherwise the View might not be ready yet. (It should also be safe to just wait Image `onLoad` if you have one). If you still have the problem, make sure your view actually have a width and height > 0.
+
+Alternatively, you can use the `ViewShot` component that will wait the first `onLayout`.
+
+### Snapshotted image does not match my width and height but is twice/3-times bigger
+
+This is because the snapshot image result is in real pixel size where the width/height defined in a React Native style are defined in "point" unit. You might want to set width and height option to force a resize. (might affect image quality)
+
+### on Android, capture GL Views
+
+A prop may be necessary to properly capture GL Surface View in the view tree:
+
+```js
+/**
+  * if true and when view is a SurfaceView or have it in the view tree, view will be captured.
+  * False by default, because it can have signoficant performance impact
+  */
+handleGLSurfaceViewOnAndroid?: boolean;
+```
+
+### Trying to share the capture result with `expo-sharing`?
+
+`tmpfile` or the default capture result works best for this. Just be sure to prepend `file://` to result before you call `shareAsync`.
+
+```js
+captureRef(viewRef)
+  .then((uri) => Sharing.shareAsync(`file://${uri}`, options)
+```
+
+---
+
+## Thanks
+
+- To initial iOS work done by @jsierles in https://github.com/jsierles/react-native-view-snapshot
+- To React Native implementation of takeSnapshot in iOS by @nicklockwood
+- To Windows implementation by @ryanlntn

--- a/apps/expo-go/modules/react-native-view-shot/android/build.gradle
+++ b/apps/expo-go/modules/react-native-view-shot/android/build.gradle
@@ -1,0 +1,61 @@
+def DEFAULT_COMPILE_SDK_VERSION = 34
+def DEFAULT_TARGET_SDK_VERSION = 34
+
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def isNewArchitectureEnabled() {
+  return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
+apply plugin: 'com.android.library'
+if (isNewArchitectureEnabled()) {
+  apply plugin: 'com.facebook.react'
+}
+
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  // Check the AGP version, add namespace if the AGP version is above 7.
+  // Once we have fully moved on, we can remove it from the AndroidManifest.xml of the package
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "fr.greweb.reactnativeviewshot"
+  }
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 21)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+    versionCode 1
+    versionName "1.0"
+    buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
+  }
+
+  buildFeatures {
+    buildConfig true
+  }
+
+  sourceSets.main {
+    java {
+      if (!isNewArchitectureEnabled()) {
+        srcDirs += ["src/paper/java"]
+      }
+    }
+  }
+}
+
+repositories {
+  maven {
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    url "$projectDir/../node_modules/react-native/android"
+  }
+  google()
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.facebook.react:react-native:+'
+  implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+}

--- a/apps/expo-go/modules/react-native-view-shot/android/src/main/AndroidManifest.xml
+++ b/apps/expo-go/modules/react-native-view-shot/android/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="fr.greweb.reactnativeviewshot">
+
+</manifest>

--- a/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
+++ b/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
@@ -1,0 +1,57 @@
+
+package fr.greweb.reactnativeviewshot;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.TurboReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.model.ReactModuleInfo;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+public class RNViewShotPackage extends TurboReactPackage {
+  @Override
+  @Nonnull
+  public List<NativeModule> createNativeModules(@Nonnull ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new RNViewShotModule(reactContext, reactContext.getCacheDir(), reactContext.getExternalCacheDir()));
+    return modules;
+  }
+  
+  @Nullable
+  @Override
+  public NativeModule getModule(@NonNull String name, @NonNull ReactApplicationContext reactApplicationContext) {
+    if (name.equals(RNViewShotModule.NAME)) {
+      return new RNViewShotModule(reactApplicationContext, reactApplicationContext.getCacheDir(), reactApplicationContext.getExternalCacheDir());
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public ReactModuleInfoProvider getReactModuleInfoProvider() {
+    return () -> {
+      final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+      boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+      moduleInfos.put(
+              RNViewShotModule.NAME,
+              new ReactModuleInfo(
+                      RNViewShotModule.NAME,
+                      RNViewShotModule.NAME,
+                      false, // canOverrideExistingModule
+                      false, // needsEagerInit
+                      false, // isCxxModule
+                      isTurboModule // isTurboModule
+              ));
+      return moduleInfos;
+    };
+  }
+}

--- a/apps/expo-go/modules/react-native-view-shot/android/src/paper/java/fr/greweb/reactnativeviewshot/NativeRNViewShotSpec.java
+++ b/apps/expo-go/modules/react-native-view-shot/android/src/paper/java/fr/greweb/reactnativeviewshot/NativeRNViewShotSpec.java
@@ -1,0 +1,36 @@
+package fr.greweb.reactnativeviewshot;
+
+import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class NativeRNViewShotSpec extends ReactContextBaseJavaModule implements TurboModule {
+  public static final String NAME = "RNViewShot";
+
+  public NativeRNViewShotSpec(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public @Nonnull String getName() {
+    return NAME;
+  }
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void releaseCapture(String uri);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void captureRef(@Nullable Double target, ReadableMap withOptions, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void captureScreen(ReadableMap options, Promise promise);
+}

--- a/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.h
+++ b/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.h
@@ -1,0 +1,15 @@
+#import <React/RCTBridgeModule.h>
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <rnviewshot/rnviewshot.h>
+#endif
+
+@interface RNViewShot : NSObject <RCTBridgeModule>
+
+@end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface RNViewShot () <NativeRNViewShotSpec>
+
+@end
+#endif
+  

--- a/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.mm
+++ b/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.mm
@@ -11,6 +11,10 @@
 #endif
 #import <React/RCTBridge.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <rnviewshot/rnviewshot.h>
+#endif
+
 @implementation RNViewShot
 
 RCT_EXPORT_MODULE()
@@ -41,7 +45,7 @@ RCT_EXPORT_METHOD(releaseCapture:(nonnull NSString *)uri)
   }
 }
 
-RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
+RCT_EXPORT_METHOD(captureRef:(NSNumber *)target
                   withOptions:(NSDictionary *)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
@@ -80,7 +84,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
         reject(RCTErrorUnspecified, [NSString stringWithFormat:@"snapshotContentContainer can only be used on a RCTScrollView. instead got: %@", view], nil);
         return;
       }
-      RCTScrollView* rctScrollView = (RCTScrollView *)view;
+      RCTScrollView* rctScrollView = view;
       scrollView = rctScrollView.scrollView;
       rendered = scrollView;
     }
@@ -117,6 +121,7 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       // this doesn't work for large views and reports incorrect success even though the image is blank
       success = [rendered drawViewHierarchyInRect:(CGRect){CGPointZero, size} afterScreenUpdates:YES];
     }
+   
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 
@@ -152,11 +157,11 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
       NSString *res = nil;
       if ([result isEqualToString:@"base64"]) {
         // Return as a base64 raw string
-        res = [data base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
+        res = [data base64EncodedStringWithOptions: 0];
       }
       else if ([result isEqualToString:@"data-uri"]) {
         // Return as a base64 data uri string
-        NSString *base64 = [data base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
+        NSString *base64 = [data base64EncodedStringWithOptions: 0];
         NSString *imageFormat = ([format isEqualToString:@"jpg"]) ? @"jpeg" : format;
         res = [NSString stringWithFormat:@"data:image/%@;base64,%@", imageFormat, base64];
       }
@@ -181,6 +186,14 @@ RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
     });
   }];
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeRNViewShotSpecJSI>(params);
+}
+#endif
 
 
 @end

--- a/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.xcodeproj/project.pbxproj
+++ b/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.xcodeproj/project.pbxproj
@@ -1,0 +1,254 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* RNViewShot.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNViewShot.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libRNViewShot.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNViewShot.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* RNViewShot.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = RNViewShot.h; sourceTree = "<group>"; tabWidth = 2; };
+		B3E7B5891CC2AC0600A0062D /* RNViewShot.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RNViewShot.m; sourceTree = "<group>"; tabWidth = 2; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libRNViewShot.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* RNViewShot.h */,
+				B3E7B5891CC2AC0600A0062D /* RNViewShot.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* RNViewShot */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNViewShot" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNViewShot;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libRNViewShot.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RNViewShot" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				58B511DA1A9E6C8500147676 /* RNViewShot */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* RNViewShot.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNViewShot;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RNViewShot;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RNViewShot" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNViewShot" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}

--- a/apps/expo-go/modules/react-native-view-shot/jsconfig.json
+++ b/apps/expo-go/modules/react-native-view-shot/jsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/apps/expo-go/modules/react-native-view-shot/package.json
+++ b/apps/expo-go/modules/react-native-view-shot/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "react-native-view-shot",
+  "version": "4.0.2",
+  "description": "Capture a React Native view to an image",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "keywords": [
+    "react-native",
+    "screenshot",
+    "viewshot",
+    "view-snapshot",
+    "snapshot",
+    "rasterize"
+  ],
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "homepage": "https://github.com/gre/react-native-view-shot",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gre/react-native-view-shot.git"
+  },
+  "dependencies": {
+    "html2canvas": "^1.4.1"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
+  "devDependencies": {
+    "flow-bin": "^0.246.0",
+    "html-webpack-plugin": "^5.5.1",
+    "react-native-windows": "^0.63.16"
+  },
+  "codegenConfig": {
+    "name": "rnviewshot",
+    "type": "modules",
+    "jsSrcsDir": "./src/specs",
+    "android": {
+      "javaPackageName": "fr.greweb.reactnativeviewshot"
+    }
+  },
+  "stableVersion": "4.0.1"
+}

--- a/apps/expo-go/modules/react-native-view-shot/react-native-view-shot.podspec
+++ b/apps/expo-go/modules/react-native-view-shot/react-native-view-shot.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/gre/react-native-view-shot.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m,mm}"
+
+  install_modules_dependencies(s)
+end
+

--- a/apps/expo-go/modules/react-native-view-shot/src/RNViewShot.js
+++ b/apps/expo-go/modules/react-native-view-shot/src/RNViewShot.js
@@ -1,0 +1,3 @@
+//@flow
+import RNViewShot from './specs/NativeRNViewShot'
+export default RNViewShot

--- a/apps/expo-go/modules/react-native-view-shot/src/RNViewShot.web.js
+++ b/apps/expo-go/modules/react-native-view-shot/src/RNViewShot.web.js
@@ -1,0 +1,42 @@
+//@flow
+import html2canvas from "html2canvas";
+
+async function captureRef(view, options) {
+  if (options.result === "tmpfile") {
+    console.warn("Tmpfile is not implemented for web. Try base64 or file.\n"+
+                 "For compatibility, it currently returns the same result as data-uri");
+  }
+
+  // TODO: implement snapshotContentContainer option
+
+  const h2cOptions = {};
+  let renderedCanvas = await html2canvas(view, h2cOptions);
+
+  if (options.width && options.height) {
+    // Resize result
+    const resizedCanvas = document.createElement('canvas');
+    const resizedContext = resizedCanvas.getContext('2d');
+    resizedCanvas.height = options.height;
+    resizedCanvas.width = options.width;
+    resizedContext.drawImage(renderedCanvas, 0, 0, resizedCanvas.width, resizedCanvas.height);
+    renderedCanvas = resizedCanvas;
+  }
+
+  const dataUrl = renderedCanvas.toDataURL("image/" + options.format, options.quality);
+  if (options.result === "data-uri" || options.result === "tmpfile") return dataUrl;
+  return dataUrl.replace(/data:image\/(\w+);base64,/, '');
+}
+
+function captureScreen(options) {
+  return captureRef(window.document.body, options);
+}
+
+function releaseCapture(uri) {
+  throw new Error("Tmpfile is not implemented for web. Try base64 or file");
+}
+
+export default {
+  captureRef,
+  captureScreen,
+  releaseCapture
+}

--- a/apps/expo-go/modules/react-native-view-shot/src/index.d.ts
+++ b/apps/expo-go/modules/react-native-view-shot/src/index.d.ts
@@ -1,0 +1,137 @@
+/*!
+ *
+ * Copyright 2017 - acrazing
+ *
+ * @author acrazing joking.young@gmail.com
+ * @since 2017-11-11 16:03:17
+ * @version 1.0.0
+ * @desc react-native-view-shot.d.ts
+ */
+
+declare module 'react-native-view-shot' {
+    import { Component, ReactInstance, RefObject, ReactNode } from 'react'
+    import { StyleProp, ViewStyle } from 'react-native'
+    import { LayoutChangeEvent } from 'react-native'
+
+
+    export interface CaptureOptions {
+        /**
+         * (Android only) the file name of the file. Must be at least 3 characters long.
+         */
+        fileName?: string;
+        /**
+         * (number): the width and height of the final image (resized from the View bound. don't provide it if you want
+         * the original pixel size).
+         */
+        width?: number;
+        /**
+         * @see {CaptureOptions#width}
+         */
+        height?: number;
+        /**
+         * either png or jpg or webm (Android). Defaults to png. raw is a ARGB array of image pixels.
+         */
+        format?: 'jpg' | 'png' | 'webm' | 'raw';
+        /**
+         * the quality. 0.0 - 1.0 (default). (only available on lossy formats like jpg)
+         */
+        quality?: number;
+        /**
+         * the method you want to use to save the snapshot, one of:
+         " - tmpfile" (default): save to a temporary file (that will only exist for as long as the app is running).
+         " - base64": encode as base64 and returns the raw string. Use only with small images as this may result of
+         *   lags (the string is sent over the bridge). N.B. This is not a data uri, use data-uri instead.
+         " - data-uri": same as base64 but also includes the Data URI scheme header.
+         " - zip-base64: compress data with zip deflate algorithm and than convert to base64 and return as a raw string."
+         */
+        result?: 'tmpfile' | 'base64' | 'data-uri' | 'zip-base64';
+        /**
+         * if true and when view is a ScrollView, the "content container" height will be evaluated instead of the
+         * container height.
+         */
+        snapshotContentContainer?: boolean;
+        /**
+         * if true and when view is a SurfaceView or have it in the view tree, view will be captured.
+         * False by default, because it can have signoficant performance impact
+         */
+        handleGLSurfaceViewOnAndroid?: boolean;
+        /**
+         * (iOS only) change the iOS snapshot strategy to use method renderInContext instead of drawViewHierarchyInRect 
+         * which may help for some use cases.
+         */
+        useRenderInContext?: boolean;
+    }
+
+    export interface ViewShotProperties {
+        options?: CaptureOptions;
+        /**
+         * - if not defined (default). the capture is not automatic and you need to use the ref and call capture()
+         *   yourself.
+         * - "mount". Capture the view once at mount. (It is important to understand image loading won't be waited, in
+         *   such case you want to use "none" with viewShotRef.capture() after Image#onLoad.)
+         * - "continuous" EXPERIMENTAL, this will capture A LOT of images continuously. For very specific use-cases.
+         * - "update" EXPERIMENTAL, this will capture images each time React redraw (on did update). For very specific
+         *   use-cases.
+         */
+        captureMode?: 'mount' | 'continuous' | 'update';
+        /**
+         * children of ViewShot component
+         */
+        children?: ReactNode;
+        /**
+         * when a captureMode is defined, this callback will be called with the capture result.
+         * @param {string} uri
+         */
+        onCapture?(uri: string): void;
+        /**
+         * when a captureMode is defined, this callback will be called when a capture fails.
+         * @param {Error} error
+         */
+        onCaptureFailure?(error: Error): void;
+        /**
+         * Invoked on mount and layout changes
+         * @param {LayoutChangeEvent} event
+         */
+        onLayout?(event: LayoutChangeEvent): void;
+        /**
+         * style prop as StyleProp<ViewStyle>
+         */
+        style?: StyleProp<ViewStyle>;
+    }
+
+    export default class ViewShot extends Component<React.PropsWithChildren<ViewShotProperties>> {
+        capture?(): Promise<string>;
+    }
+
+    /**
+     * lower level imperative API
+     *
+     * @param {number | React.ReactInstance | RefObject} viewRef
+     * @param {"react-native-view-shot".CaptureOptions} options
+     * @return {Promise<string>} Returns a Promise of the image URI.
+     */
+    export function captureRef<T>(viewRef: number | ReactInstance | RefObject<T>, options?: CaptureOptions): Promise<string>
+
+    /**
+     * This method release a previously captured uri. For tmpfile it will clean them out, for other result types it
+     * just won't do anything.
+     *
+     * NB: the tmpfile captures are automatically cleaned out after the app closes, so you might not have to worry
+     *  about this unless advanced usecases. The ViewShot component will use it each time you capture more than once
+     * (useful for continuous capture to not leak files).
+     * @param {string} uri
+     */
+    export function releaseCapture(uri: string): void
+
+    /**
+     * This method will capture the contents of the currently displayed screen as a native hardware screenshot. It does
+     * not require a ref input, as it does not work at the view level. This means that ScrollViews will not be captured
+     * in their entirety - only the portions currently visible to the user.
+     *
+     * Returns a Promise of the image URI.
+     *
+     * @param {"react-native-view-shot".CaptureOptions} options
+     * @return {Promise<string>}
+     */
+    export function captureScreen(options?: CaptureOptions): Promise<string>
+}

--- a/apps/expo-go/modules/react-native-view-shot/src/index.js
+++ b/apps/expo-go/modules/react-native-view-shot/src/index.js
@@ -1,0 +1,308 @@
+// @flow
+import React, { Component } from "react";
+import { View, Platform, findNodeHandle, StyleProp } from "react-native";
+import RNViewShot from "./RNViewShot";
+import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
+import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
+
+const neverEndingPromise = new Promise(() => {});
+
+type Options = {
+  width?: number,
+  height?: number,
+  format: "png" | "jpg" | "webm" | "raw",
+  quality: number,
+  result: "tmpfile" | "base64" | "data-uri" | "zip-base64",
+  snapshotContentContainer: boolean,
+  handleGLSurfaceViewOnAndroid: boolean,
+};
+
+if (!RNViewShot) {
+  console.warn(
+    "react-native-view-shot: RNViewShot is undefined. Make sure the library is linked on the native side."
+  );
+}
+
+const acceptedFormats = ["png", "jpg"].concat(
+  Platform.OS === "android" ? ["webm", "raw"] : []
+);
+
+const acceptedResults = ["tmpfile", "base64", "data-uri"].concat(
+  Platform.OS === "android" ? ["zip-base64"] : []
+);
+
+const defaultOptions = {
+  format: "png",
+  quality: 1,
+  result: "tmpfile",
+  snapshotContentContainer: false,
+  handleGLSurfaceViewOnAndroid: false,
+};
+
+// validate and coerce options
+function validateOptions(input: ?$Shape<Options>): {
+  options: Options,
+  errors: Array<string>,
+} {
+  const options: Options = {
+    ...defaultOptions,
+    ...input,
+  };
+  const errors = [];
+  if (
+    "width" in options &&
+    (typeof options.width !== "number" || options.width <= 0)
+  ) {
+    errors.push("option width should be a positive number");
+    delete options.width;
+  }
+  if (
+    "height" in options &&
+    (typeof options.height !== "number" || options.height <= 0)
+  ) {
+    errors.push("option height should be a positive number");
+    delete options.height;
+  }
+  if (
+    typeof options.quality !== "number" ||
+    options.quality < 0 ||
+    options.quality > 1
+  ) {
+    errors.push("option quality should be a number between 0.0 and 1.0");
+    options.quality = defaultOptions.quality;
+  }
+  if (typeof options.snapshotContentContainer !== "boolean") {
+    errors.push("option snapshotContentContainer should be a boolean");
+  }
+  if (typeof options.handleGLSurfaceViewOnAndroid !== "boolean") {
+    errors.push("option handleGLSurfaceViewOnAndroid should be a boolean");
+  }
+  if (acceptedFormats.indexOf(options.format) === -1) {
+    options.format = defaultOptions.format;
+    errors.push(
+      "option format '" +
+        options.format +
+        "' is not in valid formats: " +
+        acceptedFormats.join(" | ")
+    );
+  }
+  if (acceptedResults.indexOf(options.result) === -1) {
+    options.result = defaultOptions.result;
+    errors.push(
+      "option result '" +
+        options.result +
+        "' is not in valid formats: " +
+        acceptedResults.join(" | ")
+    );
+  }
+  return { options, errors };
+}
+
+export function ensureModuleIsLoaded() {
+  if (!RNViewShot) {
+    throw new Error(
+      "react-native-view-shot: NativeModules.RNViewShot is undefined. Make sure the library is linked on the native side."
+    );
+  }
+}
+
+export function captureRef<T: React$ElementType>(
+  view: number | ?View | React$Ref<T>,
+  optionsObject?: Object
+): Promise<string> {
+  ensureModuleIsLoaded();
+  if (
+    view &&
+    typeof view === "object" &&
+    "current" in view &&
+    // $FlowFixMe view is a ref
+    view.current
+  ) {
+    // $FlowFixMe view is a ref
+    view = view.current;
+    if (!view) {
+      return Promise.reject(new Error("ref.current is null"));
+    }
+  }
+  if (typeof view !== "number") {
+    const node = findNodeHandle(view);
+    if (!node) {
+      return Promise.reject(
+        new Error("findNodeHandle failed to resolve view=" + String(view))
+      );
+    }
+    view = node;
+  }
+  const { options, errors } = validateOptions(optionsObject);
+  if (__DEV__ && errors.length > 0) {
+    console.warn(
+      "react-native-view-shot: bad options:\n" +
+        errors.map((e) => `- ${e}`).join("\n")
+    );
+  }
+  return RNViewShot.captureRef(view, options);
+}
+
+export function releaseCapture(uri: string): void {
+  if (typeof uri !== "string") {
+    if (__DEV__) {
+      console.warn("Invalid argument to releaseCapture. Got: " + uri);
+    }
+  } else {
+    RNViewShot.releaseCapture(uri);
+  }
+}
+
+export function captureScreen(optionsObject?: Options): Promise<string> {
+  ensureModuleIsLoaded();
+  const { options, errors } = validateOptions(optionsObject);
+  if (__DEV__ && errors.length > 0) {
+    console.warn(
+      "react-native-view-shot: bad options:\n" +
+        errors.map((e) => `- ${e}`).join("\n")
+    );
+  }
+  return RNViewShot.captureScreen(options);
+}
+
+type Props = {
+  options?: Object,
+  captureMode?: "mount" | "continuous" | "update",
+  children: React$Node,
+  onLayout?: (e: *) => void,
+  onCapture?: (uri: string) => void,
+  onCaptureFailure?: (e: Error) => void,
+  style?: StyleProp<ViewStyleProp>,
+};
+
+function checkCompatibleProps(props: Props) {
+  if (!props.captureMode && props.onCapture) {
+    // in that case, it's authorized if you call capture() yourself
+  } else if (props.captureMode && !props.onCapture) {
+    console.warn(
+      "react-native-view-shot: captureMode prop is defined but onCapture prop callback is missing"
+    );
+  } else if (
+    (props.captureMode === "continuous" || props.captureMode === "update") &&
+    props.options &&
+    props.options.result &&
+    props.options.result !== "tmpfile"
+  ) {
+    console.warn(
+      "react-native-view-shot: result=tmpfile is recommended for captureMode=" +
+        props.captureMode
+    );
+  }
+}
+
+export default class ViewShot extends Component<Props> {
+  static captureRef = captureRef;
+  static releaseCapture = releaseCapture;
+
+  root: ?View;
+
+  _raf: *;
+  lastCapturedURI: ?string;
+
+  resolveFirstLayout: (layout: Object) => void;
+  firstLayoutPromise: Promise<Object> = new Promise((resolve) => {
+    this.resolveFirstLayout = resolve;
+  });
+
+  capture = (): Promise<string> =>
+    this.firstLayoutPromise
+      .then(() => {
+        const { root } = this;
+        if (!root) return neverEndingPromise; // component is unmounted, you never want to hear back from the promise
+        return captureRef(root, this.props.options);
+      })
+      .then(
+        (uri: string) => {
+          this.onCapture(uri);
+          return uri;
+        },
+        (e: Error) => {
+          this.onCaptureFailure(e);
+          throw e;
+        }
+      );
+
+  onCapture = (uri: string) => {
+    if (!this.root) return;
+    if (this.lastCapturedURI) {
+      // schedule releasing the previous capture
+      setTimeout(releaseCapture, 500, this.lastCapturedURI);
+    }
+    this.lastCapturedURI = uri;
+    const { onCapture } = this.props;
+    if (onCapture) onCapture(uri);
+  };
+
+  onCaptureFailure = (e: Error) => {
+    if (!this.root) return;
+    const { onCaptureFailure } = this.props;
+    if (onCaptureFailure) onCaptureFailure(e);
+  };
+
+  syncCaptureLoop = (captureMode: ?string) => {
+    cancelAnimationFrame(this._raf);
+    if (captureMode === "continuous") {
+      let previousCaptureURI = "-"; // needs to capture at least once at first, so we use "-" arbitrary string
+      const loop = () => {
+        this._raf = requestAnimationFrame(loop);
+        if (previousCaptureURI === this.lastCapturedURI) return; // previous capture has not finished, don't capture yet
+        previousCaptureURI = this.lastCapturedURI;
+        this.capture();
+      };
+      this._raf = requestAnimationFrame(loop);
+    }
+  };
+
+  onRef = (ref: React$ElementRef<*>) => {
+    this.root = ref;
+  };
+
+  onLayout = (e: LayoutEvent) => {
+    const { onLayout } = this.props;
+    this.resolveFirstLayout(e.nativeEvent.layout);
+    if (onLayout) onLayout(e);
+  };
+
+  componentDidMount() {
+    if (__DEV__) checkCompatibleProps(this.props);
+    if (this.props.captureMode === "mount") {
+      this.capture();
+    } else {
+      this.syncCaptureLoop(this.props.captureMode);
+    }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.captureMode !== undefined) {
+      if (this.props.captureMode !== prevProps.captureMode) {
+        this.syncCaptureLoop(this.props.captureMode);
+      }
+    }
+    if (this.props.captureMode === "update") {
+      this.capture();
+    }
+  }
+
+  componentWillUnmount() {
+    this.syncCaptureLoop(null);
+  }
+
+  render() {
+    const { children } = this.props;
+    return (
+      <View
+        ref={this.onRef}
+        collapsable={false}
+        onLayout={this.onLayout}
+        style={this.props.style}
+      >
+        {children}
+      </View>
+    );
+  }
+}

--- a/apps/expo-go/modules/react-native-view-shot/src/specs/NativeRNViewShot.ts
+++ b/apps/expo-go/modules/react-native-view-shot/src/specs/NativeRNViewShot.ts
@@ -1,0 +1,14 @@
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
+import { Int32, WithDefault } from "react-native/Libraries/Types/CodegenTypes";
+
+export interface Spec extends TurboModule {
+  releaseCapture: (uri: string) => void;
+  captureRef: (
+    target: WithDefault<number, -1>,
+    withOptions: Object
+  ) => Promise<string>;
+  captureScreen: (options: Object) => Promise<string>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>("RNViewShot");

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -77,6 +77,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
+    "react-native-view-shot": "4.0.2",
     "react-native-webview": "13.12.4",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
-    "react-native-view-shot": "~4.0.2",
+    "react-native-view-shot": "4.0.2",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.4",
     "regl": "^1.3.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-screens": "~4.1.0",
   "react-native-safe-area-context": "4.12.0",
   "react-native-svg": "15.8.0",
-  "react-native-view-shot": "~4.0.2",
+  "react-native-view-shot": "4.0.2",
   "react-native-webview": "13.12.4",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.0.0",

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -13,7 +13,30 @@ const config: VendoringTargetConfig = {
       source: 'https://github.com/aws-amplify/amplify-js.git',
     },
     'react-native-view-shot': {
-      source: 'https://github.com/gre/react-native-view-shot.git',
+      source: 'react-native-view-shot',
+      sourceType: 'npm',
+      excludeFiles: ['src/__tests__/**/*', 'windows/**/*', 'LICENSE', 'README.md'],
+      async postCopyFilesHookAsync(sourceDirectory, targetDirectory) {
+        // patch for scoped view-shot
+        const patchFile = path.join(
+          EXPOTOOLS_DIR,
+          'src/vendoring/config/react-native-view-shot-scoped.patch'
+        );
+        const patchContent = await fs.readFile(patchFile, 'utf8');
+
+        try {
+          await applyPatchAsync({
+            patchContent,
+            cwd: targetDirectory,
+            stripPrefixNum: 0,
+          });
+        } catch (e) {
+          logger.error(
+            `Failed to apply patch: \`patch -p0 -d '${targetDirectory}' < ${patchFile}\``
+          );
+          throw e;
+        }
+      },
     },
     'react-native-webview': {
       source: 'react-native-webview',

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -15,7 +15,7 @@ const config: VendoringTargetConfig = {
     'react-native-view-shot': {
       source: 'react-native-view-shot',
       sourceType: 'npm',
-      excludeFiles: ['src/__tests__/**/*', 'windows/**/*', 'LICENSE', 'README.md'],
+      excludeFiles: ['src/__tests__/**/*', 'windows/**/*'],
       async postCopyFilesHookAsync(sourceDirectory, targetDirectory) {
         // patch for scoped view-shot
         const patchFile = path.join(

--- a/tools/src/vendoring/config/react-native-view-shot-scoped.patch
+++ b/tools/src/vendoring/config/react-native-view-shot-scoped.patch
@@ -27,3 +27,23 @@
          final File cacheDir;
  
          if (externalCacheDir == null && internalCacheDir == null) {
+--- android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
++++ android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotPackage.java
+@@ -22,7 +22,7 @@ public class RNViewShotPackage extends TurboReactPackage {
+   @Nonnull
+   public List<NativeModule> createNativeModules(@Nonnull ReactApplicationContext reactContext) {
+     List<NativeModule> modules = new ArrayList<>();
+-    modules.add(new RNViewShotModule(reactContext));
++    modules.add(new RNViewShotModule(reactContext, reactContext.getCacheDir(), reactContext.getExternalCacheDir()));
+     return modules;
+   }
+   
+@@ -30,7 +30,7 @@ public class RNViewShotPackage extends TurboReactPackage {
+   @Override
+   public NativeModule getModule(@NonNull String name, @NonNull ReactApplicationContext reactApplicationContext) {
+     if (name.equals(RNViewShotModule.NAME)) {
+-      return new RNViewShotModule(reactApplicationContext);
++      return new RNViewShotModule(reactApplicationContext, reactApplicationContext.getCacheDir(), reactApplicationContext.getExternalCacheDir());
+     } else {
+       return null;
+     }

--- a/tools/src/vendoring/config/react-native-view-shot-scoped.patch
+++ b/tools/src/vendoring/config/react-native-view-shot-scoped.patch
@@ -1,0 +1,29 @@
+--- android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
++++ android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+@@ -34,12 +34,16 @@ import fr.greweb.reactnativeviewshot.ViewShot.Results;
+ public class RNViewShotModule extends NativeRNViewShotSpec {
+ 
+     private final ReactApplicationContext reactContext;
++    private final File internalCacheDir;
++    private final File externalCacheDir;
+ 
+     private final Executor executor = Executors.newCachedThreadPool();
+ 
+-    public RNViewShotModule(ReactApplicationContext reactContext) {
++    public RNViewShotModule(ReactApplicationContext reactContext, File internalCacheDir, File externalCacheDir) {
+         super(reactContext);
+         this.reactContext = reactContext;
++        this.internalCacheDir = internalCacheDir;
++        this.externalCacheDir = externalCacheDir;
+     }
+ 
+     @Override
+@@ -167,8 +171,6 @@ public class RNViewShotModule extends NativeRNViewShotSpec {
+      */
+     @NonNull
+     private File createTempFile(@NonNull final Context context, @NonNull final String ext, String fileName) throws IOException {
+-        final File externalCacheDir = context.getExternalCacheDir();
+-        final File internalCacheDir = context.getCacheDir();
+         final File cacheDir;
+ 
+         if (externalCacheDir == null && internalCacheDir == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13789,7 +13789,7 @@ react-native-svg@15.8.0:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-view-shot@4.0.2, react-native-view-shot@~4.0.2:
+react-native-view-shot@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-4.0.2.tgz#18949ff2a3083a231d055e9f53ce705ccb9d821c"
   integrity sha512-niAiQmiYe+vHtfgkcZ1WhJhTL0NzNB2REERnP6eIqro9EQcV/JqLo2rzdordn+kHJEp095/2ioLrCg3d+k3Mng==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13789,7 +13789,7 @@ react-native-svg@15.8.0:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-view-shot@~4.0.2:
+react-native-view-shot@4.0.2, react-native-view-shot@~4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-4.0.2.tgz#18949ff2a3083a231d055e9f53ce705ccb9d821c"
   integrity sha512-niAiQmiYe+vHtfgkcZ1WhJhTL0NzNB2REERnP6eIqro9EQcV/JqLo2rzdordn+kHJEp095/2ioLrCg3d+k3Mng==


### PR DESCRIPTION
# Why
View shot was still vendored in expo go. 

# How
- Removed the vendored code
- Added view shot to `expoGoConfig` and created a patch.

`et umv -m react-native-view-shot -c v4.0.2`

I had to change the view shot constructor because in the vendored code we accepted a `ScopedContext` parameter but doing this now would require the module to take a dependency on `expoview` which would cause a circular dependency. Ideally, shared code should be taken out of `expoview` and moved to a separate module but this is a significant refactor. 

# Test Plan
Expo go. ViewShot is working correctly on both iOS and Android
