### PR TITLE
[client][Android] Bump Koin to 3.5.6

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -102,16 +102,15 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion()}"
 
-  def koinVersion = "3.4.0"
-
-  api "io.insert-koin:koin-core:${koinVersion}"
+  api project.dependencies.platform("io.insert-koin:koin-bom:3.5.6")
+  api "io.insert-koin:koin-core"
 
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'androidx.test:core-ktx:1.4.0'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
-  testImplementation "io.insert-koin:koin-test:${koinVersion}"
-  testImplementation "io.insert-koin:koin-test-junit4:${koinVersion}"
+  testImplementation "io.insert-koin:koin-test"
+  testImplementation "io.insert-koin:koin-test-junit4"
   testImplementation 'io.mockk:mockk:1.12.3'
   testImplementation "org.robolectric:robolectric:4.10"
 }


### PR DESCRIPTION
# Why

Fixes a crashing incompatibility between `expo-dev-launcher` and other third-party modules.

# How

Bump Koin to 3.5.6 and use new BOM specification for consistent versioning.

# Test Plan

- bare-expo tests pass ✅ 
- Manual testing of dev menu works as expected

# More Info

See https://github.com/argyle-systems/argyle-link-react-native/issues/134 for the issue that motivates this change. I chose 3.5.6 because it appears to be the [last stable version](https://github.com/InsertKoinIO/koin/releases) before a major version bump to 4.0. This also uses the new BOM specification introduced with 3.5.0 to make versioning of the constituent Koin dependencies easier to manage.