### PR TITLE
[fingeprint] Remove extraneous arg from command help doc

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove extraneous arg from command help doc ([#33512](https://github.com/expo/expo/pull/33512) by [@wschurman](https://github.com/wschurman))
+
 ## 0.11.3 - 2024-12-02
 
 ### 🐛 Bug fixes

--- a/packages/@expo/fingerprint/cli/build/commands/generateFingerprint.js
+++ b/packages/@expo/fingerprint/cli/build/commands/generateFingerprint.js
@@ -53,7 +53,6 @@ Generate fingerprint for a project
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
-  --workflow <string>                  Workflow to use for fingerprint generation, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `, 0);

--- a/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
+++ b/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
@@ -32,7 +32,6 @@ Generate fingerprint for a project
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
-  --workflow <string>                  Workflow to use for fingerprint generation, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `,


### PR DESCRIPTION
# Why

This argument isn't for this command. Must've been an erroneous copypaste.

# How

Correct the help doc.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
