### PR TITLE
[docs] Add info about manual app submission process for Submits to app stores page

### DIFF
--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -3,7 +3,9 @@ title: Submit to app stores
 description: Learn how to submit your app to Google Play Store and Apple App Store from the command line with EAS Submit.
 ---
 
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
+import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStoreIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -101,6 +103,24 @@ The command will lead you through the process of submitting the app. It will per
 
 - A summary of the provided configuration is displayed and the submission process begins. The submission progress is displayed on the screen.
 - Your build should now be visible on [App Store Connect](https://appstoreconnect.apple.com). If something goes wrong, an appropriate message is displayed on the screen.
+
+## Manual submission to app stores
+
+To learn more about manual app submission process to Google Play Store and Apple App Store, see the following:
+
+<BoxLink
+  title="Manual first submission of an Android app"
+  description="Follow the steps from the FYI guide on manually submitting your app to Google Play Store for the first time."
+  href="https://expo.fyi/first-android-submission"
+  Icon={GoogleAppStoreIcon}
+/>
+
+<BoxLink
+  title="App submission using App Store Connect"
+  description="Learn how to submit your app manually to Apple App Store or TestFlight using App Store Connect."
+  href="/guides/local-app-production/#app-submission-using-app-store-connect"
+  Icon={AppleAppStoreIcon}
+/>
 
 ## Next step
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -57,7 +57,7 @@ This command also generates the keystore file named **my-upload-key.keystore** i
 
 ### Update gradle variables
 
-Open **android/gradle.properties** file and add the following gradle variables at the end of the file. These variables contain information about your upload key:
+Open **android/gradle.properties** file and add the following gradle variables at the end of the file. Replace the `*****` with the correct keystore and key password. These variables contain information about your upload key:
 
 ```groovy android/gradle.properties
 MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -104,7 +104,7 @@ This command will generate app-release.aab inside the **android/app/build/output
 Google Play Store requires manual app submission when submitting the **.aab** file for the first time.
 
 <BoxLink
-  title="Manual first submission of an Android app"
+  title="Manual submission of an Android app"
   description="Follow the steps from the FYI guide on manually submitting your app to Google Play Store for the first time."
   href="https://expo.fyi/first-android-submission"
   Icon={GoogleAppStoreIcon}

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -8,7 +8,7 @@ import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
 To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
@@ -76,30 +76,7 @@ MYAPP_UPLOAD_KEY_PASSWORD=*****
 
 Open **android/app/build.gradle** file and add the following configuration:
 
-```diff android/app/build.gradle
-android {
-  signingConfigs {
-    // ...
-+   release {
-+     if (project.hasProperty('MYAPP_UPLOAD_STORE_FILE')) {
-+         storeFile file(MYAPP_UPLOAD_STORE_FILE)
-+         storePassword MYAPP_UPLOAD_STORE_PASSWORD
-+         keyAlias MYAPP_UPLOAD_KEY_ALIAS
-+         keyPassword MYAPP_UPLOAD_KEY_PASSWORD
-+     }
-    }
-  }
-  buildTypes {
-    // ...
-    release {
-      signingConfig signingConfigs.debug
-+     signingConfig signingConfigs.release
-      minifyEnabled false
-      // ...
-    }
-  }
-}
-```
+<DiffBlock source="/static/diffs/android-release-build.diff" />
 
 </Step>
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -57,7 +57,9 @@ This command also generates the keystore file named **my-upload-key.keystore** i
 
 ### Update gradle variables
 
-Open **android/gradle.properties** file and add the following gradle variables at the end of the file. Replace the `*****` with the correct keystore and key password. These variables contain information about your upload key:
+Open **android/gradle.properties** file and add the following gradle variables at the end of the file. Replace the `*****` with the correct keystore and key password that you provided in the previous step.
+
+These variables contain information about your upload key:
 
 ```groovy android/gradle.properties
 MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -4,7 +4,7 @@ sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---
 
-import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
+import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -105,7 +105,7 @@ Google Play Store requires manual app submission when submitting the **.aab** fi
   title="Manual first submission of an Android app"
   description="Follow the steps from the FYI guide on manually submitting your app to Google Play Store for the first time."
   href="https://expo.fyi/first-android-submission"
-  Icon={AndroidIcon}
+  Icon={GoogleAppStoreIcon}
 />
 
 </Step>

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -4,6 +4,9 @@ sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---
 
+import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -104,11 +107,29 @@ android {
 
 ### Generate release Android Application Bundle (aab)
 
-Create a production build in **.aab** format by running Gradle's `bundleRelease` command:
+Navigate inside the **android** directory and create a production build in **.aab** format by running Gradle's `bundleRelease` command:
 
-<Terminal cmd={['$ ./gradlew app:bundleRelease']} />
+<Terminal
+  cmd={['$ cd android', '', '$ ./gradlew app:bundleRelease']}
+  cmdCopy="cd android && ./gradlew app:bundleRelease"
+/>
 
-This command will generate app-release.aab inside the android/app/build/outputs/bundle/release directory.
+This command will generate app-release.aab inside the **android/app/build/outputs/bundle/release** directory.
+
+</Step>
+
+<Step label="5">
+
+### Manual app submission to Google Play Console
+
+Google Play Store requires manual app submission when submitting the **.aab** file for the first time.
+
+<BoxLink
+  title="Manual first submission of an Android app"
+  description="Follow the steps from the FYI guide on manually submitting your app to Google Play Store for the first time."
+  href="https://expo.fyi/first-android-submission"
+  Icon={AndroidIcon}
+/>
 
 </Step>
 

--- a/docs/public/static/diffs/android-release-build.diff
+++ b/docs/public/static/diffs/android-release-build.diff
@@ -1,0 +1,27 @@
+diff --git a/android/app/build.gradle b/android/app/build.gradle
+index c50bf0c..8dd1626 100644
+--- a/android/app/build.gradle
++++ b/android/app/build.gradle
+@@ -101,6 +101,14 @@ android {
+             keyAlias 'androiddebugkey'
+             keyPassword 'android'
+         }
++        release {
++            if (project.hasProperty('MYAPP_UPLOAD_STORE_FILE')) {
++                storeFile file(MYAPP_UPLOAD_STORE_FILE)
++                storePassword MYAPP_UPLOAD_STORE_PASSWORD
++                keyAlias MYAPP_UPLOAD_KEY_ALIAS
++                keyPassword MYAPP_UPLOAD_KEY_PASSWORD
++            }
++        }
+     }
+     buildTypes {
+         debug {
+@@ -110,6 +118,7 @@ android {
+             // Caution! In production, you need to generate your own keystore file.
+             // see https://reactnative.dev/docs/signed-apk-android.
+             signingConfig signingConfigs.debug
++            signingConfig signingConfigs.release
+             shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
+             minifyEnabled enableProguardInReleaseBuilds
+             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14059

# How

<!--
How did you build this feature or fix this bug and why?
-->

**Update Create a production build locally** guide
- Update to use DiffBlock so that copy pasting changes to `android/app/build.gradle` files becomes easier
-  Add step 5 that likes to FYI guide to for manual submission to Google Play Console
- Update step 2 to add info about replacing `*****` with value entered in step 1

**Update Submit to app stores**
- Add a section that provides links to manual instructions on submitting an app binary to Google Play Console and Apple App Store using App Store Connect

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**Preview Create a production build locally** guide

![CleanShot 2024-12-02 at 17 08 50](https://github.com/user-attachments/assets/f1c73f83-6eda-46cc-88a5-63620630329b)

![CleanShot 2024-12-02 at 17 10 46](https://github.com/user-attachments/assets/9f20e4da-0d9f-41ac-abf3-ffca80d24a22)

![CleanShot 2024-12-02 at 17 08 44](https://github.com/user-attachments/assets/91c43438-1655-4183-b54f-cff6f4721efb)

**Preview Submit to app stores**

![CleanShot 2024-12-02 at 17 09 56](https://github.com/user-attachments/assets/af340217-a791-411a-bead-95a100c3ea03)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
