### PR TITLE
test(cli): resolve outdated `install` e2e test

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -174,12 +174,17 @@ it(
     // Fix all versions
     await execa('node', [bin, 'install', '--fix'], { cwd: projectRoot });
 
-    // Check that the versions are fixed
+    // Reload the dependency versions
     pkg = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
-
-    // Didn't fix expo-auth-session since we didn't pass it in
     pkgDependencies = pkg.dependencies as Record<string, string>;
-    expect(pkgDependencies['expo-auth-session']).toBe('~6.0.0');
+
+    // Load the expected dependency versions
+    const expectedVersion = await JsonFile.readAsync(
+      require.resolve('expo/bundledNativeModules.json', { paths: [projectRoot] })
+    );
+
+    // Check that the versions are fixed
+    expect(pkgDependencies['expo-auth-session']).toBe(expectedVersion['expo-auth-session']);
   },
   // Could take 45s depending on how fast npm installs
   60 * 1000


### PR DESCRIPTION
# Why

This fixes an outdated assertion in the `expo install` E2E tests.

# How

Instead of updating the hardcoded version, we use `expo/bundledNativeModules` to check the expected version. Making it more up to date with possible patch versions.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
