### PR TITLE
[android][newarch][headless] added test to avoid destroying host

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed issue with RNHeadlessAppLoader destroying the reactHost instance in the new architecture.
+
 ### 💡 Others
 
 ## 2.0.5 — 2024-11-22

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed issue with RNHeadlessAppLoader destroying the reactHost instance in the new architecture.
+- [Android] Fixed issue with RNHeadlessAppLoader destroying the reactHost instance in the new architecture. ([#33176](https://github.com/expo/expo/pull/33176) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -77,7 +77,12 @@ class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) 
         // New architecture
         val reactHost = (reactContext.applicationContext as ReactApplication).reactHost ?: throw IllegalStateException("Your application does not have a valid reactHost")
         android.os.Handler(reactContext.mainLooper).post {
-          reactHost.destroy("Closing headless task app", null)
+          // Only destroy the `ReactInstanceManager` if it does not bind with an Activity.
+          // And The Activity would take over the ownership of `ReactInstanceManager`.
+          // This case happens when a user clicks a background task triggered notification immediately.
+          if (reactHost.lifecycleState == LifecycleState.BEFORE_CREATE) {
+            reactHost.destroy("Closing headless task app", null)
+          }
           HeadlessAppLoaderNotifier.notifyAppDestroyed(appScopeKey)
           appRecords.remove(appScopeKey)
         }


### PR DESCRIPTION
# Why

When the app starts while the `expo-task-manager` has started a Headless JS context (implemented by the `RNHeadlessAppLoader`) to execute a task in the background, there is a bug that is evident on the newArch that would destroy the `reactHost` object when the headless app is invalidated.

The way this could happen is if a task was triggered by some external service causing the headless app to be setup for the task to run. If the user starts the app at the same time the task will eventually finish and then the reactHost will unfortunately be destroyed by the task manager invalidating the context.

# How

This commit fixes this by adding a test similar to the one we use on the old arch to avoid tearing down the `reactHost` if there is an app that has taken over ownership for the object.

# Test Plan

- Can be seen in the new `expo-background-task` when we kill/start the app with a task scheduled to run.
- Can probl. be seen in `expo-notifications` if the app is started by an incoming notification - and we then activate the app as a user.

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
