### PR TITLE
[fingerprint] add diff stability test

### DIFF
--- a/packages/@expo/fingerprint/src/__tests__/Fingerprint-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/Fingerprint-test.ts
@@ -519,8 +519,7 @@ describe('function api stability', () => {
     vol.reset();
   });
 
-  it('maintains consistent hash and function signature expected by eas-cli', async () => {
-    vol.fromJSON(require('../sourcer/__tests__/fixtures/ExpoManaged47Project.json'));
+  function getCreateFingerprintFixedArgs(): [string, Record<string, any>] {
     // The fixed options and arguments as called by eas-cli
     const FIXED_OPTIONS = {
       platforms: ['android', 'ios'],
@@ -528,9 +527,13 @@ describe('function api stability', () => {
       debug: true,
     };
     const PROJECT_ROOT = '/app';
-    const FIXED_ARGS = [PROJECT_ROOT, FIXED_OPTIONS];
+    return [PROJECT_ROOT, FIXED_OPTIONS];
+  }
 
-    const fingerprint = await Fingerprint.createFingerprintAsync(...FIXED_ARGS);
+  it('createFingerprintAsync - maintains consistent hash and function signature expected by eas-cli', async () => {
+    vol.fromJSON(require('../sourcer/__tests__/fixtures/ExpoManaged47Project.json'));
+    const createFingerprintFixedArgs = getCreateFingerprintFixedArgs();
+    const fingerprint = await Fingerprint.createFingerprintAsync(...createFingerprintFixedArgs);
 
     expect(fingerprint).toEqual(
       expect.objectContaining({
@@ -553,5 +556,15 @@ describe('function api stability', () => {
         );
       }
     });
+  });
+
+  it('diffFingerprint - accepts output from createFingerprintAsync with stable function signature expected by eas-cli', async () => {
+    vol.fromJSON(require('../sourcer/__tests__/fixtures/ExpoManaged47Project.json'));
+    const createFingerprintFixedArgs = getCreateFingerprintFixedArgs();
+    const fingerprint = await Fingerprint.createFingerprintAsync(...createFingerprintFixedArgs);
+
+    // The fixed arguments as called by eas-cli
+    const FIXED_ARGS = [fingerprint, fingerprint];
+    expect(Fingerprint.diffFingerprints(...FIXED_ARGS)).toBeDefined();
   });
 });


### PR DESCRIPTION
# Why

Added test coverage to ensure the `diffFingerprints` function maintains API stability with `eas-cli` integration. This complements existing tests for `createFingerprintAsync`.

# How

- Extracted common test setup into a helper function `getCreateFingerprintFixedArgs`
- Added new test case to verify `diffFingerprints` accepts output from `createFingerprintAsync`
- Renamed existing test for clarity

# Test Plan

- [ ] new tests pass

# Checklist

- [x] Documentation is up to date to reflect these changes
- [x] Conforms with the Documentation Writing Style Guide
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build