### PR TITLE
[docs] Fix typos, broken link and formatting issues in EAS environment variables guides

### DIFF
--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -1,30 +1,29 @@
 ---
 title: Environment variables in EAS
-sidebar_title: Environment variables in EAS
+sidebar_title: Environment variables
 description: Learn basic concepts about using environment variables in EAS and how to manage them.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 
-[Environment variables in Expo](/guides/environment-variables) describe how to use environment variables with the Expo framework and **.env** files to set environment variables that can be inlined in your JavaScript code.
-Expo CLI will substitute prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files on your development machine.
+[Environment variables in Expo](/guides/environment-variables) describe how to use environment variables with the Expo framework and **.env** files to set environment variables that can be inlined in your JavaScript code. Expo CLI will substitute prefixed variables in your code (for example, `process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files on your development machine.
 
-Because EAS Build and Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
+Since EAS Build and Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
+
 Additionally, you may want to use environment variables outside of your project code to customize your app binary at build time, like setting a bundle identifier or a private key for an error reporting service.
-To accommodate for those needs we have a separate (but compatible) mechanism for managing environment variables in EAS, which is focused on storing and managing environment variables on EAS' servers and synchronizing them for local development.
+To accommodate for those needs we have a separate (but compatible) mechanism for managing environment variables in EAS, which is focused on storing and managing environment variables on EAS servers and synchronizing them for local development.
 
 ## Project-wide environment variables
 
-Project-wide environment variables are specific to a single EAS project.
-You can view and manage them by navigating to the [Environment Variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) page on your project.
-These environment variables are available to any jobs run on EAS' servers and updates for this project. They can also be pulled locally for development if their visibility setting allows it.
+Project-wide environment variables are specific to a single EAS project. You can view and manage them by navigating to the [Environment Variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) page on your project.
+
+These environment variables are available in any jobs that run on EAS servers and updates for this project. They can also be pulled locally for development if their visibility setting allows it.
 
 ## Account-wide environment variables
 
-Account-wide environment variables are available across all of your projects in your EAS account.
-You can view and manage them by navigating to [Environment Variables](https://expo.dev/accounts/[account]/settings/environment-variables) page on your account.
-They are available to jobs run on EAS' servers and updates, together with project-wide variables for a project.
-You can pull them locally or read outside of EAS servers if their visibility setting allows it.
+Account-wide environment variables are available across all of your projects in your EAS account. You can view and manage them by navigating to [Environment Variables](https://expo.dev/accounts/[account]/settings/environment-variables) page on your account.
+
+They are available in jobs that run on EAS servers and updates, together with project-wide variables for a project. You can pull them locally or read outside of EAS servers if their visibility setting allows it.
 
 ## Environments
 
@@ -44,22 +43,17 @@ There are three different visibility settings:
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                         |
 | Sensitive  | Obfuscated in build and Workflows jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
-| Secret     | Not readable outside of the EAS' servers, including on the website and in EAS CLI. They are obfuscated in build and Workflows jobs logs. |
+| Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and Workflows jobs logs.  |
 
-> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**.
-> Secret type environment variables are intended to be used to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs.
-> For example: a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps.
-> Secrets do not provide any additional security for values that you end up embedding in your application itself.
+> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
 
 ## File environment variables
 
 In addition to setting strings as values, you can also upload files as the value of an environment variable.
 
-One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job.
-During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`).
-For example: you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or Workflows job.
+One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job. During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`). For example, you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or Workflows job.
 
-```js app.config.ts
+```js app.config.js
 export default {
   /* @hide ...*/ /* @end */
   android: {
@@ -75,23 +69,21 @@ One possible way to efficiently work with environment variables in your EAS proj
 
 ### Use correct visibility settings
 
-Make sure to set the visibility of your environment variables to the appropriate level.
-Avoid setting excessive secret visibility to `EXPO_PUBLIC_` variables that are used in your app's JavaScript code or are used to resolve your app's configuration.
-Be aware that environment variables with secret visibility are not readable outside of EAS servers, and can't be pulled locally for development or to bundle your app's JavaScript code for updates.
+Make sure to set the visibility of your environment variables to the appropriate level. Avoid setting excessive secret visibility to `EXPO_PUBLIC_` variables that are used in your app's JavaScript code or are used to resolve your app's configuration. Be aware that environment variables with secret visibility are not readable outside of EAS servers, and can't be pulled locally for development or to bundle your app's JavaScript code for updates.
 
-### Add **.env** files to `.gitignore`
+### Add .env files to .gitignore
 
-To avoid confusing overrides during cloud jobs and leaking sensitive information, add **.env** files to your `.gitignore` file.
+To avoid confusing overrides during cloud jobs and leaking sensitive information, add **.env** files to your **.gitignore** file.
 
 ### Use the `--environment` flag with `eas update`
 
 When publishing updates, use the `--environment` flag with the `eas update` command to ensure that the same environment variables are used for your updates as your build jobs.
-When the `--environment` flag is provided, `eas update` will use the environment variables on EAS' servers for the update job and won't use the **.env** files present in your project often used for local development.
+
+When the `--environment` flag is provided, `eas update` will use the environment variables on EAS servers for the update job and won't use the **.env** files present in your project often used for local development.
 
 ### Sync the environment variables for local development using `eas env:pull`
 
-You can use the `eas env:pull` command to pull environment variables from EAS servers to your local `.env` file for development.
-The ideal environment that can be used for this purpose is the `development` environment, as it's the default environment used for development builds.
+You can use the `eas env:pull` command to pull environment variables from EAS servers to your local **.env** file for development. The ideal environment that can be used for this purpose is the `development` environment, as it's the default environment used for development builds.
 
 ### Explicitly specify the environment for your builds
 
@@ -103,14 +95,14 @@ See the [Using EAS environment variables](/eas/using-environment-variables) for 
 
 ## Differences between handling environment variables in EAS CLI and Expo CLI
 
-One of the differences between using environment variables with the Expo framework and EAS is that EAS CLI itself does not support loading **.env** files to set environment variables when resolving the expo config.
-Instead, it's recommended to use the EAS environment variables management system with EAS CLI commands to set environment variables for your build jobs and updates to avoid confusion, and ensure that exactly the same environment variables are used both for:
+One of the differences between using environment variables with the Expo framework and EAS is that EAS CLI itself does not support loading **.env** files to set environment variables when resolving the expo config. Instead, it's recommended to use the EAS environment variables management system with EAS CLI commands to set environment variables for your build jobs and updates to avoid confusion, and ensure that exactly the same environment variables are used both for:
 
 - Local app config resolution, done by EAS CLI when preparing the expo config
 - Remote jobs happening on EAS servers, which often don't have access to your local **.env** files that are git ignored
 
 Using `eas update` is the one exception to this rule. By default, for backward compatibility reasons, it uses **.env** files present in your project directory to set environment variables for the update job, the same way [Expo CLI](/guides/environment-variables) does (it executes the `npx expo export` command under the hood).
-To ensure that you can use the same environment variables in your updates as your build jobs, you can use the `--environment` flag with the `eas update` command to force it to use **only** the environment variables set on the EAS' servers instead of the **.env** files present in your project directory. It will ignore environment variables from **.env**.
+
+To ensure that you can use the same environment variables in your updates as your build jobs, you can use the `--environment` flag with the `eas update` command to force it to use **only** the environment variables set on the EAS servers instead of the **.env** files present in your project directory. It will ignore environment variables from **.env**.
 
 ## EAS Build and Workflows job runs
 
@@ -121,33 +113,32 @@ To set the environment for your EAS Build jobs, you can use the `environment` op
 ```json eas.json
 {
   "build": {
-    "production": {
-      "environment": "production"
+    "development": {
+      "environment": "development"
     },
     "preview": {
       "environment": "preview"
     },
-    "development": {
-      "environment": "development"
+    "production": {
+      "environment": "production"
     },
     "my-profile": {
       "environment": "production"
-    }
   }
 }
 ```
 
 If you don't set the `environment` option, we will set the environment automatically based on your build's configuration:
 
-- `production`: for app store build
 - `development`: for development client build
 - `preview`: for other configurations
+- `production`: for app store build
 
 > **info** This resolution logic is only available for EAS CLI in version 13.3.0 and higher. For older CLI versions, we always assume the `production` environment for all builds.
 
 ### Built-in environment variables
 
-The following environment variables are additional system environment variables exposed to each job and can be used within any build step. They are not a part of any project environment and are not available when evaluating **app.config.ts** locally:
+The following environment variables are additional system environment variables exposed to each job and can be used within any build step. They are not a part of any project environment and are not available when evaluating **app.config.js** locally:
 
 - `CI=1`: indicates this is a CI environment
 - `EAS_BUILD=true`: indicates this is an EAS Build environment
@@ -169,7 +160,7 @@ The `set-env` executable is available in the `PATH` on EAS Build workers, and ca
 
 For example, you can add the following in one of the [EAS Build hooks](/build-reference/npm-hooks/) and the environment variable `EXAMPLE_ENV` will be available until the end of the build job.
 
-<Terminal cmd={['set-env EXAMPLE_ENV "example value"']} />
+<Terminal cmd={['$ set-env EXAMPLE_ENV "example value"']} />
 
 ### Accessing environment variables
 
@@ -179,17 +170,17 @@ After creating an environment variable, you can read it on subsequent EAS Build 
 
 #### Can I just set my environment variables on a CI provider when triggering the build using `eas build` command?
 
-Environment variables must be defined on EAS servers to be made available to EAS Build builders.
-If you are triggering builds from CI the same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets on EAS servers.
+Environment variables must be defined on EAS servers to be made available to EAS Build builders. If you are triggering builds from CI the same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets on EAS servers.
 
 #### How do environment variables work for my development builds?
 
 Environment variables set in your build profile that impact **app.config.js** will be used for configuring the development build.
+
 When you run `npx expo start` to load your app inside of your development build, only environment variables that are available on your development machine will be used.
 
 ## EAS Update
 
-### Using **.env** files with EAS Update
+### Using .env files with EAS Update
 
 When the `--environment` flag is **not provided**, `eas update` will use the **.env** files present in your project directory for the update job and won't use the environment variables set on the EAS servers.
 
@@ -199,12 +190,11 @@ Expo CLI will substitute prefixed variables in your code (for example,`process.e
 When you run `eas update`, all **.env** files will be evaluated when your JavaScript is bundled.
 Any `EXPO_PUBLIC_` variables in your application code will be replaced inline with the corresponding values from your **.env** files that are present on the machine from which the update is published, whether that is your local machine or your CI/CD server.
 
-> **info** When using `.env` files with EAS Update, `EXPO_PUBLIC_` variables in **.env** files will only be used when bundling your app's JavaScript. They will not be available when evaluating **app.config.js**.
+> **info** When using **.env** files with EAS Update, `EXPO_PUBLIC_` variables in these files will only be used when bundling your app's JavaScript. They will not be available when evaluating **app.config.js**.
 
 ### Using the `--environment` flag with EAS Update
 
-When the `--environment` flag is provided, `eas update` will use the environment variables on EAS' servers for and won't use the **.env** files present in your project.
-Expo CLI will substitute prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding plain text and sensitive environment variable values set on EAS' servers for the environment specified with the `--environment` flag.
+When the `--environment` flag is provided, `eas update` will use the environment variables on EAS servers for and won't use the **.env** files present in your project. Expo CLI will substitute prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding plain text and sensitive environment variable values set on EAS servers for the environment specified with the `--environment` flag.
 
 Any `EXPO_PUBLIC_` variables in your application code will be replaced inline with the corresponding values from your EAS environment whether that is your local machine or your CI/CD server.
 
@@ -221,9 +211,9 @@ Navigate to the [Environment Variables page on your project](https://expo.dev/ac
 
 To manage environment variables using EAS CLI, you can use the `eas env:create`, `eas env:update`, `eas env:list`, and `eas env:delete` commands.
 
-You can additionally use `eas env:pull` command to pull environment variables from EAS servers to your local `.env` file for development.
+You can additionally use `eas env:pull` command to pull environment variables from EAS servers to your local **.env** file for development.
 
-See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/README.md) for more detailed information about these commands.
+See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/README.md) for more information about these commands.
 
 ## Limitations
 

--- a/docs/pages/eas/using-environment-variables.mdx
+++ b/docs/pages/eas/using-environment-variables.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using EAS environment variables
 sidebar_title: Environment variables usage
-description: Learn how to use environment variables in EAS with practical examples.
+description: Learn how to use environment variables in EAS with examples.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
@@ -208,7 +208,7 @@ One way to supply non-secret EAS environment variables to other EAS commands is 
 
 <Terminal cmd={["$ eas env:exec --environment production 'echo $APP_VARIANT'"]} />
 
-It can be useful when uploading source maps to Sentry using a [`SENTRY_AUTH_TOKEN`](/guides/using-sentry) variable after an update bundle is created.
+For example, it can be useful when uploading source maps to Sentry using a [`SENTRY_AUTH_TOKEN`](/guides/using-sentry) variable after an update bundle is created.
 
 <Terminal
   cmd={["$ eas env:exec --environment production 'npx sentry-expo-upload-sourcemaps dist'"]}

--- a/docs/pages/eas/using-environment-variables.mdx
+++ b/docs/pages/eas/using-environment-variables.mdx
@@ -1,28 +1,24 @@
 ---
 title: Using EAS environment variables
-sidebar_title: Using EAS environment variables
-description: Learn how to use environment variables in EAS in practical scenarios.
+sidebar_title: Environment variables usage
+description: Learn how to use environment variables in EAS with practical examples.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
-In [Environment variables in EAS](/pages/eas/environment-variables) we described concepts related to using environment variables in EAS and differences in handling them with Expo CLI and EAS CLI.
-This guide will show you how to use environment variables in EAS with practical examples.
+[Environment variables in EAS](/eas/environment-variables) describes concepts related to using environment variables in EAS and differences in handling them with Expo CLI and EAS CLI. In this guide, you will learn how to use environment variables in EAS with practical examples.
 
-In this example, we'll look at a simple project that uses these common environment variables during the build process and for configuration purposes:
+The example used in this guide is a simple project that uses common environment variables during the build process and for configuration purposes:
 
 - `EXPO_PUBLIC_API_URL`: a plain text [`EXPO_PUBLIC_`](/guides/environment-variables/) variable that holds the URL of the API server
-- `SENTRY_AUTH_TOKEN`: a sensitive variable that holds the authentication token for Sentry used to upload source maps after builds and updates
 - `APP_VARIANT`: a plain text variable to select an [app variant](/tutorial/eas/multiple-app-variants/)
-- `GOOGLE_SERVICES_JSON`: a secret file variable to supply your gitignored `google-services.json` file to the build job
+- `GOOGLE_SERVICES_JSON`: a secret file variable to supply your git ignored **google-services.json** file to the build job
+- `SENTRY_AUTH_TOKEN`: a sensitive variable that holds the authentication token for Sentry used to upload source maps after builds and updates
 
-<Step label="1">
 ## Use environment variables in your code
 
-The environment variables with the [`EXPO_PUBLIC_`](/guides/environment-variables) prefix are available as `process.env` variables in your application code.
-This means you can use them to dynamically configure your app behavior based on the environment variables' values.
+The environment variables with the [`EXPO_PUBLIC_`](/guides/environment-variables) prefix are available as `process.env` variables in your app's code. This means you can use them to dynamically configure your app behavior based on the values from environment variables.
 
 ```tsx
 import { Button } from 'react-native';
@@ -38,12 +34,11 @@ function Post() {
 }
 ```
 
-In this example `EXPO_PUBLIC_API_URL` is used to dynamically set the API URL for the fetch request.
+In above example, `EXPO_PUBLIC_API_URL` is used to dynamically set the API URL for the fetch request.
 
-> **warning** Do not store sensitive info, such as private keys, in `EXPO_PUBLIC_` variables. These variables will be visible in plain-text in your compiled application.
+> **warning** Do not store sensitive information in `EXPO_PUBLIC_` variables, such as private keys. These variables will be visible in plain-text in your compiled app.
 
-Other variables, without the `EXPO_PUBLIC_` prefix, can be used during app config resolution.
-An example of this is the `APP_VARIANT` variable used to determine the app name and bundle identifier/package name based on the selected app variant.
+Other variables, without the `EXPO_PUBLIC_` prefix, can be used during app config resolution. An example of this is the `APP_VARIANT` variable used to determine the app name and package name or bundle identifier based on the selected app variant.
 
 ```js app.config.js
 const IS_DEV = process.env.APP_VARIANT === 'development';
@@ -93,13 +88,9 @@ export default {
 };
 ```
 
-In this example we additionally consider the [`SENTRY_AUTH_TOKEN`](/guides/using-sentry) as an example of a variable that can be treated as a sensitive environment variable.
-It is used to authenticate with Sentry to upload source maps after builds and updates, so we want to be able access it outside of EAS servers as well.
+The `GOOGLE_SERVICES_JSON` is a secret file variable in that is not readable outside of EAS servers and is used to provide the git ignored **google-services.json** file to the build job. To use it in the app config, you can use the `process.env` variable and provide a fallback value in case the variable is not set (for local development when you usually have it inside your project's repository).
 
-The `GOOGLE_SERVICES_JSON` is a secret file variable in our example setup that is not readable outside of EAS' servers and is used to provide the git ignored **google-services.json** file to the build job.
-To use it in the app config, we can use the `process.env` variable and provide a fallback value in case the variable is not set (for local development when we usually have it in our repo).
-
-```js app.config.ts
+```js app.config.js
 export default {
   /* @hide ...*/ /* @end */
   android: {
@@ -109,24 +100,21 @@ export default {
 };
 ```
 
-</Step>
-
-<Step label="2">
 ## Create EAS environment variables
 
-To create environment variables on EAS' servers, you can use the [environment variables creation form](https://expo.dev/accounts/[account]/projects/[project]/environment-variables/new) page or `eas env:create` command.
+To create environment variables on EAS servers, you can use the [environment variables creation form](https://expo.dev/accounts/[account]/projects/[project]/environment-variables/new) page or `eas env:create` command.
 
 In the form, you can specify the name, value, environment(s) and visibility for the variable.
 
 <ContentSpotlight
-  alt="Add environment variable from"
+  alt="Create an environment variable form"
   src="/static/images/env-vars/add.png"
   className="max-w-[600px]"
 />
 
-Created environment variables will be available in the list form on the [Environment Variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) page.
+Created environment variables will be available in the list on the [Environment Variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) page on the Expo website.
 
-Based on the environment variables in this example, the list would look like this:
+Based on the environment variables in this example, the list will look like this:
 
 <ContentSpotlight
   alt="List of successfully created environment variables"
@@ -134,22 +122,15 @@ Based on the environment variables in this example, the list would look like thi
   className="max-w-[600px]"
 />
 
-</Step>
-
-<Step label="3">
 ## Pull EAS environment variables for your local development environment
 
-The easiest way to use the EAS environment variables for local development is to pull them into a **.env** file using the `eas env:pull --environment environment` command.
-You can use the Export option on the [website](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) as well to download the file.
+The easiest way to use the EAS environment variables for local development is to pull them into a **.env** file using the `eas env:pull --environment environment` command. You can also use the Export option on the [Expo website](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to download the file and store it inside your project.
 
-After running the following command:
+Run the following command to create a **.env** file in the root of your project:
 
-<Terminal
-  cmd={['$ eas env:pull --environment development']}
-  cmdCopy="eas env:pull --environment development"
-/>
+<Terminal cmd={['$ eas env:pull --environment development']} />
 
-a **.env** file will be created in the root of your project with the following content:
+The created **.env** file will look like this:
 
 ```bash .env.local
 # Environment: development
@@ -164,9 +145,6 @@ The downloaded `EXPO_PUBLIC_` variables are available for local development when
 
 > **warning** It is best to add all of the **.env** files to **.gitignore** to avoid committing them to your repository and exposing sensitive information. Committing a **.env** file may additionally lead to environment variables resolution conflicts.
 
-</Step>
-
-<Step label="4">
 ## Use EAS environment variables with EAS Build
 
 To have a full control over the environments used for your builds, you can specify the [`environment`](/eas/json#environment) field in the build profiles settings in the **eas.json** file.
@@ -174,9 +152,9 @@ To have a full control over the environments used for your builds, you can speci
 ```json eas.json
 {
   "build": {
-    "production": {
-      /* @info Using <CODE>production</CODE> environment */
-      "environment": "production"
+    "development": {
+      /* @info Using <CODE>development</CODE> environment */
+      "environment": "development"
       /* @end */
       /* @hide ... */ /* @end */
     },
@@ -186,9 +164,9 @@ To have a full control over the environments used for your builds, you can speci
       /* @end */
       /* @hide ... */ /* @end */
     },
-    "development": {
-      /* @info Using <CODE>development</CODE> environment */
-      "environment": "development"
+    "production": {
+      /* @info Using <CODE>production</CODE> environment */
+      "environment": "production"
       /* @end */
       /* @hide ... */ /* @end */
     },
@@ -202,51 +180,36 @@ To have a full control over the environments used for your builds, you can speci
 }
 ```
 
-All of the environment variables from the selected environment will be used during the build process.
-Plain text and sensitive variables will be available when resolving build configuration based on the dynamic app config in EAS CLI as well.
+All of the environment variables from the selected environment will be used during the build process. Plain text and sensitive variables will be available when resolving build configuration based on the dynamic app config in EAS CLI as well.
 
-> **info** The secret type environment variables are not available during build configuration resolution in EAS CLI as they are not readable outside of the EAS' servers.
+> **info** The environment variables of secret type are not available during build configuration resolution in EAS CLI as they are not readable outside of the EAS servers.
 
-In our example app, all of the environment variables except `GOOGLE_SERVICES_JSON` (which is secret) will be available during build configuration resolution in EAS CLI.
+In this example app, all of the environment variables except `GOOGLE_SERVICES_JSON` (which is secret) will be available during build configuration resolution in EAS CLI.
 
-It's especially important in this context to have the correct visibility set for the `APP_VARIANT` variable so that it's available in EAS CLI so it is able to generate credentials for the correct bundle identifier and package name.
+It's especially important in this context to have the correct visibility set for the `APP_VARIANT` variable so that the variable available in EAS CLI and is able to generate credentials for the correct package name and bundle identifier.
 
-</Step>
-
-<Step label="5">
 ## Use EAS environment variables with EAS Update
 
 The most convenient way to use EAS environment variables with EAS Update is to run the `eas update` command with the `--environment` flag specified:
 
-<Terminal
-  cmd={['$ eas update --environment production']}
-  cmdCopy="eas update --environment production"
-/>
+<Terminal cmd={['$ eas update --environment production']} />
 
-When the `--environment` flag is used, **only the environment variables from the specified EAS environment will be used during the update process**.
-The `--environment` flag allows you to use the same environment variables while creating updates as with creating builds.
+When the `--environment` flag is used, **only the environment variables from the specified EAS environment will be used during the update process**. This flag allows you to use the same environment variables while creating updates as with creating builds.
 
-> **info** The secret variables will not be available during the update process as they are not readable outside of EAS' servers.
+> **info** The secret variables will not be available during the update process as they are not readable outside of EAS servers.
 
 > **warning** The default behavior of the `eas update` command is to use **.env** files if the `--environment` flag is not specified.
 
-</Step>
-
-<Step label="6">
 ## Use EAS environment variables for other commands
 
 One way to supply non-secret EAS environment variables to other EAS commands is to use the `eas env:exec` command.
 
-<Terminal
-  cmd={["$ eas env:exec --environment production 'echo $APP_VARIANT'"]}
-  cmdCopy="eas env:exec --environment production 'echo $APP_VARIANT'"
-/>
+<Terminal cmd={["$ eas env:exec --environment production 'echo $APP_VARIANT'"]} />
 
-It can be useful when uploading source maps to Sentry using a `SENTRY_AUTH_TOKEN` variable after an update bundle is created.
+It can be useful when uploading source maps to Sentry using a [`SENTRY_AUTH_TOKEN`](/guides/using-sentry) variable after an update bundle is created.
 
 <Terminal
   cmd={["$ eas env:exec --environment production 'npx sentry-expo-upload-sourcemaps dist'"]}
-  cmdCopy="eas env:exec --environment production 'npx sentry-expo-upload-sourcemaps dist'"
 />
 
-</Step>
+In above example, the `SENTRY_AUTH_TOKEN` is treated as a sensitive environment variable. It is used to authenticate with Sentry to upload source maps after builds and updates, and accessible outside of EAS servers.

--- a/docs/pages/eas/using-environment-variables.mdx
+++ b/docs/pages/eas/using-environment-variables.mdx
@@ -100,7 +100,7 @@ export default {
 };
 ```
 
-## Create EAS environment variables
+## Create environment variables
 
 To create environment variables on EAS servers, you can use the [environment variables creation form](https://expo.dev/accounts/[account]/projects/[project]/environment-variables/new) page or `eas env:create` command.
 
@@ -122,7 +122,9 @@ Based on the environment variables in this example, the list will look like this
   className="max-w-[600px]"
 />
 
-## Pull EAS environment variables for your local development environment
+In above example, the `SENTRY_AUTH_TOKEN` can be treated as a sensitive environment variable. It is used to authenticate Sentry to upload source maps after builds and updates, so it has to be accessible outside of EAS servers.
+
+## Pull environment variables for your local development
 
 The easiest way to use the EAS environment variables for local development is to pull them into a **.env** file using the `eas env:pull --environment environment` command. You can also use the Export option on the [Expo website](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to download the file and store it inside your project.
 
@@ -145,7 +147,7 @@ The downloaded `EXPO_PUBLIC_` variables are available for local development when
 
 > **warning** It is best to add all of the **.env** files to **.gitignore** to avoid committing them to your repository and exposing sensitive information. Committing a **.env** file may additionally lead to environment variables resolution conflicts.
 
-## Use EAS environment variables with EAS Build
+## Use environment variables with EAS Build
 
 To have a full control over the environments used for your builds, you can specify the [`environment`](/eas/json#environment) field in the build profiles settings in the **eas.json** file.
 
@@ -188,7 +190,7 @@ In this example app, all of the environment variables except `GOOGLE_SERVICES_JS
 
 It's especially important in this context to have the correct visibility set for the `APP_VARIANT` variable so that the variable available in EAS CLI and is able to generate credentials for the correct package name and bundle identifier.
 
-## Use EAS environment variables with EAS Update
+## Use environment variables with EAS Update
 
 The most convenient way to use EAS environment variables with EAS Update is to run the `eas update` command with the `--environment` flag specified:
 
@@ -200,7 +202,7 @@ When the `--environment` flag is used, **only the environment variables from the
 
 > **warning** The default behavior of the `eas update` command is to use **.env** files if the `--environment` flag is not specified.
 
-## Use EAS environment variables for other commands
+## Use environment variables for other commands
 
 One way to supply non-secret EAS environment variables to other EAS commands is to use the `eas env:exec` command.
 
@@ -211,5 +213,3 @@ It can be useful when uploading source maps to Sentry using a [`SENTRY_AUTH_TOKE
 <Terminal
   cmd={["$ eas env:exec --environment production 'npx sentry-expo-upload-sourcemaps dist'"]}
 />
-
-In above example, the `SENTRY_AUTH_TOKEN` is treated as a sensitive environment variable. It is used to authenticate with Sentry to upload source maps after builds and updates, and accessible outside of EAS servers.


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Multiple issues in the EAS > Environment variables guides.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the sidebar title for both guides so they appear as part of the EAS section
- Fix broken link in Using EAS environment variables
- Remove use of step component from EAS environment variables guide since those steps were not related to each other (for example, I can skip EAS update step)
- Fix the context of sentry auth token example in Using EAS environment variables guide. The info was provided in "Use environment variables in your code" section but the example is provided in the last section "Use EAS environment variables for other commands"
- Fix typos
- Updated references of app.config.ts to app.config.js in both guides since the latter is used in the examples
- Fix formatting issues

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting http://localhost:3002/eas/environment-variables/ & http://localhost:3002/eas/using-environment-variables/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
