### PR TITLE
[calendar][Android] Fix `isPrimary` always returns false

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix expo-calendar isPrimary on Android always returns false ([#33285](https://github.com/expo/expo/pull/33285) by [@joaogabrieldasilva](https://github.com/joaogabrieldasilva) [@sanchaz](https://github.com/sanchaz))
+- [Android] Fix expo-calendar isPrimary on Android always returns false ([#33285](https://github.com/expo/expo/pull/33285) by [@joaogabrieldasilva](https://github.com/joaogabrieldasilva) & [@sanchaz](https://github.com/sanchaz))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix expo-calendar isPrimary on Android always returns false ([#33285](https://github.com/expo/expo/pull/33285) by [@joaogabrieldasilva](https://github.com/joaogabrieldasilva) [@sanchaz](https://github.com/sanchaz))
+
 ### 💡 Others
 
 ## 14.0.3 — 2024-11-22

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -768,7 +768,7 @@ class CalendarModule : Module() {
     val calendar = Bundle().apply {
       putString("id", optStringFromCursor(cursor, CalendarContract.Calendars._ID))
       putString("title", optStringFromCursor(cursor, CalendarContract.Calendars.CALENDAR_DISPLAY_NAME))
-      putBoolean("isPrimary", optStringFromCursor(cursor, CalendarContract.Calendars.IS_PRIMARY) === "1")
+      putBoolean("isPrimary", optIntFromCursor(cursor, CalendarContract.Calendars.IS_PRIMARY) === 1)
       putStringArrayList("allowedAvailabilities", calendarAllowedAvailabilitiesFromDBString(stringFromCursor(cursor, CalendarContract.Calendars.ALLOWED_AVAILABILITY)))
       putString("name", optStringFromCursor(cursor, CalendarContract.Calendars.NAME))
       putString("color", String.format("#%06X", 0xFFFFFF and optIntFromCursor(cursor, CalendarContract.Calendars.CALENDAR_COLOR)))


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/28268
credit to @joaogabrieldasilva https://github.com/joaogabrieldasilva for the fix.
Just opening the PR as I need this fixed, otherwise I need to guess the calendar or implement a menu for the user to choose the calendar.

# How

# Test Plan

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


