### PR TITLE
[docs] Use CodeBlocksTable in step 4 in Tailwind guide

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -3,6 +3,7 @@ title: Tailwind CSS
 description: Learn how to configure and use Tailwind CSS in your Expo project.
 ---
 
+import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -96,13 +97,18 @@ Create a **global.css** file in the root of your project and directives for each
 
 Import the **global.css** file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
 
-```tsx
-// If your project uses Expo Router, import the global.css file in the top level_layout.tsx file:
-import '../global.css';
+<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
 
-// Otherwise, import the global.css file in the index.js file:
+```tsx
+import '../global.css';
+```
+
+```tsx
+// Import the global.css file in the index.js file:
 import './global.css';
 ```
+
+</CodeBlocksTable>
 
 > **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Improve Step 4 example to show a side by side comparison in the Tailwind CSS guide.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Use `CodeBlocksTable`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-11-27 at 17 08 37](https://github.com/user-attachments/assets/3d5faaec-ad4b-43a0-a053-54d3635e3e9f)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
