### PR TITLE
Use nullish assignment operator to assign `entries` in `FormData`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix sending a blob as fetch body not setting correct content-type. ([#33405](https://github.com/expo/expo/pull/33405) by [@aleqsio](https://github.com/aleqsio))
+- Use nullish assignment operator to assign entries in FormData ([#33445](https://github.com/expo/expo/pull/33445) by [@j-piasecki](https://github.com/j-piasecki))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix sending a blob as fetch body not setting correct content-type. ([#33405](https://github.com/expo/expo/pull/33405) by [@aleqsio](https://github.com/aleqsio))
-- Use nullish assignment operator to assign entries in FormData ([#33445](https://github.com/expo/expo/pull/33445) by [@j-piasecki](https://github.com/j-piasecki))
+- Use nullish assignment operator to assign entries in FormData. ([#33445](https://github.com/expo/expo/pull/33445) by [@j-piasecki](https://github.com/j-piasecki))
 
 ### 💡 Others
 

--- a/packages/expo/src/winter/FormData.ts
+++ b/packages/expo/src/winter/FormData.ts
@@ -121,7 +121,7 @@ export function installFormDataPatch(formData: typeof FormData) {
 
   // Required for RSC: https://github.com/facebook/react/blob/985747f81033833dca22f30b0c04704dd4bd3714/packages/react-server/src/ReactFlightServer.js#L2117
   // @ts-ignore: DOM.iterable is disabled for jest compat
-  formData.prototype.entries = function* entries(
+  formData.prototype.entries ??= function* entries(
     this: ReactNativeFormDataInternal
   ): IterableIterator<[string, FormDataEntryValue]> {
     for (const part of this._parts) {


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/31117 all methods were set using `??=` operator except for `entries`. This PR adds it also for entries. The current implementation was causing issues with SDK 52 in the Expensify app.

# How

- Used nullish assignment operator to assign `entries` method 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
