### PR TITLE
[docs] Improve detecting component types

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -55,8 +55,10 @@ const isProp = ({ name }: GeneratedData) =>
   name !== 'WebAnchorProps' &&
   name !== 'ScreenProps';
 
+const componentTypeNames = ['React.FC', 'ForwardRefExoticComponent', 'ComponentType'];
+
 const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) => {
-  if (type?.name && ['React.FC', 'ForwardRefExoticComponent'].includes(type?.name)) {
+  if (type?.name && componentTypeNames.includes(type?.name)) {
     return true;
   } else if (extendedTypes && extendedTypes.length) {
     return extendedTypes[0].name === 'Component' || extendedTypes[0].name === 'PureComponent';
@@ -74,7 +76,7 @@ const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) => {
 
 const isConstant = ({ name, type }: GeneratedData) =>
   !['default', 'Constants', 'EventEmitter', 'SharedObject', 'NativeModule'].includes(name) &&
-  !(type?.name && ['React.FC', 'ForwardRefExoticComponent'].includes(type?.name));
+  !(type?.name && componentTypeNames.includes(type?.name));
 
 const hasCategoryHeader = ({ signatures }: GeneratedData): boolean =>
   (signatures &&


### PR DESCRIPTION
# Why

While working on #33299 I noticed that `MeshGradientView` is rendered as a constant instead of a component.

# How

I checked the generated docs data and here is the entry for this type:
```json
{
  "name": "MeshGradientView",
  "variant": "declaration",
  "kind": 32,
  "type": {
    "type": "reference",
    "typeArguments": [
      {
        "type": "reference",
        "name": "MeshGradientViewProps",
        "package": "expo-mesh-gradient"
      }
    ],
    "name": "ComponentType",
    "package": "@types/react",
    "qualifiedName": "React.ComponentType",
    "target": {}
  }
}
```

As you can see, `type.name` is `ComponentType`, which is missing in our functions that detect whether the type is a component or constant.

# Test Plan

Tested as part of #33299