### PR TITLE
[docs] Fix code annotation styles

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -70,7 +70,7 @@ div:not(#root) > ::-webkit-scrollbar-track {
 }
 
 div:not(#root) > ::-webkit-scrollbar-thumb {
-  @apply bg-palette-gray5 rounded-sm;
+  @apply rounded-sm bg-palette-gray5;
 }
 
 div:not(#root) > ::-webkit-scrollbar-thumb:hover {
@@ -123,7 +123,7 @@ div.tippy-box {
 }
 
 .tippy-box[data-theme~='expo'] .tippy-content {
-  @apply text-sm text-palette-white bg-palette-black rounded-md py-3 px-4;
+  @apply rounded-md bg-palette-black px-4 py-3 text-sm text-palette-white;
   line-height: 1.525;
 }
 
@@ -143,7 +143,8 @@ div.tippy-box {
   white-space: pre-wrap;
   width: 100%;
 
-  td, th {
+  td,
+  th {
     border-bottom: none;
   }
 }
@@ -161,11 +162,11 @@ div.tippy-box {
 }
 
 .diff-gutter-col {
-  @apply bg-element w-10;
+  @apply w-10 bg-element;
 }
 
 .diff-gutter {
-  @apply text-3xs px-2;
+  @apply px-2 text-3xs;
   text-align: right;
   user-select: none;
 }
@@ -201,10 +202,10 @@ div.tippy-box {
   transition: 200ms ease all;
   transition-property: text-shadow, opacity;
   text-shadow:
-    var(--yellow-7) 0 0 10px,
-    var(--yellow-7) 0 0 10px,
-    var(--yellow-7) 0 0 10px,
-    var(--yellow-7) 0 0 10px;
+    var(--amber-6) 0 0 10px,
+    var(--amber-6) 0 0 10px,
+    var(--amber-6) 0 0 10px,
+    var(--amber-6) 0 0 10px;
 }
 
 .code-annotation.with-tooltip:hover {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Yellow code annotation shadow is broken after bumping styleguide packages.

![CleanShot 2024-11-25 at 12 25 10@2x](https://github.com/user-attachments/assets/e9819497-e133-4880-8992-7aa0aefe8081)

Follow-up #33094

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change `yellow-7` to `amber-6` variable under `.code-annotation` class in global.css file.
Rest of the changes are applied by Docs Prettier config.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally and open any page that uses generic code annotation (with `@info`).

![CleanShot 2024-11-25 at 12 24 21@2x](https://github.com/user-attachments/assets/800b0151-41f8-418c-8ef5-6f6dfde47059)

- Run `yarn run test`.

![CleanShot 2024-11-25 at 12 28 07@2x](https://github.com/user-attachments/assets/f96d058d-1561-43e0-a980-2bd4d8ccb52e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
