### PR TITLE
[image][Android] Add missing `PlaceholderDownsampleStrategy`

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -542,6 +542,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
           thumbnail(
             requestManager.load(placeholderModel.getGlideModel())
+              .downsample(PlaceholderDownsampleStrategy(newTarget))
               .apply(placeholderSource.createGlideOptions(context))
           )
         }


### PR DESCRIPTION
# Why

Adds missing `PlaceholderDownsampleStrategy` to the placeholder request.

# How

To correctly apply content fit when it is set to scale down, we need to know the size of the original asset. This was already implemented with standard source assets, but we overlooked it with the placeholders. The `PlaceholderDownsampleStrategy` only provides information about the original size of the placeholder; it does not actually perform any scaling.

# Test Plan

- NCL ✅ 