### PR TITLE
[autolinking][Android] Add first tests

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -14,6 +15,9 @@ dependencies {
   implementation(project(":shared"))
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
+
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("com.google.truth:truth:1.1.2")
 }
 
 java {
@@ -35,5 +39,14 @@ gradlePlugin {
       id = "expo-autolinking-settings"
       implementationClass = "expo.modules.plugin.ExpoAutolinkingSettingsPlugin"
     }
+  }
+}
+
+tasks.withType<Test>().configureEach {
+  testLogging {
+    exceptionFormat = TestExceptionFormat.FULL
+    showExceptions = true
+    showCauses = true
+    showStackTraces = true
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
@@ -1,0 +1,190 @@
+package expo.modules.plugin
+
+import com.google.common.truth.Truth
+import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ExpoAutolinkingSettingsPluginTest {
+  @JvmField
+  @Rule
+  var testProjectDir: TemporaryFolder = TemporaryFolder()
+
+  @Before
+  fun setUp() {
+    testProjectDir.root.removeRecursively()
+    testProjectDir.root.createProject()
+  }
+
+  @Test
+  fun `applies settings plugin`() {
+    val result = executeGradleRun()
+    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+
+  @Test
+  fun `injects expo gradle extension`() {
+    val result = executeGradleRun(":app:gradleExpoExtension")
+    val expoConfig = findPrefix("expoGradle=", result.output)
+    Truth.assertThat(expoConfig).isNotNull()
+  }
+
+  @Test
+  fun `returns correct config`() {
+    val result = executeGradleRun(":app:expoConfig")
+
+    val configStringFromPlugin = findPrefix("expoConfig=", result.output)
+    val configFromPlugin = ExpoAutolinkingConfig.decodeFromString(configStringFromPlugin!!)
+
+    val configStringFromAutolinking = testProjectDir.root.runCommand(
+      *AutolinkigCommandBuilder()
+        .command("resolve")
+        .useJson()
+        .build()
+        .toTypedArray()
+    )
+
+    val configFromAutolinking = ExpoAutolinkingConfig.decodeFromString(configStringFromAutolinking)
+
+    Truth.assertThat(configFromPlugin).isEqualTo(configFromAutolinking)
+  }
+
+  private fun executeGradleRun(task: String? = null): BuildResult =
+    GradleRunner
+      .create()
+      .withProjectDir(testProjectDir.root)
+      .apply {
+        if (task != null) {
+          withArguments(task)
+        }
+      }
+      .withPluginClasspath()
+      .build()
+
+}
+
+fun findPrefix(prefix: String, input: String): String? {
+  return input.lineSequence()
+    .map { it.trim() }
+    .find { it.startsWith(prefix) }
+    ?.substringAfter(prefix)
+    ?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * Creates a new project with the following structure:
+ * <file>
+ * ├── app
+ * │   └── build.gradle
+ * ├── build.gradle
+ * ├── settings.gradle
+ * └── package.json
+ */
+private fun File.createProject() {
+  File(this, "app").mkdir()
+  val app = File(this, "app")
+  File(app, "build.gradle").writeText(
+    """
+      task("gradleExpoExtension") {
+        doLast {
+          println("expoGradle=" + gradle.expoGradle)
+        }
+      }
+      
+      task("expoConfig") {
+        doLast {
+          println("expoConfig=" + gradle.expoGradle.config.toJson())
+        }
+      }
+      """.trimIndent()
+  )
+
+  File(this, "build.gradle").writeText(
+    """
+    buildscript {
+      repositories {
+        google()
+        mavenCentral()
+      }
+      dependencies {
+        classpath("com.android.tools.build:gradle:8.6.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+      }
+    }
+    
+    allprojects {
+      repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://www.jitpack.io' }
+      }
+    }
+    """.trimIndent()
+  )
+
+  File(this, "settings.gradle").writeText(
+    """
+      plugins {
+        id("expo-autolinking-settings")
+      }
+      
+      expoAutolinking.useExpoModules()
+
+      include(":app")      
+      """.trimIndent()
+  )
+
+  File(this, "package.json").writeText(
+    """
+      {
+        "name": "test-project",
+        "dependencies": {
+          "expo": "52.0.5",
+          "expo-image-picker": "16.0.3"
+        }
+      }
+      """.trimIndent()
+  )
+
+  runCommand("npm", "install")
+
+  // Mocks the expo and expo-modules-core build.gradle files
+  // to avoid errors during the sync process.
+  File(this, "node_modules/expo/android/build.gradle").writeText(
+    """
+    """.trimIndent()
+  )
+  File(this, "node_modules/expo-modules-core/android/build.gradle").writeText(
+    """
+    """.trimIndent()
+  )
+}
+
+/**
+ * Runs a command in the current directory and returns the output as a string.
+ */
+private fun File.runCommand(vararg command: String): String {
+  val process = ProcessBuilder(*command)
+    .directory(this)
+    .start()
+
+  val inputStream = process.inputStream
+  process.waitFor()
+  return inputStream.use {
+    it.readAllBytes().toString(Charsets.UTF_8)
+  }
+}
+
+/**
+ * Removes the file and all its children
+ */
+private fun File.removeRecursively() =
+  this
+    .walkBottomUp()
+    .filter { it != this }
+    .forEach { it.deleteRecursively() }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/settings.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/settings.gradle.kts
@@ -6,7 +6,6 @@ pluginManagement {
   }
 }
 
-
 plugins {
   kotlin("jvm") version "1.9.24" apply false
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -11,6 +12,9 @@ repositories {
 
 dependencies {
   api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("com.google.truth:truth:1.1.2")
 }
 
 java {
@@ -25,3 +29,12 @@ tasks.withType<KotlinCompile> {
 }
 
 group = "expo.modules"
+
+tasks.withType<Test>().configureEach {
+  testLogging {
+    exceptionFormat = TestExceptionFormat.FULL
+    showExceptions = true
+    showCauses = true
+    showStackTraces = true
+  }
+}

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -1,6 +1,7 @@
 package expo.modules.plugin.configuration
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
@@ -26,6 +27,10 @@ data class ExpoAutolinkingConfig(
    */
   val allAarProjects: List<GradleAarProject>
     get() = modules.flatMap { it.aarProjects }
+
+  fun toJson(): String {
+    return Json.encodeToString(this)
+  }
 
   companion object {
     private val jsonDecoder by lazy {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
@@ -1,0 +1,147 @@
+package com.modules.plugin.connfiguration
+
+import com.google.common.truth.Truth
+import expo.modules.plugin.configuration.AWSMavenCredentials
+import expo.modules.plugin.configuration.BasicMavenCredentials
+import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import expo.modules.plugin.configuration.HttpHeaderMavenCredentials
+import org.junit.Test
+
+
+class ExpoAutolinkingConfigTest {
+
+  @Test
+  fun `can deserialize config`() {
+    // language=JSON
+    val mockedConfig = """
+{
+  "extraDependencies": [],
+  "modules": [
+    {
+      "packageName": "expo",
+      "packageVersion": "52.0.11",
+      "projects": [
+        {
+          "name": "expo",
+          "sourceDir": "/Users/lukasz/work/expo/packages/expo/android"
+        }
+      ],
+      "modules": [
+        "expo.modules.fetch.ExpoFetchModule"
+      ]
+    },
+    {
+      "packageName": "expo-network-addons",
+      "packageVersion": "0.7.0",
+      "projects": [
+        {
+          "name": "expo-network-addons",
+          "sourceDir": "/Users/lukasz/work/expo/packages/expo-network-addons/android"
+        }
+      ],
+      "plugins": [
+        {
+          "id": "expo-network-addons-gradle-plugin",
+          "group": "expo.modules",
+          "sourceDir": "/Users/lukasz/work/expo/packages/expo-network-addons/expo-network-addons-gradle-plugin",
+          "applyToRootProject": true
+        }
+      ],
+      "modules": []
+    }
+  ]
+}
+    """.trimIndent()
+
+    val config = ExpoAutolinkingConfig.decodeFromString(mockedConfig)
+
+    Truth.assertThat(config.allProjects.map { it.name })
+      .containsExactly("expo", "expo-network-addons")
+    val expoModule = config.modules.find { it.packageName == "expo" }
+    val expoNetworkAddonsModule = config.modules.find { it.packageName == "expo-network-addons" }
+
+    Truth.assertThat(expoModule).isNotNull()
+    Truth.assertThat(expoNetworkAddonsModule).isNotNull()
+
+    expoModule!!
+    expoNetworkAddonsModule!!
+
+    Truth.assertThat(expoModule.projects.firstOrNull()?.sourceDir)
+      .isEqualTo("/Users/lukasz/work/expo/packages/expo/android")
+    Truth.assertThat(expoModule.modules.firstOrNull())
+      .isEqualTo("expo.modules.fetch.ExpoFetchModule")
+
+    Truth.assertThat(expoNetworkAddonsModule.projects.firstOrNull()?.sourceDir)
+      .isEqualTo("/Users/lukasz/work/expo/packages/expo-network-addons/android")
+    Truth.assertThat(expoNetworkAddonsModule.plugins.firstOrNull()?.id)
+      .isEqualTo("expo-network-addons-gradle-plugin")
+  }
+
+  @Test
+  fun `can deserialize extra dependencies`() {
+    // language=JSON
+    val mockedConfig = """
+{
+  "modules": [],
+  "extraDependencies": [
+    {
+      "url": "repo1",
+      "credentials": {
+        "username": "user",
+        "password": "password"
+      },
+      "authentication": "basic"
+    },
+    {
+      "url": "repo2",
+      "credentials": {
+        "name": "name",
+        "value": "value"
+      },
+      "authentication": "header"
+    },
+    {
+      "url": "repo3",
+      "credentials": {
+        "accessKey": "accessKey",
+        "secretKey": "secretKey"
+      },
+      "authentication": "digest"
+    }
+  ]
+}
+""".trimIndent()
+
+    val config = ExpoAutolinkingConfig.decodeFromString(mockedConfig)
+
+    val repo1 = config.extraDependencies.find { it.url == "repo1" }
+    val repo2 = config.extraDependencies.find { it.url == "repo2" }
+    val repo3 = config.extraDependencies.find { it.url == "repo3" }
+
+    Truth.assertThat(repo1).isNotNull()
+    Truth.assertThat(repo2).isNotNull()
+    Truth.assertThat(repo3).isNotNull()
+
+    repo1!!
+    repo2!!
+    repo3!!
+
+    Truth.assertThat(repo1.authentication).isEqualTo("basic")
+    Truth.assertThat(repo1.credentials).isInstanceOf(BasicMavenCredentials::class.java)
+    val basicCredentials = repo1.credentials as BasicMavenCredentials
+    Truth.assertThat(basicCredentials.username).isEqualTo("user")
+    Truth.assertThat(basicCredentials.password).isEqualTo("password")
+
+    Truth.assertThat(repo2.authentication).isEqualTo("header")
+    Truth.assertThat(repo2.credentials).isInstanceOf(HttpHeaderMavenCredentials::class.java)
+    val headerCredentials = repo2.credentials as HttpHeaderMavenCredentials
+    Truth.assertThat(headerCredentials.name).isEqualTo("name")
+    Truth.assertThat(headerCredentials.value).isEqualTo("value")
+
+    Truth.assertThat(repo3.authentication).isEqualTo("digest")
+    Truth.assertThat(repo3.credentials).isInstanceOf(AWSMavenCredentials::class.java)
+    val awsCredentials = repo3.credentials as AWSMavenCredentials
+    Truth.assertThat(awsCredentials.accessKey).isEqualTo("accessKey")
+    Truth.assertThat(awsCredentials.secretKey).isEqualTo("secretKey")
+  }
+}


### PR DESCRIPTION
# Why

Add first tests to settings plugin and to shared code. 
I'll add more tests going forward. 

# How

Unfortunately, Gradle does not offer any API for testing settings plugins. To gather the necessary information, I had to mock the project and get a bit creative. Additionally, certain files need to be mocked to avoid executing any code that could potentially disrupt the project break the synchronization phase.

# Test Plan

- unit tests ✅ 