### PR TITLE
[expo-go] Fix theme error on LauncherActivity

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -207,7 +207,6 @@ dependencies {
 
   // Our dependencies from ExpoView
   // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
-  implementation ('androidx.appcompat:appcompat:1.4.1')
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   implementation 'com.jakewharton:butterknife:10.2.1'
   implementation 'de.greenrobot:eventbus:2.4.0'

--- a/apps/expo-go/android/app/src/main/res/values/styles.xml
+++ b/apps/expo-go/android/app/src/main/res/values/styles.xml
@@ -23,6 +23,15 @@
     <item name="android:theme">@style/DevAppTheme</item>
   </style>
 
+  <style name="Theme.Exponent.Translucent" parent="Theme.AppCompat.NoActionBar">
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:colorBackgroundCacheHint">@null</item>
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowAnimationStyle">@android:style/Animation</item>
+    <item name="windowNoTitle">true</item>
+    <item name="android:windowContentOverlay">@null</item>
+  </style>
+
   <style name="ExponentButton">
     <item name="android:theme">@style/DevAppTheme</item>
     <item name="android:textColor">@color/colorPrimaryDark</item>

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -60,7 +60,7 @@
       android:name=".LauncherActivity"
       android:exported="true"
       android:launchMode="singleTask"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar">
+      android:theme="@style/Theme.Exponent.Translucent">
       <!-- START LAUNCHER INTENT FILTERS -->
       <intent-filter>
         <data android:scheme="exp"/>


### PR DESCRIPTION
# Why
Closes #33420

# How
We can't use a framework theme like `android:style/Theme.Translucent.NoTitleBar` when extending `AppCompatActivity`. There is no 1:1 equivalent in `AppCompat`. The closest is `Theme.AppCompat.NoActionBar` so I've created a custom theme to match the properties in `Theme.Translucent.NoTitleBar` and extends `Theme.AppCompat.NoActionBar`.

# Test Plan
I can't reproduce the problem. I've tried it on various emulators of different API levels and my device and can't see it. I also installed the problematic version from the store, which was working correctly on my device. Likely it's an issue for older devices than mine but I would expect to reproduce in the emulator. If anyone has any ideas let me know
