### PR TITLE
[expo-go] DevMenuManager correctly cast react host

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -302,9 +302,12 @@ class DevMenuManager {
   @Throws(Exception::class)
   private fun prepareSurface(initialProps: Bundle): ReactSurface {
     val surface = ReactSurfaceImpl.createWithView(kernel.applicationContext, DEV_MENU_JS_MODULE_NAME, initialProps)
-    surface.attach(kernel.reactHost as ReactHostImpl)
-    surface.start()
-    reactSurface = surface
+    val reactHost = kernel.reactHost as? ReactHostImpl
+    reactHost?.let {
+      surface.attach(it)
+      surface.start()
+      reactSurface = surface
+    }
     return surface
   }
 


### PR DESCRIPTION
# Why
Guards against the issue mentioned [here](https://exponent-internal.slack.com/archives/C1QNF5L3C/p1732169331541749)
The kernels react host can potentially be null causing the cast in `prepareSurface` to fail

# How
Cast to a nullable type and safely check if we have a concrete host instance before starting the surface.

# Test Plan
Expo go. I couldn't repro the issue but the change doesn't impact normal functioning. It is likely a race condition because the kernels host should not be null. This change will prevent the crash and we just won't show the dev menu if we have a null host.

