### PR TITLE
feat(cli): estimate binary path in minimal builds

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Estimate Xcode binary path in minimal builds.
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
 - Use `ios.appleTeamId` when prompting users to select the Apple identity in `expo run ios`. ([#33330](https://github.com/expo/expo/pull/33330) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Estimate Xcode binary path in minimal builds.
+- Estimate Xcode binary path in minimal builds. ([#33415](https://github.com/expo/expo/pull/33415) by [@EvanBacon](https://github.com/EvanBacon))
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
 - Use `ios.appleTeamId` when prompting users to select the Apple identity in `expo run ios`. ([#33330](https://github.com/expo/expo/pull/33330) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -5,6 +5,8 @@ import {
   getProcessOptions,
   getXcodeBuildArgsAsync,
   _assertXcodeBuildResults,
+  matchEstimatedBinaryPath,
+  getAppBinaryPath,
 } from '../XcodeBuild';
 import { ensureDeviceIsCodeSignedForDeploymentAsync } from '../codeSigning/configureCodeSigning';
 
@@ -120,6 +122,48 @@ describe(_assertXcodeBuildResults, () => {
       )
     ).toThrow(
       'This operation can fail if the version of the OS on the device is newer than the version of Xcode that is running.'
+    );
+  });
+});
+
+describe(matchEstimatedBinaryPath, () => {
+  const fixture = `Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -workspace /Users/evanbacon/Documents/GitHub/lab/dec3-52blank/ios/dec352blank.xcworkspace -configuration Debug -scheme dec352blank -destination id=7A29311A-FD92-4013-BF22-7003D5B915D9
+
+User defaults from command line:
+    IDEPackageSupportUseBuiltinSCM = YES
+
+Prepare packages
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'dec352blank' in project 'dec352blank'
+        ➜ Implicit dependency on target 'Pods-dec352blank' in project 'Pods' via file 'libPods-dec352blank.a' in build phase 'Link Binary'
+    Target 'Pods-dec352blank' in project 'Pods' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.1.sdk /Users/evanbacon/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphonesimulator18.1-22B74-3d93aac3a03ebac1dd8474c5def773dc.sdkstatcache
+    cd /Users/evanbacon/Documents/GitHub/lab/dec3-52blank/ios
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.1.sdk -o /Users/evanbacon/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphonesimulator18.1-22B74-3d93aac3a03ebac1dd8474c5def773dc.sdkstatcache
+
+ProcessInfoPlistFile /Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Products/Debug-iphonesimulator/dec352blank.app/Info.plist /Users/evanbacon/Documents/GitHub/lab/dec3-52blank/ios/dec352blank/Info.plist (in target 'dec352blank' from project 'dec352blank')
+    cd /Users/evanbacon/Documents/GitHub/lab/dec3-52blank/ios
+    builtin-infoPlistUtility /Users/evanbacon/Documents/GitHub/lab/dec3-52blank/ios/dec352blank/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Products/Debug-iphonesimulator/dec352blank.app/PkgInfo -expandbuildsettings -format binary -platform iphonesimulator -additionalcontentfile /Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Intermediates.noindex/dec352blank.build/Debug-iphonesimulator/dec352blank.build/SplashScreen-SBPartialInfo.plist -additionalcontentfile /Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Intermediates.noindex/dec352blank.build/Debug-iphonesimulator/dec352blank.build/assetcatalog_generated_info.plist -o /Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Products/Debug-iphonesimulator/dec352blank.app/Info.plist
+
+** BUILD SUCCEEDED **
+`;
+  it(`matches binary path`, () => {
+    expect(matchEstimatedBinaryPath(fixture)).toBe(
+      '/Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Products/Debug-iphonesimulator/dec352blank.app'
+    );
+  });
+  it(`matches binary path as a fallback`, () => {
+    expect(getAppBinaryPath(fixture)).toBe(
+      '/Users/evanbacon/Library/Developer/Xcode/DerivedData/dec352blank-atotwaonfbrdkmgspyclhglnaagn/Build/Products/Debug-iphonesimulator/dec352blank.app'
     );
   });
 });


### PR DESCRIPTION
# Why

In minimal Xcode builds or builds with prebuilt React iOS, the env vars used for matching the binary path are not matchable using the current heuristic. This change adds a fallback to match for the path as a final try.
