### PR TITLE
[go] upgrade crashlytics plugin v3 on android

### DIFF
--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -26,9 +26,9 @@ upload_crashlytics_symbols() {
 }
 
 if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
-  # if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-  #   upload_crashlytics_symbols "Release"
-  # fi
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    upload_crashlytics_symbols "Release"
+  fi
 
   SLUG="release-client"
   COMMIT_HASH="$(git rev-parse HEAD)"
@@ -49,9 +49,9 @@ if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
 fi
 
 if [[ "$EAS_BUILD_PROFILE" == "publish-client" ]]; then
-  # if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-  #   upload_crashlytics_symbols "Release"
-  # fi
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    upload_crashlytics_symbols "Release"
+  fi
 
   SLUG="publish-client"
   COMMIT_HASH="$(git rev-parse HEAD)"

--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -80,7 +80,6 @@ android {
       debuggable true
       firebaseCrashlytics {
         nativeSymbolUploadEnabled false
-        mappingFileUploadEnabled false
       }
     }
     release {
@@ -93,9 +92,7 @@ android {
       def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
       firebaseCrashlytics {
         nativeSymbolUploadEnabled shouldUploadCrashlytics
-        mappingFileUploadEnabled shouldUploadCrashlytics
-
-        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/release/out/lib")
+        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")
       }
     }
   }
@@ -268,7 +265,7 @@ apply plugin: 'com.google.gms.google-services'
 
 def ensureCrashlyticsDir = tasks.register('ensureCrashlyticsDir') {
   doLast {
-    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/release/out/lib"))
+    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib"))
   }
 }
 preBuild.dependsOn(ensureCrashlyticsDir)

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -21,8 +21,8 @@ buildscript {
   }
   dependencies {
     classpath expoLibs.android.gradle.plugin
-    classpath 'com.google.gms:google-services:4.3.5'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
+    classpath 'com.google.gms:google-services:4.4.2'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -169,8 +169,8 @@ dependencies {
   // Our dependencies
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.google.firebase:firebase-crashlytics:18.3.6'
-  api 'com.google.firebase:firebase-crashlytics-ndk:18.3.6'
+  api 'com.google.firebase:firebase-crashlytics:19.3.0'
+  api 'com.google.firebase:firebase-crashlytics-ndk:19.3.0'
   api "androidx.room:room-runtime:2.1.0"
   implementation 'com.google.android.material:material:1.3.0'
 


### PR DESCRIPTION
# Why

try to fix the error from upload crashlytics native symbols
close ENG-13940

# How

- bump crashlytics plugin versions to the latest
- update based on the v3 migration guide: https://firebase.google.com/docs/crashlytics/upgrade-to-crashlytics-gradle-plugin-v3
- revise the unstripped libs dir
- re-enable `uploadCrashlyticsSymbolFileRelease` task on eas build

# Test Plan

- test crash with source map symbolication: https://console.firebase.google.com/project/exponent-5dd6d/crashlytics/app/android:host.exp.exponent/issues/dec04e7e77fe4f6e50de70828faaf917
- test native crash symbolication: https://console.firebase.google.com/project/exponent-5dd6d/crashlytics/app/android:host.exp.exponent/issues/b108eff0a5e46d97ce5396adaf4cffb6

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
