### PR TITLE
[docs] point to native upgrade helper for previous versions of Expo Modules manual install guide

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.76.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.76. For previous versions, check the [native upgrade helper](bare/upgrade) to see how these files are customized.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 


### PR DESCRIPTION
…es installs

# Why
A number of users transitioning to Expo do so while on earlier versions, so they isolate their Expo migration from the React Native upgrade. It might be good in the long run to actually include these previous instructions, or to even generate the diffs programmatically and include all supported versions. But for now, let's include a link to what could help you for previous versions, the native upgrade helper

# How

Added a callout to the native upgrade helper

