### PR TITLE
Fix better sqlite build issue

### DIFF
--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@testing-library/react-native": "^12.5.2",
     "@types/better-sqlite3": "^7.6.6",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^11.6.0",
     "expo-module-scripts": "^4.0.0",
     "react-error-boundary": "^4.0.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,7 +3175,7 @@
   dependencies:
     color "^4.2.3"
 
-"@react-navigation/native-stack@^7.0.0":
+"@react-navigation/native-stack@7.0.0", "@react-navigation/native-stack@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.0.0.tgz#8f5a50919d8e58548053743a697e90a177976946"
   integrity sha512-OZEvXaQDZesWnib+XD7PgWaVeS95/oD/gCSmDXXQZLTtGBXutmLycGtvjunFHRAkQ8u3TB89oOhs9YxDBAXl5Q==
@@ -3183,7 +3183,7 @@
     "@react-navigation/elements" "^2.0.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@^7.0.0":
+"@react-navigation/native@7.0.0", "@react-navigation/native@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.0.0.tgz#d3efaca481bef01cde89c2397f4b0815682f9137"
   integrity sha512-OkfVzQNAuvy6WduON+4ctLImQWybBnOEycVpEEFA3y8nheLuo4hT+ObyyYu2DVqtslltUlTNGcd2G7pbB7y/bA==
@@ -3194,7 +3194,7 @@
     nanoid "3.3.7"
     use-latest-callback "^0.2.1"
 
-"@react-navigation/routers@^7.0.0":
+"@react-navigation/routers@7.0.0", "@react-navigation/routers@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.0.0.tgz#fb55a4d70a14e16b630c386fd09ba43664cc7409"
   integrity sha512-b2ehNmgAfDziTd0EERm0C9JI9JH1kdRS4SNBWbKQOVPv23WG+5ExovwWet26sGtMabLJ5lxSE8Z2/fByfggjNQ==
@@ -5443,10 +5443,10 @@ better-opn@~3.0.2:
   dependencies:
     open "^8.0.4"
 
-better-sqlite3@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.0.0.tgz#12083acfe0ded6abdba908ed73520f2003e3ea0e"
-  integrity sha512-1NnNhmT3EZTsKtofJlMox1jkMxdedILury74PwUbQBjWgo4tL4kf7uTAjU55mgQwjdzqakSTjkf+E1imrFwjnA==
+better-sqlite3@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.6.0.tgz#e50736956e6fe1c30dc94f1bc94a9c15d63b7b6b"
+  integrity sha512-2J6k/eVxcFYY2SsTxsXrj6XylzHWPxveCn4fKPKZFv/Vqn/Cd7lOuX4d7rGQXT5zL+97MkNL3nSbCrIoe3LkgA==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
@@ -9420,11 +9420,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 ini@~1.3.0:
   version "1.3.8"
@@ -16180,14 +16175,7 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.12.0, util@^0.12.3:
+util@^0.10.3, util@^0.12.0, util@^0.12.3, util@~0.12.4:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==


### PR DESCRIPTION
# Why

Fixes a build issue I'm seeing with node-gyp during `yarn install`.

```
error /Users/aleqsio/Work/Expo/expoA/node_modules/better-sqlite3: Command failed.
Exit code: 1
Command: prebuild-install || node-gyp rebuild --release
Arguments: 
Directory: /Users/aleqsio/Work/Expo/expoA/node_modules/better-sqlite3
Output:
prebuild-install warn install No prebuilt binaries found (target=23.3.0 runtime=node arch=arm64 libc= platform=darwin)
gyp info it worked if it ends with ok
gyp info using node-gyp@10.0.1
gyp info using node@23.3.0 | darwin | arm64
gyp info find Python using Python version 3.13.0 found at "/Users/aleqsio/.pyenv/versions/expo/bin/python3"
gyp info spawn /Users/aleqsio/.pyenv/versions/expo/bin/python3
gyp info spawn args [
gyp info spawn args '/Users/aleqsio/Work/Expo/expoA/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/aleqsio/Work/Expo/expoA/node_modules/better-sqlite3/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/aleqsio/Work/Expo/expoA/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/aleqsio/Library/Caches/node-gyp/23.3.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/aleqsio/Work/Expo/expoA/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/aleqsio/Library/Caches/node-gyp/23.3.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/aleqsio/Work/Expo/expoA/node_modules/better-sqlite3',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]

gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
  ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
  TOUCH Release/obj.target/deps/locate_sqlite3.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
  LIBTOOL-STATIC Release/sqlite3.a
  CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
In file included from ../src/better_sqlite3.cpp:4:
In file included from ./src/better_sqlite3.lzz:11:
In file included from /Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/node.h:73:
In file included from /Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/v8.h:23:
In file included from /Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/cppgc/common.h:8:
/Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/v8config.h:13:2: error: "C++20 or later required."
   13 | #error "C++20 or later required."
      |  ^
In file included from ../src/better_sqlite3.cpp:4:
./src/util/macros.lzz:31:69: error: no template named 'CopyablePersistentTraits' in namespace 'v8'; did you mean 'NonCopyablePersistentTraits'?
   31 | template <class T> using CopyablePersistent = v8::Persistent<T, v8::CopyablePersistentTraits<T>>;
      |                                                                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                     NonCopyablePersistentTraits
/Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/v8-persistent-handle.h:223:7: note: 'NonCopyablePersistentTraits' declared here
  223 | class NonCopyablePersistentTraits {
      |       ^
In file included from ../src/better_sqlite3.cpp:4:
./src/util/macros.lzz:149:6: error: no type named 'AccessorGetterCallback' in namespace 'v8'; did you mean 'AccessorNameGetterCallback'?
  149 |         v8::AccessorGetterCallback func
      |         ~~~~^~~~~~~~~~~~~~~~~~~~~~
      |             AccessorNameGetterCallback
/Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/v8-object.h:155:7: note: 'AccessorNameGetterCallback' declared here
  155 | using AccessorNameGetterCallback =
      |       ^
./src/util/macros.lzz:158:6: error: no type named 'AccessorGetterCallback' in namespace 'v8'; did you mean 'AccessorNameGetterCallback'?
  158 |         v8::AccessorGetterCallback func
      |         ~~~~^~~~~~~~~~~~~~~~~~~~~~
      |             AccessorNameGetterCallback
/Users/aleqsio/Library/Caches/node-gyp/23.3.0/include/node/v8-object.h:155:7: note: 'AccessorNameGetterCallback' declared here
  155 | using AccessorNameGetterCallback =
      |       ^
./src/util/macros.lzz:172:28: error: no member named 'SetAccessor' in 'v8::ObjectTemplate'
  172 |         recv->InstanceTemplate()->SetAccessor(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~^
./src/objects/database.lzz:17:17: error: no matching function for call to 'SetPrototypeGetter'
   17 |                 SetPrototypeGetter(isolate, data, t, "open", JS_open);
      |                 ^~~~~~~~~~~~~~~~~~
./src/util/macros.lzz:153:6: note: candidate function not viable: no known conversion from 'void (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &)' to 'v8::AccessorNameGetterCallback' (aka 'void (*)(Local<Name>, const PropertyCallbackInfo<Value> &)') for 5th argument
  153 | void SetPrototypeGetter(
      |      ^
  154 |         v8::Isolate* isolate,
  155 |         v8::Local<v8::External> data,
  156 |         v8::Local<v8::FunctionTemplate> recv,
  157 |         const char* name,
  158 |         v8::AccessorGetterCallback func
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/objects/database.lzz:18:17: error: no matching function for call to 'SetPrototypeGetter'
   18 |                 SetPrototypeGetter(isolate, data, t, "inTransaction", JS_inTransaction);
      |                 ^~~~~~~~~~~~~~~~~~
./src/util/macros.lzz:153:6: note: candidate function not viable: no known conversion from 'void (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &)' to 'v8::AccessorNameGetterCallback' (aka 'void (*)(Local<Name>, const PropertyCallbackInfo<Value> &)') for 5th argument
  153 | void SetPrototypeGetter(
      |      ^
  154 |         v8::Isolate* isolate,
  155 |         v8::Local<v8::External> data,
  156 |         v8::Local<v8::FunctionTemplate> recv,
  157 |         const char* name,
  158 |         v8::AccessorGetterCallback func
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/objects/database.lzz:180:21: warning: variable 'status' set but not used [-Wunused-but-set-variable]
  180 |                 int status = sqlite3_db_config(db_handle, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 1, NULL);
      |                     ^
./src/objects/statement.lzz:16:17: error: no matching function for call to 'SetPrototypeGetter'
   16 |                 SetPrototypeGetter(isolate, data, t, "busy", JS_busy);
      |                 ^~~~~~~~~~~~~~~~~~
./src/util/macros.lzz:153:6: note: candidate function not viable: no known conversion from 'void (v8::Local<v8::String>, const v8::PropertyCallbackInfo<v8::Value> &)' to 'v8::AccessorNameGetterCallback' (aka 'void (*)(Local<Name>, const PropertyCallbackInfo<Value> &)') for 5th argument
  153 | void SetPrototypeGetter(
      |      ^
  154 |         v8::Isolate* isolate,
  155 |         v8::Local<v8::External> data,
  156 |         v8::Local<v8::FunctionTemplate> recv,
  157 |         const char* name,
  158 |         v8::AccessorGetterCallback func
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/util/custom-table.lzz:45:9: warning: missing field 'xIntegrity' initializer [-Wmissing-field-initializers]
   45 |         };
      |         ^
./src/util/custom-table.lzz:72:9: warning: missing field 'xIntegrity' initializer [-Wmissing-field-initializers]
   72 |         };
      |         ^
3 warnings and 8 errors generated.
make: *** [Release/obj.target/better_sqlite3/src/better_sqlite3.o] Error 1
rm ba23eeee118cd63e16015df367567cb043fed872.intermediate
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack at ChildProcess.<anonymous> (/Users/aleqsio/Work/Expo/expoA/node_modules/node-gyp/lib/build.js:209:23)
gyp ERR! System Darwin 24.0.0
gyp ERR! command "/opt/homebrew/Cellar/node/23.3.0/bin/node" "/Users/aleqsio/Work/Expo/expoA/node_modules/.bin/node-gyp" "rebuild" "--release"
gyp ERR! cwd /Users/aleqsio/Work/Expo/expoA/node_modules/better-sqlite3
```

# How

Bumped better-sqlite3 to latest based on https://github.com/WiseLibs/better-sqlite3/issues/1199.
It fixed the build issue for me.

# Test Plan

Hoping tests can pass on this PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
