### PR TITLE
[tracking-transparency] Support tvOS, remove redundant version check

### DIFF
--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -3,7 +3,7 @@ title: TrackingTransparency
 description: A library for requesting permission to track the users on devices using iOS 14 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-tracking-transparency'
 packageName: 'expo-tracking-transparency'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'tvos']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
@@ -3,7 +3,7 @@ title: TrackingTransparency
 description: A library for requesting permission to track the users on devices using iOS 14 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-tracking-transparency'
 packageName: 'expo-tracking-transparency'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'tvos']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- Add Apple TV support. ([#33157](https://github.com/expo/expo/pull/33157) by [@msynowski](https://github.com/msynowski))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- Add Apple TV support. ([#33157](https://github.com/expo/expo/pull/33157) by [@msynowski](https://github.com/msynowski))
+- Added support for tvOS. ([#33157](https://github.com/expo/expo/pull/33157) by [@msynowski](https://github.com/msynowski))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-tracking-transparency/expo-module.config.json
+++ b/packages/expo-tracking-transparency/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-tracking-transparency",
-  "platforms": ["ios", "android"],
+  "platforms": ["apple", "android"],
   "ios": {
     "modulesClassNames": ["TrackingTransparencyModule"]
   },

--- a/packages/expo-tracking-transparency/ios/ExpoTrackingTransparency.podspec
+++ b/packages/expo-tracking-transparency/ios/ExpoTrackingTransparency.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1',
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
+++ b/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
@@ -9,45 +9,36 @@ public class TrackingTransparencyPermissionRequester: NSObject, EXPermissionsReq
   }
 
   public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: EXPromiseRejectBlock) {
-    if #available(iOS 14, *) {
-      ATTrackingManager.requestTrackingAuthorization() { [weak self] _ in
-        resolve(self?.getPermissions());
-      }
-    } else {
-      resolve(self.getPermissions());
+    ATTrackingManager.requestTrackingAuthorization { [weak self] _ in
+      resolve(self?.getPermissions())
     }
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
     var status: EXPermissionStatus
-    
-    if #available(iOS 14, *) {
-      var systemStatus: ATTrackingManager.AuthorizationStatus
-      
-      let trackingUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSUserTrackingUsageDescription")
-      if trackingUsageDescription == nil {
-        EXFatal(EXErrorWithMessage("""
-        This app is missing 'NSUserTrackingUsageDescription' so tracking transparency will fail. \
-        Ensure that this key exists in app's Info.plist.
-        """))
-        systemStatus = .denied
-      } else {
-        systemStatus = ATTrackingManager.trackingAuthorizationStatus
-      }
 
-      switch systemStatus {
-      case .authorized:
-        status = EXPermissionStatusGranted
-      case .restricted,
-           .denied:
-        status = EXPermissionStatusDenied
-      case .notDetermined:
-        fallthrough
-      @unknown default:
-        status = EXPermissionStatusUndetermined
-      }
+    var systemStatus: ATTrackingManager.AuthorizationStatus
+
+    let trackingUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSUserTrackingUsageDescription")
+    if trackingUsageDescription == nil {
+      EXFatal(EXErrorWithMessage("""
+      This app is missing 'NSUserTrackingUsageDescription' so tracking transparency will fail. \
+      Ensure that this key exists in app's Info.plist.
+      """))
+      systemStatus = .denied
     } else {
+      systemStatus = ATTrackingManager.trackingAuthorizationStatus
+    }
+
+    switch systemStatus {
+    case .authorized:
       status = EXPermissionStatusGranted
+    case .restricted, .denied:
+      status = EXPermissionStatusDenied
+    case .notDetermined:
+      fallthrough
+    @unknown default:
+      status = EXPermissionStatusUndetermined
     }
 
     return [


### PR DESCRIPTION
# Why

Allow applications to use expo-tracking-transparency on tvOS

# How

Added tvOS to the podspec, and removed iOS version check instead of just extending it - it's not required, as Expo apps cannot run on iOS versions without ATT API, since SDK 52

# Test Plan

- Manually test with a test app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
