### PR TITLE
[docs] import Select component, replace all raw element usages

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -1,6 +1,10 @@
 import GithubSlugger from 'github-slugger';
 import React from 'react';
 
+import versions from '~/public/static/constants/versions.json';
+
+const { BETA_VERSION, LATEST_VERSION } = versions;
+
 function hasChildren(node: React.ReactNode): node is React.ReactElement {
   return (node as React.ReactElement)?.props?.children !== undefined;
 }
@@ -104,4 +108,20 @@ export function listMissingHashLinkTargets(apiName?: string) {
     console.groupEnd();
     /* eslint-enable no-console */
   }
+}
+
+export function versionToText(version: string): string {
+  if (version === 'unversioned') {
+    return 'Next (unversioned)';
+  } else if (version === 'latest') {
+    return `${formatSdkVersion(LATEST_VERSION)} (latest)`;
+  } else if (BETA_VERSION && version === BETA_VERSION.toString()) {
+    return `${formatSdkVersion(BETA_VERSION.toString())} (beta)`;
+  }
+
+  return formatSdkVersion(version);
+}
+
+function formatSdkVersion(version: string): string {
+  return version.includes('v') ? `SDK ${version.substring(1, 3)}` : `SDK ${version}`;
 }

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, createRef, type PropsWithChildren, useRef } from '
 
 import * as RoutesUtils from '~/common/routes';
 import { appendSectionToRoute, isRouteActive } from '~/common/routes';
+import { versionToText } from '~/common/utilities';
 import * as WindowUtils from '~/common/window';
 import DocumentationHead from '~/components/DocumentationHead';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
@@ -17,7 +18,6 @@ import { Header } from '~/ui/components/Header';
 import { PagePlatformTags } from '~/ui/components/PagePlatformTags';
 import { PageTitle } from '~/ui/components/PageTitle';
 import { Separator } from '~/ui/components/Separator';
-import { versionToText } from '~/ui/components/Sidebar/ApiVersionSelect';
 import { Sidebar } from '~/ui/components/Sidebar/Sidebar';
 import {
   TableOfContentsWithManager,

--- a/docs/jest.config.js
+++ b/docs/jest.config.js
@@ -9,6 +9,8 @@ const jestConfig = {
   clearMocks: true,
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',
+    // note(simek): force Jest to use non ESM bundle
+    '^@radix-ui/react-select$': '<rootDir>/node_modules/@radix-ui/react-select/dist/index.js',
   },
   transform: {},
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -36,9 +36,10 @@ const removeConsole =
 
 /** @type {import('next').NextConfig}  */
 export default {
+  transpilePackages: ['@radix-ui/react-select'],
   trailingSlash: true,
   experimental: {
-    esmExternals: true,
+    esmExternals: false,
     // note(simek): would be nice enhancement, but it breaks the `@next/font` styles currently,
     // and results in font face swap on every page reload
     optimizeCss: false,

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@mdx-js/react": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^1.0.0",
+    "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-tooltip": "^1.1.1",
     "@reach/tabs": "^0.18.0",
     "@sentry/react": "^8.38.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "@mdx-js/react": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^1.0.0",
-    "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-select": "2.1.1",
     "@radix-ui/react-tooltip": "^1.1.1",
     "@reach/tabs": "^0.18.0",
     "@sentry/react": "^8.38.0",

--- a/docs/ui/components/Dropdown/Item.tsx
+++ b/docs/ui/components/Dropdown/Item.tsx
@@ -6,7 +6,7 @@ import { A, CALLOUT, FOOTNOTE } from '../Text';
 
 type Props = Omit<DropdownMenu.DropdownMenuItemProps, 'onClick'> & {
   label: string;
-  description?: React.ReactNode;
+  description?: ReactNode;
   href?: string;
   Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
   rightSlot?: ReactNode;

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -1,15 +1,15 @@
 import { mergeClasses } from '@expo/styleguide';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import * as RawRadixDropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import type { ReactNode } from 'react';
 
 import { Item } from '~/ui/components/Dropdown/Item';
 
 // note(simek): Radix Jest ESM issue workaround: https://github.com/radix-ui/primitives/issues/1848
-let sanitizedRadixDropdownMenu = { default: undefined, ...DropdownMenu };
-sanitizedRadixDropdownMenu = sanitizedRadixDropdownMenu.default ?? sanitizedRadixDropdownMenu;
-const { Trigger, Root, Portal, Content, Arrow } = sanitizedRadixDropdownMenu;
+let RadixDropdownMenuPrimitive = { default: undefined, ...RawRadixDropdownMenuPrimitive };
+RadixDropdownMenuPrimitive = RadixDropdownMenuPrimitive.default ?? RadixDropdownMenuPrimitive;
+const { Trigger, Root, Portal, Content, Arrow } = RadixDropdownMenuPrimitive;
 
-type Props = DropdownMenu.DropdownMenuContentProps & {
+type Props = RawRadixDropdownMenuPrimitive.DropdownMenuContentProps & {
   trigger: ReactNode;
 };
 

--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -1,55 +1,58 @@
-import { useTheme, mergeClasses } from '@expo/styleguide';
-import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
+import { Themes, useTheme } from '@expo/styleguide';
 import { Contrast02SolidIcon } from '@expo/styleguide-icons/solid/Contrast02SolidIcon';
 import { Moon01SolidIcon } from '@expo/styleguide-icons/solid/Moon01SolidIcon';
 import { SunSolidIcon } from '@expo/styleguide-icons/solid/SunSolidIcon';
 import { useEffect, useState } from 'react';
 
-export const ThemeSelector = () => {
+import { Select } from '~/ui/components/Select';
+
+const options = [
+  {
+    id: Themes.AUTO,
+    label: 'Auto',
+    Icon: Contrast02SolidIcon,
+  },
+  {
+    id: Themes.LIGHT,
+    label: 'Light',
+    Icon: SunSolidIcon,
+  },
+  {
+    id: Themes.DARK,
+    label: 'Dark',
+    Icon: Moon01SolidIcon,
+  },
+];
+
+export function ThemeSelector() {
   const { themeName, setAutoMode, setDarkMode, setLightMode } = useTheme();
-  const [isLoaded, setLoaded] = useState(false);
+
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(function didMount() {
     setLoaded(true);
   }, []);
 
-  return (
-    <div className="relative">
-      <select
-        aria-label="Theme selector"
-        title="Select theme"
-        className={mergeClasses(
-          'm-0 flex h-9 w-[50px] appearance-none items-center justify-center rounded-md border border-default bg-default p-0 indent-[-9999px] text-sm leading-[1.3] text-default shadow-xs',
-          'hocus:bg-element',
-          'max-lg-gutters:w-auto max-lg-gutters:min-w-[100px] max-lg-gutters:px-2 max-lg-gutters:pl-8 max-lg-gutters:indent-0 max-lg-gutters:text-secondary'
-        )}
-        value={themeName}
-        onChange={event => {
-          const option = event.target.value;
-          if (option === 'auto') {
-            setAutoMode();
-          }
-          if (option === 'dark') {
-            setDarkMode();
-          }
-          if (option === 'light') {
-            setLightMode();
-          }
-        }}>
-        <option value="auto">Auto</option>
-        <option value="light">Light</option>
-        <option value="dark">Dark</option>
-      </select>
-      {isLoaded && (
-        <>
-          {themeName === 'auto' && <Contrast02SolidIcon className={ICON_CLASSES} />}
-          {themeName === 'dark' && <Moon01SolidIcon className={ICON_CLASSES} />}
-          {themeName === 'light' && <SunSolidIcon className={ICON_CLASSES} />}
-        </>
-      )}
-      <ChevronDownIcon className="icon-xs pointer-events-none absolute right-2 top-3 text-icon-secondary" />
-    </div>
-  );
-};
+  function onThemeSelect(value: string) {
+    if (value === Themes.AUTO) {
+      setAutoMode();
+    }
+    if (value === Themes.DARK) {
+      setDarkMode();
+    }
+    if (value === Themes.LIGHT) {
+      setLightMode();
+    }
+  }
 
-const ICON_CLASSES = 'icon-sm absolute left-2.5 top-2.5 text-icon-secondary pointer-events-none';
+  return (
+    <Select
+      className="min-w-[108px]"
+      value={loaded ? (themeName ?? Themes.AUTO) : undefined}
+      onValueChange={onThemeSelect}
+      options={options}
+      optionsLabel="Theme"
+      ariaLabel="Theme selector"
+    />
+  );
+}

--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -1,0 +1,166 @@
+import { mergeClasses, Button } from '@expo/styleguide';
+import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
+import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
+import { ChevronUpIcon } from '@expo/styleguide-icons/outline/ChevronUpIcon';
+import * as RawSelectPrimitive from '@radix-ui/react-select';
+import { ComponentType, HTMLAttributes, ReactElement, ReactNode } from 'react';
+
+// note(simek): Radix Jest ESM issue workaround: https://github.com/radix-ui/primitives/issues/1848
+let SelectPrimitive = { default: undefined, ...RawSelectPrimitive };
+SelectPrimitive = SelectPrimitive.default ?? SelectPrimitive;
+
+export type SelectProps = RawSelectPrimitive.SelectProps & {
+  id?: string;
+  optionsLabel?: string;
+  placeholder?: string;
+  testID?: string;
+  ariaLabel?: string;
+  className?: string;
+  caption?: ReactNode;
+  size?: 'md' | 'lg';
+  options?: {
+    id: string;
+    label: string;
+    imageUrl?: string;
+    Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
+    leftSlot?: ReactElement;
+    rightSlot?: ReactElement;
+  }[];
+};
+
+export function Select({
+  options,
+  optionsLabel,
+  id,
+  value,
+  onValueChange,
+  onOpenChange,
+  placeholder,
+  testID,
+  ariaLabel,
+  className,
+  caption,
+  disabled = false,
+  size = 'md',
+}: SelectProps) {
+  const selectComponent = (
+    <SelectPrimitive.Root
+      name={id}
+      onOpenChange={onOpenChange}
+      onValueChange={onValueChange}
+      value={value}
+      disabled={disabled}>
+      <SelectPrimitive.Trigger asChild className="flex">
+        <Button
+          disabled={disabled}
+          theme="secondary"
+          size={size === 'lg' ? 'xl' : 'sm'}
+          aria-label={ariaLabel}
+          rightSlot={
+            <ChevronDownIcon
+              className={mergeClasses('icon-sm text-icon-secondary', size === 'lg' && 'icon-md')}
+            />
+          }
+          className={mergeClasses(
+            'min-h-[36px] transform-none justify-between truncate px-3',
+            !value && 'text-quaternary',
+            size === 'lg' && 'min-h-[52px]',
+            className
+          )}
+          {...{ 'data-testid': testID }}>
+          <SelectPrimitive.Value
+            placeholder={
+              <div className="whitespace-pre-wrap text-left text-sm leading-tight text-quaternary">
+                {placeholder}
+              </div>
+            }
+            aria-label={value}
+          />
+        </Button>
+      </SelectPrimitive.Trigger>
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          ref={ref =>
+            ref?.addEventListener('touchend', event => {
+              event.preventDefault();
+            })
+          }
+          // z-[605] to be above the dialogs (601)
+          className={mergeClasses(
+            'relative z-[605] max-w-[87.5vw] overflow-hidden rounded-md border border-default bg-overlay shadow-md',
+            'max-md-gutters:max-w-[unset]'
+          )}
+          data-orientation="horizontal">
+          <SelectPrimitive.ScrollUpButton className="flex h-7 items-center justify-center rounded-t-md bg-element">
+            <ChevronUpIcon className="icon-sm text-icon-secondary" />
+          </SelectPrimitive.ScrollUpButton>
+          <SelectPrimitive.Viewport>
+            <SelectPrimitive.Group>
+              {optionsLabel && (
+                <SelectPrimitive.Label className="cursor-default px-3 pb-1 pt-2 text-2xs text-tertiary">
+                  {optionsLabel}
+                </SelectPrimitive.Label>
+              )}
+              {options?.map(({ id, label, imageUrl, Icon, rightSlot, leftSlot }) => (
+                <SelectPrimitive.Item
+                  key={id}
+                  value={id}
+                  className={mergeClasses(
+                    'flex h-9 cursor-pointer items-center justify-between !rounded-none px-3 py-2',
+                    'hocus:bg-hover hocus:outline-0',
+                    size === 'lg' && 'h-[56px]'
+                  )}>
+                  <SelectPrimitive.ItemText>
+                    <div
+                      className={mergeClasses(
+                        'flex items-center gap-2 whitespace-pre-wrap text-left text-xs font-normal leading-tight text-default',
+                        size === 'lg' && 'text-lg'
+                      )}>
+                      {leftSlot}
+                      {Icon && (
+                        <SelectPrimitive.Icon>
+                          <Icon className={mergeClasses('icon-sm', size === 'lg' && 'icon-md')} />
+                        </SelectPrimitive.Icon>
+                      )}
+                      {imageUrl && (
+                        <img alt={String(id)} src={imageUrl} className="size-8 rounded-full" />
+                      )}
+                      {label}
+                      {rightSlot}
+                    </div>
+                  </SelectPrimitive.ItemText>
+                  <SelectPrimitive.ItemIndicator>
+                    <CheckIcon
+                      className={mergeClasses(
+                        'icon-sm shrink-0 text-icon-secondary',
+                        size === 'lg' && 'icon-md'
+                      )}
+                    />
+                  </SelectPrimitive.ItemIndicator>
+                </SelectPrimitive.Item>
+              ))}
+            </SelectPrimitive.Group>
+          </SelectPrimitive.Viewport>
+          <SelectPrimitive.ScrollDownButton className="flex h-7 items-center justify-center rounded-b-md bg-element">
+            <ChevronDownIcon className="icon-sm text-icon-secondary" />
+          </SelectPrimitive.ScrollDownButton>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  );
+
+  if (caption) {
+    return (
+      <div className="flex flex-col gap-1">
+        {typeof caption === 'string' ? (
+          <p className="text-xs font-medium text-tertiary">{caption}</p>
+        ) : (
+          caption
+        )}
+        {selectComponent}
+      </div>
+    );
+  }
+
+  return selectComponent;
+}

--- a/docs/ui/components/Sidebar/ApiVersionSelect.tsx
+++ b/docs/ui/components/Sidebar/ApiVersionSelect.tsx
@@ -1,11 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
-import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
+import { Beaker02Icon } from '@expo/styleguide-icons/outline/Beaker02Icon';
 
+import { versionToText } from '~/common/utilities';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
-import { A, FOOTNOTE, CALLOUT } from '~/ui/components/Text';
+import { Select } from '~/ui/components/Select';
+import { A, FOOTNOTE } from '~/ui/components/Text';
 
-const { VERSIONS, LATEST_VERSION, BETA_VERSION } = versions;
+const { VERSIONS } = versions;
 
 export function ApiVersionSelect() {
   const { version, hasVersion, setVersion } = usePageApiVersion();
@@ -21,45 +23,23 @@ export function ApiVersionSelect() {
         'max-lg-gutters:sticky max-lg-gutters:top-0 max-lg-gutters:z-10'
       )}>
       <FOOTNOTE theme="tertiary">Reference version</FOOTNOTE>
-      <div className="relative rounded-md border border-default bg-default px-3 py-2 shadow-xs">
-        <label className="flex flex-row items-center justify-between" htmlFor="api-version-select">
-          <CALLOUT className="flex">{versionToText(version)}</CALLOUT>
-          <ChevronDownIcon className="icon-sm shrink-0" />
-        </label>
-        <select
-          id="api-version-select"
-          className="absolute inset-0 size-full cursor-pointer text-xs opacity-0"
-          value={version}
-          onChange={event => {
-            setVersion(event.target.value);
-          }}>
-          {VERSIONS.map(version => (
-            <option key={version} value={version}>
-              {versionToText(version)}
-            </option>
-          ))}
-        </select>
-        {/* Changing versions is a JS only mechanism. To help crawlers find other versions, we add hidden links. */}
-        {VERSIONS.map(version => (
-          <A className="hidden" key={version} href={`/versions/${version}`} />
-        ))}
-      </div>
+      <Select
+        id="api-version-select"
+        className="min-w-full"
+        value={version}
+        onValueChange={setVersion}
+        options={VERSIONS.map(version => ({
+          id: version,
+          label: versionToText(version),
+          Icon: version === 'unversioned' ? Beaker02Icon : undefined,
+        }))}
+        optionsLabel="Reference version"
+        ariaLabel="Reference version selector"
+      />
+      {/* Changing versions is a JS only mechanism. To help crawlers find other versions, we add hidden links. */}
+      {VERSIONS.map(version => (
+        <A className="hidden" key={version} href={`/versions/${version}`} />
+      ))}
     </div>
   );
-}
-
-export function versionToText(version: string): string {
-  if (version === 'unversioned') {
-    return 'Next (unversioned)';
-  } else if (version === 'latest') {
-    return `${formatSdkVersion(LATEST_VERSION)} (latest)`;
-  } else if (BETA_VERSION && version === BETA_VERSION.toString()) {
-    return `${formatSdkVersion(BETA_VERSION.toString())} (beta)`;
-  }
-
-  return formatSdkVersion(version);
-}
-
-function formatSdkVersion(version: string): string {
-  return `SDK ${version.substring(1, 3)}`;
 }

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/VersionSelector.tsx
@@ -1,6 +1,8 @@
-import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
+import { Beaker02Icon } from '@expo/styleguide-icons/outline/Beaker02Icon';
 
+import { versionToText } from '~/common/utilities';
 import packageJson from '~/package.json';
+import { Select } from '~/ui/components/Select';
 
 export type VersionSelectorProps = {
   version?: string;
@@ -19,23 +21,17 @@ export const VersionSelector = ({
   availableVersions,
 }: VersionSelectorProps) => {
   return (
-    <div className="relative">
-      <select
-        id="version-menu"
-        className="m-0 mt-1 min-h-[40px] w-full cursor-pointer appearance-none rounded-md border border-default bg-default px-3 py-2 text-xs text-default shadow-xs"
-        value={version}
-        onChange={event => {
-          setVersion(event.target.value);
-        }}>
-        {availableVersions.map(version => (
-          <option key={version} value={version}>
-            {version === 'unversioned'
-              ? 'unversioned'
-              : `SDK ${version}${version === BETA_MAJOR_VERSION ? '  (beta)' : ''}`}
-          </option>
-        ))}
-      </select>
-      <ChevronDownIcon className="icon-sm pointer-events-none absolute right-3 top-4 text-icon-secondary" />
-    </div>
+    <Select
+      className="min-w-full"
+      value={version}
+      onValueChange={setVersion}
+      options={availableVersions.map(version => ({
+        id: version,
+        label: versionToText(version),
+        Icon: version === 'unversioned' ? Beaker02Icon : undefined,
+      }))}
+      optionsLabel="SDK version"
+      ariaLabel="SDK version selector"
+    />
   );
 };

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -48,13 +48,9 @@ export const TemplateBareMinimumDiffViewer = () => {
 
   return (
     <>
-      <div
-        className={mergeClasses(
-          'grid grid-cols-2 gap-4',
-          'max-sm-gutters:grid-cols-1 max-sm-gutters:gap-0'
-        )}>
+      <div className={mergeClasses('grid grid-cols-2 gap-4', 'max-sm-gutters:grid-cols-1')}>
         <div>
-          <RawH4 className="max-sm-gutters:!my-0">From SDK version:</RawH4>
+          <RawH4 className="mt-2 max-sm-gutters:!my-0">From SDK version:</RawH4>
           <VersionSelector
             version={fromVersion as string}
             setVersion={newFromVersion =>
@@ -64,7 +60,7 @@ export const TemplateBareMinimumDiffViewer = () => {
           />
         </div>
         <div>
-          <RawH4 className="max-sm-gutters:!my-0">To SDK version:</RawH4>
+          <RawH4 className="mt-2 max-sm-gutters:!my-0">To SDK version:</RawH4>
           <VersionSelector
             version={toVersion as string}
             setVersion={newToVersion =>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1399,6 +1399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/number@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/number@npm:1.1.0"
+  checksum: 10c0/a48e34d5ff1484de1b7cf5d7317fefc831d49e96a2229f300fd37b657bd8cfb59c922830c00ec02838ab21de3b299a523474592e4f30882153412ed47edce6a4
+  languageName: node
+  linkType: hard
+
 "@radix-ui/primitive@npm:1.0.0":
   version: 1.0.0
   resolution: "@radix-ui/primitive@npm:1.0.0"
@@ -1460,6 +1467,28 @@ __metadata:
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0
   checksum: 10c0/0b93efbf510fe935f1255658177e97aeb1630fc06192501a2707a3346067d5d89fd2375e413d5407e2b5d17c2cf4c0b1e744f478b0d5f9dc8bb748572d9b89bd
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-collection@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-collection@npm:1.1.0"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.0"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-slot": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fecb9f0871c827070a8794b39c7379fdc7d0855c4b05804f0b395eef39c37b2c2b6779865d6cb35d3bc74b6b380107bd8b3754d1730a34ea88913e6cd0eb84d4
   languageName: node
   linkType: hard
 
@@ -1577,6 +1606,19 @@ __metadata:
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0
   checksum: 10c0/9e13eb248d37a7df8d8288dda32b4688d9341c056a31302686852e230e16ecc909843c842fe028d47de11b74948359281c04562afbe0161596749daefce67583
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-direction@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-direction@npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/eb07d8cc3ae2388b824e0a11ae0e3b71fb0c49972b506e249cec9f27a5b7ef4305ee668c98b674833c92e842163549a83beb0a197dec1ec65774bdeeb61f932c
   languageName: node
   linkType: hard
 
@@ -1925,6 +1967,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-select@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@radix-ui/react-select@npm:2.1.1"
+  dependencies:
+    "@radix-ui/number": "npm:1.1.0"
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-collection": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.0"
+    "@radix-ui/react-direction": "npm:1.1.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.0"
+    "@radix-ui/react-focus-guards": "npm:1.1.0"
+    "@radix-ui/react-focus-scope": "npm:1.1.0"
+    "@radix-ui/react-id": "npm:1.1.0"
+    "@radix-ui/react-popper": "npm:1.2.0"
+    "@radix-ui/react-portal": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-slot": "npm:1.1.0"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.1.0"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.0"
+    "@radix-ui/react-use-previous": "npm:1.1.0"
+    "@radix-ui/react-visually-hidden": "npm:1.1.0"
+    aria-hidden: "npm:^1.1.1"
+    react-remove-scroll: "npm:2.5.7"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f12bce67f49f82e44f04d109f53be195d7a415e89e29aa09ec704899d6a7198486f118f3d1e37aa7afd3e14524951752fc79170ac5bd4c831cdc4032ea1c0382
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.0.0":
   version: 1.0.0
   resolution: "@radix-ui/react-slot@npm:1.0.0"
@@ -2081,6 +2162,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/9bf87ece1845c038ed95863cfccf9d75f557c2400d606343bab0ab3192b9806b9840e6aa0a0333fdf3e83cf9982632852192f3e68d7d8367bc8c788dfdf8e62b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-previous@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@radix-ui/react-use-previous@npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/9787d24790d4e330715127f2f4db56c4cbed9b0a47f97e11a68582c08a356a53c1ec41c7537382f6fb8d0db25de152770f17430e8eaf0fa59705be97760acbad
   languageName: node
   linkType: hard
 
@@ -5501,6 +5595,7 @@ __metadata:
     "@mdx-js/react": "npm:^2.2.1"
     "@radix-ui/react-dialog": "npm:^1.1.1"
     "@radix-ui/react-dropdown-menu": "npm:^1.0.0"
+    "@radix-ui/react-select": "npm:2.1.1"
     "@radix-ui/react-tooltip": "npm:^1.1.1"
     "@reach/tabs": "npm:^0.18.0"
     "@sentry/react": "npm:^8.38.0"


### PR DESCRIPTION
# Why

When working on other PR I have spotted that we still use native DOM select, instead of our own component, let's fix that, and improve the accessibility in the process.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Preview

![Screenshot 2024-12-06 at 16 05 39](https://github.com/user-attachments/assets/796eb75a-3643-40b2-8e1d-55142b049e32)
![Screenshot 2024-12-06 at 17 17 34](https://github.com/user-attachments/assets/f30b5e24-4088-476e-9b57-98314e1ae65c)
![Screenshot 2024-12-06 at 16 07 48](https://github.com/user-attachments/assets/2dfab2d1-f294-4cfa-b54b-e0c803962e95)

