### PR TITLE
[docs] Add `data-nosnippet` to Previous and Next buttons

### DIFF
--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -45,7 +45,8 @@ export const Footer = ({
             'max-xl-gutters:flex-col-reverse',
             'max-lg-gutters:flex-row',
             'max-md-gutters:flex-col-reverse'
-          )}>
+          )}
+          data-nosnippet>
           {previousPage ? (
             <LinkBase
               href={previousPage.href}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14401
Follow-up #33352

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add the `data-nosnippet` attribute to `div` that wraps Previous and Next buttons on a docs page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally: `yarn run dev`
- Go to any page that has previous or next button or both (eg: http://localhost:3002/develop/user-interface/next-steps/)
- Right-click and inspect any of the button and then see that the wrapping div has the `data-nosnippet` attribute applied (as shown below):

![CleanShot 2024-12-03 at 23 52 15](https://github.com/user-attachments/assets/73ded45d-4608-47a6-8629-1ff8023e214b)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
