### PR TITLE
[splashscreen] Guard againist null props

### DIFF
--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
@@ -14,5 +14,5 @@ type PluginConfig = {
     android?: AndroidSplashConfig;
     ios?: IOSSplashConfig;
 };
-declare const _default: ConfigPlugin<PluginConfig>;
+declare const _default: ConfigPlugin<PluginConfig | null>;
 export default _default;

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.js
@@ -5,6 +5,11 @@ const withIosSplashScreen_1 = require("@expo/prebuild-config/build/plugins/unver
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-splash-screen/package.json');
 const withSplashScreen = (config, props) => {
+    if (!props) {
+        config = (0, withAndroidSplashScreen_1.withAndroidSplashScreen)(config, null);
+        config = (0, withIosSplashScreen_1.withIosSplashScreen)(config, null);
+        return config;
+    }
     const resizeMode = props?.resizeMode || 'contain';
     const { ios: iosProps, android: androidProps, ...otherProps } = props;
     const android = {
@@ -27,7 +32,7 @@ const withSplashScreen = (config, props) => {
     };
     // Need to pass null here if we don't receive any props. This means that the plugin has not been used.
     // This only happens on Android. On iOS, if you don't use the plugin, this function won't be called.
-    config = (0, withAndroidSplashScreen_1.withAndroidSplashScreen)(config, props ? android : null);
+    config = (0, withAndroidSplashScreen_1.withAndroidSplashScreen)(config, android);
     config = (0, withIosSplashScreen_1.withIosSplashScreen)(config, ios);
     return config;
 };

--- a/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
@@ -20,7 +20,13 @@ type PluginConfig = {
   ios?: IOSSplashConfig;
 };
 
-const withSplashScreen: ConfigPlugin<PluginConfig> = (config, props) => {
+const withSplashScreen: ConfigPlugin<PluginConfig | null> = (config, props) => {
+  if (!props) {
+    config = withAndroidSplashScreen(config, null);
+    config = withIosSplashScreen(config, null);
+    return config;
+  }
+
   const resizeMode = props?.resizeMode || 'contain';
 
   const { ios: iosProps, android: androidProps, ...otherProps } = props;
@@ -46,7 +52,7 @@ const withSplashScreen: ConfigPlugin<PluginConfig> = (config, props) => {
 
   // Need to pass null here if we don't receive any props. This means that the plugin has not been used.
   // This only happens on Android. On iOS, if you don't use the plugin, this function won't be called.
-  config = withAndroidSplashScreen(config, props ? android : null);
+  config = withAndroidSplashScreen(config, android);
   config = withIosSplashScreen(config, ios);
   return config;
 };


### PR DESCRIPTION
# Why
Fixes a regression from #33472

# How
Don't attempt to destructure the props when they are null and skip flattening them

# Test Plan
Sandbox

