### PR TITLE
[ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
+
 ## 14.0.4 - 2024-11-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
@@ -13,7 +13,7 @@ public class CalendarPermissionsRequester: NSObject, EXPermissionsRequester {
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
-    var status: CalendarPermissionsStatus
+    var status: EXPermissionStatus
     var permissions: EKAuthorizationStatus
 
     let description = {
@@ -32,13 +32,13 @@ public class CalendarPermissionsRequester: NSObject, EXPermissionsRequester {
 
     switch permissions {
     case .restricted, .denied:
-      status = .denied
+      status = EXPermissionStatusDenied
     case .notDetermined:
-      status = .notDetermined
+      status = EXPermissionStatusUndetermined
     case .fullAccess:
-      status = .granted
+      status = EXPermissionStatusGranted
     @unknown default:
-      status = .unknown
+      status = EXPermissionStatusUndetermined
     }
 
     return ["status": status.rawValue]

--- a/packages/expo-calendar/ios/Requesters/CalendarPermissionsStatus.swift
+++ b/packages/expo-calendar/ios/Requesters/CalendarPermissionsStatus.swift
@@ -1,8 +1,0 @@
-import ExpoModulesCore
-
-enum CalendarPermissionsStatus: Int {
-  case denied = 0
-  case granted = 1
-  case notDetermined = 2
-  case unknown = 3
-}

--- a/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
@@ -13,7 +13,7 @@ public class RemindersPermissionRequester: NSObject, EXPermissionsRequester {
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
-    var status: CalendarPermissionsStatus
+    var status: EXPermissionStatus
     var permissions: EKAuthorizationStatus
 
     let description = {
@@ -32,13 +32,13 @@ public class RemindersPermissionRequester: NSObject, EXPermissionsRequester {
 
     switch permissions {
     case .restricted, .denied:
-      status = .denied
+      status = EXPermissionStatusDenied
     case .notDetermined:
-      status = .notDetermined
+      status = EXPermissionStatusUndetermined
     case .fullAccess:
-      status = .granted
+      status = EXPermissionStatusGranted
     @unknown default:
-      status = .unknown
+      status = EXPermissionStatusUndetermined
     }
 
     return ["status": status.rawValue]


### PR DESCRIPTION
# Why
As currently implemented, `expo-calendar` uses its own representation of permissions statuses, but these statuses are implicitly dependent on the order of `EXPermissionStatus` in `expo-modules-core`. Changing the ordering of identifiers in the enum definition of `EXPermissionStatus` or changing the integers associated with the values in `CalendarPermissionsStatus` breaks the mapping between the two packages.

For context, I discovered this after accidentally breaking calendar permissions in my local copy of Expo when I patched `expo-modules-core` to include a new `limited` access level for contacts access. That's definitely on me for trying to patch in the first place, but I do think making this change will help future-proof `expo-calendar` permission handling.

# How
To ensure that these packages are future-proofed, this change updates `expo-calendar` to return an `EXPermissionStatus` value directly instead of using its own representation. This pattern is also currently used in the permissions requesters in `expo-contacts`.

# Test Plan
I tested this locally by running EAS build for my project and ensured that permissions still work as expected. I don't see unit tests for `expo-calendar` but am also happy to add some for this change if required.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
