### PR TITLE
fix(expo-asset): add macOS platform

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [macOS] Add macOS platform support ([#33505](https://github.com/expo/expo/pull/33505) by [@hassankhan](https://github.com/hassankhan))
+
 ### 💡 Others
 
 ## 11.0.1 — 2024-11-10

--- a/packages/expo-asset/expo-module.config.json
+++ b/packages/expo-asset/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "android", "web", "tvos"],
-  "ios": {
+  "platforms": ["apple", "android", "web"],
+  "apple": {
     "modules": ["AssetModule"]
   },
   "android": {

--- a/packages/expo-asset/ios/ExpoAsset.podspec
+++ b/packages/expo-asset/ios/ExpoAsset.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
+    :macos => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When trying to build a React Native macOS app with Expo Modules, the build fails due to Expo Asset being unavailable for macOS.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added the `macos` platform to the Expo Asset's podspec.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Generated a new Expo project with `bunx create-expo-app@latest universal-app --yes --template expo-template-blank`
2. `cd universal-app`
3. `bunx react-native-macos-init --version 0.76.3`
4. `bun add -D @react-native-community/cli@latest`
5. Create a basic `metro.config.js` extending from `expo/metro-config`
6. `pod install --project-directory=macos`
7. Build and run the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
