### PR TITLE
[docs] Update the maximize size  for env variables to match what is says on the EAS dashboard

### DIFF
--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -227,6 +227,6 @@ See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/pa
 
 ## Limitations
 
-Environment variable value size is limited to 32 KiB for both string and file environment variables.
+Environment variable value size is limited to 4 KiB for both string and file environment variables.
 
 You can create up to 100 account-wide environment variables for each Expo account and 100 project-specific environment variables for each app

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -227,6 +227,6 @@ See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/pa
 
 ## Limitations
 
-Environment variable value size is limited to 4 KiB for both string and file environment variables.
+Environment variable value size is limited to 32 KB for environment variables with secret visibility and 4 KB for other visibility types.
 
 You can create up to 100 account-wide environment variables for each Expo account and 100 project-specific environment variables for each app


### PR DESCRIPTION
# Why

There was a mistake between the documentation and what it says on the EAS dashboard when attempting to upload a file as a .env value. In particular, the docs say that: "Environment variable value size is limited to 32 KiB for both string and file environment variables." However, while trying to upload to the eas dashboard, it says it is limited to a maximum of **4 KiB**.  

Here's a screenshot: 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4db90178-b00e-414b-af53-8188fd98ae6c">


# How

I have updated the documentation to reflect this.

# Test Plan

N/A

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
