### PR TITLE
[docs] Clarify behavior of updates pre-packaged workflow job

### DIFF
--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -47,7 +47,7 @@ This job outputs the following variables:
 
 ## Update
 
-This is a pre-packaged job that publishes an update. Equivalent to `eas update --auto`. When run from a Github event, the EAS Update branch name will correspond to the git branch name. When run manually, a random branch name that includes the git branch name will be supplied to avoid unintentionally unintentional deployment of an update.
+This is a pre-packaged job that publishes an update. Equivalent to `eas update --auto`. When run from a GitHub event, the EAS Update branch name will correspond to the git branch name. When run manually, a random branch name that includes the git branch name will be supplied to avoid unintentionally unintentional deployment of an update.
 
 ```yaml .eas/workflows/update.yaml
 jobs:

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -47,7 +47,7 @@ This job outputs the following variables:
 
 ## Update
 
-This is a pre-packaged job that publishes an update:
+This is a pre-packaged job that publishes an update. Equivalent to `eas update --auto`. When run from a Github event, the EAS Update branch name will correspond to the git branch name. When run manually, a random branch name that includes the git branch name will be supplied to avoid unintentionally unintentional deployment of an update.
 
 ```yaml .eas/workflows/update.yaml
 jobs:


### PR DESCRIPTION
# Why

The `update` pre-packaged workflow doesn't accept parameters (yet), so I attempted to clarify how it chooses a branch name.

# How

Updated based on discussion. Maybe a little wordy, but tried to catch both cases, since not all VCS info will be available on a manual run and that will change what the published branch is.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
