### PR TITLE
[image][Android] Fix adding a blurhash placeholder causing blurry version of the image

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixes adding a blurhash placeholder to `Image` or `ImageBackground` causing blurry version of the image.
+
 ### 💡 Others
 
 ## 2.0.2 — 2024-11-22

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixes adding a blurhash placeholder to `Image` or `ImageBackground` causing blurry version of the image.
+- [Android] Fixes adding a blurhash placeholder to `Image` or `ImageBackground` causing blurry version of the image. ([#33272](https://github.com/expo/expo/pull/33272) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -540,8 +540,10 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
           }
           newTarget.placeholderContentFit = newPlaceholderContentFit
 
-          thumbnail(requestManager.load(placeholderModel.getGlideModel()))
-            .apply(placeholderSource.createGlideOptions(context))
+          thumbnail(
+            requestManager.load(placeholderModel.getGlideModel())
+              .apply(placeholderSource.createGlideOptions(context))
+          )
         }
         .downsample(downsampleStrategy)
         .addListener(GlideRequestListener(WeakReference(this)))


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33122

# How

The size override was applied to the incorrect request.

# Test Plan

- [snack.expo.dev/@cvega/restless-violet-apples](https://snack.expo.dev/@cvega/restless-violet-apples) ✅ 