### PR TITLE
[docs] Hide TOC and add missing BoxLink icons on multiple pages

### DIFF
--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use existing credentials
 description: Learn about different options for supplying your app signing credentials to EAS Build.
+hideTOC: true
 ---
 
 EAS Build gives you two options for how you can supply your build jobs with app signing credentials:

--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use Git Submodules
 description: Learn how to configure EAS Build to use git submodules.
+hideTOC: true
 ---
 
 import { Step } from '~/ui/components/Step';

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -5,6 +5,8 @@ hideTOC: true
 description: EAS Build is a hosted service for building app binaries for your Expo and React Native projects.
 ---
 
+import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 
 **EAS Build** is a hosted service for building app binaries for your Expo and React Native projects.
@@ -19,34 +21,40 @@ It's designed to work for any native project, whether or not you use Expo and Re
   title="Create your first build"
   description="It should only take a few minutes in total to get up and running for iOS and/or Android."
   href="/build/setup"
+  Icon={Cube01Icon}
 />
 
 <BoxLink
   title="Share your apps with internal testers"
   description="EAS Build can help share preview builds of your app with a single URL."
   href="/build/internal-distribution"
+  Icon={Cube01Icon}
 />
 
 <BoxLink
   title="Automate submissions"
   description="Learn how you can have the service take your successful builds and handle uploading them to app stores for you automatically."
   href="/build/automate-submissions"
+  Icon={Cube01Icon}
 />
 
 <BoxLink
   title="App version management"
   description="Automate version bumps so you never have to think about them again."
   href="/build-reference/app-versions"
+  Icon={Cube01Icon}
 />
 
 <BoxLink
   title="Run builds locally or on your own infrastructure"
   description="EAS Build is a hosted service, but you can also run it on your own machine, for example, to debug or to comply with any company security policies."
   href="/build-reference/local-builds"
+  Icon={Cube01Icon}
 />
 
 <BoxLink
   title="Limitations"
   description="EAS Build is new and rapidly evolving, so we recommend getting familiar with the current limitations."
   href="/build-reference/limitations"
+  Icon={Cube01Icon}
 />

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -2,6 +2,7 @@
 title: Introduction to development builds
 sidebar_title: Introduction
 description: A better development environment for React Native apps.
+hideTOC: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -1,7 +1,6 @@
 ---
 title: EAS Update
 sidebar_title: Introduction
-hideTOC: true
 description: An introduction to EAS Update which is a hosted service for projects using the expo-updates library.
 ---
 

--- a/docs/pages/eas-update/standalone-service.mdx
+++ b/docs/pages/eas-update/standalone-service.mdx
@@ -2,6 +2,7 @@
 title: Using EAS Update without other EAS services
 sidebar_title: Using without other EAS services
 description: Learn how to use EAS Update independently of other EAS services, such as Build.
+hideTOC: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -4,6 +4,8 @@ sidebar_title: Get started
 description: Learn how to automate and maintain your app store presence from the command line with EAS Metadata.
 ---
 
+import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
@@ -74,10 +76,12 @@ When the store config partially fails, you can change the store config and retry
   title="Customize the store config"
   href="/eas/metadata/config"
   description="Customize the store config to adapt EAS Metadata to your preferred workflow."
+  Icon={EasMetadataIcon}
 />
 
 <BoxLink
   title="Store config schema"
   href="/eas/metadata/schema"
   description="Explore all configurable options EAS Metadata has to offer."
+  Icon={EasMetadataIcon}
 />

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -5,6 +5,8 @@ hideTOC: true
 description: An introduction to automate and maintain your app store presence from the command line with EAS Metadata.
 ---
 
+import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
@@ -30,16 +32,19 @@ Adding the store config file to your repository enables you to collaborate with 
   href="/eas/metadata/getting-started"
   title="Introduction"
   description="Add EAS Metadata to a new project, or generate the store config from an existing app."
+  Icon={EasMetadataIcon}
 />
 
 <BoxLink
   href="/eas/metadata/config"
   title="Customize the store config"
   description="Customize the store config to adapt EAS Metadata to your preferred workflow."
+  Icon={EasMetadataIcon}
 />
 
 <BoxLink
   href="/eas/metadata/schema"
   title="Store config schema"
   description="Explore all configurable options EAS Metadata has to offer."
+  Icon={EasMetadataIcon}
 />

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -2,6 +2,7 @@
 title: 'Push notifications: Overview'
 sidebar_title: Overview
 description: An overview of Expo push notification service.
+hideTOC: true
 ---
 
 import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
@@ -14,6 +15,8 @@ Expo simplifies implementing push notifications by handling much of the complexi
 Follow the video or links below to learn how to set up push notifications, send them, and handle incoming notifications in your app.
 
 <NotificationsVideo />
+
+<br />
 
 <BoxLink
   title="What you need to know about notifications"

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -1,6 +1,5 @@
 ---
 title: Push notifications setup
-sidebar_title: Push notifications setup
 description: Learn how to set up push notifications, get credentials for development and production, and send a testing push notification.
 ---
 

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -5,6 +5,9 @@ description: Learn how to develop your app for the web so you can build a univer
 hideTOC: true
 ---
 
+import { RouterLogo } from '@expo/styleguide';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
@@ -98,22 +101,26 @@ The app can be exported as a production website with:
   title="File-based routing"
   description="Build routes and navigation with Expo Router."
   href="/router/introduction"
+  Icon={RouterLogo}
 />
 
 <BoxLink
   title="Static rendering and SEO"
   description="Render your website as static HTML with Expo Router to improve SEO and performance."
   href="/router/reference/static-rendering"
+  Icon={RouterLogo}
 />
 
 <BoxLink
   title="Publish websites"
   description="Export your website and upload to any web host."
   href="/distribution/publishing-websites"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Customizing the JavaScript bundler"
   description="Customize Metro bundler for your project."
   href="/guides/customizing-metro"
+  Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Add missing `BoxLink` icons on multiple pages
- Enable `hideTOC` on multiple pages where there's only one section or no sections are present
- Remove `hideTOC` from EAS Update introduction page since there are multiple sections

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
