### PR TITLE
[camera] Fix zooming

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3081,7 +3081,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: fc27a3c4b51c81f907a3e55b33fd71bae214c9f1
+  hermes-engine: 699c9e93f5af5892ce55dabed81ca70680bb356d
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -1,6 +1,7 @@
 import AntDesign from '@expo/vector-icons/AntDesign';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import Slider from '@react-native-community/slider';
 import {
   BarcodePoint,
   BarcodeScanningResult,
@@ -15,11 +16,13 @@ import {
 } from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
 import React, { useMemo } from 'react';
-import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import * as Svg from 'react-native-svg';
 
 import GalleryScreen from './GalleryScreen';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('screen');
 
 const flashModeOrder: Record<string, FlashMode> = {
   off: 'on',
@@ -349,35 +352,44 @@ export default class CameraScreen extends React.Component<object, State> {
   );
 
   renderBottomBar = () => (
-    <View style={styles.bottomBar}>
-      <TouchableOpacity style={styles.bottomButton} onPress={this.changeMode}>
-        <MaterialCommunityIcons
-          name={this.state.mode === 'picture' ? 'image' : 'video'}
-          size={32}
-          color="white"
-        />
-      </TouchableOpacity>
-      <View style={{ flex: 0.4 }}>
-        <TouchableOpacity
-          onPress={this.state.mode === 'picture' ? this.takePicture : this.takeVideo}
-          style={{ alignSelf: 'center' }}>
-          {this.state.recording ? (
-            <MaterialCommunityIcons name="stop-circle" size={64} color="red" />
-          ) : (
-            <Ionicons
-              name="radio-button-on"
-              size={64}
-              color={this.state.mode === 'picture' ? 'white' : 'red'}
-            />
-          )}
+    <View style={{ alignItems: 'center' }}>
+      <View style={styles.bottomBar}>
+        <TouchableOpacity style={styles.bottomButton} onPress={this.changeMode}>
+          <MaterialCommunityIcons
+            name={this.state.mode === 'picture' ? 'image' : 'video'}
+            size={32}
+            color="white"
+          />
+        </TouchableOpacity>
+        <View style={{ flex: 0.4 }}>
+          <TouchableOpacity
+            onPress={this.state.mode === 'picture' ? this.takePicture : this.takeVideo}
+            style={{ alignSelf: 'center' }}>
+            {this.state.recording ? (
+              <MaterialCommunityIcons name="stop-circle" size={64} color="red" />
+            ) : (
+              <Ionicons
+                name="radio-button-on"
+                size={64}
+                color={this.state.mode === 'picture' ? 'white' : 'red'}
+              />
+            )}
+          </TouchableOpacity>
+        </View>
+        <TouchableOpacity style={styles.bottomButton} onPress={this.toggleView}>
+          <View>
+            <MaterialCommunityIcons name="apps" size={32} color="white" />
+            {this.state.newPhotos && <View style={styles.newPhotosDot} />}
+          </View>
         </TouchableOpacity>
       </View>
-      <TouchableOpacity style={styles.bottomButton} onPress={this.toggleView}>
-        <View>
-          <MaterialCommunityIcons name="apps" size={32} color="white" />
-          {this.state.newPhotos && <View style={styles.newPhotosDot} />}
-        </View>
-      </TouchableOpacity>
+      <Slider
+        minimumValue={0}
+        maximumValue={1.0}
+        step={0.1}
+        style={{ width: SCREEN_WIDTH - 20, height: 30 }}
+        onValueChange={(v) => this.setState({ zoom: parseFloat(v.toFixed(1)) })}
+      />
     </View>
   );
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `zoom` on android and adjust the magnitude on iOS.
+
 ### 💡 Others
 
 ## 16.0.7 — 2024-11-22

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `zoom` on android and adjust the magnitude on iOS.
+- Fix `zoom` on android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `zoom` on android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix `zoom` on Android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -136,9 +136,7 @@ class CameraViewModule : Module() {
       }
 
       Prop("zoom") { view, zoom: Float? ->
-        zoom?.let {
-          view.camera?.cameraControl?.setLinearZoom(it)
-        }
+        view.zoom = zoom ?: 0f
       }
 
       Prop("mode") { view, mode: CameraMode? ->
@@ -159,7 +157,13 @@ class CameraViewModule : Module() {
 
       Prop("videoQuality") { view, quality: VideoQuality? ->
         quality?.let {
-          view.videoQuality = it
+          if (view.videoQuality != quality) {
+            view.videoQuality = it
+          }
+          return@Prop
+        }
+        if (view.videoQuality != VideoQuality.VIDEO1080P) {
+          view.videoQuality = VideoQuality.VIDEO1080P
         }
       }
 
@@ -180,11 +184,12 @@ class CameraViewModule : Module() {
         pictureSize?.let {
           if (view.pictureSize != pictureSize) {
             view.pictureSize = it
-            return@Prop
           }
+          return@Prop
         }
-
-        view.pictureSize = ""
+        if (view.pictureSize.isNotEmpty()) {
+          view.pictureSize = ""
+        }
       }
 
       Prop("autoFocus") { view, autoFocus: FocusMode? ->
@@ -199,10 +204,14 @@ class CameraViewModule : Module() {
 
       Prop("mirror") { view, mirror: Boolean? ->
         mirror?.let {
-          view.mirror = it
-          return@Prop
+          if (view.mirror != mirror) {
+            view.mirror = it
+            return@Prop
+          }
         }
-        view.mirror = false
+        if (view.mirror != false) {
+          view.mirror = false
+        }
       }
 
       Prop("videoBitrate") { view, bitrate: Int? ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -146,6 +146,12 @@ class ExpoCameraView(
       shouldCreateCamera = true
     }
 
+  var zoom: Float = 0f
+    set(value) {
+      field = value
+      camera?.cameraControl?.setLinearZoom(value.coerceIn(0f, 1f))
+    }
+
   var autoFocus: FocusMode = FocusMode.OFF
     set(value) {
       field = value
@@ -415,6 +421,8 @@ class ExpoCameraView(
           camera?.let {
             observeCameraState(it.cameraInfo)
           }
+          // Set the previous zoom level after recreating the camera
+          camera?.cameraControl?.setLinearZoom(zoom.coerceIn(0f, 1f))
           this.cameraProvider = cameraProvider
         } catch (e: Exception) {
           onMountError(

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -286,7 +286,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
     do {
       try device.lockForConfiguration()
-      device.videoZoomFactor = (device.activeFormat.videoMaxZoomFactor - 1.0) * zoom + 1.0
+      let minZoom = 1.0
+      device.videoZoomFactor = minZoom * pow(device.activeFormat.videoMaxZoomFactor / minZoom, zoom)
     } catch {
       log.info("\(#function): \(error.localizedDescription)")
     }


### PR DESCRIPTION
# Why
Closes #33279
On android, we were still creating the camera view too often causing the selected zoom level to be lost when it is recreated. Also, I think the magnitude of the zoom at intermediary values on iOS was too dramatic. 

# How
On Android, I've fixed some of the props that were causing the camera to be recreated too often and reset the zoom level when the camera is recreated. 

On iOS, I've adjusted the formula for calculating the zoom to have a smoother progression curve. 

# Test Plan
Bare-expo. I've added a slider to the example screen to manipulate the zoom level. At this point, this example needs to be broken up into smaller screens.

