### PR TITLE
[docs] Add missing info about using `--clear` option when modifying babel config file

### DIFF
--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -31,6 +31,10 @@ module.exports = function (api) {
 };
 ```
 
+4. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
+
+<Terminal cmd={['$ npx expo start --clear']} />
+
 ## babel-preset-expo
 
 [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds support for decorators, tree-shaking web libraries, and loading font icons.

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -31,6 +31,10 @@ module.exports = function (api) {
 };
 ```
 
+4. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
+
+<Terminal cmd={['$ npx expo start --clear']} />
+
 ## babel-preset-expo
 
 [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) is the default preset used in Expo projects. It extends the default React Native preset (`@react-native/babel-preset`) and adds support for decorators, tree-shaking web libraries, and loading font icons.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Babel config reference missing info about using `--clear` option from Expo CLI to clear Metro bundler cache.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add missing info about using `-c` option when modifying babel config file in the Babel reference as step 4.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-12-02 at 14 03 00@2x](https://github.com/user-attachments/assets/e56f9e6a-2408-45f6-862f-bb178060b819)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
