### PR TITLE
[core][dev-menu] fix build error for react-native nightly (0.77)

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed compatibility for React Native 0.77. ([#33277](https://github.com/expo/expo/pull/33277) by [@kudo](https://github.com/kudo))
+
 ## 6.0.12 — 2024-11-22
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -30,7 +30,7 @@ class DevMenuModule : Module() {
 
       val size = callbacks.size()
       for (i in 0 until size) {
-        val callback = callbacks.getMap(i)
+        val callback = callbacks.getMap(i) ?: continue
         val name = callback.getString("name") ?: continue
         val shouldCollapse = if (callback.hasKey("shouldCollapse")) {
           callback.getBoolean("shouldCollapse")

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))
+- Fixed compatibility for React Native 0.77. ([#33277](https://github.com/expo/expo/pull/33277) by [@kudo](https://github.com/kudo))
 
 ## 2.0.6 — 2024-11-22
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
@@ -15,6 +15,7 @@ import com.facebook.react.uimanager.style.BoxShadow
 import com.facebook.react.uimanager.style.LogicalEdge
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.views.ViewDefinitionBuilder
+import expo.modules.rncompatibility.parseBoxShadow
 
 inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBorderColorProps(crossinline body: (view: T, edge: LogicalEdge, color: Int?) -> Unit) {
   PropGroup(
@@ -143,7 +144,7 @@ inline fun <reified T : View> ViewDefinitionBuilder<T>.UseBoxShadowProp(crossinl
 
     val shadowStyle = mutableListOf<BoxShadow>()
     for (i in 0..<shadows.size()) {
-      val shadow = BoxShadow.parse(shadows.getMap(i)) ?: continue
+      val shadow = parseBoxShadow(shadows.getMap(i), view.context) ?: continue
       shadowStyle.add((shadow))
     }
     body(view, shadowStyle)

--- a/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
+++ b/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
@@ -1,0 +1,14 @@
+package expo.modules.rncompatibility
+
+import android.content.Context
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.style.BoxShadow
+
+/**
+ * A compatible wrapper of [BoxShadow.parse] for React Native compatibility
+ * TODO(kudo,20241127): Remove this when we drop react-native 0.76 support
+ */
+@Suppress("UNUSED_PARAMETER")
+fun parseBoxShadow(boxShadow: ReadableMap, context: Context): BoxShadow? {
+  return BoxShadow.parse(boxShadow)
+}

--- a/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
+++ b/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
@@ -8,6 +8,6 @@ import com.facebook.react.uimanager.style.BoxShadow
  * A compatible wrapper of [BoxShadow.parse] for React Native compatibility
  * TODO(kudo,20241127): Remove this when we drop react-native 0.76 support
  */
-fun parseBoxShadow(boxShadow: ReadableMap, context: Context): BoxShadow? {
+fun parseBoxShadow(boxShadow: ReadableMap?, context: Context): BoxShadow? {
   return BoxShadow.parse(boxShadow, context)
 }

--- a/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
+++ b/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/RNCompatibleStaticWrapper.kt
@@ -1,0 +1,13 @@
+package expo.modules.rncompatibility
+
+import android.content.Context
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.style.BoxShadow
+
+/**
+ * A compatible wrapper of [BoxShadow.parse] for React Native compatibility
+ * TODO(kudo,20241127): Remove this when we drop react-native 0.76 support
+ */
+fun parseBoxShadow(boxShadow: ReadableMap, context: Context): BoxShadow? {
+  return BoxShadow.parse(boxShadow, context)
+}


### PR DESCRIPTION
# Why

fix build error for react-native nightly (0.77)

# How

- [core] introduce `RNCompatibleStaticWrapper.parseBoxShadow` to fix breaking change from [BoxShadow.parse](https://github.com/facebook/react-native/commit/145c72f8163048f0eee30d5ce850911f5dad865c)
- [dev-menu] fix build error where for nullable change

# Test Plan

- ci passed
- nightly ci passed: https://github.com/expo/expo/actions/runs/12036939218

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
