### PR TITLE
[templates][go] revert bundled react-native-webview to 13.2.2

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -47,7 +47,7 @@ PODS:
     - ExpoModulesTestCore
   - EXNotifications (0.29.8):
     - ExpoModulesCore
-  - Expo (52.0.8):
+  - Expo (52.0.9):
     - ExpoModulesCore
   - expo-dev-client (5.0.3):
     - EXManifests
@@ -525,7 +525,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSpeech (13.0.0):
     - ExpoModulesCore
-  - ExpoSplashScreen (0.29.11):
+  - ExpoSplashScreen (0.29.12):
     - ExpoModulesCore
   - ExpoSQLite (15.0.3):
     - ExpoModulesCore
@@ -548,7 +548,7 @@ PODS:
   - EXTaskManager (12.0.3):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.26.7):
+  - EXUpdates (0.26.8):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -575,7 +575,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXUpdates/Tests (0.26.7):
+  - EXUpdates/Tests (0.26.8):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -2085,7 +2085,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-webview (13.12.4):
+  - react-native-webview (13.12.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3275,7 +3275,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
   EXManifests: f30a0c5d3d6cad8db9c01bab579e0aa0df5d3cb2
   EXNotifications: c5b96ad5fffef5515c9cfc7887ae10f8720c70a5
-  Expo: c3e32beff4379726ad2e94068563fa03ae7109b0
+  Expo: 332ffb9c3dccfc1a228791227efb8b2a7c6b3a4c
   expo-dev-client: 84a7f4a302387b57388d053900b56611b28b65ee
   expo-dev-launcher: c454a423307d527de0f0016cca0aed6773a798ff
   expo-dev-menu: 30ffa4e9e93551c093d40725e81635e86b19c511
@@ -3314,7 +3314,7 @@ SPEC CHECKSUMS:
   ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMaps: 03f99cbb20655c2beb1bffdca0e6de6a0124f69e
   ExpoMediaLibrary: 83f47430d5193186029bc57bae16e2130941bc83
-  ExpoModulesCore: 28ce5c3193da2ff32648d023a282f65131ade10a
+  ExpoModulesCore: 6c76dd70d94c4d3fcb1335a46edcc09a9696dda5
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: 786e4a0f27543c9c70d595d24f59759167da854b
   ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
@@ -3325,7 +3325,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 39a198e64bf522948fe60e270e49a0c7757912c1
   ExpoSMS: 884d6627c0848795ff9492fbfc7ba6087111e344
   ExpoSpeech: 27bb25844919711ebf0e201ce0bef2897d3693c7
-  ExpoSplashScreen: a1c1b3a9648ab738be13fb109c42a85b32e08e5a
+  ExpoSplashScreen: 4802fc92fbe9de97ac6cc2b2237992a3efa6b44c
   ExpoSQLite: 56051549ddac62c16460d4391b84994faf494f00
   ExpoStoreReview: f3439c43f13fa497cfe07d16b095f39101ed5548
   ExpoSymbols: 81d7f433d7a7b20658029eae524a4fa93627159e
@@ -3336,7 +3336,7 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: f08aaf1c8a02af8a768d83793186cb6d2c69f529
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: afcec33a6643f24fed4a89062757037b185c8a88
-  EXUpdates: c459556f991a8b5fc649947fdcb2409a9f38caae
+  EXUpdates: 3559e727da3d66946e922ab5fc7939bb69b17348
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   FBLazyVector: bc70dcb22ad30ce734a7cce7210791dc737e230f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -3388,7 +3388,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-slider: 124ce99f9cd2d04c79f020da6dee9f8d38a6b8c7
   react-native-view-shot: f0b94997decfc338383ba9dc0748985b02934b8c
-  react-native-webview: 0bd56be54d01756f20eb942dad37a2cd22a6def2
+  react-native-webview: 06f91954784dde28e1210f381c791f0c5f9bd9a2
   React-nativeconfig: 470fce6d871c02dc5eff250a362d56391b7f52d6
   React-NativeModulesApple: 6297fc3136c1fd42884795c51d7207de6312b606
   React-perflogger: f2c94413cfad44817c96cab33753831e73f0d0dd
@@ -3431,7 +3431,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: bda51f73f8599e336a778b23e0956130d1e244d5
-  Yoga: c5b0e913b5b3b4cde588227c1402e747797061f3
+  Yoga: 96872ee462cfc43866ad013c8160d4ff6b85709b
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 567bb58fe91a07874d34e36dc2ed989b409d33cd

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -69,7 +69,7 @@
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "4.0.2",
-    "react-native-webview": "13.12.4",
+    "react-native-webview": "13.12.2",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
     - ExpoModulesTestCore
   - EXNotifications (0.29.8):
     - ExpoModulesCore
-  - Expo (52.0.8):
+  - Expo (52.0.9):
     - ExpoModulesCore
   - ExpoAppleAuthentication (7.1.2):
     - ExpoModulesCore
@@ -232,7 +232,7 @@ PODS:
   - EXTaskManager (12.0.3):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.26.7):
+  - EXUpdates (0.26.8):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -259,7 +259,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXUpdates/Tests (0.26.7):
+  - EXUpdates/Tests (0.26.8):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -1843,7 +1843,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-webview (13.12.4):
+  - react-native-webview (13.12.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3011,7 +3011,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
   EXManifests: f30a0c5d3d6cad8db9c01bab579e0aa0df5d3cb2
   EXNotifications: c5b96ad5fffef5515c9cfc7887ae10f8720c70a5
-  Expo: c3e32beff4379726ad2e94068563fa03ae7109b0
+  Expo: 332ffb9c3dccfc1a228791227efb8b2a7c6b3a4c
   ExpoAppleAuthentication: 218e275c9bf19963247a198c450ce3852e6a9342
   ExpoAsset: 8138f2a9ec55ae1ad7c3871448379f7d97692d15
   ExpoBackgroundFetch: a3080ab72736b60441adf5f452919426c62e0533
@@ -3044,7 +3044,7 @@ SPEC CHECKSUMS:
   ExpoLocation: e0c5b5212381b0b800a2c1f715be823d17c51b05
   ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMediaLibrary: 83f47430d5193186029bc57bae16e2130941bc83
-  ExpoModulesCore: 28ce5c3193da2ff32648d023a282f65131ade10a
+  ExpoModulesCore: 6c76dd70d94c4d3fcb1335a46edcc09a9696dda5
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: 786e4a0f27543c9c70d595d24f59759167da854b
   ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
@@ -3065,7 +3065,7 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: f08aaf1c8a02af8a768d83793186cb6d2c69f529
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: afcec33a6643f24fed4a89062757037b185c8a88
-  EXUpdates: 30abdcac4213db71620a683e91ff378c8c88642a
+  EXUpdates: f2bd8e7b0efc6bb8d33a818996de4bcceed8d988
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   FBLazyVector: bc70dcb22ad30ce734a7cce7210791dc737e230f
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
@@ -3075,7 +3075,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: f9205150d6a2d2adc171f8747cd2ea7824c06b7b
+  hermes-engine: a19fb4d0d52b26f250108aee430dc499f143ff11
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3124,7 +3124,7 @@ SPEC CHECKSUMS:
   react-native-skia: 425a5610939828363e0681b8b3e994dd4f18b711
   react-native-slider: 124ce99f9cd2d04c79f020da6dee9f8d38a6b8c7
   react-native-view-shot: f0b94997decfc338383ba9dc0748985b02934b8c
-  react-native-webview: 0bd56be54d01756f20eb942dad37a2cd22a6def2
+  react-native-webview: 06f91954784dde28e1210f381c791f0c5f9bd9a2
   React-nativeconfig: 470fce6d871c02dc5eff250a362d56391b7f52d6
   React-NativeModulesApple: 6297fc3136c1fd42884795c51d7207de6312b606
   React-perflogger: f2c94413cfad44817c96cab33753831e73f0d0dd

--- a/apps/expo-go/modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/apps/expo-go/modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -31,7 +31,7 @@ import java.util.Locale
 
 val invalidCharRegex = "[\\\\/%\"]".toRegex()
 
-class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
+class RNCWebViewManagerImpl {
     companion object {
         const val NAME = "RNCWebView"
     }
@@ -43,7 +43,6 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
     private var mDownloadingMessage: String? = null
     private var mLackPermissionToDownloadMessage: String? = null
     private var mHasOnOpenWindowEvent = false
-    private var mPendingSource: ReadableMap? = null
 
     private var mUserAgent: String? = null
     private var mUserAgentWithApplicationName: String? = null
@@ -269,13 +268,6 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         viewWrapper.webView.setBasicAuthCredential(basicAuthCredential)
     }
 
-    fun onAfterUpdateTransaction(viewWrapper: RNCWebViewWrapper) {
-        mPendingSource?.let { source ->
-            loadSource(viewWrapper, source)
-        }
-        mPendingSource = null
-    }
-
     fun onDropViewInstance(viewWrapper: RNCWebViewWrapper) {
         val webView = viewWrapper.webView
         webView.themedReactContext.removeLifecycleEventListener(webView)
@@ -381,11 +373,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
             ?: DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE
     }
 
-    fun setSource(viewWrapper: RNCWebViewWrapper, source: ReadableMap?) {
-        mPendingSource = source
-    }
-
-    private fun loadSource(viewWrapper: RNCWebViewWrapper, source: ReadableMap?) {
+    fun setSource(viewWrapper: RNCWebViewWrapper, source: ReadableMap?, newArch: Boolean = true) {
         val view = viewWrapper.webView
         if (source != null) {
             if (source.hasKey("html")) {

--- a/apps/expo-go/modules/react-native-webview/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/apps/expo-go/modules/react-native-webview/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -41,7 +41,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     public RNCWebViewManager() {
         mDelegate = new RNCWebViewManagerDelegate<>(this);
-        mRNCWebViewManagerImpl = new RNCWebViewManagerImpl(true);
+        mRNCWebViewManagerImpl = new RNCWebViewManagerImpl();
     }
 
     @Nullable
@@ -310,7 +310,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     @ReactProp(name = "newSource")
     public void setNewSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
-        mRNCWebViewManagerImpl.setSource(view, value);
+        mRNCWebViewManagerImpl.setSource(view, value, true);
     }
 
     @Override
@@ -537,12 +537,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         super.receiveCommand(reactWebView, commandId, args);
-    }
-
-    @Override
-    protected void onAfterUpdateTransaction(@NonNull RNCWebViewWrapper view) {
-        super.onAfterUpdateTransaction(view);
-        mRNCWebViewManagerImpl.onAfterUpdateTransaction(view);
     }
 
     @Override

--- a/apps/expo-go/modules/react-native-webview/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/apps/expo-go/modules/react-native-webview/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -250,7 +250,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
 
     @ReactProp(name = "source")
     public void setSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
-        mRNCWebViewManagerImpl.setSource(view, value);
+        mRNCWebViewManagerImpl.setSource(view, value, false);
     }
 
     @ReactProp(name = "textZoom")
@@ -312,12 +312,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
     public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
-    }
-
-    @Override
-    protected void onAfterUpdateTransaction(@NonNull RNCWebViewWrapper view) {
-        super.onAfterUpdateTransaction(view);
-        mRNCWebViewManagerImpl.onAfterUpdateTransaction(view);
     }
 
     @Override

--- a/apps/expo-go/modules/react-native-webview/apple/RNCWebViewImpl.m
+++ b/apps/expo-go/modules/react-native-webview/apple/RNCWebViewImpl.m
@@ -504,12 +504,9 @@ RCTAutoInsetsProtocol>
   return wkWebViewConfig;
 }
 
-- (void)initializeWebView
+- (void)didMoveToWindow
 {
-  @synchronized (self) {
-    if (_webView != nil) {
-      return;
-    }
+  if (self.window != nil && _webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
     _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     [self setBackgroundColor: _savedBackgroundColor];
@@ -561,23 +558,6 @@ RCTAutoInsetsProtocol>
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
     [self visitSource];
-  }
-}
-
-// react-native-mac os does not support didMoveToSuperView
-#if !TARGET_OS_OSX
-- (void)didMoveToSuperview
-{
-  if (self.superview != nil && _webView == nil) {
-    [self initializeWebView];
-  }
-}
-#endif // !TARGET_OS_OSX
-
-- (void)didMoveToWindow
-{
-  if (self.window != nil && _webView == nil) {
-    [self initializeWebView];
   }
 
 #if !TARGET_OS_OSX

--- a/apps/expo-go/modules/react-native-webview/package.json
+++ b/apps/expo-go/modules/react-native-webview/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "13.12.4",
+  "version": "13.12.2",
   "homepage": "https://github.com/react-native-webview/react-native-webview#readme",
   "scripts": {
     "android": "react-native run-android",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -78,7 +78,7 @@
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "4.0.2",
-    "react-native-webview": "13.12.4",
+    "react-native-webview": "13.12.2",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "redux": "^4.0.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-svg": "15.8.0",
     "react-native-view-shot": "4.0.2",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.4",
+    "react-native-webview": "13.12.2",
     "regl": "^1.3.0",
     "three": "^0.137.4",
     "url": "^0.11.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -29,7 +29,7 @@
     "react-native": "0.76.2",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
-    "react-native-webview": "13.12.4"
+    "react-native-webview": "13.12.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -97,7 +97,7 @@
   "react-native-safe-area-context": "4.12.0",
   "react-native-svg": "15.8.0",
   "react-native-view-shot": "4.0.2",
-  "react-native-webview": "13.12.4",
+  "react-native-webview": "13.12.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.0.0",
   "unimodules-image-loader-interface": "~6.1.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -39,7 +39,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.1.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.4"
+    "react-native-webview": "13.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13815,10 +13815,10 @@ react-native-web@~0.19.13:
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
 
-react-native-webview@13.12.4:
-  version "13.12.4"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.12.4.tgz#1a563a7fbd6bf53d688388d46708f273ed0ebb94"
-  integrity sha512-8lWeYPVWeOj0ya9ZpDesOQPRgczuN3ogQHlhS21sNXndd4kvfPG+WjlRdrvxYgj//udpwmzcWzagwLnEp60Aqg==
+react-native-webview@13.12.2:
+  version "13.12.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.12.2.tgz#b379b28c725632efabb42a2cf8387bd03cf34f33"
+  integrity sha512-OpRcEhf1IEushREax6rrKTeqGrHZ9OmryhZLBLQQU4PwjqVsq55iC8OdYSD61/F628f9rURn9THyxEZjrknpQQ==
   dependencies:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
# Why

react-native-webview 13.2.3 and 13.2.4 has a regression on ios. let's revert the bundled version back to 13.2.2
fixes #33064

# How

- revert react-native-webview to 13.2.2
- [go] `et uvm -m react-native-webview -c v13.12.2`
- update yarn.lock
- update podfile.lock

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
