### PR TITLE
[core] fix onHostPause AssertionError

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `AssertionError` from `ReactActivityDelegateWrapper.onPause`. ([#33309](https://github.com/expo/expo/pull/33309) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 52.0.11 — 2024-11-22

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -115,8 +115,10 @@ class ReactActivityDelegateWrapper(
         reactActivityLifecycleListeners.forEach { listener ->
           listener.onContentChanged(activity)
         }
-        shouldEmitPendingResume = false
-        onResume()
+        if (shouldEmitPendingResume) {
+          shouldEmitPendingResume = false
+          onResume()
+        }
       }
       return
     }
@@ -193,9 +195,11 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onPause() {
-    // If app is stopped before delayed `loadApp`, we should cancel the pending resume
+    // If app is stopped before the delayed `loadApp`, we should cancel the pending resume
+    // and avoid propagating the pause event because the state was never resumed.
     if (shouldEmitPendingResume) {
       shouldEmitPendingResume = false
+      return
     }
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onPause(activity)
@@ -211,9 +215,11 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onDestroy() {
-    // If app is stopped before delayed `loadApp`, we should cancel the pending resume
+    // If app is stopped before the delayed `loadApp`, we should cancel the pending resume
+    // and avoid propagating the destroy event because the state was never resumed.
     if (shouldEmitPendingResume) {
       shouldEmitPendingResume = false
+      return
     }
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onDestroy(activity)


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/15298#issuecomment-2479951439

# How

not sure how to repro the error but my hypothesis is `onPause` being called before the delayed `onResume`. this pr stop propagating the further onPause and onDestroy events

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
