### PR TITLE
[expo-go] Remove starting service from LauncherActivity

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
   implementation "androidx.lifecycle:lifecycle-process:2.8.7"
 
-    testImplementation 'junit:junit:4.13.2'
+  testImplementation 'junit:junit:4.13.2'
 
   // WHEN_VERSIONING_REPLACE_WITH_DEPENDENCIES
 

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -124,8 +124,9 @@ dependencies {
   api fileTree(dir: 'libs', include: ['*.jar'])
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
   implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+  implementation "androidx.lifecycle:lifecycle-process:2.8.7"
 
-  testImplementation 'junit:junit:4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 
   // WHEN_VERSIONING_REPLACE_WITH_DEPENDENCIES
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
@@ -4,7 +4,6 @@ package host.exp.exponent
 import android.app.IntentService
 import android.content.Context
 import android.content.Intent
-import android.os.Handler
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.kernel.Kernel

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
@@ -13,13 +13,10 @@ import javax.inject.Inject
 
 private const val ACTION_RELOAD_EXPERIENCE = "host.exp.exponent.action.RELOAD_EXPERIENCE"
 private const val ACTION_STAY_AWAKE = "host.exp.exponent.action.STAY_AWAKE"
-private const val STAY_AWAKE_MS = (1000 * 60).toLong()
 
 class ExponentIntentService : IntentService("ExponentIntentService") {
   @Inject
   lateinit var kernel: Kernel
-
-  private val handler = Handler()
 
   override fun onCreate() {
     super.onCreate()
@@ -38,7 +35,6 @@ class ExponentIntentService : IntentService("ExponentIntentService") {
         isUserAction = true
         handleActionReloadExperience(intent.getStringExtra(KernelConstants.MANIFEST_URL_KEY)!!)
       }
-      ACTION_STAY_AWAKE -> handleActionStayAwake()
     }
     if (isUserAction) {
       val kernelActivityContext = kernel.activityContext
@@ -50,19 +46,7 @@ class ExponentIntentService : IntentService("ExponentIntentService") {
 
   private fun handleActionReloadExperience(manifestUrl: String) {
     kernel.reloadVisibleExperience(manifestUrl)
-
-    // Application can't close system dialogs on Android 31 or higher.
-    // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) {
-      val intent = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
-      sendBroadcast(intent)
-    }
-
     stopSelf()
-  }
-
-  private fun handleActionStayAwake() {
-    handler.postDelayed({ stopSelf() }, STAY_AWAKE_MS)
   }
 
   companion object {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -19,6 +19,7 @@ import host.exp.expoview.BuildConfig
 import javax.inject.Inject
 
 private const val KEEP_ALIVE_MS = (1000 * 60).toLong()
+
 // This activity is transparent. It uses our custom theme @style/Theme.Exponent.Translucent.
 // Calls finish() once it is done processing Intent.
 class LauncherActivity : AppCompatActivity() {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -7,14 +7,19 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.get
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.kernel.Kernel
 import host.exp.expoview.BuildConfig
 import javax.inject.Inject
 
-// This activity is transparent. It uses android:style/Theme.Translucent.NoTitleBar.
+private const val KEEP_ALIVE_MS = (1000 * 60).toLong()
+// This activity is transparent. It uses our custom theme @style/Theme.Exponent.Translucent.
 // Calls finish() once it is done processing Intent.
 class LauncherActivity : AppCompatActivity() {
   @Inject
@@ -65,16 +70,12 @@ class LauncherActivity : AppCompatActivity() {
     )
   }
 
-  override fun onResume() {
-    super.onResume()
-    startStayAwakeServiceIfNeeded()
-  }
-
-  private fun startStayAwakeServiceIfNeeded() {
-    // Start a service to keep our process awake. This isn't necessary most of the time, but
-    // if the user has "Don't keep activities" on it's possible for the process to exit in between
-    // finishing this activity and starting the BaseExperienceActivity.
-    startService(ExponentIntentService.getActionStayAwake(applicationContext))
+  override fun onStop() {
+    // Replaces the stay awake service
+    super.onStop()
+    if (ProcessLifecycleOwner.get().lifecycle.currentState == Lifecycle.State.CREATED) {
+      Handler(Looper.getMainLooper()).postDelayed({ finish() }, KEEP_ALIVE_MS)
+    }
   }
 
   public override fun onNewIntent(intent: Intent) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -133,11 +133,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       }
     }
 
-    /*
-     *
-     * Lifecycle
-     *
-     */
+  /*
+   *
+   * Lifecycle
+   *
+   */
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -223,6 +223,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
         forceCache
       ).start(this)
     }
+    ExponentNotificationManager(this).maybeCreateExpoPersistentNotificationChannel()
     kernel.setOptimisticActivity(this, taskId)
   }
 
@@ -344,11 +345,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     }
   }
 
-    /*
-     *
-     * Experience Loading
-     *
-     */
+  /*
+   *
+   * Experience Loading
+   *
+   */
   fun startLoading() {
     isLoading = true
     showOrReconfigureManagedAppSplashScreen(manifest)
@@ -636,11 +637,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     PushNotificationHelper.instance.removeNotifications(this, unreadNotifications)
   }
 
-    /*
-     *
-     * Notification
-     *
-     */
+  /*
+   *
+   * Notification
+   *
+   */
   private fun addNotification() {
     if (manifestUrl == null || manifest == null) {
       return
@@ -684,7 +685,6 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
     notificationManager.cancel(PERSISTENT_EXPONENT_NOTIFICATION_ID)
 
-    ExponentNotificationManager(this).maybeCreateExpoPersistentNotificationChannel()
     notificationBuilder =
       NotificationCompat.Builder(
         this,
@@ -717,7 +717,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
    * @param isFromNotification true if this is the result of the user taking an
    * action in the notification view.
    */
-  fun dismissNuxViewIfVisible(isFromNotification: Boolean) {
+  private fun dismissNuxViewIfVisible(isFromNotification: Boolean) {
     if (nuxOverlayView == null) {
       return
     }
@@ -742,11 +742,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     }
   }
 
-    /*
-     *
-     * Errors
-     *
-     */
+  /*
+   *
+   * Errors
+   *
+   */
   override fun onError(intent: Intent) {
     if (manifestUrl != null) {
       intent.putExtra(ErrorActivity.MANIFEST_URL_KEY, manifestUrl)


### PR DESCRIPTION
# Why
Starting the service in the `LauncherActivity` is still causing issues. #33377 helped but it's still not enough to prevent the issue entirely. 

# How
I'm removing the "keep awake" part of the service completely. We can achieve the same result by checking the apps lifecycle and delaying it from being destroyed. This also avoids permission requirements related to starting services from the background. I'll follow up with another PR to remove the `ExponentIntentService` entirely.

# Test Plan
Expo go, working as normal

