### PR TITLE
[expo-go] Make the LauncherActivty inherit from AppCompatActivity

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -2,12 +2,13 @@
 package host.exp.exponent
 
 import android.Manifest
-import android.app.Activity
 import android.app.ActivityManager.RecentTaskInfo
+import android.app.ComponentCaller
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.kernel.Kernel
@@ -16,7 +17,7 @@ import javax.inject.Inject
 
 // This activity is transparent. It uses android:style/Theme.Translucent.NoTitleBar.
 // Calls finish() once it is done processing Intent.
-class LauncherActivity : Activity() {
+class LauncherActivity : AppCompatActivity() {
   @Inject
   lateinit var kernel: Kernel
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -3,7 +3,6 @@ package host.exp.exponent
 
 import android.Manifest
 import android.app.ActivityManager.RecentTaskInfo
-import android.app.ComponentCaller
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle


### PR DESCRIPTION
# Why
The `LauncherActivity` does not inherit from `AppCompatActivity`. This leads to a crash in the `AppContext` when `onHostResume` is called. 
https://github.com/expo/expo/blob/002e9dad4c73eca918fedb1ff44764a7925a6772/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt#L268-L270

# How
Make the `LauncherActivity` inherit from `AppCompatActivity`

# Test Plan
Expo go
