### PR TITLE
[docs] update apple advisory metadata with age rating override

### DIFF
--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -126,7 +126,8 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
       "gambling": false,
       "unrestrictedWebAccess": false,
       "kidsAgeBand": null,
-      "seventeenPlus": false
+      "ageRatingOverride": "NONE",
+      "koreaAgeRatingOverride": "NONE"
     }
   }
 }
@@ -195,19 +196,32 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
       description: 'Does the app contain profanity or crude humor?',
     },
     {
-      name: 'seventeenPlus',
-      type: 'boolean',
+      name: 'ageRatingOverride',
+      type: <MD.a href="#apple-advisory-age-rating-override">AppleAgeRatingOverride</MD.a>,
       description: [
         <MD.p>
-          If your app rates 12+ or lower, and you believe its content may not be suitable for
-          children under 17, you can manually set the age rating to 17+.
+          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating.
         </MD.p>,
         <MD.p>
-          <MD.a openInNewTab href="https://help.apple.com/app-store-connect/#/dev599d50efb">
+          <MD.a openInNewTab href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
             Learn more
           </MD.a>
         </MD.p>,
-      ],
+      ]
+    },
+    {
+      name: 'koreaAgeRatingOverride',
+      type: <MD.a href="#apple-advisory-korea-age-rating-override">AppleKoreaAgeRatingOverride</MD.a>,
+      description: [
+        <MD.p>
+          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating. Same as ageRatingOverride, but for South Korea.
+        </MD.p>,
+        <MD.p>
+          <MD.a openInNewTab href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
+            Learn more
+          </MD.a>
+        </MD.p>,
+      ]
     },
     {
       name: 'sexualContentGraphicAndNudity',
@@ -268,6 +282,39 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
     { name: 'NINE_TO_ELEVEN', description: 'For kids between the age of 9 to 11 years.' },
   ]}
 </MetadataTable>
+
+#### Apple advisory age rating override
+
+<MetadataTable headers={['Name', 'Description']}>
+  {[
+    { name: 'NONE', description: 'No age rating override' },
+    {
+      name: 'SEVENTEEN_PLUS',
+      description: 'App contains content that may not be suitable for children under the age of 17',
+    },
+    {
+      name: 'UNRATED',
+      description: 'Adults Only. This content can\'t be published on the App Store. It may be published on alternative app marketplaces on iOS or websites in the European Union',
+    },
+  ]}
+</MetadataTable>
+
+#### Apple advisory korea age rating override
+
+<MetadataTable headers={['Name', 'Description']}>
+  {[
+    { name: 'NONE', description: 'No age rating override' },
+    {
+      name: 'FIFTEEN_PLUS',
+      description: 'App contains content that may not be suitable for children under the age of 15',
+    },
+    {
+      name: 'NINETEEN_PLUS',
+      description: 'App contains content that may not be suitable for children under the age of 19',
+    },
+  ]}
+</MetadataTable>
+
 
 ### Apple categories
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -214,7 +214,7 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
       type: <MD.a href="#apple-advisory-korea-age-rating-override">AppleKoreaAgeRatingOverride</MD.a>,
       description: [
         <MD.p>
-          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating. Same as ageRatingOverride, but for South Korea.
+          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating. Same as `ageRatingOverride`, but for South Korea.
         </MD.p>,
         <MD.p>
           <MD.a openInNewTab href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
@@ -290,11 +290,11 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
     { name: 'NONE', description: 'No age rating override' },
     {
       name: 'SEVENTEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 17',
+      description: 'App contains content that may not be suitable for children under the age of 17.',
     },
     {
       name: 'UNRATED',
-      description: 'Adults Only. This content can\'t be published on the App Store. It may be published on alternative app marketplaces on iOS or websites in the European Union',
+      description: 'Adults Only. This content cannot be published on the App Store. It may be published on alternative app marketplaces on iOS or websites in the European Union.',
     },
   ]}
 </MetadataTable>
@@ -306,11 +306,11 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
     { name: 'NONE', description: 'No age rating override' },
     {
       name: 'FIFTEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 15',
+      description: 'App contains content that may not be suitable for children under the age of 15.',
     },
     {
       name: 'NINETEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 19',
+      description: 'App contains content that may not be suitable for children under the age of 19.',
     },
   ]}
 </MetadataTable>

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -200,28 +200,37 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
       type: <MD.a href="#apple-advisory-age-rating-override">AppleAgeRatingOverride</MD.a>,
       description: [
         <MD.p>
-          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating.
+          If your app rates 12+ or lower, and you believe its content may not be suitable for
+          children, you can manually override the age rating.
         </MD.p>,
         <MD.p>
-          <MD.a openInNewTab href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
+          <MD.a
+            openInNewTab
+            href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
             Learn more
           </MD.a>
         </MD.p>,
-      ]
+      ],
     },
     {
       name: 'koreaAgeRatingOverride',
-      type: <MD.a href="#apple-advisory-korea-age-rating-override">AppleKoreaAgeRatingOverride</MD.a>,
+      type: (
+        <MD.a href="#apple-advisory-korea-age-rating-override">AppleKoreaAgeRatingOverride</MD.a>
+      ),
       description: [
         <MD.p>
-          If your app rates 12+ or lower, and you believe its content may not be suitable for children, you can manually override the age rating. Same as `ageRatingOverride`, but for South Korea.
+          If your app rates 12+ or lower, and you believe its content may not be suitable for
+          children, you can manually override the age rating. Same as `ageRatingOverride`, but for
+          South Korea.
         </MD.p>,
         <MD.p>
-          <MD.a openInNewTab href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
+          <MD.a
+            openInNewTab
+            href="https://developer.apple.com/help/app-store-connect/manage-app-information/set-an-app-age-rating">
             Learn more
           </MD.a>
         </MD.p>,
-      ]
+      ],
     },
     {
       name: 'sexualContentGraphicAndNudity',
@@ -290,11 +299,13 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
     { name: 'NONE', description: 'No age rating override' },
     {
       name: 'SEVENTEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 17.',
+      description:
+        'App contains content that may not be suitable for children under the age of 17.',
     },
     {
       name: 'UNRATED',
-      description: 'Adults Only. This content cannot be published on the App Store. It may be published on alternative app marketplaces on iOS or websites in the European Union.',
+      description:
+        'Adults Only. This content cannot be published on the App Store. It may be published on alternative app marketplaces on iOS or websites in the European Union.',
     },
   ]}
 </MetadataTable>
@@ -306,15 +317,16 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
     { name: 'NONE', description: 'No age rating override' },
     {
       name: 'FIFTEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 15.',
+      description:
+        'App contains content that may not be suitable for children under the age of 15.',
     },
     {
       name: 'NINETEEN_PLUS',
-      description: 'App contains content that may not be suitable for children under the age of 19.',
+      description:
+        'App contains content that may not be suitable for children under the age of 19.',
     },
   ]}
 </MetadataTable>
-
 
 ### Apple categories
 


### PR DESCRIPTION
# Why

EAS Metadata introduced a couple of new required `$.apple.advisory`-fields last month, but they weren't documented.

# How

Brings the documentation in line with the changes from expo/eas-cli#2671

* Removes seventeen plus
* Adds age rating override
* Adds korea age rating override

I just reused the description from "seventeen plus", as it's mostly the same functionality.

Description for the different ENUM values I took from apples documentation on age ratings:
https://developer.apple.com/help/app-store-connect/reference/age-ratings

# Test Plan

Don't believe it's necessary for these changes

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
