### PR TITLE
[docs] Add redirects for new Environment variables guides

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -425,4 +425,8 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // After deleting deprecated docs from archive section
   '/guides/using-flipper/': '/debugging/devtools-plugins/',
+
+  // After new environment variables guide
+  '/build-reference/variables/': '/eas/environment-variables/',
+  '/eas-update/environment-variables/': '/eas/environment-variables/#eas-update',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -290,6 +290,10 @@ redirects[router/reference/hooks]=versions/latest/sdk/router
 # After moving custom tabs under Expo Router > Navigation patterns
 redirects[router/ui/tabs]=router/advanced/custom-tabs
 
+# After new environment variables guide
+redirects[build-reference/variables]=eas/environment-variables
+redirects[eas-update/environment-variables]=eas/environment-variables
+
 echo "::group::[5/5] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add missing redirects for new Environment variables guides


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
