### PR TITLE
[docs] include jazz in local-first doc

### DIFF
--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -67,7 +67,7 @@ It works with Expo and React Native (via [React Native Async Storage](https://gi
 ### Jazz
 
 [Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools) provides first-class support for Expo.
-To learn more, check out the [examples repository](https://github.com/garden-co/jazz/tree/main/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
+To learn more, check out the [examples](https://jazz.tools/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
 
 ### Other tools
 

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -64,6 +64,11 @@ It works with Expo and React Native (via [React Native Async Storage](https://gi
 
 [Prisma](https://prisma.io) is well known as the most popular ORM for Node.js and TypeScript backends, and it's now available for [Expo and React Native in early access](https://www.prisma.io/blog/bringing-prisma-orm-to-react-native-and-expo). Prisma aims to provide a complete local-first solution, with state management, syncing, and persistence all covered for you. While it's still early, [Beto Moedano](https://github.com/betomoedano) has put together full walkthrough of using Prisma with Expo to build a local-first Notion clone, [watch it on YouTube](https://www.youtube.com/watch?v=uTrPte0sCiw) and [check out the code on GitHub](https://github.com/betomoedano/React-Native-Notion-Clone).
 
+### Jazz
+
+[Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools) provides first-class support for Expo.
+To learn more, check out the [examples repository](https://github.com/garden-co/jazz/tree/main/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
+
 ### Other tools
 
 The following list, far from being comprehensive, provides other tools that have caught our attention and that you may find interesting to explore. For a more thorough list of tools, see ["Local-first software" community website](https://localfirstweb.dev/).

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -66,8 +66,7 @@ It works with Expo and React Native (via [React Native Async Storage](https://gi
 
 ### Jazz
 
-[Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools) provides first-class support for Expo.
-To learn more, check out the [examples](https://jazz.tools/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
+[Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, provides first-class support for Expo and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools). To learn more, check out the [examples](https://jazz.tools/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
 
 ### Other tools
 

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -66,7 +66,7 @@ It works with Expo and React Native (via [React Native Async Storage](https://gi
 
 ### Jazz
 
-[Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, provides first-class support for Expo and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools). To learn more, check out the [examples](https://jazz.tools/examples) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
+[Jazz.tools](https://jazz.tools/docs/react-native) is a framework for building local-first apps. It is open source, provides first-class support for Expo and you can self-host it or use [Jazz Cloud](https://jazz.tools/cloud) to start quickly. [Jazz](https://jazz.tools). To learn more, check out the [examples](https://jazz.tools/examples#react-native) or see the [Getting Started Guide](https://jazz.tools/docs/react-native) for detailed instructions.
 
 ### Other tools
 


### PR DESCRIPTION
# Why

Jazz has been improving and continues to enhance first-class local-first support for Expo.

# Test Plan

Run locally and verify that the page displays correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
