### PR TITLE
[router]: Change react-native-screens version to be managed by the SDK

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix typed route using `\` instead of `/` in windows ([#33146](https://github.com/expo/expo/pull/33146) by [@imranbarbhuiya](https://github.com/imranbarbhuiya))
 - Fix hash links causing page reload when there is no history with a starting hash ([#33161](https://github.com/expo/expo/pull/33161) by [@marklawlor](https://github.com/marklawlor))
+- Change `react-native-screens` to have its version managed by the SDK
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix typed route using `\` instead of `/` in windows ([#33146](https://github.com/expo/expo/pull/33146) by [@imranbarbhuiya](https://github.com/imranbarbhuiya))
 - Fix hash links causing page reload when there is no history with a starting hash ([#33161](https://github.com/expo/expo/pull/33161) by [@marklawlor](https://github.com/marklawlor))
-- Change `react-native-screens` to have its version managed by the SDK
+- Change `react-native-screens` to have its version managed by the SDK ([#33167](https://github.com/expo/expo/pull/33167) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -80,7 +80,7 @@
     "expo-linking": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": "*",
-    "react-native-screens": "^4.0.0"
+    "react-native-screens": "*"
   },
   "peerDependenciesMeta": {
     "react-native-reanimated": {


### PR DESCRIPTION
# Why

The version of `react-native-screens` should be kept current with the current SDK version. To enable this, the version needs to be `*`