### PR TITLE
[expo-media-library] Fixed issue saving videos

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed an issue where videos were unsupported. ([#33186](https://github.com/expo/expo/pull/33226) by [@nathan-ahn](https://github.com/nathan-ahn))
+
 ### 💡 Others
 
 ## 17.0.3 — 2024-11-22

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -261,25 +261,23 @@ func createAlbum(with title: String, completion: @escaping (PHAssetCollection?, 
 }
 
 func assetType(for localUri: URL) -> PHAssetMediaType {
-  guard let type = UTType(filenameExtension: localUri.pathExtension) else {
+  let fileUTI = UTType(filenameExtension: localUri.pathExtension)?.identifier as CFString?
+
+  guard let fileUTI else {
     return assetTypeExtension(for: localUri.pathExtension)
   }
-  switch type {
-  case .image:
+
+  if UTTypeConformsTo(fileUTI, kUTTypeImage) {
     return .image
-  case .video:
-    return .video
-  case .audio:
-    return .audio
-  case _ where type.conforms(to: .image):
-    return .image
-  case _ where type.conforms(to: .video):
-    return .video
-  case _ where type.conforms(to: .audio):
-    return .audio
-  default:
-    return .unknown
   }
+  if UTTypeConformsTo(fileUTI, kUTTypeMovie) {
+    return .video
+  }
+  if UTTypeConformsTo(fileUTI, kUTTypeAudio) {
+    return .audio
+  }
+
+  return .unknown
 }
 
 func assetTypeExtension(for fileExtension: String) -> PHAssetMediaType {


### PR DESCRIPTION
# Why

`v17.0.0` introduced a regression in our production app causing videos to no longer be saveable. I believe the regression was introduced in 680fdd5.

# How

I reverted `assetType` to its implementation before 680fdd5. I cleaned up the availability conditionals which are no longer necessary with iOS 15.1 support and made some basic changes to clean up variable declarations. The implementation is the same as before 680fdd5 for iOS 15.1.

# Test Plan

Implemented the PR as a patch into our app. Videos now download properly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
