### PR TITLE
[sdk-52][ios] fix failing getNetworkStateAsync on sdk-52/iOS

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added fix to getNetworkStateAsync failing on iOS as described in #33012
+- [iOS] Added fix to getNetworkStateAsync failing on iOS ([#33137](https://github.com/expo/expo/pull/33137) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added fix to getNetworkStateAsync failing on iOS as described in #33012
+
 ### 💡 Others
 
 ## 7.0.0 — 2024-10-22

--- a/packages/expo-network/ios/NetworkModule.swift
+++ b/packages/expo-network/ios/NetworkModule.swift
@@ -88,32 +88,32 @@ public final class NetworkModule: Module {
   }
 
     private func getNetworkPathAsync() -> NWPath? {
-        // create a temporary monitor to avoid interfering with the module's monitor
-        // since we want to wait for the result to be updated once:
-        let tempMonitor = NWPathMonitor()
-        var tempPath: NWPath?
+      // create a temporary monitor to avoid interfering with the module's monitor
+      // since we want to wait for the result to be updated once:
+      let tempMonitor = NWPathMonitor()
+      var tempPath: NWPath?
 
-        let semaphore = DispatchSemaphore(value: 0)
+      let semaphore = DispatchSemaphore(value: 0)
 
-        tempMonitor.pathUpdateHandler = { updatedPath in
-          tempPath = updatedPath
-          semaphore.signal() // Notify that we got the path
-        }
+      tempMonitor.pathUpdateHandler = { updatedPath in
+        tempPath = updatedPath
+        semaphore.signal() // Notify that we got the path
+      }
 
-        tempMonitor.start(queue: monitorQueue)
+      tempMonitor.start(queue: monitorQueue)
 
-        // Wait max 5 seconds to avoid any locking issues if the monitor
-        // doesn't get an update in time.
-        let result = semaphore.wait(timeout: .now() + 5)
-        tempMonitor.cancel()
+      // Wait max 5 seconds to avoid any locking issues if the monitor
+      // doesn't get an update in time.
+      let result = semaphore.wait(timeout: .now() + 5)
+      tempMonitor.cancel()
 
-        if result == .timedOut {
-          // Handle the timeout case
-          print("Timeout waiting for network path.")
-          return nil
-        }
+      if result == .timedOut {
+        // Handle the timeout case
+        print("Timeout waiting for network path.")
+        return nil
+      }
 
-        return tempPath
+      return tempPath
     }
 
   private func getNetworkStateAsync(path: NWPath? = nil) -> [String: Any] {

--- a/packages/expo-network/ios/NetworkModule.swift
+++ b/packages/expo-network/ios/NetworkModule.swift
@@ -87,34 +87,34 @@ public final class NetworkModule: Module {
     return address
   }
 
-    private func getNetworkPathAsync() -> NWPath? {
-      // create a temporary monitor to avoid interfering with the module's monitor
-      // since we want to wait for the result to be updated once:
-      let tempMonitor = NWPathMonitor()
-      var tempPath: NWPath?
+  private func getNetworkPathAsync() -> NWPath? {
+    // create a temporary monitor to avoid interfering with the module's monitor
+    // since we want to wait for the result to be updated once:
+    let tempMonitor = NWPathMonitor()
+    var tempPath: NWPath?
 
-      let semaphore = DispatchSemaphore(value: 0)
+    let semaphore = DispatchSemaphore(value: 0)
 
-      tempMonitor.pathUpdateHandler = { updatedPath in
-        tempPath = updatedPath
-        semaphore.signal() // Notify that we got the path
-      }
-
-      tempMonitor.start(queue: monitorQueue)
-
-      // Wait max 5 seconds to avoid any locking issues if the monitor
-      // doesn't get an update in time.
-      let result = semaphore.wait(timeout: .now() + 5)
-      tempMonitor.cancel()
-
-      if result == .timedOut {
-        // Handle the timeout case
-        print("Timeout waiting for network path.")
-        return nil
-      }
-
-      return tempPath
+    tempMonitor.pathUpdateHandler = { updatedPath in
+      tempPath = updatedPath
+      semaphore.signal() // Notify that we got the path
     }
+
+    tempMonitor.start(queue: monitorQueue)
+
+    // Wait max 5 seconds to avoid any locking issues if the monitor
+    // doesn't get an update in time.
+    let result = semaphore.wait(timeout: .now() + 5)
+    tempMonitor.cancel()
+
+    if result == .timedOut {
+      // Handle the timeout case
+      print("Timeout waiting for network path.")
+      return nil
+    }
+
+    return tempPath
+  }
 
   private func getNetworkStateAsync(path: NWPath? = nil) -> [String: Any] {
     let currentPath = path ?? getNetworkPathAsync()

--- a/packages/expo-network/ios/NetworkModule.swift
+++ b/packages/expo-network/ios/NetworkModule.swift
@@ -87,9 +87,38 @@ public final class NetworkModule: Module {
     return address
   }
 
+    private func getNetworkPath() -> NWPath? {
+        // create a temporary monitor to avoid interfering with the module's monitor
+        // since we want to wait for the result to be updated once:
+        let tempMonitor = NWPathMonitor()
+        var tempPath: NWPath?
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        tempMonitor.pathUpdateHandler = { updatedPath in
+          tempPath = updatedPath
+          semaphore.signal() // Notify that we got the path
+        }
+
+        tempMonitor.start(queue: monitorQueue)
+
+        // Wait max 5 seconds to avoid any locking issues if the monitor
+        // doesn't get an update in time.
+        let result = semaphore.wait(timeout: .now() + 5)
+        tempMonitor.cancel()
+
+        if result == .timedOut {
+          // Handle the timeout case
+          print("Timeout waiting for network path.")
+          return nil
+        }
+
+        return tempPath
+    }
+
   private func getNetworkStateAsync(path: NWPath? = nil) -> [String: Any] {
-    let currentPath = path ?? monitor.currentPath
-    let isConnected = currentPath.status == .satisfied
+    let currentPath = path ?? getNetworkPath()
+    let isConnected = currentPath?.status == .satisfied
 
     if !isConnected {
       return [
@@ -102,7 +131,7 @@ public final class NetworkModule: Module {
     let connectionType = NWInterface
       .InterfaceType
       .allCases
-      .filter { currentPath.usesInterfaceType($0) }
+      .filter { currentPath?.usesInterfaceType($0) == true }
       .first
 
     var currentNetworkType = NetworkType.unknown

--- a/packages/expo-network/ios/NetworkModule.swift
+++ b/packages/expo-network/ios/NetworkModule.swift
@@ -87,7 +87,7 @@ public final class NetworkModule: Module {
     return address
   }
 
-    private func getNetworkPath() -> NWPath? {
+    private func getNetworkPathAsync() -> NWPath? {
         // create a temporary monitor to avoid interfering with the module's monitor
         // since we want to wait for the result to be updated once:
         let tempMonitor = NWPathMonitor()
@@ -117,7 +117,7 @@ public final class NetworkModule: Module {
     }
 
   private func getNetworkStateAsync(path: NWPath? = nil) -> [String: Any] {
-    let currentPath = path ?? getNetworkPath()
+    let currentPath = path ?? getNetworkPathAsync()
     let isConnected = currentPath?.status == .satisfied
 
     if !isConnected {


### PR DESCRIPTION
# Why
On iOS in SDK52 the getNetworkStateAsync fails to return the correct network state.

In SDK-52 we added support for monitoring network changes, resulting in the swift monitor object only being active when someone is listening (through the `useNetworkState` hook or directly).

This causes the `getNetworkStateAsync` function to evaluate wrong if the monitor is not active:

<img src="https://github.com/user-attachments/assets/e84f978e-5ab4-449f-bf64-486bfffbb001" width=250 />

Observe that the network states are different.

This was reported in #[33012](https://github.com/expo/expo/issues/33012) 

# How
Added a function for retrieving the network state (`getNetworkPathAsync`) was added. This function sets up a temporary monitor and waits for it to finish reporting the network state (with a timeout of 5 seconds).

Closes #[ENG-14290](https://linear.app/expo/issue/ENG-14290)

# Test Plan

Use BareExpo and verify that we have a valid network setting are the same:

<img src="https://github.com/user-attachments/assets/380701f9-8205-4501-8b0d-dbac8fd4d122" width=250 />

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
