### PR TITLE
[iOS][core] Retire EXAppDelegateWrapper in favor of ExpoAppDelegate

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))
 
+### ⚠️ Notices
+
+- Deprecated `EXAppDelegateWrapper` in favor of `ExpoAppDelegate`. ([#33348](https://github.com/expo/expo/pull/33348) by [@tsapeta](https://github.com/tsapeta)))
+
 ## 2.1.1 - 2024-12-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+__deprecated_msg("EXAppDelegateWrapper is deprecated as of SDK 53. Migrate your AppDelegate to Swift and use ExpoAppDelegate instead.")
 @interface EXAppDelegateWrapper : RCTAppDelegate
 
 @property (nonatomic, strong, readonly) EXReactDelegateWrapper *reactDelegate;

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-__deprecated_msg("EXAppDelegateWrapper is deprecated as of SDK 53. Migrate your AppDelegate to Swift and use ExpoAppDelegate instead.")
+__deprecated_msg("EXAppDelegateWrapper is deprecated as of SDK 52. Migrate your AppDelegate to Swift and use ExpoAppDelegate instead.")
 @interface EXAppDelegateWrapper : RCTAppDelegate
 
 @property (nonatomic, strong, readonly) EXReactDelegateWrapper *reactDelegate;

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -6,9 +6,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface RCTAppDelegate ()
+
+- (RCTRootViewFactory *)createRCTRootViewFactory;
+
+@end
+
 @interface EXAppDelegateWrapper : RCTAppDelegate
 
 @property (nonatomic, strong, readonly) EXReactDelegateWrapper *reactDelegate;
+
++ (void)customizeRootView:(nonnull UIView *)rootView byAppDelegate:(nonnull RCTAppDelegate *)appDelegate;
 
 @end
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -17,6 +17,11 @@ __deprecated_msg("EXAppDelegateWrapper is deprecated as of SDK 53. Migrate your 
 
 @property (nonatomic, strong, readonly) EXReactDelegateWrapper *reactDelegate;
 
+/**
+ Currently (RN 0.76) `customizeRootView` signature in `RCTAppDelegate` is broken as it uses `RCTRootView` type,
+ but this type is no longer used. It should rather be `RCTSurfaceHostingView`, but for simplicity it could be just `UIView`.
+ We need a helper function in Objective-C to actually make it to work, otherwise the types will conflict in Swift.
+ */
 + (void)customizeRootView:(nonnull UIView *)rootView byAppDelegate:(nonnull RCTAppDelegate *)appDelegate;
 
 @end

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -9,14 +9,7 @@
 #import <React/RCTComponentViewFactory.h> // Allows non-umbrella since it's coming from React-RCTFabric
 #import <ReactCommon/RCTHost.h> // Allows non-umbrella because the header is not inside a clang module
 
-
 @interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider, RCTHostDelegate>
-@end
-
-@interface RCTRootViewFactoryConfiguration ()
-
-- (void)setCustomizeRootView:(void (^)(UIView *rootView))customizeRootView;
-
 @end
 
 @implementation EXAppDelegateWrapper {
@@ -36,8 +29,7 @@
 // which `UIApplicationDelegate` selectors are implemented.
 - (BOOL)respondsToSelector:(SEL)selector
 {
-  return [super respondsToSelector:selector]
-    || [_expoAppDelegate respondsToSelector:selector];
+  return [super respondsToSelector:selector] || [_expoAppDelegate respondsToSelector:selector];
 }
 
 // Forwards all invocations to `ExpoAppDelegate` object.
@@ -46,21 +38,25 @@
   return _expoAppDelegate;
 }
 
-#if !TARGET_OS_OSX
+#pragma mark - RCTAppDelegate
+
+// Make sure to override all necessary methods from `RCTAppDelegate` here, explicitly forwarding everything to `_expoAppDelegate`.
+// `forwardingTargetForSelector` works only for methods that are not specified in this and `RCTAppDelegate` classes.
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   [super application:application didFinishLaunchingWithOptions:launchOptions];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-result"
-  [_expoAppDelegate application:application didFinishLaunchingWithOptions:launchOptions];
-#pragma clang diagnostic pop
-  return YES;
+  return [_expoAppDelegate application:application didFinishLaunchingWithOptions:launchOptions];
 }
-#endif // !TARGET_OS_OSX
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+  return [_expoAppDelegate applicationDidBecomeActive:application];
+}
 
 - (UIViewController *)createRootViewController
 {
-  return [self.reactDelegate createRootViewController];
+  return [_expoAppDelegate createRootViewController];
 }
 
 - (RCTRootViewFactory *)createRCTRootViewFactory
@@ -68,11 +64,10 @@
   return [_expoAppDelegate createRCTRootViewFactory];
 }
 
-#if !TARGET_OS_OSX
-- (void)customizeRootView:(UIView *)rootView {
+- (void)customizeRootView:(UIView *)rootView
+{
   [_expoAppDelegate customizeRootView:rootView];
 }
-#endif // !TARGET_OS_OSX
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -19,12 +19,6 @@
 
 @end
 
-@interface EXAppDelegateWrapper()
-
-@property (nonatomic, strong) EXReactDelegateWrapper *reactDelegate;
-
-@end
-
 @implementation EXAppDelegateWrapper {
   EXExpoAppDelegate *_expoAppDelegate;
 }
@@ -33,7 +27,6 @@
 {
   if (self = [super init]) {
     _expoAppDelegate = [[EXExpoAppDelegate alloc] init];
-    _reactDelegate = [[EXReactDelegateWrapper alloc] initWithExpoReactDelegate:_expoAppDelegate.reactDelegate];
   }
   return self;
 }
@@ -72,57 +65,7 @@
 
 - (RCTRootViewFactory *)createRCTRootViewFactory
 {
-  __weak __typeof(self) weakSelf = self;
-  RCTBundleURLBlock bundleUrlBlock = ^{
-    RCTAppDelegate *strongSelf = weakSelf;
-    return strongSelf.bundleURL;
-  };
-
-  RCTRootViewFactoryConfiguration *configuration =
-      [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock
-                                                       newArchEnabled:self.newArchEnabled
-                                                   turboModuleEnabled:self.newArchEnabled
-                                                    bridgelessEnabled:self.newArchEnabled];
-
-  configuration.createRootViewWithBridge = ^UIView *(RCTBridge *bridge, NSString *moduleName, NSDictionary *initProps)
-  {
-    return [weakSelf createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
-  };
-
-  configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> delegate, NSDictionary *launchOptions)
-  {
-    return [weakSelf createBridgeWithDelegate:delegate launchOptions:launchOptions];
-  };
-
-  configuration.customizeRootView = ^(UIView *_Nonnull rootView) {
-    [weakSelf customizeRootView:(RCTRootView *)rootView];
-  };
-
-  // NOTE(kudo): `sourceURLForBridge` is not referenced intentionally because it does not support New Architecture.
-  configuration.sourceURLForBridge = nil;
-
-  if ([self respondsToSelector:@selector(extraModulesForBridge:)]) {
-    configuration.extraModulesForBridge = ^NSArray<id<RCTBridgeModule>> *_Nonnull(RCTBridge *_Nonnull bridge)
-    {
-      return [weakSelf extraModulesForBridge:bridge];
-    };
-  }
-
-  if ([self respondsToSelector:@selector(extraLazyModuleClassesForBridge:)]) {
-    configuration.extraLazyModuleClassesForBridge =
-        ^NSDictionary<NSString *, Class> *_Nonnull(RCTBridge *_Nonnull bridge)
-    {
-      return [weakSelf extraLazyModuleClassesForBridge:bridge];
-    };
-  }
-
-  if ([self respondsToSelector:@selector(bridge:didNotFindModule:)]) {
-    configuration.bridgeDidNotFindModule = ^BOOL(RCTBridge *_Nonnull bridge, NSString *_Nonnull moduleName) {
-      return [weakSelf bridge:bridge didNotFindModule:moduleName];
-    };
-  }
-
-  return [[EXReactRootViewFactory alloc] initWithReactDelegate:self.reactDelegate configuration:configuration turboModuleManagerDelegate:self];
+  return [_expoAppDelegate createRCTRootViewFactory];
 }
 
 #if !TARGET_OS_OSX
@@ -150,6 +93,13 @@
                exceptionId:(NSUInteger)exceptionId
                    isFatal:(BOOL)isFatal
 {
+}
+
+#pragma mark - Helpers
+
++ (void)customizeRootView:(nonnull UIView *)rootView byAppDelegate:(nonnull RCTAppDelegate *)appDelegate
+{
+  [appDelegate customizeRootView:(RCTRootView *)rootView];
 }
 
 @end

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -39,7 +39,11 @@ open class ExpoAppDelegate: ExpoAppInstance {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    if UIApplication.shared.delegate is ExpoAppDelegate {
+      // Super function from `RCTAppDelegate` must be called only when the class is used as the base class of the AppDelegate.
+      // For backwards compatibility `EXAppDelegateWrapper` creates a detached instance of `ExpoAppDelegate`, in which case this call must be skipped.
+      super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
 
     return subscribers.reduce(false) { result, subscriber in
       return subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? false || result

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -15,7 +15,10 @@ open class ExpoAppDelegate: ExpoAppInstance {
   #if os(iOS) || os(tvOS)
   // MARK: - Initializing the App
 
-  open override func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+  open override func application(
+    _ application: UIApplication,
+    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
     let parsedSubscribers = subscribers.filter {
       $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
     }
@@ -32,7 +35,10 @@ open class ExpoAppDelegate: ExpoAppInstance {
     }
   }
 
-  open override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+  open override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
     return subscribers.reduce(false) { result, subscriber in
@@ -73,7 +79,11 @@ open class ExpoAppDelegate: ExpoAppInstance {
 
   // MARK: - Downloading Data in the Background
 
-  open override func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+  open override func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
     let selector = #selector(application(_:handleEventsForBackgroundURLSession:completionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
@@ -200,7 +210,11 @@ open class ExpoAppDelegate: ExpoAppInstance {
   }
 
 #if !os(tvOS)
-  open override func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+  open override func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
     let selector = #selector(application(_:performActionFor:completionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
@@ -230,7 +244,10 @@ open class ExpoAppDelegate: ExpoAppInstance {
 
   // MARK: - Background Fetch
 
-  open override func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+  open override func application(
+    _ application: UIApplication,
+    performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
     let selector = #selector(application(_:performFetchWithCompletionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -45,9 +45,11 @@ open class ExpoAppDelegate: ExpoAppInstance {
       super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
-    return subscribers.reduce(false) { result, subscriber in
-      return subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? false || result
+    subscribers.forEach { subscriber in
+      // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
+      _ = subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions)
     }
+    return true
   }
 
   // TODO: - Configuring and Discarding Scenes

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -1,0 +1,86 @@
+import React_RCTAppDelegate
+
+private var reactDelegateHandlers = [ExpoReactDelegateHandler]()
+
+@objc(EXAppInstance)
+open class ExpoAppInstance: RCTAppDelegate {
+  @objc
+  public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
+
+  open override func createRootViewController() -> UIViewController {
+    return reactDelegate.createRootViewController()
+  }
+
+  open override func createRCTRootViewFactory() -> RCTRootViewFactory {
+    let bundleUrlBlock: RCTBundleURLBlock = { [weak self] in
+      return self?.bundleURL()
+    }
+
+    let configuration = RCTRootViewFactoryConfiguration(
+      bundleURLBlock: bundleUrlBlock,
+      newArchEnabled: newArchEnabled(),
+      turboModuleEnabled: turboModuleEnabled(),
+      bridgelessEnabled: bridgelessEnabled()
+    )
+
+    configuration.createRootViewWithBridge = { bridge, moduleName, initProps in
+      return self.createRootView(with: bridge, moduleName: moduleName, initProps: initProps)
+    }
+
+    configuration.createBridgeWithDelegate = { delegate, launchOptions in
+      return self.createBridge(with: delegate, launchOptions: launchOptions)
+    }
+
+    configuration.customizeRootView = { rootView in
+      // @tsapeta: Currently (RN 0.76) `customizeRootView` signature in `RCTAppDelegate` is broken as it uses `RCTRootView` type,
+      // but this type is no longer used. It should rather be `RCTSurfaceHostingView`, but for simplicity it could be just `UIView`.
+      // We need a helper function in Objective-C to actually make it to work, otherwise the types will conflict in Swift.
+      return EXAppDelegateWrapper.customizeRootView(rootView, by: self)
+    }
+
+    // NOTE(kudo): `sourceURLForBridge` is not referenced intentionally because it does not support New Architecture.
+    configuration.sourceURLForBridge = nil
+
+    if responds(to: #selector(extraModules(for:))) {
+      configuration.extraModulesForBridge = { bridge in
+        return self.extraModules(for: bridge)
+      }
+    }
+
+    if responds(to: #selector(extraLazyModuleClasses(for:))) {
+      configuration.extraLazyModuleClassesForBridge = { bridge in
+        return self.extraLazyModuleClasses(for: bridge)
+      }
+    }
+
+    if responds(to: #selector(bridge(_:didNotFindModule:))) {
+      configuration.bridgeDidNotFindModule = { bridge, moduleName in
+        return self.bridge(bridge, didNotFindModule: moduleName)
+      }
+    }
+
+    return ExpoReactRootViewFactory(
+      reactDelegate: reactDelegate,
+      configuration: configuration,
+      turboModuleManagerDelegate: self
+    )
+  }
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // This method is called only in the old architecture. For compatibility just use the result of a new `bundleURL` method.
+    return bundleURL()
+  }
+
+  // MARK: - Statics
+
+  @objc
+  public static func registerReactDelegateHandlersFrom(modulesProvider: ModulesProvider) {
+    modulesProvider.getReactDelegateHandlers()
+      .sorted { tuple1, tuple2 -> Bool in
+        return ModulePriorities.get(tuple1.packageName) > ModulePriorities.get(tuple2.packageName)
+      }
+      .forEach { handlerTuple in
+        reactDelegateHandlers.append(handlerTuple.handler.init())
+      }
+  }
+}

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -34,7 +34,7 @@ open class ExpoAppInstance: RCTAppDelegate {
     }
 
     configuration.customizeRootView = { rootView in
-      // @tsapeta: We cannot just call `self.customize(rootView)` – see the description of the below method.
+      // @tsapeta: We cannot just call `self.customize(rootView)` – see the comment of the `customizeRootView:byAppDelegate:` function in EXAppDelegateWrapper.h
       return EXAppDelegateWrapper.customizeRootView(rootView, by: self)
     }
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -34,9 +34,7 @@ open class ExpoAppInstance: RCTAppDelegate {
     }
 
     configuration.customizeRootView = { rootView in
-      // @tsapeta: Currently (RN 0.76) `customizeRootView` signature in `RCTAppDelegate` is broken as it uses `RCTRootView` type,
-      // but this type is no longer used. It should rather be `RCTSurfaceHostingView`, but for simplicity it could be just `UIView`.
-      // We need a helper function in Objective-C to actually make it to work, otherwise the types will conflict in Swift.
+      // @tsapeta: We cannot just call `self.customize(rootView)` – see the description of the below method.
       return EXAppDelegateWrapper.customizeRootView(rootView, by: self)
     }
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -7,10 +7,12 @@ open class ExpoAppInstance: RCTAppDelegate {
   @objc
   public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
 
+  @objc
   open override func createRootViewController() -> UIViewController {
     return reactDelegate.createRootViewController()
   }
 
+  @objc
   open override func createRCTRootViewFactory() -> RCTRootViewFactory {
     let bundleUrlBlock: RCTBundleURLBlock = { [weak self] in
       return self?.bundleURL()

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
@@ -3,22 +3,23 @@
 #pragma once
 
 #import <ExpoModulesCore/Platform.h>
-#import <ExpoModulesCore/EXReactDelegateWrapper.h>
 #import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class EXReactDelegate;
+
 NS_SWIFT_NAME(ExpoReactRootViewFactory)
 @interface EXReactRootViewFactory : RCTRootViewFactory
 
-@property (nonatomic, weak, nullable) EXReactDelegateWrapper *reactDelegate;
+@property (nonatomic, weak, nullable) EXReactDelegate *reactDelegate;
 
 /**
  Initializer for EXAppDelegateWrapper integration
  */
-- (instancetype)initWithReactDelegate:(nullable EXReactDelegateWrapper *)reactDelegate
+- (instancetype)initWithReactDelegate:(nullable EXReactDelegate *)reactDelegate
                         configuration:(RCTRootViewFactoryConfiguration *)configuration
-           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate;
+           turboModuleManagerDelegate:(nullable id)turboModuleManagerDelegate;
 
 /**
  Calls super `viewWithModuleName:initialProperties:launchOptions:` from `RCTRootViewFactory`.

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -1,9 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
-
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
 #import <ExpoModulesCore/RCTAppDelegateUmbrella.h>
+#import <ExpoModulesCore/Swift.h>
 
 @interface RCTRootViewFactory ()
 
@@ -13,9 +13,9 @@
 
 @implementation EXReactRootViewFactory
 
-- (instancetype)initWithReactDelegate:(nullable EXReactDelegateWrapper *)reactDelegate
+- (instancetype)initWithReactDelegate:(nullable EXReactDelegate *)reactDelegate
                         configuration:(RCTRootViewFactoryConfiguration *)configuration
-           turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+           turboModuleManagerDelegate:(nullable id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
 {
   if (self = [super initWithConfiguration:configuration andTurboModuleManagerDelegate:turboModuleManagerDelegate]) {
     self.reactDelegate = reactDelegate;
@@ -28,7 +28,7 @@
                  launchOptions:(nullable NSDictionary *)launchOptions
 {
   if (self.reactDelegate != nil) {
-    return [self.reactDelegate createReactRootView:moduleName initialProperties:initialProperties launchOptions:launchOptions];
+    return [self.reactDelegate createReactRootViewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
   }
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
 }


### PR DESCRIPTION
# Why

As of React Native 0.77, the app template will have the AppDelegate in Swift. We should migrate our own too, in SDK 53. I think it's a good chance to start retiring `EXAppDelegateWrapper` and `EXLegacyAppDelegateWrapper` in favor of `ExpoAppDelegate` that is written in Swift.

# How

- Separated logic not related to app delegate subscribers to `ExpoAppInstance` that inherits from `RCTAppDelegate`. In the future it could be used to set up a new app instance in Expo Go or brownfield apps. I'd like to keep `ExpoAppDelegate` clean, without custom logic regarding React delegate handlers and all the setup required for `RCTAppDelegate`.
- `EXAppDelegateWrapper` was wrapping `ExpoAppDelegate` and it has to stay as is – for backwards compatibility. However, some logic has been moved to the new `ExpoAppInstance`.
- `ExpoAppDelegate` now inherits from `ExpoAppInstance`, so also from `RCTAppDelegate`.
- In some places we can now use `ExpoReactDelegate` directly instead of `EXReactDelegateWrapper`.

# Test Plan

Tested with bare-expo, using both the legacy `EXAppDelegateWrapper` and `ExpoAppDelegate`.

# To do next

- Migrate AppDelegate to Swift in bare-expo and the app template
- Ensure `install-expo-modules` script works as expected