### PR TITLE
[expo-go] Catch potential null pointer when generating uuid

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
@@ -34,11 +34,7 @@ internal class ExponentInstallationId(
         // Cache for future calls
         uuid = UUID.fromString(bufferedReader.readLine()).toString()
       }
-    } catch (e: IOException) {
-      // do nothing, try other sources
-    } catch (e: IllegalArgumentException) {
-      // do nothing, try other sources
-    } catch (e: NullPointerException) {
+    } catch (e: Throwable) {
       // do nothing, try other sources
     }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
@@ -3,9 +3,9 @@ package host.exp.exponent.storage
 import android.content.Context
 import android.content.SharedPreferences
 import host.exp.exponent.analytics.EXL
-import java.io.*
-import java.lang.IllegalArgumentException
-import java.util.*
+import java.io.File
+import java.io.IOException
+import java.util.UUID
 
 /**
  * An installation ID provider - it solves two purposes:

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.kt
@@ -38,6 +38,8 @@ internal class ExponentInstallationId(
       // do nothing, try other sources
     } catch (e: IllegalArgumentException) {
       // do nothing, try other sources
+    } catch (e: NullPointerException) {
+      // do nothing, try other sources
     }
 
     // We could have returned inside try clause,


### PR DESCRIPTION
# Why
`bufferedReader.readLine()` will return null in the event of an empty file or the end of the stream has been reached. Passing a null to `UUID.fromString` will cause a `NullPointerException` which we don't explicitly catch.

# How
Add a catch for potential `NullPointerException`'s 

# Test Plan
Expo go

