### PR TITLE
[docs] Update typo in code signing docs

### DIFF
--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -50,7 +50,7 @@ This command generated a key pair along with a code signing certificate to be in
 ## Configure your project to use code signing
 
 <Terminal
-  cmdCopy="npx expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys"
+  cmdCopy="npx expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory ../keys"
   cmd={[
     '$ npx expo-updates codesigning:configure \\',
     '  --certificate-input-directory certs \\',


### PR DESCRIPTION
# Why

Was following this guide and noticed the copied test didn't match what was on screen.

Closes ENG-14448.

# How

Fix mismatch.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
