### PR TITLE
[cli] Fix error after consecutive `run:ios` commands

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix a build error when running `expo run:ios` consecutively without closing the app.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix a build error when running `expo run:ios` consecutively without closing the app.
+- Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -75,8 +75,8 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     try {
       await simctlAsync(['terminate', props.device.udid, launchInfo.bundleId]);
     } catch (error) {
-      // If we failed the app was not running to begin with and we will get an `invalid device` error
-      debug('Failed to terminate app:', error);
+      // If we failed it's likely that the app was not running to begin with and we will get an `invalid device` error
+      debug('Failed to terminate app (possibly because it was not running):', error);
     }
   }
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -15,6 +15,7 @@ import { getLaunchInfoForBinaryAsync, launchAppAsync } from './launchApp';
 import { resolveOptionsAsync } from './options/resolveOptions';
 import { getValidBinaryPathAsync } from './validateExternalBinary';
 import { exportEagerAsync } from '../../export/embed/exportEager';
+import { simctlAsync } from '../../start/platforms/ios/simctl';
 
 const debug = require('debug')('expo:run:ios');
 
@@ -68,6 +69,16 @@ export async function runIosAsync(projectRoot: string, options: Options) {
 
   const launchInfo = await getLaunchInfoForBinaryAsync(binaryPath);
   const isCustomBinary = !!options.binary;
+
+  // Always close the app before launching on a simulator. Otherwise certain cached resources like the splashscreen will not be available.
+  if (props.isSimulator) {
+    try {
+      await simctlAsync(['terminate', props.device.udid, launchInfo.bundleId]);
+    } catch (error) {
+      // If we failed the app was not running to begin with and we will get an `invalid device` error
+      debug('Failed to terminate app:', error);
+    }
+  }
 
   // Start the dev server which creates all of the required info for
   // launching the app on a simulator.


### PR DESCRIPTION
# Why
Closes #33227
When `expo run:ios` is run consecutively on a simulator without closing the app, the app will crash because of missing resources such as the storyboard. 

# How
If we are running on a simulator, we will attempt to close the app if it is currently running. If it's not, we will proceed as normal. This also seems to align with the behaviour you would see when running the app from Xcode. The app is always shut down and then launched. Currently, we don't do that, leading to an error. 

# Test Plan
Running `expo run:ios` locally. The app launches successively regardless of whether it is running or not.
