### PR TITLE
chore(cli): add `User-Agent: expo-cli/<version>` to all fetch requests

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 💡 Others
 
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))
+- Add `User-Agent: expo-cli/<version>` to all CLI requests.
 
 ## 0.22.0 - 2024-11-29
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### 💡 Others
 
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))
-- Add `User-Agent: expo-cli/<version>` to all CLI requests.
+- Add `User-Agent: expo-cli/<version>` to all CLI requests. ([#33471](https://github.com/expo/expo/pull/33471) by [@byCedric](https://github.com/byCedric))
 
 ## 0.22.0 - 2024-11-29
 

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -17,6 +17,7 @@ import { fetch } from '../../utils/fetch';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { wrapFetchWithOffline } from '../rest/wrapFetchWithOffline';
 import { wrapFetchWithProxy } from '../rest/wrapFetchWithProxy';
+import { wrapFetchWithUserAgent } from '../rest/wrapFetchWithUserAgent';
 import { getAccessToken, getSession } from '../user/UserSettings';
 
 type AccessTokenHeaders = {
@@ -39,7 +40,7 @@ export const graphqlClient = createUrqlClient({
     fetchExchange,
   ],
   // @ts-ignore Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.
-  fetch: wrapFetchWithOffline(wrapFetchWithProxy(fetch)),
+  fetch: wrapFetchWithOffline(wrapFetchWithProxy(wrapFetchWithUserAgent(fetch))),
   fetchOptions: (): { headers?: AccessTokenHeaders | SessionHeaders } => {
     const token = getAccessToken();
     if (token) {

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -14,6 +14,7 @@ jest.mock('../../user/UserSettings', () => ({
   getSession: jest.fn(),
 }));
 jest.mock('../../../utils/fetch', () => ({
+  ...jest.requireActual('../../../utils/fetch'),
   fetch: jest.fn(jest.requireActual('../../../utils/fetch').fetch),
 }));
 

--- a/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithUserAgent.test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithUserAgent.test.ts
@@ -14,12 +14,11 @@ describe(wrapFetchWithUserAgent, () => {
 
     expect(fetch).toHaveBeenCalledWith(
       'https://example.com',
-      expect.objectContaining({
-        headers: {
-          'User-Agent': 'expo-cli/1.33.7',
-        },
-      })
+      expect.objectContaining({ headers: expect.any(Headers) })
     );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
+      ['user-agent', 'expo-cli/1.33.7'],
+    ]);
   });
 
   it('adds user-agent with header object', async () => {
@@ -31,8 +30,14 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect(headers['User-Agent']).toBe('expo-cli/1.33.7');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'expo-cli/1.33.7'],
+    ]);
   });
 
   it('adds user-agent with header object with existing user-agent', async () => {
@@ -45,8 +50,14 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect(headers['User-Agent']).toBe('test, expo-cli/1.33.7');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'test, expo-cli/1.33.7'],
+    ]);
   });
 
   it('adds user-agent with header array', async () => {
@@ -56,10 +67,13 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect(headers).toEqual([
-      ['Authorization', 'bearer some-token'],
-      ['User-Agent', 'expo-cli/1.33.7'],
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'expo-cli/1.33.7'],
     ]);
   });
 
@@ -73,10 +87,13 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect(headers).toEqual([
-      ['Authorization', 'bearer some-token'],
-      ['User-Agent', 'test, expo-cli/1.33.7'],
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'test, expo-cli/1.33.7'],
     ]);
   });
 
@@ -89,8 +106,11 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect([...headers.entries()]).toEqual([
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
       ['authorization', 'bearer some-token'],
       ['user-agent', 'expo-cli/1.33.7'],
     ]);
@@ -106,8 +126,11 @@ describe(wrapFetchWithUserAgent, () => {
 
     await wrapped('https://example.com', { headers });
 
-    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
-    expect([...headers.entries()]).toEqual([
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    );
+    expect([...fetch.mock.calls[0][1].headers.entries()]).toEqual([
       ['authorization', 'bearer some-token'],
       ['user-agent', 'test, expo-cli/1.33.7'],
     ]);

--- a/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithUserAgent.test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithUserAgent.test.ts
@@ -1,0 +1,115 @@
+import { wrapFetchWithUserAgent } from '../wrapFetchWithUserAgent';
+
+jest.mock('node:process', () => ({
+  ...jest.requireActual('node:process'),
+  env: { __EXPO_VERSION: '1.33.7' },
+}));
+
+describe(wrapFetchWithUserAgent, () => {
+  it('adds user-agent without headers', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+
+    await wrapped('https://example.com');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({
+        headers: {
+          'User-Agent': 'expo-cli/1.33.7',
+        },
+      })
+    );
+  });
+
+  it('adds user-agent with header object', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = {
+      Authorization: 'bearer some-token',
+    };
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect(headers['User-Agent']).toBe('expo-cli/1.33.7');
+  });
+
+  it('adds user-agent with header object with existing user-agent', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = {
+      Authorization: 'bearer some-token',
+      'User-Agent': 'test',
+    };
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect(headers['User-Agent']).toBe('test, expo-cli/1.33.7');
+  });
+
+  it('adds user-agent with header array', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = [['Authorization', 'bearer some-token']];
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect(headers).toEqual([
+      ['Authorization', 'bearer some-token'],
+      ['User-Agent', 'expo-cli/1.33.7'],
+    ]);
+  });
+
+  it('adds user-agent with header array with existing user-agent', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = [
+      ['Authorization', 'bearer some-token'],
+      ['User-Agent', 'test'],
+    ];
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect(headers).toEqual([
+      ['Authorization', 'bearer some-token'],
+      ['User-Agent', 'test, expo-cli/1.33.7'],
+    ]);
+  });
+
+  it('adds user-agent with Headers instance', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = new Headers({
+      Authorization: 'bearer some-token',
+    });
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect([...headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'expo-cli/1.33.7'],
+    ]);
+  });
+
+  it('adds user-agent with Headers instance with existing user-agent', async () => {
+    const fetch = jest.fn();
+    const wrapped = wrapFetchWithUserAgent(fetch);
+    const headers = new Headers({
+      Authorization: 'bearer some-token',
+      'User-Agent': 'test',
+    });
+
+    await wrapped('https://example.com', { headers });
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ headers }));
+    expect([...headers.entries()]).toEqual([
+      ['authorization', 'bearer some-token'],
+      ['user-agent', 'test, expo-cli/1.33.7'],
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -7,13 +7,13 @@ import { wrapFetchWithBaseUrl } from './wrapFetchWithBaseUrl';
 import { wrapFetchWithOffline } from './wrapFetchWithOffline';
 import { wrapFetchWithProgress } from './wrapFetchWithProgress';
 import { wrapFetchWithProxy } from './wrapFetchWithProxy';
+import { wrapFetchWithUserAgent } from './wrapFetchWithUserAgent';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
 import { fetch } from '../../utils/fetch';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { disableNetwork } from '../settings';
 import { getAccessToken, getExpoHomeDirectory, getSession } from '../user/UserSettings';
-import { wrapFetchWithUserAgent } from './wrapFetchWithUserAgent';
 
 export class ApiV2Error extends Error {
   readonly name = 'ApiV2Error';

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -13,6 +13,7 @@ import { fetch } from '../../utils/fetch';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { disableNetwork } from '../settings';
 import { getAccessToken, getExpoHomeDirectory, getSession } from '../user/UserSettings';
+import { wrapFetchWithUserAgent } from './wrapFetchWithUserAgent';
 
 export class ApiV2Error extends Error {
   readonly name = 'ApiV2Error';
@@ -144,7 +145,7 @@ function isNetworkError(error: Error & { code?: string }) {
   );
 }
 
-const fetchWithOffline = wrapFetchWithOffline(fetch);
+const fetchWithOffline = wrapFetchWithOffline(wrapFetchWithUserAgent(fetch));
 
 const fetchWithBaseUrl = wrapFetchWithBaseUrl(fetchWithOffline, getExpoApiBaseUrl() + '/v2/');
 

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithUserAgent.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithUserAgent.ts
@@ -1,43 +1,14 @@
 import process from 'node:process';
 
 import { FetchLike } from './client.types';
+import { Headers } from '../../utils/fetch';
 
 export function wrapFetchWithUserAgent(fetch: FetchLike): FetchLike {
-  // Version is added in the build script
-  const userAgent = `expo-cli/${process.env.__EXPO_VERSION}`;
-
   return (url, init = {}) => {
-    init.headers ??= {};
-
-    if (Array.isArray(init.headers)) {
-      const header = init.headers.find(([name]) => name === 'User-Agent');
-      if (header) {
-        header[1] = `${header[1]}, ${userAgent}`;
-      } else {
-        init.headers.push(['User-Agent', userAgent]);
-      }
-    } else if (canAppendHeader(init.headers)) {
-      init.headers.append('User-Agent', userAgent);
-    } else if (typeof init.headers === 'object') {
-      const headers = init.headers as Record<string, string | string[]>;
-      if (Array.isArray(headers['User-Agent'])) {
-        headers['User-Agent'].push(userAgent);
-      } else if (headers['User-Agent']) {
-        headers['User-Agent'] = `${headers['User-Agent']}, ${userAgent}`;
-      } else {
-        headers['User-Agent'] = userAgent;
-      }
-    }
-
+    const headers = new Headers(init.headers);
+    // Version is added in the build script
+    headers.append('User-Agent', `expo-cli/${process.env.__EXPO_VERSION}`);
+    init.headers = headers;
     return fetch(url, init);
   };
-}
-
-function canAppendHeader(value: unknown): value is Headers {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    'append' in value &&
-    typeof value['append'] === 'function'
-  );
 }

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithUserAgent.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithUserAgent.ts
@@ -1,0 +1,43 @@
+import process from 'node:process';
+
+import { FetchLike } from './client.types';
+
+export function wrapFetchWithUserAgent(fetch: FetchLike): FetchLike {
+  // Version is added in the build script
+  const userAgent = `expo-cli/${process.env.__EXPO_VERSION}`;
+
+  return (url, init = {}) => {
+    init.headers ??= {};
+
+    if (Array.isArray(init.headers)) {
+      const header = init.headers.find(([name]) => name === 'User-Agent');
+      if (header) {
+        header[1] = `${header[1]}, ${userAgent}`;
+      } else {
+        init.headers.push(['User-Agent', userAgent]);
+      }
+    } else if (canAppendHeader(init.headers)) {
+      init.headers.append('User-Agent', userAgent);
+    } else if (typeof init.headers === 'object') {
+      const headers = init.headers as Record<string, string | string[]>;
+      if (Array.isArray(headers['User-Agent'])) {
+        headers['User-Agent'].push(userAgent);
+      } else if (headers['User-Agent']) {
+        headers['User-Agent'] = `${headers['User-Agent']}, ${userAgent}`;
+      } else {
+        headers['User-Agent'] = userAgent;
+      }
+    }
+
+    return fetch(url, init);
+  };
+}
+
+function canAppendHeader(value: unknown): value is Headers {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'append' in value &&
+    typeof value['append'] === 'function'
+  );
+}

--- a/packages/@expo/cli/src/utils/fetch.ts
+++ b/packages/@expo/cli/src/utils/fetch.ts
@@ -5,4 +5,11 @@ import type { FetchLike } from '../api/rest/client.types';
  * @todo(cedric): remove this once we min-support a Node version where fetch can't be disabled
  */
 export const fetch: FetchLike =
-  typeof globalThis.fetch === 'function' ? globalThis.fetch : require('undici').fetch;
+  typeof globalThis.fetch !== 'undefined' ? globalThis.fetch : require('undici').fetch;
+
+/**
+ * Node's built-in fetch Headers class, or the polyfilled Headers from `undici` when unavailable.
+ * @todo(cedric): remove this once we min-support a Node version where fetch can't be disabled
+ */
+export const Headers: typeof import('undici').Headers =
+  typeof globalThis.Headers !== 'undefined' ? globalThis.Headers : require('undici').Headers;


### PR DESCRIPTION
# Why

We are trying to isolate an issue related to fetching from the CLI. Having this `User-Agent` header to all fetch requests coming from the CLI helps us isolate what versions are affected.

> Note, we likely have to backport this to all supported SDK versions - happy to do that though.

# How

- Added `wrapFetchWithUserAgent` that appends `User-Agent: expo-cli/<version>`

# Test Plan

- See added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
