### PR TITLE
fix(cli): resolve remaining Windows pathing issues in CLI E2E

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix manifest url and API route exports on Windows.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
-- Fix manifest url and API route exports on Windows.
+- Fix manifest url and API route exports on Windows. ([#33408](https://github.com/expo/expo/pull/33408) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -165,7 +165,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     }
 
     for (const route of manifest.apiRoutes) {
-      const filepath = route.file.startsWith('/') ? route.file : path.join(appDir, route.file);
+      const filepath = path.isAbsolute(route.file) ? route.file : path.join(appDir, route.file);
       const contents = await this.bundleApiRoute(filepath, { platform });
 
       const artifactFilename =

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -44,7 +44,9 @@ export function getEntryWithServerRoot(
       `Failed to resolve the project's entry file: The platform "${props.platform}" is not supported.`
     );
   }
-  return path.relative(getMetroServerRoot(projectRoot), resolveEntryPoint(projectRoot, props));
+  return convertPathToModuleSpecifier(
+    path.relative(getMetroServerRoot(projectRoot), resolveEntryPoint(projectRoot, props))
+  );
 }
 
 /** Get the main entry module ID (file) relative to the project root. */

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -4,6 +4,7 @@ import resolveFrom from 'resolve-from';
 
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
+import { toPosixPath } from '../../../utils/filePath';
 import { getRouterDirectoryModuleIdWithManifest } from '../metro/router';
 
 const debug = require('debug')('expo:metro:options') as typeof console.log;
@@ -384,7 +385,7 @@ export function createBundleUrlSearchParams(options: ExpoMetroOptions): URLSearc
  * @see https://github.com/facebook/metro/pull/1286
  */
 export function convertPathToModuleSpecifier(pathLike: string) {
-  return pathLike.replaceAll('\\', '/');
+  return toPosixPath(pathLike);
 }
 
 export function getMetroOptionsFromUrl(urlFragment: string) {


### PR DESCRIPTION
# Why

Split of from #33204

These are the last remaining smaller path issues on Windows, found running the E2E tests.

# How

- Fixed malformed `manifest.launchAsset.url` by converting the relative `getEntryWithServerRoot` return value as module specifier (POSIX)
- Fixed error when returning RSC from API routes on Windows related to multiple absolute paths being appended as single route / file path.

# Test Plan

See tests / CI, need to merge all split off PRs from #33204 to enable Windows and see the results on the E2E though.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
