### PR TITLE
[core] Make `bundleURL` open

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppInstance.swift
@@ -12,7 +12,7 @@ open class ExpoAppInstance: RCTAppDelegate {
     return reactDelegate.createRootViewController()
   }
 
-  public override func bundleURL() -> URL? {
+  open override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else


### PR DESCRIPTION
# Why
We need to make `bundleURL` open so classes outside of the module can override it

# How
Add `open` to the method

# Test Plan
Bare-expo compiles and runs 
