### PR TITLE
fix: Incorrect usage of reanimated shared value in expo-template-default app

### DIFF
--- a/templates/expo-template-default/components/HelloWave.tsx
+++ b/templates/expo-template-default/components/HelloWave.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -12,10 +13,12 @@ import { ThemedText } from '@/components/ThemedText';
 export function HelloWave() {
   const rotationAnimation = useSharedValue(0);
 
-  rotationAnimation.value = withRepeat(
-    withSequence(withTiming(25, { duration: 150 }), withTiming(0, { duration: 150 })),
-    4 // Run the animation 4 times
-  );
+  useEffect(() => {
+    rotationAnimation.value = withRepeat(
+      withSequence(withTiming(25, { duration: 150 }), withTiming(0, { duration: 150 })),
+      4 // Run the animation 4 times
+    );
+  }, []);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${rotationAnimation.value}deg` }],


### PR DESCRIPTION
# Why

This PR fixes incorrect usage of the Reanimated `SharedValue` in the `HelloWave` component. In Reanimated `3.16.0` we introduced a warning displayed when the `SharedValue` is read/written when the component renders (see [this](https://github.com/software-mansion/react-native-reanimated/pull/6310) PR for more details).

Basically, we should read from/read to the shared value only in hooks or callback functions, not in the top level scope of the function component.

closes #33197

# How

Just wrapped the assignment to the shared value with the `useEffect` hook.

# Test Plan

Build the example app and either add an interval updating state in the `HelloWave` component or just trigger hot reload (by adding/removing some code from the component) to see that the warning is no longer visible.

This warning was visible before:

![image](https://github.com/user-attachments/assets/c451c9f0-1a6f-4041-afb5-2389ecf2e7dd)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
