### PR TITLE
[template][Android] Reduce the number of `node` processes during the sync phase

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -35,7 +35,7 @@ def reactNativeAndroidDir = new File(
 def jscAndroidDir = new File(
   providers.exec {
     workingDir(rootDir)
-    commandLine("node", "--print", "require.resolve('jsc-android/package.json')")
+    commandLine("node", "--print", "require.resolve('jsc-android/package.json', { paths: [require.resolve('react-native/package.json')] })")
   }.standardOutput.asText.get().trim(),
   "../dist"
 )

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -24,43 +24,43 @@ buildscript {
   }
 }
 
+def reactNativeAndroidDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('react-native/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../android"
+)
+
+def jscAndroidDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('jsc-android/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../dist"
+)
+
+def expoCameraDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('expo-camera/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../android/maven"
+)
+
 allprojects {
   repositories {
     mavenLocal()
     maven {
       // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-      url(
-          new File(
-              providers.exec {
-                workingDir(rootDir)
-                commandLine("node", "--print", "require.resolve('react-native/package.json')")
-              }.standardOutput.asText.get().trim(),
-              "../android"
-          )
-      )
+      url(reactNativeAndroidDir)
     }
     maven {
       // Android JSC is installed from npm
-      url(
-          new File(
-              providers.exec {
-                workingDir(rootDir)
-                commandLine("node", "--print", "require.resolve('jsc-android/package.json')")
-              }.standardOutput.asText.get().trim(),
-              "../dist"
-          )
-      )
+      url(jscAndroidDir)
     }
     maven {
-      url(
-          new File(
-              providers.exec {
-                workingDir(rootDir)
-                commandLine("node", "--print", "require.resolve('expo-camera/package.json')")
-              }.standardOutput.asText.get().trim(),
-              "../android/maven"
-          )
-      )
+      url(expoCameraDir)
     }
 
     google()

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -40,14 +40,6 @@ def jscAndroidDir = new File(
   "../dist"
 )
 
-def expoCameraDir = new File(
-  providers.exec {
-    workingDir(rootDir)
-    commandLine("node", "--print", "require.resolve('expo-camera/package.json')")
-  }.standardOutput.asText.get().trim(),
-  "../android/maven"
-)
-
 allprojects {
   repositories {
     mavenLocal()
@@ -58,9 +50,6 @@ allprojects {
     maven {
       // Android JSC is installed from npm
       url(jscAndroidDir)
-    }
-    maven {
-      url(expoCameraDir)
     }
 
     google()

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -23,15 +23,31 @@ buildscript {
 
 apply plugin: "com.facebook.react.rootproject"
 
+def reactNativeAndroidDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('react-native/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../android"
+)
+
+def jscAndroidDir = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('jsc-android/package.json', { paths: [require.resolve('react-native/package.json')] })")
+  }.standardOutput.asText.get().trim(),
+  "../dist"
+)
+
 allprojects {
     repositories {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url(new File(['node', '--print', "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), '../android'))
+            url(reactNativeAndroidDir)
         }
         maven {
             // Android JSC is installed from npm
-            url(new File(['node', '--print', "require.resolve('jsc-android/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim(), '../dist'))
+            url(jscAndroidDir)
         }
 
         google()


### PR DESCRIPTION
# Why

Reduces the number of `node` processes spawned during the sync phase.
Before:
![image](https://github.com/user-attachments/assets/2019a151-4a0a-4140-b5c8-1b28eb8abd4b)
After:
![image](https://github.com/user-attachments/assets/27ab78fb-04c0-453b-bda9-ae0fb3ef6bf8)

# How

We resolved the same paths in each project rather than resolving them once and using the same solution for each project.

# Test Plan

- bare-expo ✅ 