### PR TITLE
[docs] Update multiple API reference links to use sdk/latest instead of v52.0.0

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -20,7 +20,7 @@ A splash screen and an app icon are fundamental elements of a mobile app. They p
 
 ## Splash screen
 
-> **warning** This section uses the `splash` property from the app config. **Starting SDK 52**, using `expo-splash-screen` config plugin is recommended because using a full screen splash image on Android 12+ will not work so the following information for Android is outdated. See [`expo-splash-screen` reference](/versions/v52.0.0/sdk/splash-screen/#configuration) on how to use the config plugin and for up-to-date information.
+> **warning** This section uses the `splash` property from the app config. **Starting SDK 52**, using `expo-splash-screen` config plugin is recommended because using a full screen splash image on Android 12+ will not work so the following information for Android is outdated. See [`expo-splash-screen` reference](/versions/latest/sdk/splash-screen/#configuration) on how to use the config plugin and for up-to-date information.
 
 A splash screen, also known as a launch screen, is the first screen a user sees when they open your app. It stays visible while the app is loading. You can also control the behavior of when a splash screen disappears by using the native [SplashScreen API](/versions/latest/sdk/splash-screen).
 

--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -24,7 +24,7 @@ Expo Router will always evaluate a URL with the assumption that the URL targets 
 
 In such scenarios, the URL needs to be rewritten to correctly target a route.
 
-To facilitate this, create a special file called **+native-intent.tsx** at the top level of your project's **app** directory. This file exports a special [`redirectSystemPath`](/versions/v52.0.0/sdk/router/#nativeintent) method designed to handle URL/path processing. When invoked, it receives an `options` object with two attributes: `path` and `initial`.
+To facilitate this, create a special file called **+native-intent.tsx** at the top level of your project's **app** directory. This file exports a special [`redirectSystemPath`](/versions/latest/sdk/router/#nativeintent) method designed to handle URL/path processing. When invoked, it receives an `options` object with two attributes: `path` and `initial`.
 
 <FileTree files={['app/+native-intent.tsx']} />
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
 
 To configure a route's option dynamically, you can always use the `<Stack.Screen>` component in that route's file.
 
-As an alternative, you can also use the [imperative API's `router.setParams()`](/versions/v52.0.0/sdk/router/#router) function to configure the route dynamically.
+As an alternative, you can also use the [imperative API's `router.setParams()`](/versions/latest/sdk/router/#router) function to configure the route dynamically.
 
 ```tsx app/details.tsx
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';

--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -34,7 +34,7 @@ Expo Router enables fine-tuned error handling to enable a more opinionated data-
   className="max-w-[720px]"
 />
 
-You can export a nested [`ErrorBoundary`](/versions/v52.0.0/sdk/router/#errorboundary) component from any route to intercept and format component-level errors using [React Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary):
+You can export a nested [`ErrorBoundary`](/versions/latest/sdk/router/#errorboundary) component from any route to intercept and format component-level errors using [React Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary):
 
 {/* prettier-ignore */}
 ```tsx app/home.tsx
@@ -67,7 +67,7 @@ function Route({ ErrorBoundary, Component }) {
 }
 ```
 
-When `ErrorBoundary` is not present, the error will be thrown to the nearest parent's `ErrorBoundary` and accepts [`error`](/versions/v52.0.0/sdk/router/#error) and [`retry`](/versions/v52.0.0/sdk/router/#retry) props.
+When `ErrorBoundary` is not present, the error will be thrown to the nearest parent's `ErrorBoundary` and accepts [`error`](/versions/latest/sdk/router/#error) and [`retry`](/versions/latest/sdk/router/#retry) props.
 
 ### Work in progress
 

--- a/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/latest/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/v52.0.0/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/v52.0.0/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/latest/sdk/audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14110

Follow up https://github.com/expo/expo/pull/32588

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating SDK 52 specific API reference links in multiple docs to `/latest`, which also currently directs to SDK 52 docs as well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
