### PR TITLE
[expo-go] Safely cast `devSettings`

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -250,10 +250,8 @@ class InternalHeadlessAppLoader(private val context: Context) :
     val reactHost = ReactHostFactory.createFromReactNativeHost(context, wrapper)
 
     val devSupportManager = reactHost.devSupportManager
-    if (devSupportManager != null) {
-      val devSettings = devSupportManager.devSettings as DevInternalSettings
-      devSettings.setExponentActivityId(activityId)
-    }
+    val devSettings = devSupportManager.devSettings as? DevInternalSettings
+    devSettings?.setExponentActivityId(activityId)
 
     // keep a reference in app record, so it can be invalidated through AppRecord.invalidate()
     appRecord!!.setReactHost(reactHost)


### PR DESCRIPTION
# Why
The `devSettings` on the `devSupportManager` is nullable but was being cast to a non-nullable type causing crashes.

# How
Use a safe cast when accessing the `devSettings`

# Test Plan
Expo go
