### PR TITLE
[bare][Android] Use correct `exec` in `build.gradle`

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -203,7 +203,7 @@ dependencies {
 class ExecuteSetupAndroidProject implements Plugin<Project> {
     @Override
     void apply(Project target) {
-        target.exec {
+        target.providers.exec {
             def configuration = target.gradle.startParameter.taskNames.any {
                 it.toLowerCase().contains("release")
             } ? "release" : "debug"


### PR DESCRIPTION
# Why

Uses a correctly, cache friendly `exec` inside of the `bare-expo/app/build.gralde`. 

# How

Replace `Project.exec` with `Project.providers.exec`.

# Test Plan

- bare-expo ✅ 