### PR TITLE
[core] Add `bundleURL` implementation to `ExpoAppInstance`

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -12,6 +12,14 @@ open class ExpoAppInstance: RCTAppDelegate {
     return reactDelegate.createRootViewController()
   }
 
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
   @objc
   open override func createRCTRootViewFactory() -> RCTRootViewFactory {
     let bundleUrlBlock: RCTBundleURLBlock = { [weak self] in


### PR DESCRIPTION
# Why
Follow up of #33348


# How
Adds a default implementation of `bundleURL` to `ExpoAppInstance`

# Test Plan
A newly created app loads correctly

