### PR TITLE
fix(babel-preset-expo): test for UNIX paths when removing console polyfill from RSC client output

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add support for `TSInterfaceDeclaration` in server component plugin. ([#33121](https://github.com/expo/expo/pull/33121) by [@EvanBacon](https://github.com/EvanBacon))
-- Test for UNIX paths when removing console polyfill from RSC client output.
+- Test for UNIX paths when removing console polyfill from RSC client output. ([#33397](https://github.com/expo/expo/pull/33397) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add support for `TSInterfaceDeclaration` in server component plugin. ([#33121](https://github.com/expo/expo/pull/33121) by [@EvanBacon](https://github.com/EvanBacon))
+- Test for UNIX paths when removing console polyfill from RSC client output.
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -134,7 +134,8 @@ function reactClientReferencesPlugin(api) {
                         return;
                     }
                     // HACK: Mock out the polyfill that doesn't run through the normal bundler pipeline.
-                    if (filePath.endsWith('@react-native/js-polyfills/console.js')) {
+                    if (filePath.endsWith('@react-native/js-polyfills/console.js') ||
+                        filePath.endsWith('@react-native\\js-polyfills\\console.js')) {
                         // Clear the body
                         path.node.body = [];
                         path.node.directives = [];

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -158,7 +158,10 @@ export function reactClientReferencesPlugin(api: ConfigAPI): babel.PluginObj {
           }
 
           // HACK: Mock out the polyfill that doesn't run through the normal bundler pipeline.
-          if (filePath.endsWith('@react-native/js-polyfills/console.js')) {
+          if (
+            filePath.endsWith('@react-native/js-polyfills/console.js') ||
+            filePath.endsWith('@react-native\\js-polyfills\\console.js')
+          ) {
             // Clear the body
             path.node.body = [];
             path.node.directives = [];


### PR DESCRIPTION
# Why

Split of from #33204

# How

This was the most mysterious bug I found so far on Windows related to RSC. Turned out that we didn't remove the console polyfill in RSC client output on Windows, due to a POSIX only check. It resulted in `react-server-dom-webpack/server` being marked as external package, and resolved once the RSC code is evaluated on the server - [as `react-server-dom-webpack/server` is literally an error](https://unpkg.com/browse/react-server-dom-webpack@19.0.0-rc-fb9a90fa48-20240614/server.js) and needs to be resolved to `/server.edge` or `/server.node`.

# Test Plan

See CI / Tests, need to resolve a Windows related Metro error to fully ensure RSC works on Windows through E2E tests though.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
