### PR TITLE
[iOS] Re-export ExpoModulesCore from Expo on iOS

### DIFF
--- a/packages/expo/ios/Expo.swift
+++ b/packages/expo/ios/Expo.swift
@@ -1,0 +1,2 @@
+// Export public API from the modules core, so modules and the AppDelegate can simply `import Expo`.
+@_exported import ExpoModulesCore


### PR DESCRIPTION
# Why

In some cases it would be nice to `import Expo` instead of `import ExpoModulesCore`. One of the examples is the `AppDelegate` when it gets migrated to Swift. I think in the future we may want module authors to import from `Expo` pod as well, just like we're doing in JS right now (importing `expo` package instead of `expo-modules-core`).

# How

Re-exported `ExpoModulesCore` from `Expo`.

# Test Plan

Tested as part of another upcoming PR, where I'm migrating the AppDelegate in bare-expo to Swift.