### PR TITLE
[docs] Fix unique key error in development for `SidebarLink`

### DIFF
--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -68,7 +68,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isChapterCompleted(childSlug);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={childSlug}>
+            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
               {child.sidebarTitle ?? child.name}
               {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
             </SidebarLink>
@@ -126,7 +126,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isGetStartedChapterCompleted(childSlug);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={childSlug}>
+            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
               {child.sidebarTitle ?? child.name}
               {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
             </SidebarLink>

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -68,7 +68,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isChapterCompleted(childSlug);
 
           return (
-            <SidebarLink info={child} className="flex flex-1">
+            <SidebarLink info={child} className="flex flex-1" key={childSlug}>
               {child.sidebarTitle ?? child.name}
               {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
             </SidebarLink>
@@ -126,7 +126,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           const completed = isGetStartedChapterCompleted(childSlug);
 
           return (
-            <SidebarLink info={child} className="flex flex-1">
+            <SidebarLink info={child} className="flex flex-1" key={childSlug}>
               {child.sidebarTitle ?? child.name}
               {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
             </SidebarLink>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`SidebarLink` component usage in `SidebarGroup` shows the following error when navigating to Learn section in the docs: 

![CleanShot 2024-11-27 at 23 39 49@2x](https://github.com/user-attachments/assets/ccf72eae-6940-4b25-ae2a-78c326ba6ab4)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `key` prop with unique value (as it was in [this diff](https://github.com/expo/expo/pull/33001/files#diff-a70f4b9c48a8041678e938a25cb2fa5176aacb875143e36ece5d18298735a0f9)).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn run dev`
- Visit: http://localhost:3002/ui-programming/z-index/

There should be no development error as shared in the screenshot above.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
