### PR TITLE
[expo-file-system][next] Cleanup path joining in tests

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -81,27 +81,27 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('When a wrong class already exists', () => {
         it("Doesn't allow operations when a file is used with an existing folder path", () => {
-          const directory = new Directory(testDirectory + 'test');
+          const directory = new Directory(testDirectory, 'test');
           directory.create();
-          const file = new File(testDirectory + 'test');
+          const file = new File(testDirectory, 'test');
           expect(() => {
             file.text();
           }).toThrow();
         });
 
         it("Doesn't allow operations when a folder is used with an existing file path", () => {
-          const file = new File(testDirectory + 'test');
+          const file = new File(testDirectory, 'test');
           file.create();
-          const directory = new Directory(testDirectory + 'test');
+          const directory = new Directory(testDirectory, 'test');
           expect(() => {
             directory.create();
           }).toThrow();
         });
 
         it('Returns exists false', () => {
-          const file = new File(testDirectory + 'test');
+          const file = new File(testDirectory, 'test');
           file.create();
-          const directory = new Directory(testDirectory + 'test');
+          const directory = new Directory(testDirectory, 'test');
           expect(file.exists).toBe(true);
           expect(directory.exists).toBe(false);
         });
@@ -124,7 +124,7 @@ export async function test({ describe, expect, it, ...t }) {
       });
 
       it('Reads a string from a file reference', () => {
-        const outputFile = new File(testDirectory + 'file2.txt');
+        const outputFile = new File(testDirectory, 'file2.txt');
         outputFile.write('Hello world');
         expect(outputFile.exists).toBe(true);
         const content = outputFile.text();
@@ -132,7 +132,7 @@ export async function test({ describe, expect, it, ...t }) {
       });
 
       it('Deletes a file reference', () => {
-        const outputFile = new File(testDirectory + 'file3.txt');
+        const outputFile = new File(testDirectory, 'file3.txt');
         outputFile.write('Hello world');
         expect(outputFile.exists).toBe(true);
 
@@ -146,26 +146,26 @@ export async function test({ describe, expect, it, ...t }) {
       });
 
       it('Creates a folder', () => {
-        const folder = new Directory(testDirectory + 'newFolder');
+        const folder = new Directory(testDirectory, 'newFolder');
         folder.create();
         expect(folder.exists).toBe(true);
       });
 
       it('Creates a folder without a slash', () => {
-        const folder = new Directory(testDirectory + 'newFolder2');
+        const folder = new Directory(testDirectory, 'newFolder2');
         folder.create();
         expect(folder.exists).toBe(true);
       });
 
       it('Creates an empty file', () => {
-        const file = new File(testDirectory + 'newFolder');
+        const file = new File(testDirectory, 'newFolder');
         file.create();
         expect(file.exists).toBe(true);
         expect(file.text()).toBe('');
       });
 
       it('Deletes a folder', () => {
-        const folder = new Directory(testDirectory + 'newFolder');
+        const folder = new Directory(testDirectory, 'newFolder');
         folder.create();
         expect(folder.exists).toBe(true);
 
@@ -175,36 +175,36 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('When copying a file', () => {
         it("Throws an error when it doesn't exist", () => {
-          const src = new File(testDirectory + 'file.txt');
-          const dstFolder = new Directory(testDirectory + 'destination');
+          const src = new File(testDirectory, 'file.txt');
+          const dstFolder = new Directory(testDirectory, 'destination');
           dstFolder.create();
           expect(() => src.copy(dstFolder)).toThrow();
         });
 
         it('Copies it to a folder', () => {
-          const src = new File(testDirectory + 'file.txt');
+          const src = new File(testDirectory, 'file.txt');
           src.write('Hello world');
-          const dstFolder = new Directory(testDirectory + 'destination');
+          const dstFolder = new Directory(testDirectory, 'destination');
           dstFolder.create();
           src.copy(dstFolder);
           expect(src.exists).toBe(true);
           expect(src.text()).toBe('Hello world');
-          const dst = new File(testDirectory + '/destination/file.txt');
+          const dst = new File(testDirectory, '/destination/file.txt');
           expect(dst.exists).toBe(true);
           expect(dst.text()).toBe('Hello world');
         });
 
         it('Throws an error when copying to a nonexistant folder without options', () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
-          const folder = new Directory(testDirectory + 'destination');
+          const folder = new Directory(testDirectory, 'destination');
           expect(() => file.copy(folder)).toThrow();
         });
 
         it('Copies it to a file', () => {
-          const src = new File(testDirectory + 'file.txt');
+          const src = new File(testDirectory, 'file.txt');
           src.write('Hello world');
-          const dst = new File(testDirectory + 'file2.txt');
+          const dst = new File(testDirectory, 'file2.txt');
           src.copy(dst);
           expect(dst.exists).toBe(true);
           expect(dst.text()).toBe('Hello world');
@@ -223,7 +223,7 @@ export async function test({ describe, expect, it, ...t }) {
           } catch {}
           src.write('Hello world');
           src.copy(dst);
-          expect(dst.uri).toBe(FS.documentDirectory + 'file.txt');
+          expect(dst.uri).toBe(FS.documentDirectory, 'file.txt');
           expect(dst.exists).toBe(true);
           expect(dst.md5).toBe(src.md5);
         });
@@ -231,36 +231,36 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('When copying a directory', () => {
         it('copies it to a folder', () => {
-          const src = new Directory(testDirectory + 'directory');
+          const src = new Directory(testDirectory, 'directory');
           src.create();
-          const dstFolder = new Directory(testDirectory + 'destination');
+          const dstFolder = new Directory(testDirectory, 'destination');
           dstFolder.create();
           src.copy(dstFolder);
           expect(src.exists).toBe(true);
-          expect(new Directory(testDirectory + 'destination/directory').exists).toBe(true);
+          expect(new Directory(testDirectory, 'destination/directory').exists).toBe(true);
         });
 
         it('Throws an error when copying to a nonexistant folder without options', () => {
-          const file = new Directory(testDirectory + 'directory/');
+          const file = new Directory(testDirectory, 'directory/');
           file.create();
-          const folder = new Directory(testDirectory + 'some/nonexistent/directory/');
+          const folder = new Directory(testDirectory, 'some/nonexistent/directory/');
           expect(() => file.copy(folder)).toThrow();
         });
 
         it('Creates a copy of the directory if only the bottom level destination directory does not exist', () => {
-          const file = new Directory(testDirectory + 'source/');
+          const file = new Directory(testDirectory, 'source/');
           file.create();
-          const destination = new Directory(testDirectory + 'newDestination/');
+          const destination = new Directory(testDirectory, 'newDestination/');
           file.copy(destination);
-          expect(destination.uri).toBe(testDirectory + 'newDestination/');
-          expect(file.uri).toBe(testDirectory + 'source/');
+          expect(destination.uri).toBe(testDirectory, 'newDestination/');
+          expect(file.uri).toBe(testDirectory, 'source/');
         });
 
         // this should not be allowed by TS, but we can handle it anyways
         it('throws an error when copying it to a file', () => {
-          const src = new Directory(testDirectory + 'directory/');
+          const src = new Directory(testDirectory, 'directory/');
           src.create();
-          const dst = new File(testDirectory + 'file2.txt');
+          const dst = new File(testDirectory, 'file2.txt');
           dst.create();
           // @ts-expect-error
           expect(() => src.copy(dst)).toThrow();
@@ -269,36 +269,36 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('When moving a file', () => {
         it("Throws an error when it doesn't exist", () => {
-          const src = new File(testDirectory + 'file.txt');
-          const dstFolder = new Directory(testDirectory + 'destination');
+          const src = new File(testDirectory, 'file.txt');
+          const dstFolder = new Directory(testDirectory, 'destination');
           dstFolder.create();
           expect(() => src.move(dstFolder)).toThrow();
         });
 
         it('moves it to a folder', () => {
-          const src = new File(testDirectory + 'file.txt');
+          const src = new File(testDirectory, 'file.txt');
           src.write('Hello world');
-          const dstFolder = new Directory(testDirectory + 'destination');
+          const dstFolder = new Directory(testDirectory, 'destination');
           dstFolder.create();
           src.move(dstFolder);
           expect(src.exists).toBe(true);
-          const dst = new File(testDirectory + '/destination/file.txt');
+          const dst = new File(testDirectory, '/destination/file.txt');
           expect(src.uri).toBe(dst.uri);
           expect(dst.exists).toBe(true);
           expect(dst.text()).toBe('Hello world');
         });
 
         it('Throws an error when moving to a nonexistant folder without options', () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
-          const folder = new Directory(testDirectory + 'destination');
+          const folder = new Directory(testDirectory, 'destination');
           expect(() => file.move(folder)).toThrow();
         });
 
         it('moves it to a file', () => {
-          const src = new File(testDirectory + 'file.txt');
+          const src = new File(testDirectory, 'file.txt');
           src.write('Hello world');
-          const dst = new File(testDirectory + 'file2.txt');
+          const dst = new File(testDirectory, 'file2.txt');
           src.move(dst);
           expect(dst.exists).toBe(true);
           expect(dst.text()).toBe('Hello world');
@@ -309,37 +309,37 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('When moving a directory', () => {
         it('moves it to a folder', () => {
-          const src = new Directory(testDirectory + 'directory/');
+          const src = new Directory(testDirectory, 'directory/');
           src.create();
-          const dstFolder = new Directory(testDirectory + 'destination/');
+          const dstFolder = new Directory(testDirectory, 'destination/');
           dstFolder.create();
           src.move(dstFolder);
           expect(src.exists).toBe(true);
-          const dst = new Directory(testDirectory + 'destination/directory/');
+          const dst = new Directory(testDirectory, 'destination/directory/');
           expect(src.uri).toBe(dst.uri);
           expect(dst.exists).toBe(true);
         });
 
         it('Throws an error when moving to a nonexistant folder without options', () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
-          const folder = new Directory(testDirectory + 'some/nonexistent/directory/');
+          const folder = new Directory(testDirectory, 'some/nonexistent/directory/');
           expect(() => file.move(folder)).toThrow();
         });
 
         it('Renames the directory if only the bottom level destination directory does not exist', () => {
-          const file = new Directory(testDirectory + 'source/');
+          const file = new Directory(testDirectory, 'source/');
           file.create();
-          const folder = new Directory(testDirectory + 'newDestination/');
+          const folder = new Directory(testDirectory, 'newDestination/');
           file.move(folder);
-          expect(file.uri).toBe(testDirectory + 'newDestination/');
+          expect(file.uri).toBe(testDirectory, 'newDestination/');
         });
 
         // this should not be allowed by TS, but we can handle it anyways
         it('throws an error when moving it to a file', () => {
-          const src = new Directory(testDirectory + 'directory/');
+          const src = new Directory(testDirectory, 'directory/');
           src.create();
-          const dst = new File(testDirectory + 'file2.txt');
+          const dst = new File(testDirectory, 'file2.txt');
           dst.create();
           // @ts-expect-error
           expect(() => src.move(dst)).toThrow();
@@ -349,7 +349,7 @@ export async function test({ describe, expect, it, ...t }) {
       describe('Downloads files', () => {
         it('downloads a file to a target file', async () => {
           const url = 'https://picsum.photos/id/237/200/300';
-          const file = new File(testDirectory + 'image.jpeg');
+          const file = new File(testDirectory, 'image.jpeg');
           const output = await File.downloadFileAsync(url, file);
           expect(file.exists).toBe(true);
           expect(output.uri).toBe(file.uri);
@@ -361,7 +361,8 @@ export async function test({ describe, expect, it, ...t }) {
           const output = await File.downloadFileAsync(url, directory);
 
           const file = new File(
-            testDirectory + (Platform.OS === 'android' ? '300.jpg' : '237-200x300.jpg')
+            testDirectory,
+            Platform.OS === 'android' ? '300.jpg' : '237-200x300.jpg'
           );
           expect(file.exists).toBe(true);
           expect(output.uri).toBe(file.uri);
@@ -369,7 +370,7 @@ export async function test({ describe, expect, it, ...t }) {
 
         it('throws an error if destination file already exists', async () => {
           const url = 'https://picsum.photos/id/237/200/300';
-          const file = new File(testDirectory + 'image.jpeg');
+          const file = new File(testDirectory, 'image.jpeg');
           file.create();
           let error;
           try {
@@ -383,25 +384,25 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('Computes file properties', () => {
         it('computes size', async () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
           expect(file.size).toBe(11);
         });
 
         it('computes md5', async () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
           expect(file.md5).toBe('3e25960a79dbc69b674cd4ec67a72c62');
         });
 
         it('returns null size and md5 for nonexistent files', async () => {
-          const file = new File(testDirectory + 'file2.txt');
+          const file = new File(testDirectory, 'file2.txt');
           expect(file.size).toBe(null);
           expect(file.md5).toBe(null);
         });
 
         it('computes md5', async () => {
-          const file = new File(testDirectory + 'file.txt');
+          const file = new File(testDirectory, 'file.txt');
           file.write('Hello world');
           expect(file.md5).toBe('3e25960a79dbc69b674cd4ec67a72c62');
         });
@@ -409,7 +410,7 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('Returns base64', () => {
         it('gets base64 of a file', async () => {
-          const src = new File(testDirectory + 'file.txt');
+          const src = new File(testDirectory, 'file.txt');
           src.write('Hello world');
           expect(src.base64()).toBe('SGVsbG8gd29ybGQ=');
         });
@@ -427,11 +428,11 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('Lists directory contents', () => {
         it('for newly created directories', () => {
-          new File(testDirectory + 'file.txt').create();
-          new Directory(testDirectory + 'directory').create();
+          new File(testDirectory, 'file.txt').create();
+          new Directory(testDirectory, 'directory').create();
           expect(new Directory(testDirectory).list()).toEqual([
-            new File(testDirectory + 'file.txt'),
-            new Directory(testDirectory + 'directory'),
+            new File(testDirectory, 'file.txt'),
+            new Directory(testDirectory, 'directory'),
           ]);
           expect(new Directory(testDirectory).list()[0] instanceof File).toBe(true);
         });
@@ -439,18 +440,18 @@ export async function test({ describe, expect, it, ...t }) {
 
       describe('JS-only properties for path manipulation', () => {
         it('return parentDirectory for files', () => {
-          const file = new File(testDirectory + 'image.jpeg');
+          const file = new File(testDirectory, 'image.jpeg');
           expect(file.parentDirectory.uri).toBe(new Directory(testDirectory).uri);
         });
         it('return parentDirectory for directories', () => {
-          const directory = new Directory(testDirectory + '/testdirectory/sampleDir');
+          const directory = new Directory(testDirectory, '/testdirectory/sampleDir');
           expect(directory.parentDirectory.parentDirectory.uri).toBe(
             new Directory(testDirectory).uri
           );
         });
         it('return extension for files', () => {
-          expect(new File(testDirectory + 'image.jpeg').extension).toBe('.jpeg');
-          expect(new File(testDirectory + 'image.pdf.jpeg').extension).toBe('.jpeg');
+          expect(new File(testDirectory, 'image.jpeg').extension).toBe('.jpeg');
+          expect(new File(testDirectory, 'image.pdf.jpeg').extension).toBe('.jpeg');
         });
 
         it('joins paths', () => {
@@ -479,7 +480,7 @@ export async function test({ describe, expect, it, ...t }) {
         });
         it('can be easily used with joining paths', () => {
           const file = new File(Paths.document, 'file.txt');
-          expect(file.uri).toBe(FS.documentDirectory + 'file.txt');
+          expect(file.uri).toBe(FS.documentDirectory, 'file.txt');
         });
       });
 
@@ -658,14 +659,14 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }) {
     });
 
     scopedIt('Writes a string to a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir + 'file.txt');
+      const outputFile = new File(sharedContainerTestDir, 'file.txt');
       expect(outputFile.exists).toBe(false);
       outputFile.write('Hello world');
       expect(outputFile.exists).toBe(true);
     });
 
     scopedIt('Deletes a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir + 'file3.txt');
+      const outputFile = new File(sharedContainerTestDir, 'file3.txt');
       outputFile.write('Hello world');
       expect(outputFile.exists).toBe(true);
 
@@ -674,13 +675,13 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }) {
     });
 
     scopedIt('Creates a folder', () => {
-      const folder = new Directory(sharedContainerTestDir + 'newFolder');
+      const folder = new Directory(sharedContainerTestDir, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
     });
 
     scopedIt('Deletes a folder', () => {
-      const folder = new Directory(sharedContainerTestDir + 'newFolder');
+      const folder = new Directory(sharedContainerTestDir, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
 

--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -223,7 +223,7 @@ export async function test({ describe, expect, it, ...t }) {
           } catch {}
           src.write('Hello world');
           src.copy(dst);
-          expect(dst.uri).toBe(FS.documentDirectory, 'file.txt');
+          expect(dst.uri).toBe(FS.documentDirectory + 'file.txt');
           expect(dst.exists).toBe(true);
           expect(dst.md5).toBe(src.md5);
         });
@@ -252,8 +252,8 @@ export async function test({ describe, expect, it, ...t }) {
           file.create();
           const destination = new Directory(testDirectory, 'newDestination/');
           file.copy(destination);
-          expect(destination.uri).toBe(testDirectory, 'newDestination/');
-          expect(file.uri).toBe(testDirectory, 'source/');
+          expect(destination.uri).toBe(testDirectory + 'newDestination/');
+          expect(file.uri).toBe(testDirectory + 'source/');
         });
 
         // this should not be allowed by TS, but we can handle it anyways
@@ -332,7 +332,7 @@ export async function test({ describe, expect, it, ...t }) {
           file.create();
           const folder = new Directory(testDirectory, 'newDestination/');
           file.move(folder);
-          expect(file.uri).toBe(testDirectory, 'newDestination/');
+          expect(file.uri).toBe(testDirectory + 'newDestination/');
         });
 
         // this should not be allowed by TS, but we can handle it anyways
@@ -480,7 +480,7 @@ export async function test({ describe, expect, it, ...t }) {
         });
         it('can be easily used with joining paths', () => {
           const file = new File(Paths.document, 'file.txt');
-          expect(file.uri).toBe(FS.documentDirectory, 'file.txt');
+          expect(file.uri).toBe(FS.documentDirectory + 'file.txt');
         });
       });
 


### PR DESCRIPTION
# Why

We want to document correct path joining behavior in tests.

# Test Plan

Test suite should still pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
