### PR TITLE
[core][updates] fix incompatible jvm target error from expo-updates

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Introduced `applyKspJvmToolchain()` gradle helper to enforce JVM Toolchain version for KSP. ([#33148](https://github.com/expo/expo/pull/33148) by [@kudo](https://github.com/kudo))
+
 ## 2.0.4 — 2024-11-19
 
 ### 🎉 New features

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -51,6 +51,13 @@ ext.applyKotlinExpoModulesCorePlugin = {
   apply plugin: KotlinExpoModulesCorePlugin
 }
 
+// Apply JVM Toolchain version for KSP
+ext.applyKspJvmToolchain = {
+  project.ksp {
+    kotlin.jvmToolchain(17)
+  }
+}
+
 // Setup build options that are common for all modules
 ext.useDefaultAndroidSdkVersions = {
   project.android {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Inconsistent JVM-target compatibility` error when building with JDK 21. ([#33148](https://github.com/expo/expo/pull/33148) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Introduced `ReactNativeFeatureFlags` compat to fix React Native 0.77 breaking changes. ([#33077](https://github.com/expo/expo/pull/33077) by [@kudo](https://github.com/kudo))

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -21,6 +21,7 @@ version = '0.26.8'
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 apply from: expoModulesCorePlugin
 applyKotlinExpoModulesCorePlugin()
+applyKspJvmToolchain()
 useCoreDependencies()
 useDefaultAndroidSdkVersions()
 useExpoPublishing()


### PR DESCRIPTION
# Why

fix incompatible jvm target error from expo-updates when using jdk 21
```
Execution failed for task ':expo-updates:kspDebugKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'kspDebugKotlin' (21).
```

fixes #33107

# How

RNGP is not able to enforce jvm toolchain version in KSP. this pr tries to add jvm toolchain inside the ksp configuration. also introducing a `applyKspJvmToolchain()` from core, so that we can control the jdk version from core to reduce maintenance cost.

# Test Plan

- ci passed
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleDebug` in bare-expo. the new jdk inside android studio is jdk 21

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---------

```
Co-authored-by: Vojtech Novak <vonovak@gmail.com>
Co-authored-by: lukmccall <kosmatylukasz@gmail.com>
```