### PR TITLE
[docs] Add `StructuredData` component for Development Builds introduction page

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -15,17 +15,9 @@ import { StructuredData } from '~/ui/components/StructuredData';
 <StructuredData
   data={{
     '@context': 'https://schema.org',
-    '@type': 'Article',
+    '@type': 'TechArticle',
     headline: 'Development builds introduction',
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': 'https://docs.expo.dev/develop/development-builds/introduction/',
-    },
     description: 'A better development environment for React Native apps.',
-    publisher: {
-      '@type': 'Organization',
-      name: 'Expo',
-    },
   }}
 />
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -10,6 +10,24 @@ import { VideoRecorderIcon } from '@expo/styleguide-icons/outline/VideoRecorderI
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { StructuredData } from '~/ui/components/StructuredData';
+
+<StructuredData
+  data={{
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Development builds introduction',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://docs.expo.dev/develop/development-builds/introduction/',
+    },
+    description: 'A better development environment for React Native apps.',
+    publisher: {
+      '@type': 'Organization',
+      name: 'Expo',
+    },
+  }}
+/>
 
 A **development build** is a debug build of your app that contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. By using development builds instead of [Expo Go](/get-started/set-up-your-environment/), you gain full control over the native runtime, so you can [install any native libraries](/workflow/using-libraries/#determining-third-party-library-compatibility), [modify any project configuration](/config-plugins/introduction/), or [write your own native code](/modules/get-started/). With Expo development builds, you are building your own native app, while with Expo Go you are running your project in a sandboxed native app environment.
 

--- a/docs/ui/components/StructuredData/index.tsx
+++ b/docs/ui/components/StructuredData/index.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+
+type Props = {
+  data: Record<string, any>;
+};
+
+export function StructuredData({ data }: Props) {
+  return (
+    <Head>
+      <script
+        key="structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      />
+    </Head>
+  );
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-13546

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Copy and add `StructuredData` UI component from Universe
- Use `StructuredData` in the Introduction to Development builds page markup by defining a modified [`headline`](https://schema.org/headline), adding a link to the page manually, and using the same description from the page for the `description` field. These properties are validated from https://schema.org/docs/documents.html.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test that the structured-data content with type `application/ld+json` is added to the Introduction to Development builds page:
- Run `yarn run dev` to kickstart the docs development server locally
- Go to http://localhost:3002/develop/development-builds/introduction/
- Open Chrome's Developer Tools and find `application/ld+json`
- You will find the following script:

![CleanShot 2024-12-02 at 19 28 21](https://github.com/user-attachments/assets/3b82efc8-23c4-4bd6-bf88-adda180594f6)

This script is only applied to this page. You can verify this by navigating to any other docs page and repeating the same steps from the Test plan. The outcome will be that there's no structured data script present for any other page.

After publishing these changes, the next step will be to monitor if the main issue improves when searching for "expo development" using Google Search (details in Linear task linked above).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
