### PR TITLE
[docs] APISection: move platform tags below entity name, tweaks

### DIFF
--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -22,7 +22,6 @@ export const APIBox = ({ header, platforms, children, className }: APIBoxProps) 
         className,
         '!pb-4 last:[&>*]:!mb-1'
       )}>
-      {platforms && <APISectionPlatformTags prefix="Only for:" userProvidedPlatforms={platforms} />}
       {header && (
         <H3Code tags={platforms}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -30,6 +29,7 @@ export const APIBox = ({ header, platforms, children, className }: APIBoxProps) 
           </MONOSPACE>
         </H3Code>
       )}
+      {platforms && <APISectionPlatformTags prefix="Only for:" userProvidedPlatforms={platforms} />}
       {children}
     </div>
   );

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -350,7 +350,7 @@ for more details.
                 class="inline"
               >
                 <code
-                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
                   data-text="true"
                 >
                   buttonStyle
@@ -384,7 +384,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-[14px] font-medium text-secondary mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-2.5"
         >
           Type:
            
@@ -426,7 +426,7 @@ for more details.
                 class="inline"
               >
                 <code
-                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
                   data-text="true"
                 >
                   buttonType
@@ -460,7 +460,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-[14px] font-medium text-secondary mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-2.5"
         >
           Type:
            
@@ -502,7 +502,7 @@ for more details.
                 class="inline"
               >
                 <code
-                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
                   data-text="true"
                 >
                   cornerRadius
@@ -536,7 +536,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-[14px] font-medium text-secondary mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-2.5"
         >
           Optional • 
           Type:
@@ -582,7 +582,7 @@ for more details.
                 class="inline"
               >
                 <code
-                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
                   data-text="true"
                 >
                   onPress
@@ -616,7 +616,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-[14px] font-medium text-secondary mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-2.5"
         >
           Type:
            
@@ -677,7 +677,7 @@ in here.
                 class="inline"
               >
                 <code
-                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
                   data-text="true"
                 >
                   style
@@ -711,7 +711,7 @@ in here.
           </h3>
         </div>
         <div
-          class="text-[14px] font-medium text-secondary mb-3.5"
+          class="text-[14px] font-medium text-secondary mb-2.5"
         >
           Optional • 
           Type:
@@ -4765,10 +4765,10 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5023,10 +5023,10 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5264,7 +5264,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <div
-        class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
+        class="flex flex-row items-start [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -5323,10 +5323,10 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5671,10 +5671,10 @@ for more details.
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5954,10 +5954,10 @@ for more details.
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6235,10 +6235,10 @@ for more details.
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6755,7 +6755,7 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
       <div
-        class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
+        class="flex flex-row items-start [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -8505,10 +8505,10 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-3"
+      class="min-h-[56px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -330,51 +330,55 @@ for more details.
       <div
         class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-          data-heading="true"
+        <div
+          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
         >
-          <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-            href="#buttonstyle"
-            id="buttonstyle"
+          <h3
+            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+            data-heading="true"
           >
-            <span
-              class="inline"
+            <a
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+              href="#buttonstyle"
+              id="buttonstyle"
             >
-              <code
-                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
-                data-text="true"
+              <span
+                class="inline"
               >
-                buttonStyle
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </h3>
+                <code
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  data-text="true"
+                >
+                  buttonStyle
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </h3>
+        </div>
         <div
           class="text-[14px] font-medium text-secondary mb-3.5"
         >
@@ -402,51 +406,55 @@ for more details.
       <div
         class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-          data-heading="true"
+        <div
+          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
         >
-          <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-            href="#buttontype"
-            id="buttontype"
+          <h3
+            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+            data-heading="true"
           >
-            <span
-              class="inline"
+            <a
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+              href="#buttontype"
+              id="buttontype"
             >
-              <code
-                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
-                data-text="true"
+              <span
+                class="inline"
               >
-                buttonType
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </h3>
+                <code
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  data-text="true"
+                >
+                  buttonType
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </h3>
+        </div>
         <div
           class="text-[14px] font-medium text-secondary mb-3.5"
         >
@@ -474,51 +482,55 @@ for more details.
       <div
         class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-          data-heading="true"
+        <div
+          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
         >
-          <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-            href="#cornerradius"
-            id="cornerradius"
+          <h3
+            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+            data-heading="true"
           >
-            <span
-              class="inline"
+            <a
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+              href="#cornerradius"
+              id="cornerradius"
             >
-              <code
-                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
-                data-text="true"
+              <span
+                class="inline"
               >
-                cornerRadius
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </h3>
+                <code
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  data-text="true"
+                >
+                  cornerRadius
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </h3>
+        </div>
         <div
           class="text-[14px] font-medium text-secondary mb-3.5"
         >
@@ -550,51 +562,55 @@ for more details.
       <div
         class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-          data-heading="true"
+        <div
+          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
         >
-          <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-            href="#onpress"
-            id="onpress"
+          <h3
+            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+            data-heading="true"
           >
-            <span
-              class="inline"
+            <a
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+              href="#onpress"
+              id="onpress"
             >
-              <code
-                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
-                data-text="true"
+              <span
+                class="inline"
               >
-                onPress
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </h3>
+                <code
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  data-text="true"
+                >
+                  onPress
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </h3>
+        </div>
         <div
           class="text-[14px] font-medium text-secondary mb-3.5"
         >
@@ -641,51 +657,55 @@ in here.
       <div
         class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-          data-heading="true"
+        <div
+          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
         >
-          <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-            href="#style"
-            id="style"
+          <h3
+            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+            data-heading="true"
           >
-            <span
-              class="inline"
+            <a
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+              href="#style"
+              id="style"
             >
-              <code
-                class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
-                data-text="true"
+              <span
+                class="inline"
               >
-                style
-              </code>
-            </span>
-            <svg
-              aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </a>
-        </h3>
+                <code
+                  class="leading-[1.6154] text-default font-medium wrap-anywhere mb-1 inline-block prose-code:mb-0"
+                  data-text="true"
+                >
+                  style
+                </code>
+              </span>
+              <svg
+                aria-label="permalink"
+                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </a>
+          </h3>
+        </div>
         <div
           class="text-[14px] font-medium text-secondary mb-3.5"
         >
@@ -886,51 +906,55 @@ properties.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#formatfullnamefullname-formatstyle"
-        id="formatfullnamefullname-formatstyle"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#formatfullnamefullname-formatstyle"
+          id="formatfullnamefullname-formatstyle"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            formatFullName(fullName, formatStyle)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              formatFullName(fullName, formatStyle)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -1113,51 +1137,55 @@ properties.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#getcredentialstateasyncuser"
-        id="getcredentialstateasyncuser"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#getcredentialstateasyncuser"
+          id="getcredentialstateasyncuser"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            getCredentialStateAsync(user)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              getCredentialStateAsync(user)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -1389,51 +1417,55 @@ value depending on the state of the credential.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#isavailableasync"
-        id="isavailableasync"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#isavailableasync"
+          id="isavailableasync"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            isAvailableAsync()
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              isAvailableAsync()
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -1532,51 +1564,55 @@ value depending on the state of the credential.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#refreshasyncoptions"
-        id="refreshasyncoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#refreshasyncoptions"
+          id="refreshasyncoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            refreshAsync(options)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              refreshAsync(options)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -1773,51 +1809,55 @@ refresh operation.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#signinasyncoptions"
-        id="signinasyncoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#signinasyncoptions"
+          id="signinasyncoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            signInAsync(options)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              signInAsync(options)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -2061,51 +2101,55 @@ sign-in operation.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#signoutasyncoptions"
-        id="signoutasyncoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#signoutasyncoptions"
+          id="signoutasyncoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            signOutAsync(options)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              signOutAsync(options)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -2376,51 +2420,55 @@ sign-out operation.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#addrevokelistenerlistener"
-        id="addrevokelistenerlistener"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#addrevokelistenerlistener"
+          id="addrevokelistenerlistener"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            addRevokeListener(listener)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              addRevokeListener(listener)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -2568,51 +2616,55 @@ sign-out operation.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#appleauthenticationcredential"
-        id="appleauthenticationcredential"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#appleauthenticationcredential"
+          id="appleauthenticationcredential"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationCredential
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              AppleAuthenticationCredential
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -3113,51 +3165,55 @@ developers.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#appleauthenticationfullname"
-        id="appleauthenticationfullname"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#appleauthenticationfullname"
+          id="appleauthenticationfullname"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationFullName
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              AppleAuthenticationFullName
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -3467,51 +3523,55 @@ may be
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#appleauthenticationfullnameformatstyle"
-        id="appleauthenticationfullnameformatstyle"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#appleauthenticationfullnameformatstyle"
+          id="appleauthenticationfullnameformatstyle"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationFullNameFormatStyle
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              AppleAuthenticationFullNameFormatStyle
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
@@ -3634,51 +3694,55 @@ for more details.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#appleauthenticationrefreshoptions"
-        id="appleauthenticationrefreshoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#appleauthenticationrefreshoptions"
+          id="appleauthenticationrefreshoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationRefreshOptions
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              AppleAuthenticationRefreshOptions
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -3944,51 +4008,55 @@ OAuth 2.0 protocol
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#appleauthenticationsigninoptions"
-        id="appleauthenticationsigninoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#appleauthenticationsigninoptions"
+          id="appleauthenticationsigninoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationSignInOptions
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              AppleAuthenticationSignInOptions
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -4271,51 +4339,55 @@ OAuth 2.0 protocol
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#appleauthenticationsignoutoptions"
-        id="appleauthenticationsignoutoptions"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#appleauthenticationsignoutoptions"
+          id="appleauthenticationsignoutoptions"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationSignOutOptions
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              AppleAuthenticationSignOutOptions
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -4510,51 +4582,55 @@ OAuth 2.0 protocol
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#subscription"
-        id="subscription"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#subscription"
+          id="subscription"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            Subscription
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              Subscription
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -4687,51 +4763,55 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationbuttonstyle"
-          id="appleauthenticationbuttonstyle"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationbuttonstyle"
+            id="appleauthenticationbuttonstyle"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationButtonStyle
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationButtonStyle
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -4751,7 +4831,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -4952,51 +5032,55 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationbuttontype"
-          id="appleauthenticationbuttontype"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationbuttontype"
+            id="appleauthenticationbuttontype"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationButtonType
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationButtonType
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -5016,7 +5100,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -5198,7 +5282,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <div
-        class="mb-3.5 flex flex-row items-center"
+        class="mb-3.5 flex flex-row items-start"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -5212,7 +5296,7 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
           >
             <svg
               class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
@@ -5259,51 +5343,55 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationcredentialstate"
-          id="appleauthenticationcredentialstate"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationcredentialstate"
+            id="appleauthenticationcredentialstate"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationCredentialState
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationCredentialState
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -5376,7 +5464,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -5614,53 +5702,57 @@ for more details.
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationoperation"
-          id="appleauthenticationoperation"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationoperation"
+            id="appleauthenticationoperation"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationOperation
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationOperation
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -5904,51 +5996,55 @@ for more details.
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationscope"
-          id="appleauthenticationscope"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationscope"
+            id="appleauthenticationscope"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationScope
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationScope
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -6064,7 +6160,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -6192,51 +6288,55 @@ for more details.
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#appleauthenticationuserdetectionstatus"
-          id="appleauthenticationuserdetectionstatus"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#appleauthenticationuserdetectionstatus"
+            id="appleauthenticationuserdetectionstatus"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              AppleAuthenticationUserDetectionStatus
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                AppleAuthenticationUserDetectionStatus
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
         data-text="true"
@@ -6297,7 +6397,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span
@@ -6540,51 +6640,55 @@ exports[`APISection expo-pedometer 1`] = `
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#getpermissionsasync"
-        id="getpermissionsasync"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#getpermissionsasync"
+          id="getpermissionsasync"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            getPermissionsAsync()
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              getPermissionsAsync()
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -6664,84 +6768,88 @@ exports[`APISection expo-pedometer 1`] = `
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#getstepcountasyncstart-end"
-        id="getstepcountasyncstart-end"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
+      >
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#getstepcountasyncstart-end"
+          id="getstepcountasyncstart-end"
+        >
+          <span
+            class="inline"
+          >
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              getStepCountAsync(start, end)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+      <div
+        class="mb-3.5 flex flex-row items-start"
       >
         <span
-          class="inline"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <div
+            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
           >
-            getStepCountAsync(start, end)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
-    <div
-      class="mb-3.5 flex flex-row items-center"
-    >
-      <span
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
-        data-text="true"
-      >
-        <div
-          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
-        >
-          <svg
-            class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
-            fill="none"
-            role="img"
-            viewBox="0 0 24 24"
-          >
-            <g
-              id="apple-custom-icon"
+            <svg
+              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
             >
-              <path
-                d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
-                fill="currentColor"
-                id="Vector"
-              />
-            </g>
-          </svg>
-          <span
-            class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
-          >
-            iOS
-          </span>
-        </div>
-      </span>
+              <g
+                id="apple-custom-icon"
+              >
+                <path
+                  d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
+                  fill="currentColor"
+                  id="Vector"
+                />
+              </g>
+            </svg>
+            <span
+              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+            >
+              iOS
+            </span>
+          </div>
+        </span>
+      </div>
     </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
@@ -7020,51 +7128,55 @@ a start date that is more than seven days in the past returns only the available
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#isavailableasync"
-        id="isavailableasync"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#isavailableasync"
+          id="isavailableasync"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            isAvailableAsync()
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              isAvailableAsync()
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -7157,51 +7269,55 @@ available on this device.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#requestpermissionsasync"
-        id="requestpermissionsasync"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#requestpermissionsasync"
+          id="requestpermissionsasync"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            requestPermissionsAsync()
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              requestPermissionsAsync()
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -7281,51 +7397,55 @@ available on this device.
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#watchstepcountcallback"
-        id="watchstepcountcallback"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#watchstepcountcallback"
+          id="watchstepcountcallback"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            watchStepCount(callback)
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              watchStepCount(callback)
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -7601,51 +7721,55 @@ On iOS, the
   <div
     class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#permissionresponse"
-        id="permissionresponse"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#permissionresponse"
+          id="permissionresponse"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            PermissionResponse
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              PermissionResponse
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -7889,51 +8013,55 @@ in order to enable/disable the permission.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#pedometerresult"
-        id="pedometerresult"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#pedometerresult"
+          id="pedometerresult"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            PedometerResult
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              PedometerResult
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -8005,52 +8133,56 @@ in order to enable/disable the permission.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#pedometerupdatecallback"
-        id="pedometerupdatecallback"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#pedometerupdatecallback"
+          id="pedometerupdatecallback"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            PedometerUpdateCallback
-            ()
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              PedometerUpdateCallback
+              ()
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -8164,51 +8296,55 @@ in order to enable/disable the permission.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#permissionexpiration"
-        id="permissionexpiration"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#permissionexpiration"
+          id="permissionexpiration"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            PermissionExpiration
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              PermissionExpiration
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
@@ -8252,51 +8388,55 @@ in order to enable/disable the permission.
   <div
     class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
-        href="#subscription"
-        id="subscription"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
+          href="#subscription"
+          id="subscription"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium"
-            data-text="true"
+          <span
+            class="inline"
           >
-            Subscription
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium"
+              data-text="true"
+            >
+              Subscription
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -8429,53 +8569,57 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="px-5 pt-4"
     >
-      <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-        data-heading="true"
+      <div
+        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
       >
-        <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-          href="#permissionstatus"
-          id="permissionstatus"
+        <h3
+          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+          data-heading="true"
         >
-          <span
-            class="inline"
+          <a
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+            href="#permissionstatus"
+            id="permissionstatus"
           >
-            <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere"
-              data-text="true"
+            <span
+              class="inline"
             >
-              PermissionStatus
-            </code>
-          </span>
-          <svg
-            aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </a>
-      </h3>
+              <code
+                class="leading-[1.6154] text-default font-medium wrap-anywhere"
+                data-text="true"
+              >
+                PermissionStatus
+              </code>
+            </span>
+            <svg
+              aria-label="permalink"
+              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h3>
+      </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mb-0 !border-b-0"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
         data-text="true"
       >
         <span

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#component"
       id="component"
     >
@@ -43,14 +43,14 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !shadow-none"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !shadow-none"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#appleauthenticationbutton"
         id="appleauthenticationbutton"
       >
@@ -287,7 +287,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="relative decoration-0 scroll-m-6 flex flex-row items-center gap-2 font-medium text-tertiary"
+            class="relative decoration-0 scroll-m-5 flex flex-row items-center gap-2 font-medium text-tertiary"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -328,14 +328,14 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#buttonstyle"
             id="buttonstyle"
           >
@@ -400,14 +400,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#buttontype"
             id="buttontype"
           >
@@ -472,14 +472,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#cornerradius"
             id="cornerradius"
           >
@@ -548,14 +548,14 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#onpress"
             id="onpress"
           >
@@ -639,14 +639,14 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
           data-heading="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#style"
             id="style"
           >
@@ -784,7 +784,7 @@ properties.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#inherited-props"
           id="inherited-props"
         >
@@ -848,7 +848,7 @@ properties.
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#methods"
       id="methods"
     >
@@ -884,14 +884,14 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#formatfullnamefullname-formatstyle"
         id="formatfullnamefullname-formatstyle"
       >
@@ -1111,14 +1111,14 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#getcredentialstateasyncuser"
         id="getcredentialstateasyncuser"
       >
@@ -1387,14 +1387,14 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -1530,14 +1530,14 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#refreshasyncoptions"
         id="refreshasyncoptions"
       >
@@ -1771,14 +1771,14 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#signinasyncoptions"
         id="signinasyncoptions"
       >
@@ -2059,14 +2059,14 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#signoutasyncoptions"
         id="signoutasyncoptions"
       >
@@ -2338,7 +2338,7 @@ sign-out operation.
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#event-subscriptions"
       id="event-subscriptions"
     >
@@ -2374,14 +2374,14 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#addrevokelistenerlistener"
         id="addrevokelistenerlistener"
       >
@@ -2530,7 +2530,7 @@ sign-out operation.
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#types"
       id="types"
     >
@@ -2566,14 +2566,14 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#appleauthenticationcredential"
         id="appleauthenticationcredential"
       >
@@ -3111,14 +3111,14 @@ developers.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#appleauthenticationfullname"
         id="appleauthenticationfullname"
       >
@@ -3465,14 +3465,14 @@ may be
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#appleauthenticationfullnameformatstyle"
         id="appleauthenticationfullnameformatstyle"
       >
@@ -3632,14 +3632,14 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#appleauthenticationrefreshoptions"
         id="appleauthenticationrefreshoptions"
       >
@@ -3942,14 +3942,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#appleauthenticationsigninoptions"
         id="appleauthenticationsigninoptions"
       >
@@ -4269,14 +4269,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#appleauthenticationsignoutoptions"
         id="appleauthenticationsignoutoptions"
       >
@@ -4508,14 +4508,14 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -4646,7 +4646,7 @@ After calling this function, the listener will no longer receive any events from
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#enums"
       id="enums"
     >
@@ -4682,7 +4682,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -4692,7 +4692,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationbuttonstyle"
           id="appleauthenticationbuttonstyle"
         >
@@ -4770,7 +4770,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#white"
           id="white"
         >
@@ -4831,7 +4831,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#white_outline"
           id="white_outline"
         >
@@ -4892,7 +4892,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#black"
           id="black"
         >
@@ -4947,7 +4947,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -4957,7 +4957,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationbuttontype"
           id="appleauthenticationbuttontype"
         >
@@ -5035,7 +5035,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#sign_in"
           id="sign_in"
         >
@@ -5096,7 +5096,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#continue"
           id="continue"
         >
@@ -5152,54 +5152,12 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
-      <div
-        class="mb-2 flex flex-row items-center"
-      >
-        <span
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
-            data-text="true"
-          >
-            Only for:
-             
-          </span>
-          <div
-            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
-          >
-            <svg
-              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
-            >
-              <g
-                id="apple-custom-icon"
-              >
-                <path
-                  d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
-                  fill="currentColor"
-                  id="Vector"
-                />
-              </g>
-            </svg>
-            <span
-              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
-            >
-              iOS 13.2+
-            </span>
-          </div>
-          <br />
-        </span>
-      </div>
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#sign_up"
           id="sign_up"
         >
@@ -5239,6 +5197,48 @@ After calling this function, the listener will no longer receive any events from
           </svg>
         </a>
       </h4>
+      <div
+        class="mb-3.5 flex flex-row items-center"
+      >
+        <span
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+          data-text="true"
+        >
+          <span
+            class="leading-[1.6154] font-medium text-secondary !text-inherit !font-medium"
+            data-text="true"
+          >
+            Only for:
+             
+          </span>
+          <div
+            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+          >
+            <svg
+              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <g
+                id="apple-custom-icon"
+              >
+                <path
+                  d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
+                  fill="currentColor"
+                  id="Vector"
+                />
+              </g>
+            </svg>
+            <span
+              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+            >
+              iOS 13.2+
+            </span>
+          </div>
+          <br />
+        </span>
+      </div>
       <code
         class="text-secondary mb-3 inline-flex text-xs"
         data-text="true"
@@ -5254,7 +5254,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -5264,7 +5264,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationcredentialstate"
           id="appleauthenticationcredentialstate"
         >
@@ -5395,7 +5395,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#revoked"
           id="revoked"
         >
@@ -5450,7 +5450,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#authorized"
           id="authorized"
         >
@@ -5505,7 +5505,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#not_found"
           id="not_found"
         >
@@ -5560,7 +5560,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#transferred"
           id="transferred"
         >
@@ -5609,7 +5609,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -5619,7 +5619,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationoperation"
           id="appleauthenticationoperation"
         >
@@ -5679,7 +5679,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#implicit"
           id="implicit"
         >
@@ -5740,7 +5740,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#login"
           id="login"
         >
@@ -5795,7 +5795,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#refresh"
           id="refresh"
         >
@@ -5850,7 +5850,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#logout"
           id="logout"
         >
@@ -5899,7 +5899,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -5909,7 +5909,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationscope"
           id="appleauthenticationscope"
         >
@@ -6083,7 +6083,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#full_name"
           id="full_name"
         >
@@ -6138,7 +6138,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#email"
           id="email"
         >
@@ -6187,7 +6187,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -6197,7 +6197,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#appleauthenticationuserdetectionstatus"
           id="appleauthenticationuserdetectionstatus"
         >
@@ -6316,7 +6316,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#unsupported"
           id="unsupported"
         >
@@ -6377,7 +6377,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#unknown"
           id="unknown"
         >
@@ -6438,7 +6438,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#likely_real"
           id="likely_real"
         >
@@ -6502,7 +6502,7 @@ exports[`APISection expo-pedometer 1`] = `
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#methods"
       id="methods"
     >
@@ -6538,14 +6538,14 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#getpermissionsasync"
         id="getpermissionsasync"
       >
@@ -6662,48 +6662,14 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
-    <div
-      class="mb-2 flex flex-row items-center"
-    >
-      <span
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
-        data-text="true"
-      >
-        <div
-          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
-        >
-          <svg
-            class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
-            fill="none"
-            role="img"
-            viewBox="0 0 24 24"
-          >
-            <g
-              id="apple-custom-icon"
-            >
-              <path
-                d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
-                fill="currentColor"
-                id="Vector"
-              />
-            </g>
-          </svg>
-          <span
-            class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
-          >
-            iOS
-          </span>
-        </div>
-      </span>
-    </div>
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#getstepcountasyncstart-end"
         id="getstepcountasyncstart-end"
       >
@@ -6743,6 +6709,40 @@ exports[`APISection expo-pedometer 1`] = `
         </svg>
       </a>
     </h3>
+    <div
+      class="mb-3.5 flex flex-row items-center"
+    >
+      <span
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+        data-text="true"
+      >
+        <div
+          class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+        >
+          <svg
+            class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+            fill="none"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="apple-custom-icon"
+            >
+              <path
+                d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
+                fill="currentColor"
+                id="Vector"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+          >
+            iOS
+          </span>
+        </div>
+      </span>
+    </div>
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
     >
@@ -7018,14 +7018,14 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -7155,14 +7155,14 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#requestpermissionsasync"
         id="requestpermissionsasync"
       >
@@ -7279,14 +7279,14 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#watchstepcountcallback"
         id="watchstepcountcallback"
       >
@@ -7563,7 +7563,7 @@ On iOS, the
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#interfaces"
       id="interfaces"
     >
@@ -7599,14 +7599,14 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#permissionresponse"
         id="permissionresponse"
       >
@@ -7851,7 +7851,7 @@ in order to enable/disable the permission.
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#types"
       id="types"
     >
@@ -7887,14 +7887,14 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#pedometerresult"
         id="pedometerresult"
       >
@@ -8003,14 +8003,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#pedometerupdatecallback"
         id="pedometerupdatecallback"
       >
@@ -8162,14 +8162,14 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
         href="#permissionexpiration"
         id="permissionexpiration"
       >
@@ -8250,14 +8250,14 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <h3
       class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
       data-heading="true"
     >
       <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12 break-words wrap-anywhere"
+        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8 break-words wrap-anywhere"
         href="#subscription"
         id="subscription"
       >
@@ -8388,7 +8388,7 @@ After calling this function, the listener will no longer receive any events from
     data-heading="true"
   >
     <a
-      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+      class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
       href="#enums"
       id="enums"
     >
@@ -8424,7 +8424,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
       class="px-5 pt-4"
@@ -8434,7 +8434,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#permissionstatus"
           id="permissionstatus"
         >
@@ -8494,7 +8494,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#denied"
           id="denied"
         >
@@ -8555,7 +8555,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#granted"
           id="granted"
         >
@@ -8616,7 +8616,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-6"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-5"
           href="#undetermined"
           id="undetermined"
         >

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -43,53 +43,57 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !shadow-none"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !shadow-none"
   >
-    <h3
-      class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
-      data-heading="true"
+    <div
+      class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
     >
-      <a
-        class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
-        href="#appleauthenticationbutton"
-        id="appleauthenticationbutton"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
+        data-heading="true"
       >
-        <span
-          class="inline"
+        <a
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
+          href="#appleauthenticationbutton"
+          id="appleauthenticationbutton"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
-            data-text="true"
+          <span
+            class="inline"
           >
-            AppleAuthenticationButton
-          </code>
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h3>
+            <code
+              class="leading-[1.6154] text-default font-medium wrap-anywhere"
+              data-text="true"
+            >
+              AppleAuthenticationButton
+            </code>
+          </span>
+          <svg
+            aria-label="permalink"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </a>
+      </h3>
+    </div>
     <p
       class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3.5"
       data-text="true"
@@ -298,7 +302,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -328,10 +332,10 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
-          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+          class="flex flex-wrap justify-between max-md-gutters:flex-col"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -354,7 +358,7 @@ for more details.
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -404,10 +408,10 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
-          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+          class="flex flex-wrap justify-between max-md-gutters:flex-col"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -430,7 +434,7 @@ for more details.
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -480,10 +484,10 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
-          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+          class="flex flex-wrap justify-between max-md-gutters:flex-col"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -506,7 +510,7 @@ for more details.
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -560,10 +564,10 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
-          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+          class="flex flex-wrap justify-between max-md-gutters:flex-col"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -586,7 +590,7 @@ for more details.
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -655,10 +659,10 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
-          class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+          class="flex flex-wrap justify-between max-md-gutters:flex-col"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -681,7 +685,7 @@ in here.
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -815,7 +819,7 @@ properties.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -879,7 +883,7 @@ properties.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -904,10 +908,10 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -930,7 +934,7 @@ properties.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -1135,10 +1139,10 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -1161,7 +1165,7 @@ properties.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -1415,10 +1419,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -1441,7 +1445,7 @@ value depending on the state of the credential.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -1562,10 +1566,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -1588,7 +1592,7 @@ value depending on the state of the credential.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -1807,10 +1811,10 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -1833,7 +1837,7 @@ refresh operation.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -2099,10 +2103,10 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -2125,7 +2129,7 @@ sign-in operation.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -2393,7 +2397,7 @@ sign-out operation.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -2418,10 +2422,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -2444,7 +2448,7 @@ sign-out operation.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -2589,7 +2593,7 @@ sign-out operation.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -2614,10 +2618,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -2640,7 +2644,7 @@ sign-out operation.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -3163,10 +3167,10 @@ developers.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -3189,7 +3193,7 @@ developers.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -3521,10 +3525,10 @@ may be
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -3547,7 +3551,7 @@ may be
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -3692,10 +3696,10 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -3718,7 +3722,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4006,10 +4010,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -4032,7 +4036,7 @@ OAuth 2.0 protocol
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4337,10 +4341,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -4363,7 +4367,7 @@ OAuth 2.0 protocol
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4580,10 +4584,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -4606,7 +4610,7 @@ OAuth 2.0 protocol
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4733,7 +4737,7 @@ After calling this function, the listener will no longer receive any events from
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -4758,13 +4762,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -4787,7 +4791,7 @@ After calling this function, the listener will no longer receive any events from
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -4830,20 +4834,9 @@ After calling this function, the listener will no longer receive any events from
         </a>
         .
       </p>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationButtonStyle Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -4866,7 +4859,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4891,7 +4884,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -4904,7 +4897,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -4927,7 +4920,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -4952,7 +4945,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -4965,7 +4958,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -4988,7 +4981,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5013,7 +5006,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -5027,13 +5020,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5056,7 +5049,7 @@ After calling this function, the listener will no longer receive any events from
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -5099,20 +5092,9 @@ After calling this function, the listener will no longer receive any events from
         </a>
         .
       </p>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationButtonType Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5135,7 +5117,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5160,7 +5142,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -5173,7 +5155,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5196,7 +5178,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5221,7 +5203,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -5234,7 +5216,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5257,7 +5239,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5282,7 +5264,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <div
-        class="mb-3.5 flex flex-row items-start"
+        class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -5296,10 +5278,10 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
           >
             <svg
-              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+              class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -5315,7 +5297,7 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+              class="whitespace-nowrap !text-3xs font-normal !leading-none"
             >
               iOS 13.2+
             </span>
@@ -5324,7 +5306,7 @@ After calling this function, the listener will no longer receive any events from
         </span>
       </div>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -5338,13 +5320,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5367,7 +5349,7 @@ After calling this function, the listener will no longer receive any events from
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -5463,20 +5445,9 @@ for more details.
           </p>
         </div>
       </blockquote>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationCredentialState Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5499,7 +5470,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5524,14 +5495,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5554,7 +5525,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5579,14 +5550,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5609,7 +5580,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5634,14 +5605,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5664,7 +5635,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5689,7 +5660,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5697,13 +5668,13 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -5726,7 +5697,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -5751,20 +5722,9 @@ for more details.
           </a>
         </h3>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationOperation Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5787,7 +5747,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5812,7 +5772,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -5825,7 +5785,7 @@ for more details.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5848,7 +5808,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5873,14 +5833,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5903,7 +5863,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5928,14 +5888,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -5958,7 +5918,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -5983,7 +5943,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5991,13 +5951,13 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6020,7 +5980,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6159,20 +6119,9 @@ for more details.
           </p>
         </div>
       </blockquote>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationScope Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -6195,7 +6144,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6220,14 +6169,14 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
       </code>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -6250,7 +6199,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6275,7 +6224,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6283,13 +6232,13 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6312,7 +6261,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6396,20 +6345,9 @@ for more details.
           </p>
         </div>
       </blockquote>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          AppleAuthenticationUserDetectionStatus Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -6432,7 +6370,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6457,7 +6395,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -6470,7 +6408,7 @@ for more details.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -6493,7 +6431,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6518,7 +6456,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -6531,7 +6469,7 @@ for more details.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -6554,7 +6492,7 @@ for more details.
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6579,7 +6517,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -6613,7 +6551,7 @@ exports[`APISection expo-pedometer 1`] = `
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -6638,10 +6576,10 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6664,7 +6602,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6766,10 +6704,10 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -6792,7 +6730,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6817,17 +6755,17 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
       <div
-        class="mb-3.5 flex flex-row items-start"
+        class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
           data-text="true"
         >
           <div
-            class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
           >
             <svg
-              class="translate-z icon-xs mt-[-0.5px] text-palette-blue12 opacity-80"
+              class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -6843,7 +6781,7 @@ exports[`APISection expo-pedometer 1`] = `
               </g>
             </svg>
             <span
-              class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+              class="whitespace-nowrap !text-3xs font-normal !leading-none"
             >
               iOS
             </span>
@@ -7126,10 +7064,10 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -7152,7 +7090,7 @@ a start date that is more than seven days in the past returns only the available
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -7267,10 +7205,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -7293,7 +7231,7 @@ available on this device.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -7395,10 +7333,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -7421,7 +7359,7 @@ available on this device.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -7694,7 +7632,7 @@ On iOS, the
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -7719,10 +7657,10 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary p-5 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-5 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -7745,7 +7683,7 @@ On iOS, the
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -7986,7 +7924,7 @@ in order to enable/disable the permission.
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -8011,10 +7949,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -8037,7 +7975,7 @@ in order to enable/disable the permission.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8131,10 +8069,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -8158,7 +8096,7 @@ in order to enable/disable the permission.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8294,10 +8232,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -8320,7 +8258,7 @@ in order to enable/disable the permission.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8386,10 +8324,10 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4"
   >
     <div
-      class="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1"
+      class="flex flex-wrap justify-between max-md-gutters:flex-col"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -8412,7 +8350,7 @@ in order to enable/disable the permission.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8539,7 +8477,7 @@ After calling this function, the listener will no longer receive any events from
       </span>
       <svg
         aria-label="permalink"
-        class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+        class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
         fill="none"
         height="24"
         viewBox="0 0 24 24"
@@ -8564,13 +8502,13 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-6 rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="px-5 pt-4"
+      class="px-5 pt-3"
     >
       <div
-        class="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0"
+        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group"
@@ -8593,7 +8531,7 @@ After calling this function, the listener will no longer receive any events from
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+              class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -8618,20 +8556,9 @@ After calling this function, the listener will no longer receive any events from
           </a>
         </h3>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 mb-0 mt-2 border-b-0"
-        data-text="true"
-      >
-        <span
-          class="text-[14px] leading-[1.5715] tracking-[-0.006rem] flex flex-row items-center gap-2 font-medium text-tertiary"
-          data-text="true"
-        >
-          PermissionStatus Values
-        </span>
-      </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -8654,7 +8581,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8679,7 +8606,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -8692,7 +8619,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -8715,7 +8642,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8740,7 +8667,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -8753,7 +8680,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary p-5 pb-0 pt-4"
+      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <h4
         class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group"
@@ -8776,7 +8703,7 @@ After calling this function, the listener will no longer receive any events from
           </span>
           <svg
             aria-label="permalink"
-            class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+            class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -8801,7 +8728,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <code
-        class="text-secondary mb-3 inline-flex text-xs"
+        class="text-secondary mb-2 inline-flex text-xs"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -5264,7 +5264,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <div
-        class="flex flex-row items-start [table_&]:mb-2.5"
+        class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -6755,7 +6755,7 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
       <div
-        class="flex flex-row items-start [table_&]:mb-2.5"
+        class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -96,7 +96,7 @@ const renderClass = (
       key={`class-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -96,12 +96,12 @@ const renderClass = (
       key={`class-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {name}
         </MONOSPACE>
       </H3Code>
+      <APISectionPlatformTags comment={comment} />
       {(extendedTypes?.length || implementedTypes?.length) && (
         <CALLOUT className="mb-3">
           <SPAN theme="secondary" weight="medium">

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -96,12 +96,14 @@ const renderClass = (
       key={`class-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
-          {name}
-        </MONOSPACE>
-      </H3Code>
-      <APISectionPlatformTags comment={comment} />
+      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium" className="wrap-anywhere">
+            {name}
+          </MONOSPACE>
+        </H3Code>
+        <APISectionPlatformTags comment={comment} />
+      </div>
       {(extendedTypes?.length || implementedTypes?.length) && (
         <CALLOUT className="mb-3">
           <SPAN theme="secondary" weight="medium">

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -1,5 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { APISectionPlatformTags } from '~/components/plugins/api/components/APISectionPlatformTags';
 import { H2, DEMI, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
 import {
@@ -63,11 +64,14 @@ const renderComponent = (
       key={`component-definition-${resolvedName}`}
       className={mergeClasses(STYLES_APIBOX, '!shadow-none')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
-          {resolvedName}
-        </MONOSPACE>
-      </H3Code>
+      <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0">
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium" className="wrap-anywhere">
+            {resolvedName}
+          </MONOSPACE>
+        </H3Code>
+        <APISectionPlatformTags comment={comment} />
+      </div>
       {resolvedType && resolvedTypeParameters && (
         <P className={ELEMENT_SPACING}>
           <DEMI theme="secondary">Type:</DEMI>{' '}

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -25,13 +25,15 @@ const renderConstant = (
     key={`constant-definition-${name}`}
     className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
     <APISectionDeprecationNote comment={comment} sticky />
-    <H3Code tags={getTagNamesList(comment)}>
-      <MONOSPACE weight="medium" className="wrap-anywhere">
-        {apiName ? `${apiName}.` : ''}
-        {name}
-      </MONOSPACE>
-    </H3Code>
-    <APISectionPlatformTags comment={comment} />
+    <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+      <H3Code tags={getTagNamesList(comment)}>
+        <MONOSPACE weight="medium" className="wrap-anywhere">
+          {apiName ? `${apiName}.` : ''}
+          {name}
+        </MONOSPACE>
+      </H3Code>
+      <APISectionPlatformTags comment={comment} />
+    </div>
     {type && (
       <P className={STYLES_SECONDARY}>
         Type: <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -25,13 +25,13 @@ const renderConstant = (
     key={`constant-definition-${name}`}
     className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
     <APISectionDeprecationNote comment={comment} sticky />
-    <APISectionPlatformTags comment={comment} />
     <H3Code tags={getTagNamesList(comment)}>
       <MONOSPACE weight="medium" className="wrap-anywhere">
         {apiName ? `${apiName}.` : ''}
         {name}
       </MONOSPACE>
     </H3Code>
+    <APISectionPlatformTags comment={comment} />
     {type && (
       <P className={STYLES_SECONDARY}>
         Type: <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -25,7 +25,7 @@ const renderConstant = (
     key={`constant-definition-${name}`}
     className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
     <APISectionDeprecationNote comment={comment} sticky />
-    <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+    <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {apiName ? `${apiName}.` : ''}

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -32,22 +32,22 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
     <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
       <div className="px-5 pt-4">
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <BoxSectionHeader text={`${name} Values`} className="!mb-0 !border-b-0" />
       </div>
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-          <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" disableFallback />
           <H4 hideInSidebar>
             <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
           </H4>
+          <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" disableFallback />
           <MONOSPACE theme="secondary" className="mb-3 inline-flex text-xs">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -32,14 +32,16 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
     <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
       <div className="px-5 pt-4">
         <APISectionDeprecationNote comment={comment} />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0">
+          <H3Code tags={getTagNamesList(comment)}>
+            <MONOSPACE weight="medium" className="wrap-anywhere">
+              {name}
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <BoxSectionHeader text={`${name} Values`} className="!mb-0 !border-b-0" />
+        <BoxSectionHeader text={`${name} Values`} className="mb-0 mt-2 border-b-0" />
       </div>
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -30,9 +30,9 @@ const renderEnumValue = (value: any, fallback?: string) =>
 function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefinitionData }) {
   return (
     <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
-      <div className="px-5 pt-3">
+      <div className="min-h-[56px] px-5 pt-3">
         <APISectionDeprecationNote comment={comment} />
-        <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0">
+        <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -4,7 +4,7 @@ import { H2, H4, MONOSPACE } from '~/ui/components/Text';
 
 import { EnumDefinitionData, EnumValueData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
-import { getTagNamesList, H3Code, BoxSectionHeader } from './APISectionUtils';
+import { getTagNamesList, H3Code } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { STYLES_APIBOX } from './styles';
@@ -30,9 +30,9 @@ const renderEnumValue = (value: any, fallback?: string) =>
 function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefinitionData }) {
   return (
     <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
-      <div className="px-5 pt-4">
+      <div className="px-5 pt-3">
         <APISectionDeprecationNote comment={comment} />
-        <div className="grid grid-cols-auto-min-2 items-baseline gap-2 max-md-gutters:grid-cols-1 [&_h3]:mb-0">
+        <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}
@@ -41,16 +41,17 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           <APISectionPlatformTags comment={comment} />
         </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <BoxSectionHeader text={`${name} Values`} className="mb-0 mt-2 border-b-0" />
       </div>
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
-        <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
+        <div
+          className="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+          key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
           <H4 hideInSidebar>
             <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
           </H4>
           <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" disableFallback />
-          <MONOSPACE theme="secondary" className="mb-3 inline-flex text-xs">
+          <MONOSPACE theme="secondary" className="mb-2 inline-flex text-xs">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -125,12 +125,12 @@ const renderInterface = (
       key={`interface-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {name}
         </MONOSPACE>
       </H3Code>
+      <APISectionPlatformTags comment={comment} />
       {extendedTypes?.length ? (
         <CALLOUT className={ELEMENT_SPACING}>
           <CALLOUT tag="span" theme="secondary" weight="medium">

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -125,12 +125,14 @@ const renderInterface = (
       key={`interface-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
-          {name}
-        </MONOSPACE>
-      </H3Code>
-      <APISectionPlatformTags comment={comment} />
+      <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium" className="wrap-anywhere">
+            {name}
+          </MONOSPACE>
+        </H3Code>
+        <APISectionPlatformTags comment={comment} />
+      </div>
       {extendedTypes?.length ? (
         <CALLOUT className={ELEMENT_SPACING}>
           <CALLOUT tag="span" theme="secondary" weight="medium">

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -125,7 +125,7 @@ const renderInterface = (
       key={`interface-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -70,23 +70,25 @@ export const renderMethod = (
         key={`method-signature-${method.name || name}-${parameters?.length ?? 0}`}
         className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <HeaderComponent>
-          <MONOSPACE
-            weight="medium"
-            className={mergeClasses(
-              'wrap-anywhere',
-              !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
-            )}>
-            {getMethodName(
-              method as MethodDefinitionData,
-              apiName,
-              name,
-              parameters,
-              typeParameter
-            )}
-          </MONOSPACE>
-        </HeaderComponent>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+          <HeaderComponent>
+            <MONOSPACE
+              weight="medium"
+              className={mergeClasses(
+                'wrap-anywhere',
+                !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
+              )}>
+              {getMethodName(
+                method as MethodDefinitionData,
+                apiName,
+                name,
+                parameters,
+                typeParameter
+              )}
+            </MONOSPACE>
+          </HeaderComponent>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         {parameters && parameters.length > 0 && (
           <>
             {renderParams(parameters, sdkVersion)}

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -70,7 +70,7 @@ export const renderMethod = (
         key={`method-signature-${method.name || name}-${parameters?.length ?? 0}`}
         className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <HeaderComponent>
             <MONOSPACE
               weight="medium"

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -70,7 +70,6 @@ export const renderMethod = (
         key={`method-signature-${method.name || name}-${parameters?.length ?? 0}`}
         className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <HeaderComponent>
           <MONOSPACE
             weight="medium"
@@ -87,6 +86,7 @@ export const renderMethod = (
             )}
           </MONOSPACE>
         </HeaderComponent>
+        <APISectionPlatformTags comment={comment} />
         {parameters && parameters.length > 0 && (
           <>
             {renderParams(parameters, sdkVersion)}

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -44,12 +44,14 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
   return (
     <div key={`class-definition-${name}`} className={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
-          {name}
-        </MONOSPACE>
-      </H3Code>
-      <APISectionPlatformTags comment={comment} />
+      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium" className="wrap-anywhere">
+            {name}
+          </MONOSPACE>
+        </H3Code>
+        <APISectionPlatformTags comment={comment} />
+      </div>
       <APICommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -44,12 +44,12 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
   return (
     <div key={`class-definition-${name}`} className={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {name}
         </MONOSPACE>
       </H3Code>
+      <APISectionPlatformTags comment={comment} />
       <APICommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -44,7 +44,7 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
   return (
     <div key={`class-definition-${name}`} className={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -21,7 +21,7 @@ import {
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APISectionPlatformTags } from './components/APISectionPlatformTags';
-import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
+import { STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -122,14 +122,14 @@ export const renderProp = (
             weight="medium"
             className={mergeClasses(
               'wrap-anywhere',
-              !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
+              !exposeInSidebar && 'inline-block prose-code:mb-0'
             )}>
             {name}
           </MONOSPACE>
         </HeaderComponent>
         <APISectionPlatformTags comment={comment} />
       </div>
-      <div className={mergeClasses(STYLES_SECONDARY, extractedComment && ELEMENT_SPACING)}>
+      <div className={mergeClasses(STYLES_SECONDARY, extractedComment && 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}
         <>Type:</>{' '}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -116,7 +116,6 @@ export const renderProp = (
       key={`prop-entry-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!pb-4 [&>*:last-child]:!mb-0')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <APISectionPlatformTags comment={comment} />
       <HeaderComponent tags={getTagNamesList(comment)}>
         <MONOSPACE
           weight="medium"
@@ -127,6 +126,7 @@ export const renderProp = (
           {name}
         </MONOSPACE>
       </HeaderComponent>
+      <APISectionPlatformTags comment={comment} />
       <div className={mergeClasses(STYLES_SECONDARY, extractedComment && ELEMENT_SPACING)}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -16,7 +16,7 @@ import {
   extractDefaultPropValue,
   getCommentOrSignatureComment,
   getH3CodeWithBaseNestingLevel,
-  getTagNamesList, H3Code,
+  getTagNamesList,
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
@@ -116,7 +116,7 @@ export const renderProp = (
       key={`prop-entry-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!pb-4 [&>*:last-child]:!mb-0')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <HeaderComponent tags={getTagNamesList(comment)}>
           <MONOSPACE
             weight="medium"

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -16,7 +16,7 @@ import {
   extractDefaultPropValue,
   getCommentOrSignatureComment,
   getH3CodeWithBaseNestingLevel,
-  getTagNamesList,
+  getTagNamesList, H3Code,
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
@@ -116,17 +116,19 @@ export const renderProp = (
       key={`prop-entry-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!pb-4 [&>*:last-child]:!mb-0')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <HeaderComponent tags={getTagNamesList(comment)}>
-        <MONOSPACE
-          weight="medium"
-          className={mergeClasses(
-            'wrap-anywhere',
-            !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
-          )}>
-          {name}
-        </MONOSPACE>
-      </HeaderComponent>
-      <APISectionPlatformTags comment={comment} />
+      <div className="grid grid-cols-auto-min-2 gap-2 max-md-gutters:grid-cols-1">
+        <HeaderComponent tags={getTagNamesList(comment)}>
+          <MONOSPACE
+            weight="medium"
+            className={mergeClasses(
+              'wrap-anywhere',
+              !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
+            )}>
+            {name}
+          </MONOSPACE>
+        </HeaderComponent>
+        <APISectionPlatformTags comment={comment} />
+      </div>
       <div className={mergeClasses(STYLES_SECONDARY, extractedComment && ELEMENT_SPACING)}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -146,13 +146,13 @@ const renderType = (
     return (
       <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
           <MONOSPACE weight="medium">
             {name}
             {type.declaration.signatures ? '()' : ''}
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         {type.declaration.children && renderTypeDeclarationTable(type.declaration, sdkVersion)}
         {type.declaration.signatures
@@ -185,10 +185,10 @@ const renderType = (
     return (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
           <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT className={STYLES_SECONDARY}>
           Tuple: <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
@@ -209,12 +209,12 @@ const renderType = (
       return (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}
             </MONOSPACE>
           </H3Code>
+          <APISectionPlatformTags comment={comment} />
           <APICommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
@@ -258,12 +258,12 @@ const renderType = (
       return (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}
             </MONOSPACE>
           </H3Code>
+          <APISectionPlatformTags comment={comment} />
           <CALLOUT className="mb-3">
             <SPAN theme="secondary" weight="medium">
               Literal Type:{' '}
@@ -292,12 +292,12 @@ const renderType = (
         key={`record-definition-${name}`}
         className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <CALLOUT className="mb-3">
           <SPAN theme="secondary" weight="medium">
             Type:{' '}
@@ -311,12 +311,12 @@ const renderType = (
     return (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <SPAN theme="secondary" weight="medium">
@@ -330,12 +330,12 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}&lt;{type.checkType.name}&gt;
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <SPAN theme="secondary" weight="medium">
@@ -375,12 +375,12 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
             {name}
           </MONOSPACE>
         </H3Code>
+        <APISectionPlatformTags comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -146,7 +146,7 @@ const renderType = (
     return (
       <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
             <MONOSPACE weight="medium">
               {name}
@@ -187,7 +187,7 @@ const renderType = (
     return (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
             <MONOSPACE weight="medium">{name}</MONOSPACE>
           </H3Code>
@@ -213,7 +213,7 @@ const renderType = (
       return (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
             <H3Code tags={getTagNamesList(comment)}>
               <MONOSPACE weight="medium" className="wrap-anywhere">
                 {name}
@@ -264,7 +264,7 @@ const renderType = (
       return (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
             <H3Code tags={getTagNamesList(comment)}>
               <MONOSPACE weight="medium" className="wrap-anywhere">
                 {name}
@@ -301,7 +301,7 @@ const renderType = (
         className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
         <APISectionDeprecationNote comment={comment} sticky />
 
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}
@@ -322,7 +322,7 @@ const renderType = (
     return (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}
@@ -343,7 +343,7 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}&lt;{type.checkType.name}&gt;
@@ -390,7 +390,7 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
               {name}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -146,13 +146,15 @@ const renderType = (
     return (
       <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
-          <MONOSPACE weight="medium">
-            {name}
-            {type.declaration.signatures ? '()' : ''}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
+            <MONOSPACE weight="medium">
+              {name}
+              {type.declaration.signatures ? '()' : ''}
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         {type.declaration.children && renderTypeDeclarationTable(type.declaration, sdkVersion)}
         {type.declaration.signatures
@@ -185,10 +187,12 @@ const renderType = (
     return (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
-          <MONOSPACE weight="medium">{name}</MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
+            <MONOSPACE weight="medium">{name}</MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT className={STYLES_SECONDARY}>
           Tuple: <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
@@ -209,12 +213,14 @@ const renderType = (
       return (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
+          <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+            <H3Code tags={getTagNamesList(comment)}>
+              <MONOSPACE weight="medium" className="wrap-anywhere">
+                {name}
+              </MONOSPACE>
+            </H3Code>
+            <APISectionPlatformTags comment={comment} />
+          </div>
           <APICommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
@@ -258,12 +264,14 @@ const renderType = (
       return (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
+          <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+            <H3Code tags={getTagNamesList(comment)}>
+              <MONOSPACE weight="medium" className="wrap-anywhere">
+                {name}
+              </MONOSPACE>
+            </H3Code>
+            <APISectionPlatformTags comment={comment} />
+          </div>
           <CALLOUT className="mb-3">
             <SPAN theme="secondary" weight="medium">
               Literal Type:{' '}
@@ -292,12 +300,15 @@ const renderType = (
         key={`record-definition-${name}`}
         className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)}>
+            <MONOSPACE weight="medium" className="wrap-anywhere">
+              {name}
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <CALLOUT className="mb-3">
           <SPAN theme="secondary" weight="medium">
             Type:{' '}
@@ -311,12 +322,14 @@ const renderType = (
     return (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)}>
+            <MONOSPACE weight="medium" className="wrap-anywhere">
+              {name}
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <SPAN theme="secondary" weight="medium">
@@ -330,12 +343,14 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}&lt;{type.checkType.name}&gt;
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)}>
+            <MONOSPACE weight="medium" className="wrap-anywhere">
+              {name}&lt;{type.checkType.name}&gt;
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <SPAN theme="secondary" weight="medium">
@@ -375,12 +390,14 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
+        <div className="grid grid-cols-auto-min-2 items-center max-md-gutters:grid-cols-1">
+          <H3Code tags={getTagNamesList(comment)}>
+            <MONOSPACE weight="medium" className="wrap-anywhere">
+              {name}
+            </MONOSPACE>
+          </H3Code>
+          <APISectionPlatformTags comment={comment} />
+        </div>
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="mb-2 flex flex-row items-center"
+    class="mb-3.5 flex flex-row items-center"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
       <div
-        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-2 py-1 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
+        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
       >
         <svg
           class="translate-z icon-xs mt-[-0.5px] text-palette-green12 opacity-80"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,17 +14,17 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="mb-3.5 flex flex-row items-start"
+    class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
       <div
-        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
+        class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
       >
         <svg
-          class="translate-z icon-xs mt-[-0.5px] text-palette-green12 opacity-80"
+          class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80"
           fill="none"
           role="img"
           viewBox="0 0 24 24"
@@ -40,7 +40,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           </g>
         </svg>
         <span
-          class="text-2xs font-normal !leading-[16px] [table_&]:text-3xs"
+          class="whitespace-nowrap !text-3xs font-normal !leading-none"
         >
           Android
         </span>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="mb-3.5 flex flex-row items-center"
+    class="mb-3.5 flex flex-row items-start"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
       data-text="true"
     >
       <div
-        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
+        class="mr-2 inline-flex select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
       >
         <svg
           class="translate-z icon-xs mt-[-0.5px] text-palette-green12 opacity-80"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="mb-4 flex flex-row items-start [table_&]:mb-2.5"
+    class="flex flex-row items-start [table_&]:mb-2.5"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="flex flex-row items-start [table_&]:mb-2.5"
+    class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -42,7 +42,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="mb-3.5 flex flex-row items-start">
+    <div className="mb-4 flex flex-row items-start [table_&]:mb-2.5">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -42,7 +42,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="mb-3.5 flex flex-row items-center">
+    <div className="mb-3.5 flex flex-row items-start">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -42,7 +42,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="mb-2 flex flex-row items-center">
+    <div className="mb-3.5 flex flex-row items-center">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -42,7 +42,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="mb-4 flex flex-row items-start [table_&]:mb-2.5">
+    <div className="flex flex-row items-start [table_&]:mb-2.5">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -42,7 +42,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="flex flex-row items-start [table_&]:mb-2.5">
+    <div className="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5">
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -9,7 +9,7 @@ export const STYLES_OPTIONAL = mergeClasses('pt-5 !text-[13px] text-secondary');
 export const STYLES_APIBOX = mergeClasses(
   'mb-6 rounded-lg border border-secondary p-5 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
-  '[&_h3]:mb-2.5',
+  '[&_h3]:mb-1.5',
   '[&_li]:mb-0',
   '[&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary',
   '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none',

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -7,7 +7,7 @@ export const STYLES_SECONDARY = mergeClasses('text-[14px] font-medium text-secon
 export const STYLES_OPTIONAL = mergeClasses('pt-5 !text-[13px] text-secondary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-6 rounded-lg border border-secondary p-5 shadow-xs',
+  'mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
   '[&_li]:mb-0',

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#name"
           id="name"
         >
@@ -151,14 +151,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#androidnavigationbar"
           id="androidnavigationbar"
         >
@@ -373,14 +373,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#visible"
             id="visible"
           >
@@ -533,14 +533,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
-              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
               href="#always"
               id="always"
             >
@@ -619,14 +619,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#backgroundcolor"
             id="backgroundcolor"
           >
@@ -719,14 +719,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
         data-text="true"
       >
         <a
-          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+          class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
           href="#intentfilters"
           id="intentfilters"
         >
@@ -893,14 +893,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#autoverify"
             id="autoverify"
           >
@@ -978,14 +978,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
           data-text="true"
         >
           <a
-            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+            class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
             href="#data"
             id="data"
           >
@@ -1056,14 +1056,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-2.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
             data-text="true"
           >
             <a
-              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-12"
+              class="relative inline-flex items-center gap-1.5 text-[inherit] decoration-0 scroll-m-8"
               href="#host"
               id="host"
             >

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -26,7 +26,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -151,7 +151,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -173,7 +173,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -373,7 +373,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -395,7 +395,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -533,7 +533,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -555,7 +555,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -641,7 +641,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -719,7 +719,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -741,7 +741,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md invisible inline-flex group-hover:visible group-focus-visible:visible"
+            class="icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -893,7 +893,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -915,7 +915,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -978,7 +978,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -1000,7 +1000,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
             <svg
               aria-label="permalink"
-              class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+              class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1056,7 +1056,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-secondary p-5 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&_th]:px-4 [&_th]:py-2.5 [&_th]:text-tertiary max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group"
@@ -1078,7 +1078,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </span>
               <svg
                 aria-label="permalink"
-                class="invisible inline-flex group-hover:visible group-focus-visible:visible icon-sm"
+                class="invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible icon-sm"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function PagePlatformTags({ platforms }: Props) {
   return (
-    <div className="mt-3 inline-flex flex-wrap gap-y-1.5">
+    <div className="mt-3 inline-flex flex-wrap gap-2">
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {
@@ -16,7 +16,7 @@ export function PagePlatformTags({ platforms }: Props) {
             return (
               <Tooltip.Root key={platform}>
                 <Tooltip.Trigger className="cursor-default">
-                  <PlatformTag platform={platform} className="!rounded-full !px-2.5" />
+                  <PlatformTag platform={platform} className="rounded-full px-2.5 py-1.5" />
                 </Tooltip.Trigger>
                 <Tooltip.Content side="bottom">
                   {platform.startsWith('android') && (
@@ -28,7 +28,11 @@ export function PagePlatformTags({ platforms }: Props) {
             );
           }
           return (
-            <PlatformTag platform={platform} key={platform} className="rounded-full px-2.5 py-1" />
+            <PlatformTag
+              platform={platform}
+              key={platform}
+              className="rounded-full px-2.5 py-1.5"
+            />
           );
         })}
     </div>

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -28,7 +28,7 @@ export function PagePlatformTags({ platforms }: Props) {
             );
           }
           return (
-            <PlatformTag platform={platform} key={platform} className="!rounded-full !px-2.5" />
+            <PlatformTag platform={platform} key={platform} className="rounded-full px-2.5 py-1" />
           );
         })}
     </div>

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -36,7 +36,7 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
       <LinkBase
         className={mergeClasses(
           'relative inline-flex items-center gap-1.5 text-[inherit] decoration-0',
-          props.additionalProps?.sidebarType === 'text' ? 'scroll-m-6' : 'scroll-m-12',
+          props.additionalProps?.sidebarType === 'text' ? 'scroll-m-5' : 'scroll-m-8',
           props.additionalProps?.className
         )}
         href={'#' + heading.slug}

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -45,7 +45,7 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
         <span className="inline">{children}</span>
         <PermalinkIcon
           className={mergeClasses(
-            'icon-md invisible inline-flex group-hover:visible group-focus-visible:visible',
+            'icon-md invisible inline-flex shrink-0 group-hover:visible group-focus-visible:visible',
             props.nestingLevel >= 4 && 'icon-sm'
           )}
         />

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -115,7 +115,7 @@ export const TableOfContents = forwardRef<
 
     slugScrollingTo.current = slug;
 
-    const scrollOffset = type === 'inlineCode' ? 50 : 26;
+    const scrollOffset = type === 'inlineCode' ? 35 : 21;
 
     contentRef?.current?.getScrollRef().current?.scrollTo({
       behavior: reducedMotion ? 'instant' : 'smooth',

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -17,18 +17,20 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return (
         <AppleIcon
           className={mergeClasses(
-            'icon-xs mt-[-0.5px] text-palette-blue12 opacity-80',
+            'icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80',
             platform === 'macos' && 'text-palette-purple12',
             platform === 'tvos' && 'text-palette-pink12'
           )}
         />
       );
     case 'android':
-      return <AndroidIcon className="icon-xs mt-[-0.5px] text-palette-green12 opacity-80" />;
+      return (
+        <AndroidIcon className="icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80" />
+      );
     case 'web':
-      return <AtSignIcon className="icon-2xs text-palette-orange12 opacity-80" />;
+      return <AtSignIcon className="icon-2xs shrink-0 text-palette-orange12 opacity-80" />;
     case 'expo':
-      return <ExpoGoLogo className="icon-xs text-palette-purple12 opacity-80" />;
+      return <ExpoGoLogo className="icon-2xs shrink-0 text-palette-purple12 opacity-80" />;
     default:
       return null;
   }

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -16,7 +16,7 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
   return (
     <div
       className={mergeClasses(
-        'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5',
+        'mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5',
         'last:mr-0',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
@@ -24,7 +24,7 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
         className
       )}>
       <PlatformIcon platform={platformName} />
-      <span className={mergeClasses('text-2xs font-normal !leading-[16px]', '[table_&]:text-3xs')}>
+      <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
         {formatName(platform)}
       </span>
     </div>

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -16,7 +16,7 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
   return (
     <div
       className={mergeClasses(
-        'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-2 py-1',
+        'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         getTagClasses(platformName),

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -17,6 +17,7 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
     <div
       className={mergeClasses(
         'mr-2 inline-flex select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5',
+        'last:mr-0',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         getTagClasses(platformName),

--- a/docs/ui/components/Tag/PlatformTags.tsx
+++ b/docs/ui/components/Tag/PlatformTags.tsx
@@ -20,9 +20,11 @@ export const PlatformTags = ({ prefix, platforms }: PlatformTagsProps) => {
           {prefix}&ensp;
         </DEMI>
       )}
-      {platforms.map(platform => (
-        <PlatformTag key={platform} platform={platform} />
-      ))}
+      {platforms
+        .sort((a, b) => a.localeCompare(b))
+        .map(platform => (
+          <PlatformTag key={platform} platform={platform} />
+        ))}
       {prefix && <br />}
     </CALLOUT>
   );


### PR DESCRIPTION
# Why

With SDK 52 we have changed how we approach the platform compatibility display in API Section. With platforms tags always visible in default docs it makes sense to move platform tags below entity name.

# How

The following changes have been made:
* move platform tags to the right of entity name, wrap below for longer header and on mobile
* reduce the platform tags padding when used in APIBox
* tweak the scroll margin and match the distance of ToC scroll to header
* sort platform tags on display, so platform order in JSDoc comment does not matter
* streamline the enum render layout

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-12-12 at 16 06 57](https://github.com/user-attachments/assets/d0c5c69d-073e-4b7f-b014-abbc7a4c35e3)

