### PR TITLE
[go] fix unsupported snack list item

### DIFF
--- a/apps/expo-go/src/components/SnacksListItem.tsx
+++ b/apps/expo-go/src/components/SnacksListItem.tsx
@@ -32,7 +32,7 @@ export function SnacksListItem(snackData: Props) {
   const theme = useExpoTheme();
 
   const normalizedDescription = normalizeDescription(description);
-  const isSupported = sdkVersion ? sdkVersion === Environment.supportedSdksString : true;
+  const isSupported = Environment.isSupportedSdkVersion(sdkVersion);
 
   const handlePressProject = () => {
     if (isSupported) {

--- a/apps/expo-go/src/components/SnacksListItem.tsx
+++ b/apps/expo-go/src/components/SnacksListItem.tsx
@@ -15,7 +15,7 @@ type Props = {
   isDraft: boolean;
   first: boolean;
   last: boolean;
-  sdkVersion?: string;
+  sdkVersion: string;
 };
 
 function normalizeDescription(description?: string): string | undefined {

--- a/apps/expo-go/src/utils/Environment.ts
+++ b/apps/expo-go/src/utils/Environment.ts
@@ -17,8 +17,21 @@ const sortedSupportedExpoSdks = SupportedExpoSdks.sort();
 
 const supportedSdksString = `${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join('')}`;
 
+const isSupportedSdkVersion = (sdkVersion: string | undefined) => {
+  if (!sdkVersion) {
+    return false;
+  }
+  for (const supportedSdk of sortedSupportedExpoSdks) {
+    if (semver.satisfies(sdkVersion, `~${supportedSdk}`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export default {
   IOSClientReleaseType,
   IsIOSRestrictedBuild,
+  isSupportedSdkVersion,
   supportedSdksString,
 };

--- a/apps/expo-go/src/utils/Environment.ts
+++ b/apps/expo-go/src/utils/Environment.ts
@@ -17,10 +17,7 @@ const sortedSupportedExpoSdks = SupportedExpoSdks.sort();
 
 const supportedSdksString = `${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join('')}`;
 
-const isSupportedSdkVersion = (sdkVersion: string | undefined) => {
-  if (!sdkVersion) {
-    return false;
-  }
+const isSupportedSdkVersion = (sdkVersion: string) => {
   for (const supportedSdk of sortedSupportedExpoSdks) {
     if (semver.satisfies(sdkVersion, `~${supportedSdk}`)) {
       return true;


### PR DESCRIPTION
# Why

fix the snack item always showing unsupported. this is coming from #32548

# How

the `sdkVersion` passing from snack is like `52.0.0` and the `Environment.supportedSdksString` is like `52. this pr tries to add a `Environment.isSupportedSdkVersion` to check whether the sdkVersion is compatible.

# Test Plan

test expo-go with local home

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
