### PR TITLE
[cli] Display tunneling url when running headless bundler

### DIFF
--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -85,6 +85,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
     headless: !props.shouldStartBundler,
+    hostname: props.host,
     // If a scheme is specified then use that instead of the package name.
 
     scheme: isCustomBinary

--- a/packages/@expo/cli/src/run/startBundler.ts
+++ b/packages/@expo/cli/src/run/startBundler.ts
@@ -14,10 +14,12 @@ export async function startBundlerAsync(
     port,
     headless,
     scheme,
+    hostname,
   }: {
     port: number;
     headless?: boolean;
     scheme?: string;
+    hostname?: string;
   }
 ): Promise<DevServerManager> {
   const options: BundlerStartOptions = {
@@ -28,6 +30,7 @@ export async function startBundlerAsync(
 
     location: {
       scheme,
+      hostname,
     },
   };
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -37,7 +37,7 @@ export type DevServerInstance = {
     url: string;
     port: number;
     protocol: 'http' | 'https';
-    host?: string;
+    host?: string | null;
   };
   /** Additional middleware that's attached to the `server`. */
   middleware: any;
@@ -104,6 +104,7 @@ export abstract class BundlerDevServer {
   private notifier: FileNotifier | null = null;
   protected readonly devToolsPluginManager: DevToolsPluginManager;
   public isDevClient: boolean;
+  public hostname = 'localhost';
 
   constructor(
     /** Project root folder. */
@@ -200,9 +201,9 @@ export abstract class BundlerDevServer {
         // The port is the main thing we want to send back.
         port: options.port,
         // localhost isn't always correct.
-        host: 'localhost',
+        host: options.location.hostname,
         // http is the only supported protocol on native.
-        url: `http://localhost:${options.port}`,
+        url: `http://${this.hostname}:${options.port}`,
         protocol: 'http',
       },
       middleware: {},
@@ -371,6 +372,9 @@ export abstract class BundlerDevServer {
     const { location } = instance;
     if (options.hostType === 'localhost') {
       return `${location.protocol}://localhost:${location.port}`;
+    }
+    if (location.host) {
+      return `${location.protocol}://${location.host}`;
     }
     return location.url ?? null;
   }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/33118

# How

Fetch app manifest when resolving bundler props in order to determine the hostname

# Test Plan

run `yarn start` in one terminal and then run `npx expo run:ios -d` in a different terminal

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
