### PR TITLE
[video][android] Fix controls sometimes flashing on initial display of the `VideoView`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed `border` related props weren't applied correctly. ([#33075](https://github.com/expo/expo/pull/33075) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix controls sometimes flashing on initial display of the view, when `useNativeControls` is `false` ([#33238](https://github.com/expo/expo/pull/33238) by [@behenate](https://github.com/behenate))
 
 ## 2.0.0 — 2024-11-11
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -95,6 +95,12 @@ class VideoModule : Module() {
       OnViewDestroys {
         VideoManager.unregisterVideoView(it)
       }
+
+      OnViewDidUpdateProps { view ->
+        if (view.playerView.useController != view.useNativeControls) {
+          view.playerView.useController = view.useNativeControls
+        }
+      }
     }
 
     Class(VideoPlayer::class) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -107,6 +107,9 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   init {
     VideoManager.registerVideoView(this)
     playerView.setFullscreenButtonClickListener { enterFullscreen() }
+    // The prop `useNativeControls` prop is sometimes applied after the view is created, and sometimes there is a visible
+    // flash of controls event when they are set to off. Initially we set it to `false` and apply it in `onAttachedToWindow` to avoid this.
+    this.playerView.useController = false
     addView(
       playerView,
       ViewGroup.LayoutParams(
@@ -249,6 +252,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
         .commitAllowingStateLoss()
     }
     applyAutoEnterPiP(currentActivity, autoEnterPiP)
+    this.playerView.useController = useNativeControls
   }
 
   override fun onDetachedFromWindow() {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -252,7 +252,6 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
         .commitAllowingStateLoss()
     }
     applyAutoEnterPiP(currentActivity, autoEnterPiP)
-    this.playerView.useController = useNativeControls
   }
 
   override fun onDetachedFromWindow() {


### PR DESCRIPTION
# Why

When `useNativeControls` is set to false the controls will be sometimes visible for few frames on the initial render of the view.

# How

Made the native default for `useNativeControls` to be false, the actual value (true by default) is applied in `onAttachedToWindow`.

@lukmccall Maybe there is a better way to do this? 

# Test Plan

Tested in BareExpo on Android.
