### PR TITLE
Update audio.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -109,7 +109,7 @@ import { View, StyleSheet, Button } from 'react-native';
 import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
 
 export default function App() {
-  const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY;);
+  const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
 
   const record = () => audioRecorder.record();
 

--- a/docs/pages/versions/v52.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio.mdx
@@ -110,7 +110,7 @@ import { View, StyleSheet, Button } from 'react-native';
 import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
 
 export default function App() {
-  const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY;);
+  const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
 
   const record = () => audioRecorder.record();
 


### PR DESCRIPTION
# Why

Syntax error in docs

# How

Removed semi-colon in the wrong place of the code syntax

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
