### PR TITLE
[docs] Update "kB" to "KiB" in EAS Environment variables guide

### DIFF
--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -217,6 +217,6 @@ See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/pa
 
 ## Limitations
 
-Environment variable value size is limited to 32 KB for environment variables with secret visibility and 4 KiB for other visibility types.
+Environment variable value size is limited to 32 KiB for environment variables with secret visibility and 4 KiB for other visibility types.
 
 You can create up to 100 account-wide environment variables for each Expo account and 100 project-specific environment variables for each app

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -217,6 +217,6 @@ See the [EAS CLI command reference](https://github.com/expo/eas-cli/blob/main/pa
 
 ## Limitations
 
-Environment variable value size is limited to 32 KB for environment variables with secret visibility and 4 KB for other visibility types.
+Environment variable value size is limited to 32 KB for environment variables with secret visibility and 4 KiB for other visibility types.
 
 You can create up to 100 account-wide environment variables for each Expo account and 100 project-specific environment variables for each app


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #33338 & #33292

After going through the expo.dev dashboard, found that we use KiB and not kB for .env file size:

![CleanShot 2024-12-04 at 17 1 01](https://github.com/user-attachments/assets/f64ad19d-50fe-4b90-ab26-0d889a96f36a)

![CleanShot 2024-12-04 at 17 15 00](https://github.com/user-attachments/assets/473c3d46-e2a0-42a0-93cb-b750bf4d5c3e)

This change also follows our writing style guide.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
