### PR TITLE
[ci] use macos-15 runner for ios-test

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -79,15 +79,12 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
-    # runs-on: macos-15
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      # - name: 🔨 Switch to Xcode 16.0
-      #   run: sudo xcode-select --switch /Applications/Xcode_16.0.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -94,15 +94,12 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
-    # runs-on: macos-15
+    runs-on: macos-15
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      # - name: 🔨 Switch to Xcode 16.0
-      #   run: sudo xcode-select --switch /Applications/Xcode_16.0.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -5,10 +5,8 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import path from 'path';
 
-const TARGET_DEVICE = 'iPhone 14';
-const TARGET_DEVICE_IOS_VERSION = 16;
-// const TARGET_DEVICE = 'iPhone 15';
-// const TARGET_DEVICE_IOS_VERSION = 17;
+const TARGET_DEVICE = 'iPhone 16 Pro';
+const TARGET_DEVICE_IOS_VERSION = 18;
 const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start


### PR DESCRIPTION
# Why

macos-12 is deprecated. let's try to use macos-15

# How

bump runner to macos-15 and use its default xcode version for testing. the ios-test time increased from 10m to 12~15m, which is much better than the previous macos-13 runner. we can use the latest runner again.

# Test Plan

ci passed

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
