### PR TITLE
[updates] Fix `deferredRootView`

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix black screen appearing instead of the splashscreen on launch.
+
 ### 💡 Others
 
 ## 0.26.9 — 2024-11-22

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix black screen appearing instead of the splashscreen on launch.
+- Fix black screen appearing instead of the splashscreen on launch. ([#33432](https://github.com/expo/expo/pull/33432) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -81,45 +81,6 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     stateMachine.queueExecution(stateMachineProcedure: startupProcedure)
   }
 
-  /**
-   Starts the update process to launch a previously-loaded update and (if configured to do so)
-   check for a new update from the server. This method should be called as early as possible in
-   the application's lifecycle.
-
-   Note that iOS may stop showing the app's splash screen in case the update is taking a while
-   to load. This method will attempt to find `LaunchScreen.xib` and load it into view while the
-   update is loading.
-   */
-  public func startAndShowLaunchScreen(_ window: UIWindow) {
-    var view: UIView?
-    let mainBundle = Bundle.main
-    let launchScreen = mainBundle.object(forInfoDictionaryKey: "UILaunchStoryboardName") as? String ?? "LaunchScreen"
-
-    if mainBundle.path(forResource: launchScreen, ofType: "nib") != nil {
-      let views = mainBundle.loadNibNamed(launchScreen, owner: self)
-      view = views?.first as? UIView
-      view?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    } else if mainBundle.path(forResource: launchScreen, ofType: "storyboard") != nil ||
-      mainBundle.path(forResource: launchScreen, ofType: "storyboardc") != nil {
-      let launchScreenStoryboard = UIStoryboard(name: launchScreen, bundle: nil)
-      let viewController = launchScreenStoryboard.instantiateInitialViewController()
-      view = viewController?.view
-      viewController?.view = nil
-    } else {
-      logger.warn(message: "Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.")
-      view = UIView()
-      view?.backgroundColor = .white
-    }
-
-    if window.rootViewController == nil {
-      window.rootViewController = UIViewController()
-    }
-    window.rootViewController!.view = view
-    window.makeKeyAndVisible()
-
-    start()
-  }
-
   public func onEventListenerStartObserving() {
     stateMachine.sendContextToJS()
   }

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -43,7 +43,7 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       // The deferredRootView needs to be dark mode aware so we set the color to be the same as the splashscreen background.
       rootView.backgroundColor = UIColor(named: "SplashScreenBackground") ?? .white
       rootView.addSubview(view)
-      
+
       NSLayoutConstraint.activate([
         view.centerXAnchor.constraint(equalTo: rootView.centerXAnchor),
         view.centerYAnchor.constraint(equalTo: rootView.centerYAnchor)

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -36,6 +36,18 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     self.rootViewModuleName = moduleName
     self.rootViewInitialProperties = initialProperties
     self.deferredRootView = EXDeferredRCTRootView()
+    // This view can potentially be displayed for a while. We should use the splashscreens view here otherwise a black view appears in the middle of the loading sequence.
+    if let view = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()?.view, let rootView = self.deferredRootView {
+      view.translatesAutoresizingMaskIntoConstraints = false
+      // The deferredRootView needs to be dark mode aware so we set the color to the same as the splashscreen view
+      rootView.backgroundColor = UIColor(named: "SplashScreenBackground") ?? .white
+      rootView.addSubview(view)
+      
+      NSLayoutConstraint.activate([
+        view.centerXAnchor.constraint(equalTo: rootView.centerXAnchor),
+        view.centerYAnchor.constraint(equalTo: rootView.centerYAnchor)
+      ])
+    }
     return self.deferredRootView
   }
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -38,7 +38,7 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     self.deferredRootView = EXDeferredRCTRootView()
     // This view can potentially be displayed for a while.
     // We should use the splashscreens view here, otherwise a black view appears in the middle of the launch sequence.
-    if let view = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()?.view, let rootView = self.deferredRootView {
+    if let view = createSplashScreenview(), let rootView = self.deferredRootView {
       view.translatesAutoresizingMaskIntoConstraints = false
       // The deferredRootView needs to be dark mode aware so we set the color to be the same as the splashscreen background.
       rootView.backgroundColor = UIColor(named: "SplashScreenBackground") ?? .white
@@ -92,6 +92,25 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     self.deferredRootView = nil
     self.rootViewModuleName = nil
     self.rootViewInitialProperties = nil
+  }
+
+  private func createSplashScreenview() -> UIView? {
+    var view: UIView?
+    let mainBundle = Bundle.main
+    let launchScreen = mainBundle.object(forInfoDictionaryKey: "UILaunchStoryboardName") as? String ?? "LaunchScreen"
+
+    if mainBundle.path(forResource: launchScreen, ofType: "storyboard") != nil ||
+      mainBundle.path(forResource: launchScreen, ofType: "storyboardc") != nil {
+      let launchScreenStoryboard = UIStoryboard(name: launchScreen, bundle: nil)
+      let viewController = launchScreenStoryboard.instantiateInitialViewController()
+      view = viewController?.view
+      viewController?.view = nil
+    } else if mainBundle.path(forResource: launchScreen, ofType: "nib") != nil {
+      let views = mainBundle.loadNibNamed(launchScreen, owner: self)
+      view = views?.first as? UIView
+    }
+
+    return view
   }
 
   private func getWindow() -> UIWindow {

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -36,10 +36,11 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     self.rootViewModuleName = moduleName
     self.rootViewInitialProperties = initialProperties
     self.deferredRootView = EXDeferredRCTRootView()
-    // This view can potentially be displayed for a while. We should use the splashscreens view here otherwise a black view appears in the middle of the loading sequence.
+    // This view can potentially be displayed for a while.
+    // We should use the splashscreens view here, otherwise a black view appears in the middle of the launch sequence.
     if let view = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()?.view, let rootView = self.deferredRootView {
       view.translatesAutoresizingMaskIntoConstraints = false
-      // The deferredRootView needs to be dark mode aware so we set the color to the same as the splashscreen view
+      // The deferredRootView needs to be dark mode aware so we set the color to be the same as the splashscreen background.
       rootView.backgroundColor = UIColor(named: "SplashScreenBackground") ?? .white
       rootView.addSubview(view)
       


### PR DESCRIPTION
# Why
When updates is launched, it uses a blank placeholder view as the root view while it finishes its tasks. This interrupts the splashscreen causing a black flicker and depending on the number of assets you are loading, can be present for even longer.

Fixes #33257

# How
We should use the splashscreens view for this deferred view. This makes a seamless transition that should not be noticeable to the user.

# Test Plan

### Before
https://github.com/user-attachments/assets/c1af0720-6a3a-412c-adba-924a299786c0

### After
https://github.com/user-attachments/assets/b8da8ff8-a531-469c-8c96-f31bdbceb181


