### PR TITLE
[android][network] Added is connected null check

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Added `netInfo` null check. ([#33559](https://github.com/expo/expo/pull/33559)) by [@pchalupa](https://github.com/pchalupa)
+
 ### 💡 Others
 
 ## 7.0.3 - 2024-12-02

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -96,9 +96,10 @@ class NetworkModule : Module() {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) { // use getActiveNetworkInfo before api level 29
         val netInfo = connectivityManager.activeNetworkInfo
         val connectionType = getConnectionType(netInfo)
+        val isInternetReachable = netInfo?.isConnected ?: false
 
         result.apply {
-          putBoolean("isInternetReachable", netInfo!!.isConnected)
+          putBoolean("isInternetReachable", isInternetReachable)
           putString("type", connectionType.value)
           putBoolean("isConnected", connectionType.isDefined)
         }


### PR DESCRIPTION
# Why

Recently I got this error:
```log
Call to function 'ExpoNetwork.getNetworkStateAsync' has been rejected.
→ Caused by: Unable to access network information
```
The device has Android 9 and was offline. I believe the root of this error lies in the non-null assertion `netInfo!!.isConnected` because the device was offline so the `netInfo` should be null.
# How

<!--
How did you build this feature or fix this bug and why?
-->
I added the check for nullability with default value of `false`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
