### PR TITLE
[core][Android] Add the option to disable `overflow: hidden`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default.
+- [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.0.6 — 2024-11-22
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default.
+
 ## 2.0.6 — 2024-11-22
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
@@ -49,11 +49,15 @@ abstract class ExpoView(
     }
   }
 
-  override fun dispatchDraw(canvas: Canvas) {
+  open fun clipToPaddingBox(canvas: Canvas) {
     // When the border radius is set, we need to clip the content to the padding box.
     // This is because the border radius is applied to the background drawable, not the view itself.
     // It is the same behavior as in React Native.
     BackgroundStyleApplicator.clipToPaddingBox(this, canvas)
+  }
+
+  override fun dispatchDraw(canvas: Canvas) {
+    clipToPaddingBox(canvas)
     super.dispatchDraw(canvas)
   }
 }


### PR DESCRIPTION
# Why

Adds the option to disable `overflow: hidden` which is applied by default to each native view. 
If a developer wishes to manage CSS properties themselves, they may want to modify how view clipping functions. Currently, this is challenging because overriding `dispatchDraw` prevents you from calling `super.dispatchDraw` without triggering the `BackgroundStyleApplicator.clipToPaddingBox` function. This pull request provides a way to override the `clipToPaddingBox` function, allowing customization of its behavior for your custom view.