### PR TITLE
[go][iOS] Handle `initialUrl` passed in the `argv`

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -288,6 +288,11 @@ continueUserActivity:(NSUserActivity *)userActivity
 {
   NSURL *initialUrl;
 
+  // Gets the `initialUrl` from `argv` passed to the process.
+  // If `initialUrl` is found in both the process information and the launch options, we will use the one from the launch options.
+  // However, it doesn't appear to be possible to pass it twice.
+  initialUrl = [self initialUrlFromProcessInfo];
+  
   if (launchOptions) {
     if (launchOptions[UIApplicationLaunchOptionsURLKey]) {
       initialUrl = launchOptions[UIApplicationLaunchOptionsURLKey];
@@ -301,6 +306,26 @@ continueUserActivity:(NSUserActivity *)userActivity
   }
 
   return initialUrl;
+}
+
++ (NSURL *)initialUrlFromProcessInfo
+{
+  NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+  NSArray *arguments = [processInfo arguments];
+  BOOL nextIsUrl = NO;
+  
+  for (NSString *arg in arguments) {
+    if (nextIsUrl) {
+      NSURL *url = [NSURL URLWithString:arg];
+      if (url) {
+        return url;
+      }
+    }
+    if ([arg isEqualToString:@"--initialUrl"]) {
+      nextIsUrl = YES;
+    }
+  }
+  return nil;
 }
 
 @end


### PR DESCRIPTION
# Why

Handles the `initialUrl` argument when passed as a process argument.

In the Radeon IDE, the application is currently opened via a deep link, which presents a significant drawback: there is no way to access the process's stdout. The IDE team would like to launch the application using `xcrun simctl launch` to access process logs and capture native errors. This pull request adds support for an `initialUrl` parameter passed in the `argv`.

# How

Parsed the `argv` when calculating the `initialUrl`. 

# Test Plan

- launch app from icon ✅ 
- launch app using `xcrun simctl launch` ✅
	```
	xcrun simctl launch <device_id> host.exp.Exponent --initialUrl "exp://192.168.0.235:8081"
	```
- launch app using deep link ✅ 
	```
	xcrun simctl openurl booted exp://192.168.0.235:8081
	```