### PR TITLE
[docs] APISection: fix missing single-line examples content

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -14,6 +14,7 @@ export type GeneratedData = EnumDefinitionData &
 // Shared data types
 
 export type CommentData = {
+  name?: string;
   summary: CommentContentData[];
   returns?: string;
   blockTags?: CommentTagData[];
@@ -22,6 +23,7 @@ export type CommentData = {
 
 export type CommentTagData = {
   tag: string;
+  name?: string;
   content: CommentContentData[];
 };
 

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -774,6 +774,16 @@ export const getAllTagData = (tagName: string, comment?: CommentData) =>
             } as CommentContentData,
           ],
         };
+      } else if (tag.content.length === 0 && tag.name) {
+        return {
+          tag: tag.tag,
+          content: [
+            {
+              kind: 'text',
+              text: '`' + tag.name + '`',
+            } as CommentContentData,
+          ],
+        };
       }
       return tag;
     })
@@ -871,7 +881,7 @@ export const CommentTextBlock = ({
         <BoxSectionHeader text="Example" className="!mt-1" Icon={CodeSquare01Icon} />
       )}
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
-        {getCommentContent(example.content)}
+        {getCommentContent(example.content ?? example.name)}
       </ReactMarkdown>
     </div>
   ));


### PR DESCRIPTION
# Why

With one of the TypeDoc updates they added an optional example title, which broke the compatibility with some of our code examples, leading to display only "Example" section title, i.e.:
* https://docs.expo.dev/versions/latest/sdk/audio/#recordingoptionsios

When comment author uses backticked `@exmple` value there will be warning visible in command line (it's not visible for regular, undecorated stings tho):

![Screenshot 2024-12-06 at 14 04 39](https://github.com/user-attachments/assets/b0981a00-f87a-4231-b05c-0f0322cb98f1)

To avoid an urgent need of refactoring multiple packages comments, and regenerating a lot of data I have introduced a fallback when processing JSDoc tags, but in long term we should adhere to the pattern which TypeDoc requires, so we don't repeat bad patterns.

# How

Add a fallback for `@exmple` tag with inline value to prevent rendering empty "Example" blocks.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-12-06 at 14 00 58](https://github.com/user-attachments/assets/c9768fd8-5576-47ba-bb88-83a5dd3ba172)
