### PR TITLE
Updated the definition for modelName (web), I felt that needed to be …

### DIFF
--- a/packages/expo-device/src/Device.ts
+++ b/packages/expo-device/src/Device.ts
@@ -53,7 +53,7 @@ export const modelId = ExpoDevice ? ExpoDevice.modelId || null : null;
  *
  * @example
  * ```js
- * Device.modelName; // Android: "Pixel 2"; iOS: "iPhone XS Max"; web: "iPhone", null
+ * Device.modelName; // Android: "Pixel 2"; iOS: "iPhone XS Max"; web: null
  * ```
  */
 export const modelName: string | null = ExpoDevice ? ExpoDevice.modelName : null;


### PR DESCRIPTION
…set to null right?

It's a typing change.

If this is accepted, should we then add the 
 * @platform android
 * @platform ios

To the block? 

Thanks

# Why

<!--
I was going through the doc for my personal use and that line felt odd

` * @example
 * ```js
 * Device.modelName; // Android: "Pixel 2"; iOS: "iPhone XS Max"; web: "iPhone", null
 * ```
 */
export const modelName: string | null = ExpoDevice ? ExpoDevice.modelName : null;
`

is web really "Iphone" also what's the null after the ,. 
-->

# How

<!--
How did you build this feature or fix this bug and why?

It is just a typescript change
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

Mostly just a typescript change
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
