### PR TITLE
[fingerprint] fix error from USE_RNCORE_AUTOLINKING_FROM_EXPO

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `USE_RNCORE_AUTOLINKING_FROM_EXPO does not exist and no fallback value provided.` error. ([#33323](https://github.com/expo/expo/pull/33323) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.2 — 2024-11-04

--- a/packages/@expo/fingerprint/cli/build/commands/generateFingerprint.js
+++ b/packages/@expo/fingerprint/cli/build/commands/generateFingerprint.js
@@ -64,7 +64,9 @@ Generate fingerprint for a project
     }
     const options = {
         debug: !!process.env.DEBUG || args['--debug'],
-        useRNCoreAutolinkingFromExpo: (0, getenv_1.boolish)('USE_RNCORE_AUTOLINKING_FROM_EXPO', undefined),
+        useRNCoreAutolinkingFromExpo: process.env['USE_RNCORE_AUTOLINKING_FROM_EXPO']
+            ? (0, getenv_1.boolish)('USE_RNCORE_AUTOLINKING_FROM_EXPO')
+            : undefined,
         ...(platform ? { platforms: [platform] } : null),
         silent: true,
     };

--- a/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
+++ b/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
@@ -47,7 +47,9 @@ Generate fingerprint for a project
 
   const options: Options = {
     debug: !!process.env.DEBUG || args['--debug'],
-    useRNCoreAutolinkingFromExpo: boolish('USE_RNCORE_AUTOLINKING_FROM_EXPO', undefined),
+    useRNCoreAutolinkingFromExpo: process.env['USE_RNCORE_AUTOLINKING_FROM_EXPO']
+      ? boolish('USE_RNCORE_AUTOLINKING_FROM_EXPO')
+      : undefined,
     ...(platform ? { platforms: [platform] } : null),
     silent: true,
   };


### PR DESCRIPTION
# Why

sorry for my worse feedback from https://github.com/expo/expo/pull/32541#discussion_r1826526998, which actually introducing the error

```sh
$ npx @expo/fingerprint fingerprint:generate
Error: GetEnv.Nonexistent: USE_RNCORE_AUTOLINKING_FROM_EXPO does not exist and no fallback value provided.
Error: GetEnv.Nonexistent: USE_RNCORE_AUTOLINKING_FROM_EXPO does not exist and no fallback value provided.
    at _value (/Users/kudo/sdk52/node_modules/getenv/index.js:14:13)
    at /Users/kudo/sdk52/node_modules/getenv/index.js:83:21
    at generateFingerprintAsync (/Users/kudo/sdk52/node_modules/@expo/fingerprint/cli/build/commands/generateFingerprint.js:67:60)
    at /Users/kudo/sdk52/node_modules/@expo/fingerprint/cli/build/cli.js:94:25
```

# How

`getenv.boolish` does not support undefined as fallback. we need it's being undefined to use core autolinking from expo by sdk version: https://github.com/expo/expo/blob/e66d4ad58f53170e757dd6ed68e72f4d57a1ef59/packages/%40expo/fingerprint/src/sourcer/Sourcer.ts#L33-L39

this pr tries to use boolish only when `process.env.USE_RNCORE_AUTOLINKING_FROM_EXPO` is defined

# Test Plan

- ci passed
- apply this patch to a default sdk 52 project and run `fingerprint:generate`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
