### PR TITLE
[expo-go] Fix loading progress crash

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
@@ -26,6 +26,9 @@ class LoadingProgressPopupController(activity: Activity) {
 
   fun show() {
     mWeakActivity.get()?.let { activity ->
+      if (activity.isFinishing || activity.isDestroyed) {
+        return
+      }
       activity.runOnUiThread {
         if (mPopupWindow != null) {
           // already showing
@@ -42,7 +45,9 @@ class LoadingProgressPopupController(activity: Activity) {
         mPopupWindow = PopupWindow(mContainer, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).also {
           it.isTouchable = false
           activity.window.decorView.post {
-            it.showAtLocation(activity.window.decorView, Gravity.BOTTOM, 0, 0)
+            if (!activity.isFinishing || !activity.isDestroyed) {
+              it.showAtLocation(activity.window.decorView, Gravity.BOTTOM, 0, 0)
+            }
           }
         }
       }


### PR DESCRIPTION
# Why
Attempts to address the most common crash reported on Crashlytics for Expo Go on Android.

# How
Sometimes we are attempting to show the loading indicator on an activity that has already finished. We should check the state of the activity before attempting to show the popup.

# Test Plan
The call is triggered from updates so it's difficult to repro. The changes do not impact how expo go works normally, and should prevent the crash from occurring.

