### PR TITLE
[sentry] Update recommended version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,5 +103,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "1.5.0",
   "@shopify/flash-list": "1.7.1",
-  "@sentry/react-native": "~6.1.0"
+  "@sentry/react-native": "~6.3.0"
 }


### PR DESCRIPTION
# Why
Closes #33316
The current recommended version of sentry causes a problem with `expo-splash-screen`

# How
Updating to `6.3.0` resolves the problem

# Test Plan

