### PR TITLE
[image][Android] Fixed `useImage` causing a native crash when uri is unresolvable

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `useImage` causing a native crash when uri is unresolvable.
+- [Android] Fixed `useImage` causing a native crash when uri is unresolvable. ([#33268](https://github.com/expo/expo/pull/33268) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `useImage` causing a native crash when uri is unresolvable.
+
 ### 💡 Others
 
 ## 2.0.2 — 2024-11-22

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -31,15 +31,13 @@ import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.EitherOfThree
 import expo.modules.kotlin.types.toKClass
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class ExpoImageModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -110,10 +108,8 @@ class ExpoImageModule : Module() {
       }
     }
 
-    AsyncFunction("loadAsync") { source: SourceMap, options: ImageLoadOptions?, promise: Promise ->
-      CoroutineScope(Dispatchers.Main).launch {
-        ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load(promise)
-      }
+    AsyncFunction("loadAsync") Coroutine { source: SourceMap, options: ImageLoadOptions? ->
+      ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load()
     }
 
     Class(Image::class) {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
@@ -1,42 +1,36 @@
 package expo.modules.image
 
-import android.graphics.drawable.Drawable
 import com.bumptech.glide.Glide
 import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 
-open class ImageLoadTask(private val appContext: AppContext, private val source: SourceMap, private val options: ImageLoadOptions) {
-  private var task: Job? = null
+open class ImageLoadTask(
+  private val appContext: AppContext,
+  private val source: SourceMap,
+  private val options: ImageLoadOptions
+) {
+  suspend fun load(): Image {
+    val context =
+      this@ImageLoadTask.appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
-  suspend fun load(promise: Promise) {
-    return coroutineScope {
-      val deferred = async {
-        val context = this@ImageLoadTask.appContext.reactContext ?: throw Exceptions.ReactContextLost()
-        withContext(Dispatchers.IO) {
-          Glide
-            .with(context)
-            .asDrawable()
-            .load(source.uri)
-            .centerInside()
-            .submit(options.maxWidth, options.maxHeight)
-            .get()
-        }
+    try {
+      val bitmap = withContext(Dispatchers.IO) {
+        Glide
+          .with(context)
+          .asDrawable()
+          .load(source.uri)
+          .centerInside()
+          .submit(options.maxWidth, options.maxHeight)
+          .get()
       }
-      task = deferred
-      try {
-        val bitmap: Drawable = deferred.await()
-        promise.resolve(Image(bitmap))
-      } catch (e: Exception) {
-        promise.reject(ImageLoadFailed(e))
-      }
+
+      return Image(bitmap)
+    } catch (e: Exception) {
+      throw ImageLoadFailed(e)
     }
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33115

# How

The current code doesn't correctly handle errors. I've simplified it and introduced much simpler and more natural way of handling errors.

# Test Plan

- [snack.expo.dev/@lovegaoshi/moody-orange-french-fries?platform=android](https://snack.expo.dev/@lovegaoshi/moody-orange-french-fries?platform=android) ✅ 
