### PR TITLE
[expo-audio] Support Apple TV

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#33365](https://github.com/expo/expo/pull/33365) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 - Update docs and API so all units of time are returned as seconds, not milliseconds. ([#33320](https://github.com/expo/expo/pull/33320) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/expo-module.config.json
+++ b/packages/expo-audio/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "tvos", "android"],
   "ios": {
     "modules": ["AudioModule"]
   },

--- a/packages/expo-audio/ios/AudioComponentRegistry.swift
+++ b/packages/expo-audio/ios/AudioComponentRegistry.swift
@@ -1,7 +1,9 @@
 class AudioComponentRegistry {
   static let shared = AudioComponentRegistry()
   var players = [String: AudioPlayer]()
+  #if os(iOS)
   var recorders = [String: AudioRecorder]()
+  #endif
 
   private init() {}
 
@@ -9,20 +11,26 @@ class AudioComponentRegistry {
     players[player.id] = player
   }
 
+  #if os(iOS)
   func add(_ recorder: AudioRecorder) {
     recorders[recorder.id] = recorder
   }
+  #endif
 
   func remove(_ player: AudioPlayer) {
     players.removeValue(forKey: player.id)
   }
 
+  #if os(iOS)
   func remove(_ recorder: AudioRecorder) {
     recorders.removeValue(forKey: recorder.id)
   }
+  #endif
 
   func removeAll() {
     players.removeAll()
+    #if os(iOS)
     recorders.removeAll()
+    #endif
   }
 }

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -69,6 +69,7 @@ struct RecordingUtils {
 }
 
 struct AudioUtils {
+  #if os(iOS)
   static func createRecorder(directory: URL?, with options: RecordingOptions) -> AVAudioRecorder {
     if let directory {
       let fileUrl = createRecordingUrl(from: directory, with: options)
@@ -80,6 +81,7 @@ struct AudioUtils {
     }
     return AVAudioRecorder()
   }
+  #endif
 
   static func createAVPlayer(from source: AudioSource?) -> AVPlayer {
     if let source, let url = source.uri {
@@ -139,6 +141,7 @@ struct AudioUtils {
   }
 
   private static func getFormatIDFromString(typeString: String) -> UInt32? {
+    // swiftlint:disable:next legacy_objc_type
     if let s = (typeString as NSString).utf8String {
       return UInt32(s[3]) | (UInt32(s[2]) << 8) | (UInt32(s[1]) << 16) | (UInt32(s[0]) << 24)
     }
@@ -148,9 +151,11 @@ struct AudioUtils {
   static func validateAudioMode(mode: AudioMode) throws {
     if !mode.playsInSilentMode && mode.interruptionMode == .duckOthers {
       throw InvalidAudioModeException("playsInSilentMode == false and duckOthers == true cannot be set on iOS")
-    } else if !mode.playsInSilentMode && mode.allowsRecording {
+    }
+    if !mode.playsInSilentMode && mode.allowsRecording {
       throw InvalidAudioModeException("playsInSilentMode == false and duckOthers == true cannot be set on iOS")
-    } else if !mode.playsInSilentMode && mode.shouldPlayInBackground {
+    }
+    if !mode.playsInSilentMode && mode.shouldPlayInBackground {
       throw InvalidAudioModeException("playsInSilentMode == false and staysActiveInBackground == true cannot be set on iOS.")
     }
   }

--- a/packages/expo-audio/ios/ExpoAudio.podspec
+++ b/packages/expo-audio/ios/ExpoAudio.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
@@ -25,4 +26,7 @@ Pod::Spec.new do |s|
   }
   
   s.source_files = "**/*.{h,m,swift}"
+  s.tvos.exclude_files = "**/AudioRecorder.swift",
+                         "**/AudioRecordingRequester.swift",
+                         "**/RecordingDelegate.swift"
 end

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -51,6 +51,7 @@ function getExpoDependencyChunks({
     ...(includeTV
       ? [
           [
+            'expo-audio',
             'expo-av',
             'expo-blur',
             'expo-image',


### PR DESCRIPTION
# Why

Apple TV needs audio support.

# How

- Add tvOS to module definition and podspec
- Exclude unsupported recording APIs from tvOS
- Fix some SwiftLint violations

# Test Plan

- Test project should work on TV
- CI (TV compile test) should pass

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
