### PR TITLE
[docs] fix DotGrid color, improve Diagram 'auto' theme handling

### DIFF
--- a/docs/ui/components/Diagram/Diagram.tsx
+++ b/docs/ui/components/Diagram/Diagram.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@expo/styleguide';
+import { useEffect, useState } from 'react';
 
 import { DotGrid } from './DotGrid';
 
@@ -11,7 +12,15 @@ type Props = {
 
 export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
   const { themeName } = useTheme();
-  const isDark = themeName === 'dark';
+  const [isDark, setDark] = useState(themeName === 'dark');
+
+  useEffect(() => {
+    if (themeName === 'auto') {
+      setDark(window.matchMedia('(prefers-color-scheme: dark)').matches);
+    } else {
+      setDark(themeName === 'dark');
+    }
+  }, [themeName]);
 
   if (!source.match(/\.png$/)) {
     return (

--- a/docs/ui/components/Diagram/DotGrid.tsx
+++ b/docs/ui/components/Diagram/DotGrid.tsx
@@ -6,7 +6,7 @@ export function DotGrid() {
       <svg width="100%" height="100%">
         <defs>
           <pattern id="dot-grid" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
-            <circle fill="var(--slate4)" cx="1" cy="1" r="1" />
+            <circle fill="var(--slate-4)" cx="1" cy="1" r="1" />
           </pattern>
         </defs>
         <rect x="0" y="0" width="100%" height="100%" fill="url(#dot-grid)" />


### PR DESCRIPTION
# Why

Fixes 
* https://github.com/expo/expo/issues/33193

# How

Correct renamed CSS variable, improve `auto` theme handling in diagram component.

# Test Plan

The changes have been reviewe dby running docs app locally.

# Preview


https://github.com/user-attachments/assets/17afbdce-5446-4f5f-aeec-f68a7c79bd23

