### PR TITLE
[docs] Collapsible: fix open state desync, tweak permalink style

### DIFF
--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -74,11 +74,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Name of your app.
       </p>
       <details
-        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow"
       >
         <summary
-          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
@@ -101,19 +101,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline"
+            class="ml-auto inline rounded-md p-1 hocus:bg-element"
             href="#bare-workflow"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -221,11 +221,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="expokit"
       >
         <summary
-          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
@@ -248,19 +248,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             ExpoKit
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline"
+            class="ml-auto inline rounded-md p-1 hocus:bg-element"
             href="#expokit"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -297,11 +297,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <details
-        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow-1"
       >
         <summary
-          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
@@ -324,19 +324,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline"
+            class="ml-auto inline rounded-md p-1 hocus:bg-element"
             href="#bare-workflow-1"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -457,11 +457,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+          class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
           id="expokit-1"
         >
           <summary
-            class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+            class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
           >
             <div
               class="ml-1.5 mr-2 mt-[5px] self-baseline"
@@ -484,19 +484,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </div>
             <span
-              class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+              class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
               data-text="true"
             >
               ExpoKit
             </span>
             <a
               aria-label="Permalink"
-              class="ml-auto inline"
+              class="ml-auto inline rounded-md p-1 hocus:bg-element"
               href="#expokit-1"
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
+                class="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -789,11 +789,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="mb-3 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         id="bare-workflow-2"
       >
         <summary
-          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
@@ -816,19 +816,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-2 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Bare Workflow
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline"
+            class="ml-auto inline rounded-md p-1 hocus:bg-element"
             href="#bare-workflow-2"
           >
             <svg
               aria-label="permalink"
-              class="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -6,9 +6,7 @@ import {
   type PropsWithChildren,
   type ReactNode,
   useRef,
-  useState,
   useEffect,
-  MouseEventHandler,
 } from 'react';
 
 import withHeadingManager, {
@@ -39,58 +37,44 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
     headingManager,
     open = false,
   }: CollapsibleProps & HeadingManagerProps) => {
-    // track open state so we can collapse header if it is set to open by the URL hash
-    const [isOpen, setIsOpen] = useState<boolean>(open);
     const router = useRouter();
+    const detailsRef = useRef<HTMLDetailsElement>(null);
 
     // HeadingManager is used to generate a slug that corresponds to the collapsible summary.
     // These are normally generated for MD (#) headings, but Collapsible doesn't have those.
     // This is a ref because identical tags will keep incrementing the number if it is not.
     const heading = useRef(headingManager.addHeading(summary, 1, undefined));
 
-    // expand collapsible if the current hash matches the heading
+    // note(simek) expand collapsible if the current hash matches the heading
     useEffect(() => {
       if (router?.asPath) {
         const splitUrl = router.asPath.split('#');
         const hash = splitUrl.length ? splitUrl[1] : undefined;
         if (hash && hash === heading.current.slug) {
-          setIsOpen(true);
+          detailsRef?.current?.setAttribute('open', '');
         }
       }
     }, []);
 
-    const onToggle: MouseEventHandler<HTMLElement> = event => {
-      // Detect if we are clicking the PermalinkIcon. Probably a better way to do this?
-      if (event.target instanceof SVGElement) {
-        if (!isOpen) {
-          setIsOpen(true);
-        }
-      } else {
-        setIsOpen(!isOpen);
-        // Ensure that the collapsible opens nicely on the first click
-        event.preventDefault();
-      }
-    };
-
     return (
       <details
+        ref={detailsRef}
         id={heading.current.slug}
         className={mergeClasses(
-          'mb-3 rounded-md border border-default bg-default p-0',
+          'mb-3 scroll-m-4 rounded-md border border-default bg-default p-0',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
         )}
-        open={isOpen}
+        open={open}
         data-testid={testID}>
         <summary
           className={mergeClasses(
             'group m-0 grid cursor-pointer select-none grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3',
-            isOpen && 'rounded-b-none',
+            '[details[open]>&]:rounded-b-none',
             '[&_h4]:my-0',
             '[&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug'
-          )}
-          onClick={onToggle}>
+          )}>
           <div className="ml-1.5 mr-2 mt-[5px] self-baseline">
             <TriangleDownIcon
               className={mergeClasses(
@@ -102,7 +86,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           </div>
           <DEMI
             className={mergeClasses(
-              'relative mr-2 inline scroll-m-5 items-center gap-1.5',
+              'relative mr-1 inline scroll-m-5 items-center gap-1.5',
               'group-hover:text-secondary group-hover:[&_code]:text-secondary'
             )}>
             {summary}
@@ -110,9 +94,12 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           <LinkBase
             href={'#' + heading.current.slug}
             ref={heading.current.ref}
-            className="ml-auto inline"
+            onClick={() => {
+              detailsRef?.current?.setAttribute('open', '');
+            }}
+            className="ml-auto inline rounded-md p-1 hocus:bg-element"
             aria-label="Permalink">
-            <PermalinkIcon className="icon-sm invisible mb-auto inline-flex group-hover:visible group-focus-visible:visible" />
+            <PermalinkIcon className="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible" />
           </LinkBase>
           <div />
         </summary>


### PR DESCRIPTION
# Why

Found out that the code responsible for special permalink handling and a way in which we manage the initial details state of Collapsible could cause desyncs between DOM and JS.

# How

Remove fully JS control over `open` state, replace too generic permalink SVG matcher, add scroll margin and a visual hover interaction for the permalink button.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

https://github.com/user-attachments/assets/8f48d4aa-44b3-4ba7-adb0-0b9fcaf54a3f
