### PR TITLE
[docs] Update blurhash encoding to use Uint8ClampedArray for consistency

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -133,7 +133,13 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
+  const blurhash = encode(
+    new Uint8ClampedArray(data),
+    info.width,
+    info.height,
+    componentX,
+    componentY
+  );
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -133,7 +133,7 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(data, info.width, info.height, componentX, componentY);
+  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v50.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/image.mdx
@@ -135,7 +135,7 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(data, info.width, info.height, componentX, componentY);
+  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v50.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/image.mdx
@@ -135,7 +135,13 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
+  const blurhash = encode(
+    new Uint8ClampedArray(data),
+    info.width,
+    info.height,
+    componentX,
+    componentY
+  );
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v51.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/image.mdx
@@ -133,7 +133,13 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
+  const blurhash = encode(
+    new Uint8ClampedArray(data),
+    info.width,
+    info.height,
+    componentX,
+    componentY
+  );
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v51.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/image.mdx
@@ -133,7 +133,7 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(data, info.width, info.height, componentX, componentY);
+  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v52.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/image.mdx
@@ -133,7 +133,13 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
+  const blurhash = encode(
+    new Uint8ClampedArray(data),
+    info.width,
+    info.height,
+    componentX,
+    componentY
+  );
   res.json({ blurhash });
 });
 ```

--- a/docs/pages/versions/v52.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/image.mdx
@@ -133,7 +133,7 @@ app.post('/blurhash', upload.single('image'), async (req, res) => {
     resolveWithObject: true,
   });
 
-  const blurhash = encode(data, info.width, info.height, componentX, componentY);
+  const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);
   res.json({ blurhash });
 });
 ```


### PR DESCRIPTION
# Why
The data type is Buffer, but the type required by encode is Uint8ClampedArray

# How
Update blurhash encoding to use Uint8ClampedArray for consistency

```
 const { data, info } = await sharp(file.buffer).ensureAlpha().raw().toBuffer({
    resolveWithObject: true,
  });
 const blurhash = encode(new Uint8ClampedArray(data), info.width, info.height, componentX, componentY);

```


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
![image](https://github.com/user-attachments/assets/4f2264b2-4afb-42e6-9ce0-632fde2a1738)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


