### PR TITLE
[cli][create-expo] Support GitHub shorthand for templates

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
+
 ### 🐛 Bug fixes
 
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
@@ -77,6 +77,19 @@ describe(resolveTemplateOption, () => {
     vol.reset();
   });
 
+  it('resolves GitHub shorthand', () => {
+    expect(resolveTemplateOption('expo/template-repo')).toEqual({
+      type: 'repository',
+      uri: 'https://github.com/expo/template-repo',
+    });
+  });
+
+  it('resolves GitHub shorthand using repository path', () => {
+    expect(resolveTemplateOption('expo/expo/templates/expo-template-bare-minimum')).toEqual({
+      type: 'repository',
+      uri: 'https://github.com/expo/expo/templates/expo-template-bare-minimum',
+    });
+  });
   it('resolves a URL template', () => {
     expect(resolveTemplateOption('http://foo')).toEqual({
       type: 'repository',

--- a/packages/@expo/cli/src/prebuild/resolveOptions.ts
+++ b/packages/@expo/cli/src/prebuild/resolveOptions.ts
@@ -41,6 +41,20 @@ export function resolvePackageManagerOptions(args: any) {
 export function resolveTemplateOption(template: string): ResolvedTemplateOption {
   assert(template, 'template is required');
 
+  if (
+    // Expands github shorthand (owner/repo) to full URLs
+    template.includes('/') &&
+    !(
+      template.startsWith('@') || // Scoped package
+      template.startsWith('.') || // Relative path
+      template.startsWith(path.sep) || // Absolute path
+      // Contains a protocol
+      /^[a-z][-a-z0-9\\.\\+]*:/.test(template)
+    )
+  ) {
+    template = `https://github.com/${template}`;
+  }
+
   if (template.startsWith('https://') || template.startsWith('http://')) {
     if (!validateUrl(template)) {
       throw new CommandError('BAD_ARGS', 'Invalid URL provided as a template');

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -297,6 +297,26 @@ xdescribe('templates', () => {
     expectFileNotExists(projectName, 'node_modules');
   });
 
+  it('downloads a github repo with shorthand', async () => {
+    const projectName = 'github-shorthand-url';
+    const results = await executePassing([
+      projectName,
+      '--no-install',
+      '--template',
+      'expo/examples/tree/master/blank',
+    ]);
+
+    // Test that the user was warned about deps
+    expect(results.stdout).toMatch(/make sure you have modules installed/);
+    expect(results.stdout).toMatch(/yarn/);
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, 'README.md');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
+  });
+
   it('downloads a github repo with sub-project', async () => {
     const projectName = 'full-url';
     const results = await executePassing([

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -68,6 +68,20 @@ function coerceUrl(urlString: string) {
 
 export function resolvePackageModuleId(moduleId: string) {
   if (
+    // Expands github shorthand (owner/repo) to full URLs
+    moduleId.includes('/') &&
+    !(
+      moduleId.startsWith('@') || // Scoped package
+      moduleId.startsWith('.') || // Relative path
+      moduleId.startsWith(path.sep) || // Absolute path
+      // Contains a protocol
+      /^[a-z][-a-z0-9\\.\\+]*:/.test(moduleId)
+    )
+  ) {
+    moduleId = `https://github.com/${moduleId}`;
+  }
+
+  if (
     // Supports github repository URLs
     /^(https?:\/\/)?github\.com\//.test(moduleId)
   ) {

--- a/packages/create-expo/src/__tests__/Template.test.ts
+++ b/packages/create-expo/src/__tests__/Template.test.ts
@@ -45,6 +45,24 @@ describe(resolvePackageModuleId, () => {
       uri: 'basic',
     });
   });
+  it('resolves github shorthand', () => {
+    expect(resolvePackageModuleId('expo/template-example')).toMatchObject({
+      type: 'repository',
+      uri: expect.objectContaining({
+        href: 'https://github.com/expo/template-example',
+      }),
+    });
+  });
+  it('resolves GitHub shorthand with repository path', () => {
+    expect(
+      resolvePackageModuleId('expo/expo/tree/sdk-49/templates/expo-template-bare-minimum')
+    ).toMatchObject({
+      type: 'repository',
+      uri: expect.objectContaining({
+        href: 'https://github.com/expo/expo/tree/sdk-49/templates/expo-template-bare-minimum',
+      }),
+    });
+  });
   it('resolves github repository url', () => {
     expect(
       resolvePackageModuleId(


### PR DESCRIPTION
# Why

This adds support for using GitHub shorthand to specify template. Currently creating a project fails when a shorthand is specified.

This will allow us to have nicer commands, e.g.:

```sh
npx create-expo-app@latest --template react-navigation/template
```

It follows similar pattern to npm where it can accept `owner/repo` for a package.

# How

Currently `create-expo-app` already includes support for GitHub URLs. I added an additional check to check for GitHub shorthand and convert it to full URL before it gets processed further.

The check for GitHub shorthand is adapted from https://github.com/npm/hosted-git-info/blob/3baf85298e5fd6f1363d060ec9e826ce51971cd1/lib/from-url.js#L6 which is used by npm - however it's slightly different as `create-expo-app` supports links to specific path inside the repo while npm does not.

I have not updated the documentation as support for GitHub repos is currently not documented.

# Test Plan

I have added unit and e2e tests.

To test this change locally, build the package:

```sh
cd packages/create-expo
yarn prepare
```

Then in another folder, point to the built file to create the project:

```sh
./expo/packages/create-expo/build/index.js --template react-navigation/template
```


https://github.com/user-attachments/assets/0bc964fd-dc18-4ac6-9831-485b0498ee6f



# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
