### PR TITLE
[docs] Migrate Tailwind CSS instructions into a guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -177,6 +177,7 @@ const general = [
         makePage('distribution/publishing-websites.mdx'),
         makePage('guides/dom-components.mdx'),
         makePage('guides/progressive-web-apps.mdx'),
+        makePage('guides/tailwind.mdx'),
       ],
       { expanded: false }
     ),

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -7,7 +7,7 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **info** Standard Tailwind CSS supports only web platform and not Android and iOS. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
+> **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 
 [Tailwind CSS](https://tailwindcss.com/) is a utility-first CSS framework and can be used with Metro for web projects. This guide explains how to configure your Expo project to use the framework.
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -1,0 +1,193 @@
+---
+title: Tailwind CSS
+description: Learn how to configure and use Tailwind CSS in your Expo project.
+---
+
+import { FileTree } from '~/ui/components/FileTree';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+> **info** Standard Tailwind CSS supports only web platform and not Android and iOS. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
+
+[Tailwind CSS](https://tailwindcss.com/) is a utility-first CSS framework and can be used with Metro for web projects. This guide explains how to configure your Expo project to use the framework.
+
+## Prerequisites
+
+The following files will be modified to set the Tailwind CSS configuration:
+
+<FileTree files={['app.json', 'package.json', 'global.css', 'tailwind.config.js', 'index.js']} />
+
+Ensure that your project is using Metro for web. You can verify this by checking the `web.bundler` field which is set to `metro` in the **app.json** file.
+
+```json app.json
+{
+  "expo": {
+    "web": {
+      /* @info The <CODE>bundler</CODE> must be set to <CODE>metro</CODE>. */
+      "bundler": "metro"
+      /* @end */
+    }
+  }
+}
+```
+
+## Configuration
+
+Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS documentation](https://tailwindcss.com/docs/installation/using-postcss).]
+
+<Step label="1">
+
+Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
+
+<Terminal
+  cmd={[
+    '# Install Tailwind and its peer dependencies',
+    '$ npx expo add tailwindcss postcss autoprefixer -- --dev',
+    '',
+    '# Create a Tailwind config file',
+    '$ npx tailwindcss init -p',
+  ]}
+/>
+
+</Step>
+
+<Step label="2">
+
+Add paths to all of your template files inside **tailwind.config.js**.
+
+```js tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    // Ensure this points to your source code...
+    './app/**/*.{js,tsx,ts,jsx}',
+    // If you use a `src` folder, add: './src/**/*.{js,tsx,ts,jsx}'
+    // Do the same with `components`, `hooks`, `styles`, or any other top-level folders...
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+> If you are using Expo Router, consider using a root **src** directory to simplify this step. Learn more about [top-level src directory](/router/reference/src-directory/).
+
+</Step>
+
+<Step label="3">
+
+Create a **global.css** file in the root of your project and directives for each of Tailwind's layers:
+
+```css global.css
+/* This file adds the requisite utility classes for Tailwind to work. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+</Step>
+
+<Step label="4">
+
+Import the **global.css** file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+
+```tsx
+// If your project uses Expo Router, import the global.css file in the top level_layout.tsx file:
+import '../global.css';
+
+// Otherwise, import the global.css file in the index.js file:
+import './global.css';
+```
+
+> **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
+
+</Step>
+
+<Step label="5">
+
+You now start your project and use Tailwind CSS classes in your components.
+
+<Terminal cmd={['$ npx expo start']} />
+
+</Step>
+
+## Usage
+
+You can use Tailwind with React DOM elements as is:
+
+{/* prettier-ignore */}
+```tsx app/index.tsx
+export default function Index() {
+  return (
+    <div className="bg-slate-100 rounded-xl">
+      <p className="text-lg font-medium">Welcome to Tailwind</p>
+    </div>
+  );
+}
+```
+
+You can use the `{ $$css: true }` syntax to use Tailwind with React Native web elements:
+
+```tsx app/index.tsx
+import { View, Text } from 'react-native';
+
+export default function Index() {
+  return (
+    <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
+      <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
+    </View>
+  );
+}
+```
+
+## Tailwind for Android and iOS
+
+Tailwind does not support Android and iOS platforms. You can use a compatibility library such as [NativeWind](https://www.nativewind.dev/) for universal support.
+
+## Alternative for Android and iOS
+
+Alternatively, you can use [DOM components](/guides/dom-components) to render your Tailwind web code in a `WebView` on native.
+
+{/* prettier-ignore */}
+```tsx app/index.tsx
+'use dom';
+
+// Remember to import the global.css file in each DOM component.
+import '../global.css';
+
+export default function Page() {
+  return (
+    <div className="bg-slate-100 rounded-xl">
+      <p className="text-lg font-medium">Welcome to Tailwind</p>
+    </div>
+  );
+}
+```
+
+## Troubleshooting
+
+If you have a custom `config.cacheStores` in your **metro.config.js**, you need to extend the Expo superclass of `FileStore`:
+
+```js metro.config.js
+// Import the Expo superclass which has support for PostCSS.
+const { FileStore } = require('@expo/metro-config/file-store');
+
+config.cacheStores = [
+  new FileStore({
+    root: '/path/to/custom/cache',
+  }),
+];
+
+module.exports = config;
+```
+
+Ensure you don't have CSS disabled in your **metro.config.js**:
+
+```js metro.config.js
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname, {
+  // Do not disable CSS support when using Tailwind.
+  isCSSEnabled: true,
+});
+```

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -114,7 +114,7 @@ You now start your project and use Tailwind CSS classes in your components.
 
 ## Usage
 
-You can use Tailwind with React DOM elements as is:
+You can use Tailwind with React DOM elements as-is:
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -39,6 +39,8 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 
 Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
 
+{/* <!-- vale off --> */}
+
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
@@ -48,6 +50,8 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
     '$ npx tailwindcss init -p',
   ]}
 />
+
+{/* <!-- vale on --> */}
 
 </Step>
 
@@ -59,10 +63,10 @@ Add paths to all of your template files inside **tailwind.config.js**.
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    // Ensure this points to your source code...
+    // Ensure this points to your source code
     './app/**/*.{js,tsx,ts,jsx}',
-    // If you use a `src` folder, add: './src/**/*.{js,tsx,ts,jsx}'
-    // Do the same with `components`, `hooks`, `styles`, or any other top-level folders...
+    // If you use a `src` directory, add: './src/**/*.{js,tsx,ts,jsx}'
+    // Do the same with `components`, `hooks`, `styles`, or any other top-level directories
   ],
   theme: {
     extend: {},

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -3,9 +3,11 @@ title: metro.config.js
 description: A reference of available configurations in Metro.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
@@ -220,166 +222,14 @@ Then, ensure [CSS is setup](#css) in the **metro.config.js** file.
 
 ### Tailwind
 
-> **info** Standard Tailwind does not support native platforms. This is web-only. For universal support, use a compatible library like [Nativewind](https://www.nativewind.dev/).
+> **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 
-[Tailwind](https://tailwindcss.com/) can be used with Metro for web. The following files are required to be modified to set it up:
-
-<FileTree files={['app.json', 'package.json', 'global.css', 'tailwind.config.js', 'index.js']} />
-
-First, ensure you are using Metro for web in your **app.json**:
-
-```json app.json
-{
-  "expo": {
-    "web": {
-      "bundler": "metro"
-    }
-  }
-}
-```
-
-Then, configure Tailwind according to the [Tailwind PostCSS docs](https://tailwindcss.com/docs/installation/using-postcss).
-
-<Step label="1">
-
-Install `tailwindcss` and its peer dependencies, and create a **tailwind.config.js** file:
-
-<Terminal
-  cmd={['$ npx expo add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init -p']}
+<BoxLink
+  title="Tailwind CSS"
+  description="Learn how to configure and use Tailwind CSS in your Expo project."
+  href="/guides/tailwind/"
+  Icon={BookOpen02Icon}
 />
-
-</Step>
-
-<Step label="2">
-
-Add the paths to all of your template files in your **tailwind.config.js** file:
-
-```js tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    // Ensure this points to your source code...
-    './app/**/*.{js,tsx,ts,jsx}',
-    // If you use a `src` folder, add: './src/**/*.{js,tsx,ts,jsx}'
-    // Do the same with `components`, `hooks`, `styles`, or any other top-level folders...
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-```
-
-> Consider using a root `/src` directory to simplify this step. Learn more in [`src` directory](/router/reference/src-directory).
-
-</Step>
-
-<Step label="3">
-
-Create **global.css** in your project and add directives for each of Tailwind's layers:
-
-```css global.css
-/* This file adds the requisite utility classes for Tailwind to work. */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-Ensure you import this file in your root-most JavaScript file:
-
-```js index.js
-import './global.css';
-```
-
-If you're using [DOM Components](/guides/dom-components), ensure you import this file in each module marked with `"use dom"` as they don't share globals.
-
-> When using Expo Router, you can use **./index.js** or **./app/\_layout.js**. They both work the same.
-
-</Step>
-
-<Step label="4">
-
-Start your project:
-
-<Terminal cmd={['$ npx expo']} />
-
-</Step>
-
-#### Tailwind usage
-
-You can use Tailwind with React DOM elements as-is:
-
-```jsx
-export default function Page() {
-  return (
-    <div className="bg-slate-100 rounded-xl">
-      <p className="text-lg font-medium">Welcome to Tailwind</p>
-    </div>
-  );
-}
-```
-
-You can use the `{ $$css: true }` syntax to use Tailwind with React Native web elements:
-
-```jsx
-import { View, Text } from 'react-native';
-
-export default function Page() {
-  return (
-    <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
-      <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
-    </View>
-  );
-}
-```
-
-#### Tailwind for native
-
-Tailwind does not support native platforms directly but you can use the compatibility library [nativewind](https://www.nativewind.dev/) for universal support.
-
-Alternatively, you can use [DOM Components](/guides/dom-components) to render your Tailwind web code in a WebView on native.
-
-```tsx app/index.tsx
-'use dom';
-
-// Remember to import the global.css file in each DOM component.
-import '../global.css';
-
-export default function Page() {
-  return (
-    <div className="bg-slate-100 rounded-xl">
-      <p className="text-lg font-medium">Welcome to Tailwind</p>
-    </div>
-  );
-}
-```
-
-#### Tailwind troubleshooting
-
-If you have a custom `config.cacheStores` in your **metro.config.js**, you need to extend the Expo superclass of `FileStore`:
-
-```js metro.config.js
-// Import the Expo superclass which has support for PostCSS.
-const { FileStore } = require('@expo/metro-config/file-store');
-
-config.cacheStores = [
-  new FileStore({
-    root: '/path/to/custom/cache',
-  }),
-];
-
-module.exports = config;
-```
-
-Ensure you don't have CSS disabled in your **metro.config.js**:
-
-```js metro.config.js
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  // Do not disable CSS support when using Tailwind.
-  isCSSEnabled: true,
-});
-```
 
 ## Extending the Babel transformer
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -3,9 +3,11 @@ title: metro.config.js
 description: A reference of available configurations in Metro.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
@@ -220,156 +222,14 @@ Then, ensure [CSS is setup](#css) in the **metro.config.js** file.
 
 ### Tailwind
 
-> **info** Standard Tailwind does not support native platforms. This is web-only. For universal support, use a compatible library like [Nativewind](https://www.nativewind.dev/).
+> **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 
-[Tailwind](https://tailwindcss.com/) can be used with Metro for web. The following files are required to be modified to set it up:
-
-<FileTree files={['app.json', 'package.json', 'global.css', 'tailwind.config.js', 'index.js']} />
-
-First, ensure you are using Metro for web in your **app.json**:
-
-```json app.json
-{
-  "expo": {
-    "web": {
-      "bundler": "metro"
-    }
-  }
-}
-```
-
-Then, configure Tailwind according to the [Tailwind PostCSS docs](https://tailwindcss.com/docs/installation/using-postcss).
-
-<Step label="1">
-
-Install `tailwindcss` and its peer dependencies, and create a **tailwind.config.js** file:
-
-<Terminal cmd={['$ yarn add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init']} />
-
-</Step>
-
-<Step label="2">
-
-Add `tailwindcss` and `autoprefixer` to your **postcss.config.js** file:
-
-```js postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-```
-
-</Step>
-
-<Step label="3">
-
-Add the paths to all of your template files in your **tailwind.config.js** file:
-
-```js tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    // Ensure this points to your source code...
-    './app/**/*.{js,tsx,ts,jsx}',
-    // If you use a `src` folder, add: './src/**/*.{js,tsx,ts,jsx}'
-    // Do the same with `components`, `hooks`, `styles`, or any other top-level folders...
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-```
-
-> Consider using a root `/src` directory to simplify this step. Learn more in [`src` directory](/router/reference/src-directory).
-
-</Step>
-
-<Step label="4">
-
-Create **global.css** in your project and add directives for each of Tailwind's layers:
-
-```css global.css
-/* This file adds the requisite utility classes for Tailwind to work. */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-Ensure you import this file in your root-most JavaScript file:
-
-```js index.js
-import './global.css';
-```
-
-> When using Expo Router, you can use **./index.js** or **./app/\_layout.js**. They both work the same.
-
-</Step>
-
-<Step label="5">
-
-Start your project by clearing the transform cache for good measure:
-
-<Terminal cmd={['$ npx expo --clear']} />
-
-</Step>
-
-#### Tailwind usage
-
-You can use Tailwind with React DOM elements as-is:
-
-```jsx
-export default function Page() {
-  return (
-    <div className="bg-slate-100 rounded-xl">
-      <p className="text-lg font-medium">Welcome to Tailwind</p>
-    </div>
-  );
-}
-```
-
-You can use the `{ $$css: true }` syntax to use Tailwind with React Native web elements:
-
-```jsx
-import { View, Text } from 'react-native';
-
-export default function Page() {
-  return (
-    <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
-      <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
-    </View>
-  );
-}
-```
-
-#### Tailwind troubleshooting
-
-If you have a custom `config.cacheStores` in your **metro.config.js**, you need to extend the Expo superclass of `FileStore`:
-
-```js metro.config.js
-// Import the Expo superclass which has support for PostCSS.
-const { FileStore } = require('@expo/metro-config/file-store');
-
-config.cacheStores = [
-  new FileStore({
-    root: '/path/to/custom/cache',
-  }),
-];
-
-module.exports = config;
-```
-
-Ensure you don't have CSS disabled in your **metro.config.js**:
-
-```js metro.config.js
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  // Do not disable CSS support when using Tailwind.
-  isCSSEnabled: true,
-});
-```
+<BoxLink
+  title="Tailwind CSS"
+  description="Learn how to configure and use Tailwind CSS in your Expo project."
+  href="/guides/tailwind/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Extending the Babel transformer
 

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -3,9 +3,11 @@ title: metro.config.js
 description: A reference of available configurations in Metro.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
@@ -220,166 +222,14 @@ Then, ensure [CSS is setup](#css) in the **metro.config.js** file.
 
 ### Tailwind
 
-> **info** Standard Tailwind does not support native platforms. This is web-only. For universal support, use a compatible library like [Nativewind](https://www.nativewind.dev/).
+> **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 
-[Tailwind](https://tailwindcss.com/) can be used with Metro for web. The following files are required to be modified to set it up:
-
-<FileTree files={['app.json', 'package.json', 'global.css', 'tailwind.config.js', 'index.js']} />
-
-First, ensure you are using Metro for web in your **app.json**:
-
-```json app.json
-{
-  "expo": {
-    "web": {
-      "bundler": "metro"
-    }
-  }
-}
-```
-
-Then, configure Tailwind according to the [Tailwind PostCSS docs](https://tailwindcss.com/docs/installation/using-postcss).
-
-<Step label="1">
-
-Install `tailwindcss` and its peer dependencies, and create a **tailwind.config.js** file:
-
-<Terminal
-  cmd={['$ npx expo add --dev tailwindcss postcss autoprefixer', '$ npx tailwindcss init -p']}
+<BoxLink
+  title="Tailwind CSS"
+  description="Learn how to configure and use Tailwind CSS in your Expo project."
+  href="/guides/tailwind/"
+  Icon={BookOpen02Icon}
 />
-
-</Step>
-
-<Step label="2">
-
-Add the paths to all of your template files in your **tailwind.config.js** file:
-
-```js tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    // Ensure this points to your source code...
-    './app/**/*.{js,tsx,ts,jsx}',
-    // If you use a `src` folder, add: './src/**/*.{js,tsx,ts,jsx}'
-    // Do the same with `components`, `hooks`, `styles`, or any other top-level folders...
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-```
-
-> Consider using a root `/src` directory to simplify this step. Learn more in [`src` directory](/router/reference/src-directory).
-
-</Step>
-
-<Step label="3">
-
-Create **global.css** in your project and add directives for each of Tailwind's layers:
-
-```css global.css
-/* This file adds the requisite utility classes for Tailwind to work. */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-Ensure you import this file in your root-most JavaScript file:
-
-```js index.js
-import './global.css';
-```
-
-If you're using [DOM Components](/guides/dom-components), ensure you import this file in each module marked with `"use dom"` as they don't share globals.
-
-> When using Expo Router, you can use **./index.js** or **./app/\_layout.js**. They both work the same.
-
-</Step>
-
-<Step label="4">
-
-Start your project:
-
-<Terminal cmd={['$ npx expo']} />
-
-</Step>
-
-#### Tailwind usage
-
-You can use Tailwind with React DOM elements as-is:
-
-```jsx
-export default function Page() {
-  return (
-    <div className="bg-slate-100 rounded-xl">
-      <p className="text-lg font-medium">Welcome to Tailwind</p>
-    </div>
-  );
-}
-```
-
-You can use the `{ $$css: true }` syntax to use Tailwind with React Native web elements:
-
-```jsx
-import { View, Text } from 'react-native';
-
-export default function Page() {
-  return (
-    <View style={{ $$css: true, _: 'bg-slate-100 rounded-xl' }}>
-      <Text style={{ $$css: true, _: 'text-lg font-medium' }}>Welcome to Tailwind</Text>
-    </View>
-  );
-}
-```
-
-#### Tailwind for native
-
-Tailwind does not support native platforms directly but you can use the compatibility library [nativewind](https://www.nativewind.dev/) for universal support.
-
-Alternatively, you can use [DOM Components](/guides/dom-components) to render your Tailwind web code in a WebView on native.
-
-```tsx app/index.tsx
-'use dom';
-
-// Remember to import the global.css file in each DOM component.
-import '../global.css';
-
-export default function Page() {
-  return (
-    <div className="bg-slate-100 rounded-xl">
-      <p className="text-lg font-medium">Welcome to Tailwind</p>
-    </div>
-  );
-}
-```
-
-#### Tailwind troubleshooting
-
-If you have a custom `config.cacheStores` in your **metro.config.js**, you need to extend the Expo superclass of `FileStore`:
-
-```js metro.config.js
-// Import the Expo superclass which has support for PostCSS.
-const { FileStore } = require('@expo/metro-config/file-store');
-
-config.cacheStores = [
-  new FileStore({
-    root: '/path/to/custom/cache',
-  }),
-];
-
-module.exports = config;
-```
-
-Ensure you don't have CSS disabled in your **metro.config.js**:
-
-```js metro.config.js
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  // Do not disable CSS support when using Tailwind.
-  isCSSEnabled: true,
-});
-```
 
 ## Extending the Babel transformer
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @EvanBacon.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Migrate Tailwind CSS instructions from metro reference to a guide under Web section
- Fix command to install `tailwindcss` and its peer dependencies
- Improve verbiage
- Backlink this new guide to metro config reference (unversioned, SDK 52, SDK 51)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: /guides/tailwind/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).