### PR TITLE
[docs] [ENG-14302] Update workflow flow control docs

### DIFF
--- a/docs/pages/workflows/control-flow.mdx
+++ b/docs/pages/workflows/control-flow.mdx
@@ -7,7 +7,7 @@ You can control the flow of your workflows with conditions that run certain jobs
 
 ## `needs`
 
-You can add a list of previous job names using the `needs` keyword on a job. If any job from that list fails, the current job will be skipped.
+You can add a list of previous job names using the `needs` keyword on a job. If any job from that list fails, the current job will be failed, and if any job from the list is skipped, the current job will be skipped as well.
 
 ```yaml .eas/workflows/prerequisite.yaml
 jobs:
@@ -67,3 +67,7 @@ jobs:
       profile: production
       platform: ios
 ```
+
+## Combining conditions
+
+You can use both `needs` and `if` conditions in the same job definition. Note that the job will be run if all jobs on the `needs` list are successful **AND** the `if` condition is true. If any job on the `needs` list had been skipped or the `if` condition is false, the current job will be skipped. If any job on the `needs` list had failed, the current job will be failed.

--- a/docs/pages/workflows/control-flow.mdx
+++ b/docs/pages/workflows/control-flow.mdx
@@ -70,4 +70,4 @@ jobs:
 
 ## Combining conditions
 
-You can use both `needs` and `if` conditions in the same job definition. Note that the job will be run if all jobs on the `needs` list are successful **AND** the `if` condition is true. If any job on the `needs` list had been skipped or the `if` condition is false, the current job will be skipped. If any job on the `needs` list had failed, the current job will be failed.
+You can use both `needs` and `if` conditions in the same job definition. **Note that the job will be run if all jobs on the `needs` list are successful and the `if` condition is true.** If any job on the `needs` list has been skipped or the `if` condition is false, the current job will be skipped. If any job on the `needs` list has failed, the current job will be failed.


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14302/require-needs-to-be-successful-before-starting-a-job-even-if-the-job
Companion to: https://github.com/expo/universe/pull/17806

# How

Updated the docs regarding workflow flow control after both `needs` and `if`, if present, are required to be successful to run the job.

# Test Plan

Tested manually
<img width="1117" alt="Screenshot 2024-12-03 at 16 50 03" src="https://github.com/user-attachments/assets/ae8ebe79-2575-4cef-8d6c-6e122eb20b82">
<img width="1117" alt="Screenshot 2024-12-03 at 16 50 24" src="https://github.com/user-attachments/assets/333e53a1-c2d4-4269-880b-7e6e2fe7a794">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
