### PR TITLE
fix(expo-modules-core): allow SwiftUI views to work on macOS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Ensure `uuid.v4`and`uuid.v5` is available on old react native architecture. ([#33621](https://github.com/expo/expo/pull/33621) by [@andrejpavlovic](https://github.com/andrejpavlovic))
 - Changed `import` to `import type` for TS type declarations. ([#33447](https://github.com/expo/expo/pull/33447) by [@j-piasecki](https://github.com/j-piasecki))
+- [macOS] Allow SwiftUI views to work on macOS ([#33506](https://github.com/expo/expo/pull/33506) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
@@ -9,6 +9,16 @@ extension ExpoSwiftUI {
   struct UIViewHost: UIViewRepresentable {
     let view: UIView
 
+    #if os(macOS)
+    func makeNSView(context: Context) -> NSView {
+      return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Nothing to do here
+    }
+    #endif
+
     func makeUIView(context: Context) -> UIView {
       return view
     }

--- a/packages/expo-modules-core/ios/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform.swift
@@ -10,5 +10,6 @@ public typealias UIResponder = NSResponder
 public typealias UIApplicationDelegate = NSApplicationDelegate
 public typealias UIWindow = NSWindow
 public typealias UIHostingController = NSHostingController
+public typealias UIViewRepresentable = NSViewRepresentable
 
 #endif // os(macOS)


### PR DESCRIPTION
# Why

When trying to build a React Native macOS app with Expo Modules, the build fails due to a missing implementation for macOS.

I've added ifdefs and an equivalent implementation for macOS, but there's likely a better way of doing this so I'd love to get some feedback from @expo.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added ifdefs around iOS and macOS-specific code.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Generated a new Expo project with `bunx create-expo-app@latest universal-app --yes --template expo-template-blank`
2. `cd universal-app`
3. `bunx react-native-macos-init --version 0.76.3`
4. `bun add -D @react-native-community/cli@latest`
5. Create a basic `metro.config.js` extending from `expo/metro-config`
6. `pod install --project-directory=macos`
7. Build and run the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
