### PR TITLE
[core][Android] Fix failing test

### DIFF
--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -211,7 +211,12 @@ void installClass(jsi::Runtime &runtime) {
     // To provide backwards compatibility with the old EventEmitter where the native module object was passed as an argument.
     // We're checking if the argument is already an instance of the new emitter and if so, just return it without unnecessarily wrapping it.
     if (count > 0) {
-      const jsi::Object &firstArg = LazyObject::unwrapObjectIfNecessary(runtime, args[0].asObject(runtime));
+      // We need the tmp object to correctly unwrap the lazy object.
+      // For some reason, if we inline the retrieval of the first argument, the instanceOf check fails on Android.
+      // This is probably because the object is copied somewhere in the process.
+      const jsi::Object &tmp = args[0].asObject(runtime);
+      const jsi::Object &firstArg = LazyObject::unwrapObjectIfNecessary(runtime, tmp);
+
       jsi::Function constructor = thisValue.getObject(runtime).getPropertyAsFunction(runtime, "constructor");
 
       if (firstArg.instanceOf(runtime, constructor)) {


### PR DESCRIPTION
# Why

Fixes failing test - see https://exponent-internal.slack.com/archives/C1QP38NQ5/p1732896111485919?thread_ts=1732886478.170639&cid=C1QP38NQ5

# How

For some reason, if we inline the retrieval of the first argument, the instanceOf check fails on Android. This is probably because the object is copied somewhere in the process.

# Test Plan

- e2e ✅ 
- test-suite ✅ 