### PR TITLE
fix(expo-file-system): add macOS availability checks

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [macOS][next]: Add availability checks ([#33504](https://github.com/expo/expo/pull/33504) by [@hassankhan](https://github.com/hassankhan))
+
 ### 💡 Others
 
 ## 18.0.4 — 2024-11-19

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -102,7 +102,7 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
 }
 
 internal func isPhotoLibraryStatusAuthorized() -> Bool {
-  if #available(iOS 14, tvOS 14, *) {
+  if #available(iOS 14, macOS 11, tvOS 14, *) {
     let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     return status == .authorized || status == .limited
   }

--- a/packages/expo-file-system/ios/Next/FileSystemFileHandle.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemFileHandle.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ExpoModulesCore
 
+@available(iOS 14, macOS 11, tvOS 14, *)
 internal final class FileSystemFileHandle: SharedRef<FileHandle> {
   let file: FileSystemFile
   let handle: FileHandle

--- a/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
@@ -2,6 +2,7 @@
 
 import ExpoModulesCore
 
+@available(iOS 14, macOS 11, tvOS 14, *)
 public final class FileSystemNextModule: Module {
   public func definition() -> ModuleDefinition {
     Name("FileSystemNext")


### PR DESCRIPTION
# Why

When trying to build a React Native macOS app with Expo Modules, the build fails due to some missing availability checks for macOS.

/cc @tsapeta 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added missing availability checks.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Generated a new Expo project with `bunx create-expo-app@latest universal-app --yes --template expo-template-blank`
2. `cd universal-app`
3. `bunx react-native-macos-init --version 0.76.3`
4. `bun add -D @react-native-community/cli@latest`
5. Create a basic `metro.config.js` extending from `expo/metro-config`
6. `pod install --project-directory=macos`
7. Build and run the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
