### PR TITLE
chore(cli): enable Windows CLI E2E tests on GitHub Actions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: 🧪 E2E Test CLI
         working-directory: packages/@expo/cli
-        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   jest-windows:
     runs-on: windows-2022
@@ -168,7 +168,7 @@ jobs:
 
       - name: 🧪 E2E Test CLI
         working-directory: packages/@expo/cli
-        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
   
   playwright-ubuntu:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -99,7 +99,10 @@ jobs:
 
   jest-windows:
     runs-on: windows-2022
-    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
@@ -159,7 +162,7 @@ jobs:
 
       - name: 🧪 E2E Test CLI
         working-directory: packages/@expo/cli
-        run: yarn test:e2e
+        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
   
   playwright-ubuntu:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,38 +42,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.experimental == 'allow-errors' }}
+  e2e-linux:
+    runs-on: linux-22.04
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
-        os: [linux]
-        experimental: ['disallow-errors']
-        include:
-          - os: windows
-            shard: 1
-            experimental: allow-errors
-          - os: windows
-            shard: 2
-            experimental: allow-errors
-          - os: windows
-            shard: 3
-            experimental: allow-errors
-          - os: windows
-            shard: 4
-            experimental: allow-errors
     steps:
-      - name: 🪟 Setup Windows
-        if: runner.os == 'Windows'
-        # Configure Git to use LF line endlings, and Bun to use a faster cache disk on Windows
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-          echo "BUN_INSTALL_CACHE_DIR=$GITHUB_WORKSPACE\.bun\install\cache" >> $GITHUB_ENV
-        shell: bash
-
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
@@ -107,36 +82,84 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir (Linux/macOS)
-        if: runner.os != 'Windows'
         run: yarn install --prefer-offline --frozen-lockfile
         env:
           YARN_IGNORE_SCRIPTS: 'true'
-      - name: 🧶 Install node modules in root dir (Windows)
-        if: runner.os == 'Windows'
+      
+      - name: 👷 Build Expo CLI
+        run: yarn workspace @expo/cli prepare
+
+      - name: 🔎 Type Check CLI
+        working-directory: packages/@expo/cli
+        run: yarn typecheck
+
+      - name: 🧪 E2E Test CLI
+        working-directory: packages/@expo/cli
+        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+
+  e2e-windows:
+    runs-on: windows-2022
+    continue-on-error: true
+    steps:
+      - name: 🪟 Setup Windows
+        shell: bash
+        # Configure Git to use LF line endlings, and Bun to use a faster cache disk on Windows
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          echo "BUN_INSTALL_CACHE_DIR=$GITHUB_WORKSPACE\.bun\install\cache" >> $GITHUB_ENV
+      
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
+          # TODO(cedric): swap `latest` back once the issue is resolved
+          bun-version: latest
+
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+
+      - name: 🔎 Find Yarn Cache
+        id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: ♻️ Restore Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
         run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
         env:
           YARN_IGNORE_SCRIPTS: 'true'
-      
-      - name: Build Expo CLI
+
+      - name: 👷 Build Expo CLI
         run: yarn workspace @expo/cli prepare
 
-      - name: 🔎 Type Check CLI (Linux/macOS)
-        working-directory: packages/@expo/cli
-        run: yarn typecheck
       - name: 🔎 Type Check CLI (Windows)
         working-directory: packages/@expo/cli
         # TODO(cedric): expo module scripts is incompatible with Windows, forcing us to manually set up these steps instead of `yarn typecheck`
         run: yarn tsc --noEmit
 
-      - name: 🧪 E2E Test CLI (Linux/macOS)
-        working-directory: packages/@expo/cli
-        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
       - name: 🧪 E2E Test CLI (Windows)
         working-directory: packages/@expo/cli
         # NOTE(cedric): Windows is significantly slower and suffers from IO congestion when running more than 2 workers
-        run: yarn test:e2e --max-workers 2 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
-
+        run: yarn test:e2e --max-workers 2
+  
   web:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,8 +42,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-linux:
-    runs-on: linux-22.04
+  e2e-ubuntu:
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +81,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: 🧶 Install node modules in root dir (Linux/macOS)
+      - name: 🧶 Install node modules in root dir
         run: yarn install --prefer-offline --frozen-lockfile
         env:
           YARN_IGNORE_SCRIPTS: 'true'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -152,15 +152,14 @@ jobs:
       - name: 👷 Build Expo CLI
         run: yarn workspace @expo/cli prepare
 
-      - name: 🔎 Type Check CLI (Windows)
+      - name: 🔎 Type Check CLI
         working-directory: packages/@expo/cli
         # TODO(cedric): expo module scripts is incompatible with Windows, forcing us to manually set up these steps instead of `yarn typecheck`
         run: yarn tsc --noEmit
 
-      - name: 🧪 E2E Test CLI (Windows)
+      - name: 🧪 E2E Test CLI
         working-directory: packages/@expo/cli
-        # NOTE(cedric): Windows is significantly slower and suffers from IO congestion when running more than 2 workers
-        run: yarn test:e2e --max-workers 2
+        run: yarn test:e2e
   
   web:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -103,6 +103,15 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
+    env:
+      # Change bun, npm, and yarn caches to the much faster D:\ drive
+      # See: https://github.com/twpayne/chezmoi/pull/4064
+      BUN_INSTALL_CACHE_DIR: D:\_temp\bun
+      NPM_CACHE_LOCATION: D:\_temp\npm
+      YARN_CACHE_FOLDER: D:\_temp\yarn
+      # Change the Expo E2E project directory to the same drive as the repository,
+      # allowing to run Expo from source (avoiding Metro's multi-drive limitation)
+      EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
     steps:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
@@ -118,13 +127,10 @@ jobs:
 
       - name: 🪟 Setup Windows
         shell: bash
-        # Configure Git to use LF line endlings, Bun to use a faster cache disk, and the E2E to use the same drive for testing as the repository
-        # Note that the GitHub workspace is structured as `D:\a\<owner>\<repo>` and has an existing `D:\a\_temp` directory
+        # Configure Git to use LF line endlings
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-          echo "BUN_INSTALL_CACHE_DIR=$(node --print 'require(`path`).join(process.env.GITHUB_WORKSPACE,  `./../../_temp/bun`)')" >> $GITHUB_ENV
-          echo "EXPO_E2E_TEMP_DIR=$(node --print 'require(`path`).join(process.env.GITHUB_WORKSPACE,  `./../../_temp/expo-cli-e2e`)')" >> $GITHUB_ENV
 
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-ubuntu:
+  jest-ubuntu:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -97,7 +97,7 @@ jobs:
         working-directory: packages/@expo/cli
         run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
-  e2e-windows:
+  jest-windows:
     runs-on: windows-2022
     continue-on-error: true
     steps:
@@ -161,7 +161,7 @@ jobs:
         working-directory: packages/@expo/cli
         run: yarn test:e2e
   
-  web:
+  playwright-ubuntu:
     runs-on: ubuntu-22.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -101,14 +101,6 @@ jobs:
     runs-on: windows-2022
     continue-on-error: true
     steps:
-      - name: 🪟 Setup Windows
-        shell: bash
-        # Configure Git to use LF line endlings, and Bun to use a faster cache disk on Windows
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-          echo "BUN_INSTALL_CACHE_DIR=$GITHUB_WORKSPACE\.bun\install\cache" >> $GITHUB_ENV
-      
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
@@ -120,6 +112,16 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
+
+      - name: 🪟 Setup Windows
+        shell: bash
+        # Configure Git to use LF line endlings, Bun to use a faster cache disk, and the E2E to use the same drive for testing as the repository
+        # Note that the GitHub workspace is structured as `D:\a\<owner>\<repo>` and has an existing `D:\a\_temp` directory
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          echo "BUN_INSTALL_CACHE_DIR=$(node --print 'require(`path`).join(process.env.GITHUB_WORKSPACE,  `./../../_temp/bun`)')" >> $GITHUB_ENV
+          echo "EXPO_E2E_TEMP_DIR=$(node --print 'require(`path`).join(process.env.GITHUB_WORKSPACE,  `./../../_temp/expo-cli-e2e`)')" >> $GITHUB_ENV
 
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,50 +43,99 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ matrix.experimental == 'allow-errors' }}
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
+        os: [linux]
+        experimental: ['disallow-errors']
+        include:
+          - os: windows
+            shard: 1
+            experimental: allow-errors
+          - os: windows
+            shard: 2
+            experimental: allow-errors
+          - os: windows
+            shard: 3
+            experimental: allow-errors
+          - os: windows
+            shard: 4
+            experimental: allow-errors
     steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 100
-      - uses: actions/setup-node@v3
+      - name: 🪟 Setup Windows
+        if: runner.os == 'Windows'
+        # Configure Git to use LF line endlings, and Bun to use a faster cache disk on Windows
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          echo "BUN_INSTALL_CACHE_DIR=$GITHUB_WORKSPACE\.bun\install\cache" >> $GITHUB_ENV
+        shell: bash
+
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: ⬇️ Fetch commits from base branch
-        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-
-      - name: ♻️ Restore Yarn Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: 🧶 Install node modules in root dir
-        run: YARN_IGNORE_SCRIPTS=true yarn install --prefer-offline --frozen-lockfile
-      
-      - name: Build Expo CLI
-        run: yarn workspace @expo/cli prepare
 
       - name: 🏗️ Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
 
-      - name: 🔎 Type Check CLI
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+
+      - name: 🔎 Find Yarn Cache
+        id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: ♻️ Restore Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 🧶 Install node modules in root dir (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: yarn install --prefer-offline --frozen-lockfile
+        env:
+          YARN_IGNORE_SCRIPTS: 'true'
+      - name: 🧶 Install node modules in root dir (Windows)
+        if: runner.os == 'Windows'
+        # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
+        env:
+          YARN_IGNORE_SCRIPTS: 'true'
+      
+      - name: Build Expo CLI
+        run: yarn workspace @expo/cli prepare
+
+      - name: 🔎 Type Check CLI (Linux/macOS)
+        working-directory: packages/@expo/cli
         run: yarn typecheck
+      - name: 🔎 Type Check CLI (Windows)
         working-directory: packages/@expo/cli
-      - name: E2E Test CLI
+        # TODO(cedric): expo module scripts is incompatible with Windows, forcing us to manually set up these steps instead of `yarn typecheck`
+        run: yarn tsc --noEmit
+
+      - name: 🧪 E2E Test CLI (Linux/macOS)
+        working-directory: packages/@expo/cli
         run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+      - name: 🧪 E2E Test CLI (Windows)
         working-directory: packages/@expo/cli
+        # NOTE(cedric): Windows is significantly slower and suffers from IO congestion when running more than 2 workers
+        run: yarn test:e2e --max-workers 2 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   web:
     runs-on: ubuntu-22.04

--- a/packages/@expo/cli/e2e/jest.config.js
+++ b/packages/@expo/cli/e2e/jest.config.js
@@ -19,13 +19,7 @@ const config = {
   testTimeout: process.platform === 'win32' ? 300_000 : 180_000,
 };
 
-// Only run 2 separate tests concurrently on CI
 if (boolish('CI', false)) {
-  config.maxWorkers = 2;
-}
-
-// Run tests serially when CI is running in debug mode
-if (boolish('RUNNER_DEBUG', false)) {
   config.maxWorkers = 1;
 }
 

--- a/packages/@expo/cli/e2e/jest.config.js
+++ b/packages/@expo/cli/e2e/jest.config.js
@@ -1,12 +1,11 @@
 /* eslint-env node */
-const { boolish } = require('getenv');
 const path = require('node:path');
 const process = require('node:process');
 
 const roots = ['../__mocks__', '.'];
 
 /** @type {import('jest').Config} */
-const config = {
+module.exports = {
   testEnvironment: 'node',
   preset: 'ts-jest',
   testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
@@ -18,9 +17,3 @@ const config = {
   // Configure the global jest timeout to 3m, on Windows increase this to 5m
   testTimeout: process.platform === 'win32' ? 300_000 : 180_000,
 };
-
-if (boolish('CI', false)) {
-  config.maxWorkers = 1;
-}
-
-module.exports = config;


### PR DESCRIPTION
# Why

Split off from #33204, stacked on #33401 ([for the `EXPO_E2E_TEMP_DIR` workaround](https://github.com/expo/expo/pull/33387#discussion_r1871455847))

This enables running CLI E2E tests on Windows, allowing it to fail until we've merged all fixes required for Windows.

> [!IMPORTANT]
> We should merge this _after_ all Windows fixes have been merged, to ensure we cleared all current Windows pathing issues surfaced from the Jest E2E tests.
> - https://github.com/expo/expo/pull/33401
> - https://github.com/expo/expo/pull/33408
> - https://github.com/expo/expo/pull/33397
> - https://github.com/expo/expo/pull/33396
> - https://github.com/expo/expo/pull/33395
> - https://github.com/expo/expo/pull/33394
> - https://github.com/expo/expo/pull/33393

# How

- Modified **.github/workflows/cli.yml** to include Windows (and allow it to fail).

# Test Plan

- See GitHub Action

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
