### PR TITLE
[ios][expo-calendar] added reading calendarId in createEventInCalendarAsync

### DIFF
--- a/apps/native-component-list/src/screens/EventsScreen.tsx
+++ b/apps/native-component-list/src/screens/EventsScreen.tsx
@@ -47,7 +47,7 @@ type Links = {
 
 type Props = StackScreenProps<Links, 'Events'>;
 
-function createEvent(recurring: boolean = false) {
+function createEvent(calendarId: string, recurring: boolean = false) {
   const timeInOneHour = new Date();
   timeInOneHour.setHours(timeInOneHour.getHours() + 1);
   const newEvent: Parameters<typeof Calendar.createEventAsync>[1] = {
@@ -57,6 +57,7 @@ function createEvent(recurring: boolean = false) {
     endDate: timeInOneHour,
     notes: 'This is a cool note',
     timeZone: 'America/Los_Angeles',
+    calendarId,
   };
   if (recurring) {
     newEvent.recurrenceRule = {
@@ -103,7 +104,7 @@ export default class EventsScreen extends React.Component<Props, State> {
     }
 
     try {
-      const newEvent = createEvent(recurring);
+      const newEvent = createEvent(calendar.id, recurring);
       await Calendar.createEventAsync(calendar.id, newEvent);
       Alert.alert('Event saved successfully');
       this._findEvents(calendar.id);
@@ -211,7 +212,8 @@ export default class EventsScreen extends React.Component<Props, State> {
         <Button onPress={() => this._addEvent(true)} title="Add New Recurring Event" />
         <Button
           onPress={async () => {
-            const newEvent = createEvent(true);
+            const { calendar } = this.props.route.params!;
+            const newEvent = createEvent(calendar.id);
             const result = await Calendar.createEventInCalendarAsync(newEvent);
             setTimeout(() => {
               Alert.alert('createEventInCalendarAsync result', JSON.stringify(result), undefined, {

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed missing deserialization of calendarId field when calling createEventInCalendarAsync
+
 ### 💡 Others
 
 ## 14.0.2 — 2024-10-24

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed missing deserialization of calendarId field when calling createEventInCalendarAsync
+- [iOS] Fixed missing deserialization of calendarId field when calling createEventInCalendarAsync ([#33142](https://github.com/expo/expo/pull/33142) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -398,6 +398,13 @@ public class CalendarModule: Module {
       calendarEvent.endDate = parse(date: endDate)
     }
 
+    if let calendarId = event.calendarId {
+      guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
+        throw CalendarIdNotFoundException(calendarId)
+      }
+      calendarEvent.calendar = calendar
+    }
+
     calendarEvent.title = event.title
     calendarEvent.location = event.location
     calendarEvent.notes = event.notes


### PR DESCRIPTION
# Why

The implementation of `createEventInCalendarAsync` did not use the field CalendarId when creating new events. This is a field that should set the calendar field in the iOS dialog for creating/editing an event if provided.

Closes #33116

# How

Added reading the calendar field when initializing a new event in Swift from the JS event. 

# Test Plan

Test in BareExpo under API -> Calendar. Select multiple calendars (you might need to create extra calendars) and press the "Create event using the OS dialog" button. Ensure that the selected calendar comes up as the designated calendar in the dialog.

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
