### PR TITLE
[sandbox] Revert prebuild changes

### DIFF
--- a/apps/sandbox/app.json
+++ b/apps/sandbox/app.json
@@ -16,13 +16,10 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "userInterfaceStyle": "automatic",
     "ios": {
-      "supportsTablet": true,
-      "bundleIdentifier": "com.gabrieldonadel.sandbox"
+      "supportsTablet": true
     },
     "plugins": [
       [

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -4,8 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios"
+    "android": "expo start --android",
+    "ios": "expo start --ios"
   },
   "dependencies": {
     "expo": "~52.0.0",


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/33181

# How

Revert sandbox changes caused by running `npx expo prebuild`

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
