### PR TITLE
Update outdated info about no Cocoapods caching

### DIFF
--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -14,7 +14,7 @@ See [Server infrastructure reference](/build-reference/infrastructure) for more 
 
 ## Limited dependency caching
 
-Build jobs for Android install npm and Maven dependencies from a local cache. Build jobs for iOS install npm dependencies from a local cache, but there is no caching for CocoaPods yet.
+Build jobs for Android install npm and Maven dependencies from a local cache. Build jobs for iOS install npm dependencies from a local cache, and CocoaPods artifacts from a cache server.
 
 Intermediate artifacts like **node_modules** directories are not cached and restored (for example, based on **package-lock.json** or **yarn.lock**), but if you commit them to your Git repository then they will be uploaded to build servers.
 


### PR DESCRIPTION
# Why

From what I can read in https://docs.expo.dev/build-reference/caching/ Cocoapods artifacts are in fact being
cached on a server. This seems like some text that is currently outdated. The whole section on "Limited dependency caching" might need to be rewritten


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
