### PR TITLE
[docs][location] clarify differences in geofencing on ios/android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -141,7 +141,12 @@ To use Geofencing methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
 - The Geofencing task must be defined in the top-level scope, using [TaskManager.defineTask](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
-- On iOS, there is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
+
+When using Geofencing, the following platform differences apply:
+
+- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered geofence(s) at app startup.
+- <PlatformTag platform="ios" /> There is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
+- <PlatformTag platform="android" /> You are allowed [up to 100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active geofences per app.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -144,14 +144,14 @@ To use Geofencing methods, the following requirements apply:
 
 When using Geofencing, the following platform differences apply:
 
+- <PlatformTag platform="android" /> You are allowed [up to
+  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
+  geofences per app.
 - <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered
   geofence(s) at app startup.
 - <PlatformTag platform="ios" /> There is a [limit of
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
-- <PlatformTag platform="android" /> You are allowed [up to
-  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
-  geofences per app.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -144,9 +144,14 @@ To use Geofencing methods, the following requirements apply:
 
 When using Geofencing, the following platform differences apply:
 
-- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered geofence(s) at app startup.
-- <PlatformTag platform="ios" /> There is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
-- <PlatformTag platform="android" /> You are allowed [up to 100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active geofences per app.
+- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered
+  geofence(s) at app startup.
+- <PlatformTag platform="ios" /> There is a [limit of
+  20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
+  `regions` that can be simultaneously monitored.
+- <PlatformTag platform="android" /> You are allowed [up to
+  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
+  geofences per app.
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -141,7 +141,12 @@ To use Geofencing methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
 - The Geofencing task must be defined in the top-level scope, using [TaskManager.defineTask](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
-- On iOS, there is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
+
+When using Geofencing, the following platform differences apply:
+
+- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered geofence(s) at app startup.
+- <PlatformTag platform="ios" /> There is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
+- <PlatformTag platform="android" /> You are allowed [up to 100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active geofences per app.
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -144,14 +144,14 @@ To use Geofencing methods, the following requirements apply:
 
 When using Geofencing, the following platform differences apply:
 
+- <PlatformTag platform="android" /> You are allowed [up to
+  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
+  geofences per app.
 - <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered
   geofence(s) at app startup.
 - <PlatformTag platform="ios" /> There is a [limit of
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
-- <PlatformTag platform="android" /> You are allowed [up to
-  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
-  geofences per app.
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -144,9 +144,14 @@ To use Geofencing methods, the following requirements apply:
 
 When using Geofencing, the following platform differences apply:
 
-- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered geofence(s) at app startup.
-- <PlatformTag platform="ios" /> There is a [limit of 20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions) `regions` that can be simultaneously monitored.
-- <PlatformTag platform="android" /> You are allowed [up to 100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active geofences per app.
+- <PlatformTag platform="ios" /> Expo Location will report the initial state of the registered
+  geofence(s) at app startup.
+- <PlatformTag platform="ios" /> There is a [limit of
+  20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
+  `regions` that can be simultaneously monitored.
+- <PlatformTag platform="android" /> You are allowed [up to
+  100](https://developer.android.com/develop/sensors-and-location/location/geofencing) active
+  geofences per app.
 
 ## Usage
 


### PR DESCRIPTION
# Why

There are some subtle differences between Android and iOS when it comes to geofencing. This commit updates the docs on SDK 52 / unversioned to clarify these differences.


Related to #33433

# How

- Added information about iOS giving you the state of your geofences on startup
- Added information about max number of geofences on Android

Upated both `unversioned` and `v52.0.0`

# Checklist

- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
