### PR TITLE
[sqlite] fix error from converting null blob

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed exceptions when converting empty blob data on iOS. ([#33564](https://github.com/expo/expo/pull/33564) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 15.0.3 — 2024-11-12

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -493,7 +493,7 @@ public final class SQLiteModule: Module {
       return String(cString: text)
     case SQLITE_BLOB:
       guard let blob = exsqlite3_column_blob(instance, index) else {
-        throw InvalidConvertibleException("Null blob")
+        return Data()
       }
       let size = exsqlite3_column_bytes(instance, index)
       return Data(bytes: blob, count: Int(size))


### PR DESCRIPTION
# Why

fixes #33522

# How

> The return value from `sqlite3_column_blob()` for a zero-length BLOB is a NULL pointer.

in this case we should return empty `Data()` rather than having an exception

# Test Plan

test repro from #33522. also verify that it works fine on android already.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
