### PR TITLE
[docs] update cocoapods version for Xcode 16.1 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -291,7 +291,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - pnpm 9.12.3
 - npm 9.8.1
 - fastlane 2.225.0
-- CocoaPods 1.16.0
+- CocoaPods 1.16.2
 - Ruby 3.2
 - node-gyp 10.2.0
 


### PR DESCRIPTION
# Why

Update cocoapods version for Xcode 16.1 image

# How

Update cocoapods version for Xcode 16.1 image

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
