### PR TITLE
[android][camera] Handle `pictureSize` safely

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- On `Android`, parse the `pictureSize` prop safely to prevent invalid values causing exceptions.
+- On `Android`, parse the `pictureSize` prop safely to prevent invalid values causing exceptions. ([#33566](https://github.com/expo/expo/pull/33566) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.0.8 - 2024-11-29
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- On `Android`, parse the `pictureSize` prop safely to prevent invalid values causing exceptions.
+
 ## 16.0.8 - 2024-11-29
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why
The `pictureSize` prop accepts a `String` but should only be given a value from the array received from calling `getAvailablePictureSizesAsync`. The expected value should in this format `{width}x{height}`. We're not handling the case where a bad value is passed leading to crash when calling `Size.parseSize` with the invalid value.

# How
Check if the string is in a valid format and fallback to the default if it is not. Also, wrap the call to `Size.parseSize` in a try/catch to catch invalid numbers when the format is correct .

# Test Plan
Bare-expo. Passing a bad value will fallback to the default. Correct values work as before.

