### PR TITLE
[iOS] Fix the AppDelegate in Expo Go

### DIFF
--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import Foundation
-import ExpoModulesCore
+import Expo
 
 @UIApplicationMain
 class AppDelegate: ExpoAppDelegate {
@@ -9,6 +8,9 @@ class AppDelegate: ExpoAppDelegate {
 
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     ExpoGoReactNativeFeatureFlags.setup()
+
+    // Tell `ExpoAppDelegate` to skip calling the React Native instance setup from `RCTAppDelegate`.
+    self.shouldCallReactNativeSetup = false
 
     if application.applicationState != UIApplication.State.background {
       // App launched in foreground
@@ -24,18 +26,14 @@ class AppDelegate: ExpoAppDelegate {
   }
 
   private func setUpUserInterfaceForApplication(_ application: UIApplication, withLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-    if self.window != nil {
-      return
-    }
-
     ExpoKit.sharedInstance().registerRootViewControllerClass(EXRootViewController.self)
     ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
 
     window = UIWindow(frame: UIScreen.main.bounds)
-    window?.backgroundColor = UIColor.white
+    window.backgroundColor = UIColor.white
     rootViewController = (ExpoKit.sharedInstance().rootViewController() as! EXRootViewController)
-    window?.rootViewController = rootViewController
+    window.rootViewController = rootViewController
 
-    window?.makeKeyAndVisible()
+    window.makeKeyAndVisible()
   }
 }

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3081,7 +3081,7 @@ SPEC CHECKSUMS:
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 699c9e93f5af5892ce55dabed81ca70680bb356d
+  hermes-engine: fc27a3c4b51c81f907a3e55b33fd71bae214c9f1
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -20,6 +20,7 @@
 {
   if (self = [super init]) {
     _expoAppDelegate = [[EXExpoAppDelegate alloc] init];
+    _expoAppDelegate.shouldCallReactNativeSetup = NO;
   }
   return self;
 }

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -12,6 +12,14 @@ var subscribers = [ExpoAppDelegateSubscriberProtocol]()
  */
 @objc(EXExpoAppDelegate)
 open class ExpoAppDelegate: ExpoAppInstance {
+  /**
+   Whether to skip calling the React Native instance setup from `RCTAppDelegate`.
+   Set this property to `false` if your app delegate is not supposed to initialize a React Native app,
+   but only to handle the app delegate subscribers.
+   */
+  @objc
+  public var shouldCallReactNativeSetup: Bool = true
+
   #if os(iOS) || os(tvOS)
   // MARK: - Initializing the App
 
@@ -39,9 +47,7 @@ open class ExpoAppDelegate: ExpoAppInstance {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    if UIApplication.shared.delegate is ExpoAppDelegate {
-      // Super function from `RCTAppDelegate` must be called only when the class is used as the base class of the AppDelegate.
-      // For backwards compatibility `EXAppDelegateWrapper` creates a detached instance of `ExpoAppDelegate`, in which case this call must be skipped.
+    if shouldCallReactNativeSetup {
       super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 


### PR DESCRIPTION
# Why

#33348 introduced an issue in Expo Go.
The AppDelegate in Expo Go was already extending `ExpoAppDelegate` to handle app delegate subscribers. Now `ExpoAppDelegate` also calls the setup from `RCTAppDelegate` by default as part of `application(_:didFinishLaunchingWithOptions:)`. We already had a check for when the setup should be called for backwards compatibility with `EXAppDelegateWrapper`, but it turns out we need more customization.

# How

Introduced a new property `shouldCallReactNativeSetup` to disable calling the setup from `RCTAppDelegate`. This property can also be used by `EXAppDelegateWrapper`.

# Test Plan

Expo Go compiles and launches home app correctly. Also checked bare-expo app.