### PR TITLE
[expo-go] Safely start service

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -19,7 +19,6 @@ import javax.inject.Inject
 class LauncherActivity : Activity() {
   @Inject
   lateinit var kernel: Kernel
-  private var isAppInForeground = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -68,22 +67,14 @@ class LauncherActivity : Activity() {
 
   override fun onResume() {
     super.onResume()
-    isAppInForeground = true
     startStayAwakeServiceIfNeeded()
   }
 
-  override fun onPause() {
-    super.onPause()
-    isAppInForeground = false
-  }
-
   private fun startStayAwakeServiceIfNeeded() {
-    if (isAppInForeground) {
-      // Start a service to keep our process awake. This isn't necessary most of the time, but
-      // if the user has "Don't keep activities" on it's possible for the process to exit in between
-      // finishing this activity and starting the BaseExperienceActivity.
-      startService(ExponentIntentService.getActionStayAwake(applicationContext))
-    }
+    // Start a service to keep our process awake. This isn't necessary most of the time, but
+    // if the user has "Don't keep activities" on it's possible for the process to exit in between
+    // finishing this activity and starting the BaseExperienceActivity.
+    startService(ExponentIntentService.getActionStayAwake(applicationContext))
   }
 
   public override fun onNewIntent(intent: Intent) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -78,7 +78,7 @@ class LauncherActivity : Activity() {
   }
 
   private fun startStayAwakeServiceIfNeeded() {
-    if (isAppInForeground){
+    if (isAppInForeground) {
       // Start a service to keep our process awake. This isn't necessary most of the time, but
       // if the user has "Don't keep activities" on it's possible for the process to exit in between
       // finishing this activity and starting the BaseExperienceActivity.


### PR DESCRIPTION
# Why
Starting a service while the app is still backgrounded will cause a `BackgroundServiceStartNotAllowedException` on newer versions of android. 

# How
Wait until we are in the foreground before attempting to start the service. The `IntentService` class is deprecated so I will follow up with removing our usage of this class.

# Test Plan
Expo go

