### PR TITLE
[android][network] Handle `fetchNetworkState` exception

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Added `netInfo` null check. ([#33559](https://github.com/expo/expo/pull/33559)) by [@pchalupa](https://github.com/pchalupa)
+- On `Android`, Prevent crash from the `networkCallback` calling `fetchNetworkState`.
 
 ### 💡 Others
 

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Added `netInfo` null check. ([#33559](https://github.com/expo/expo/pull/33559)) by [@pchalupa](https://github.com/pchalupa)
-- On `Android`, Prevent crash from the `networkCallback` calling `fetchNetworkState`.
+- On `Android`, Prevent crash from the `networkCallback` calling `fetchNetworkState`. ([#33563](https://github.com/expo/expo/pull/33563) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -124,7 +124,12 @@ class NetworkModule : Module() {
         return result
       }
     } catch (e: Exception) {
-      throw NetworkAccessException(e)
+      result.apply {
+        putString("type", NetworkStateType.UNKNOWN.value)
+        putBoolean("isInternetReachable", false)
+        putBoolean("isConnected", false)
+      }
+      return result
     }
   }
 


### PR DESCRIPTION
# Why
I noticed in the crashlytics logs that the NetworkModule is causing a fatal crash. This is because the `networkCallback` is registered in `OnCreate` and calls `fetchNetworkState` which can throw an exception.

# How
Instead of throwing in `fetchNetworkState` we return an undetermined result. 

# Test Plan
Bare-expo. This can happen when the app does not have `android.permission.ACCESS_NETWORK_STATE`. 
