### PR TITLE
[autolinking][Android] Handle additional options passed from native side to plugin

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -36,7 +36,7 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     project.logger.quiet("")
 
     // Creates a task that generates a list of expo modules.
-    val generatePackagesList = createGeneratePackagesListTask(project)
+    val generatePackagesList = createGeneratePackagesListTask(project, gradleExtension.options)
 
     // Ensures that the task is executed before the build.
     project.tasks
@@ -66,12 +66,15 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     return project.layout.buildDirectory.file(packageListRelativePath)
   }
 
-  fun createGeneratePackagesListTask(project: Project): TaskProvider<GeneratePackagesListTask> {
+  fun createGeneratePackagesListTask(project: Project, options: AutolinkingOptions): TaskProvider<GeneratePackagesListTask> {
     return project.tasks.register("generatePackagesList", GeneratePackagesListTask::class.java) {
       it.hash.set(project.extensions.getByType(ExpoGradleExtension::class.java).hash)
       it.namespace.set(generatedPackageListNamespace)
       it.outputFile.set(getPackageListFile(project))
       it.workingDir = project.rootDir
+      // Serializes the autolinking options to JSON to pass them to the task.
+      // The types supported as a task input are limited to primitives, strings, and files.
+      it.options.set(options.toJson())
     }
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/GeneratePackagesListTask.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/GeneratePackagesListTask.kt
@@ -22,6 +22,12 @@ abstract class GeneratePackagesListTask : Exec() {
   abstract val hash: Property<String>
 
   /**
+   * Serialized autolinking options.
+   */
+  @get:Input
+  abstract val options: Property<String>
+
+  /**
    * Java package name under which the package list should be placed.
    */
   @get:Input
@@ -34,11 +40,13 @@ abstract class GeneratePackagesListTask : Exec() {
   abstract val outputFile: RegularFileProperty
 
   override fun exec() {
+    val autolingOptions = AutolinkingOptions.fromJson(options.get())
     commandLine(
       AutolinkigCommandBuilder()
         .command("generate-package-list")
         .option("namespace", namespace.get())
         .option("target", outputFile.get().asFile.absolutePath)
+        .useAutolinkingOptions(autolingOptions)
         .build()
     )
     super.exec()

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -2,9 +2,7 @@ package expo.modules.plugin
 
 import org.gradle.api.initialization.Settings
 
-open class ExpoAutolinkingSettingsExtension(settings: Settings) {
-  private val settingsManager = SettingsManager(settings)
-
+open class ExpoAutolinkingSettingsExtension(val settings: Settings) {
   /**
    * Command that should be provided to `react-native` to resolve the configuration.
    */
@@ -14,9 +12,30 @@ open class ExpoAutolinkingSettingsExtension(settings: Settings) {
     .build()
 
   /**
+   * A list of paths relative to the app's root directory where
+   * the autolinking script should search for Expo modules.
+   */
+  var searchPaths: List<String>? = null
+
+  /**
+   * Paths to ignore when looking up for modules.
+   */
+  var ignorePaths: List<String>? = null
+
+  /**
+   * Package names to exclude when looking up for modules.
+   */
+  var exclude: List<String>? = null
+
+  /**
    * Uses Expo modules autolinking.
    */
   fun useExpoModules() {
-    settingsManager.useExpoModules()
+    SettingsManager(
+      settings,
+      searchPaths,
+      ignorePaths,
+      exclude
+    ).useExpoModules()
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -15,7 +15,18 @@ import expo.modules.plugin.text.Emojis
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 
-class SettingsManager(val settings: Settings) {
+class SettingsManager(
+  val settings: Settings,
+  searchPaths: List<String>? = null,
+  ignorePaths: List<String>? = null,
+  exclude: List<String>? = null
+) {
+  private val autolinkingOptions = AutolinkingOptions(
+    searchPaths,
+    ignorePaths,
+    exclude
+  )
+
   /**
    * Resolved configuration from `expo-modules-autolinking`.
    */
@@ -23,6 +34,7 @@ class SettingsManager(val settings: Settings) {
     val command = AutolinkigCommandBuilder()
       .command("resolve")
       .useJson()
+      .useAutolinkingOptions(autolinkingOptions)
       .build()
 
     val result = settings.providers.exec { env ->
@@ -61,7 +73,7 @@ class SettingsManager(val settings: Settings) {
         }
     }
 
-    settings.gradle.extensions.create("expoGradle", ExpoGradleExtension::class.java, config)
+    settings.gradle.extensions.create("expoGradle", ExpoGradleExtension::class.java, config, autolinkingOptions)
   }
 
   /**

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
@@ -23,6 +23,7 @@ class AutolinkigCommandBuilder {
   private var autolinkingCommand = emptyList<String>()
   private var useJson = emptyList<String>()
   private val optionsMap = mutableMapOf<String, String>()
+  private var searchPaths = emptyList<String>()
 
   /**
    * Set the autolinking command to run.
@@ -39,10 +40,30 @@ class AutolinkigCommandBuilder {
   }
 
   /**
+   * Add a list of values as an option to the command.
+   */
+  fun option(key: String, value: List<String>) = apply {
+    optionsMap[key] = value.joinToString(" ")
+  }
+
+  /**
    * Whether it should output json.
    */
   fun useJson() = apply {
     useJson = listOf("--json")
+  }
+
+  /**
+   * Set the search paths for the autolinking script.
+   */
+  fun searchPaths(paths: List<String>) = apply {
+    searchPaths = paths
+  }
+
+  fun useAutolinkingOptions(autolinkingOptions: AutolinkingOptions) = apply {
+    autolinkingOptions.ignorePaths?.let { option(IGNORE_PATHS_KEY, it) }
+    autolinkingOptions.exclude?.let { option(EXCLUDE_KEY, it) }
+    autolinkingOptions.searchPaths?.let { searchPaths(it) }
   }
 
   fun build(): List<String> {
@@ -50,7 +71,13 @@ class AutolinkigCommandBuilder {
       autolinkingCommand +
       platform +
       useJson +
-      optionsMap.map { (key, value) -> listOf("--$key", value) }.flatMap { it }
+      optionsMap.map { (key, value) -> listOf("--$key", value) }.flatMap { it } +
+      searchPaths
     return Os.windowsAwareCommandLine(command)
+  }
+
+  companion object {
+    const val IGNORE_PATHS_KEY = "ignore-paths"
+    const val EXCLUDE_KEY = "exclude"
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
@@ -1,13 +1,33 @@
 package expo.modules.plugin
 
 import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.security.MessageDigest
+
+@Serializable
+data class AutolinkingOptions(
+  val searchPaths: List<String>? = null,
+  val ignorePaths: List<String>? = null,
+  val exclude: List<String>? = null
+) {
+  fun toJson(): String {
+    return Json.encodeToString(AutolinkingOptions.serializer(), this)
+  }
+
+  companion object {
+    fun fromJson(jsonString: String): AutolinkingOptions {
+      return Json.decodeFromString(jsonString)
+    }
+  }
+}
 
 /**
  * Extension that will be added to Gradle, making it possible to access the configuration in all projects.
  */
 open class ExpoGradleExtension(
-  val config: ExpoAutolinkingConfig
+  val config: ExpoAutolinkingConfig,
+  val options: AutolinkingOptions = AutolinkingOptions()
 ) {
   /**
    * MD5 hash of the configuration.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -1,7 +1,6 @@
 package expo.modules.plugin.configuration
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
@@ -29,7 +28,7 @@ data class ExpoAutolinkingConfig(
     get() = modules.flatMap { it.aarProjects }
 
   fun toJson(): String {
-    return Json.encodeToString(this)
+    return Json.encodeToString(serializer(), this)
   }
 
   companion object {


### PR DESCRIPTION
# Why

Adds support for additional options that can be passed to the autolinking plugin. Those were supported by old implementation.


# Test Plan

- bare-expo and manually check using `--info` flag which command were executed during sync and build ✅ 