### PR TITLE
[docs] tweaks for `expo-video` reference page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -125,9 +125,11 @@ const styles = StyleSheet.create({
 The changes in properties of the [`VideoPlayer`](#videoplayer) do not update the React state. Therefore, to display the information about the current state of the `VideoPlayer`, it is necessary to listen to the [events](#videoplayerevents) it emits.
 The event system is based on the [`EventEmitter`](../sdk/expo/#eventemitter) class and [hooks](../sdk/expo/#hooks) from the [`expo`](../sdk/expo) package. There are a few ways to listen to events:
 
-- `useEvent` hook: it creates a listener that will return a stateful value that can be used in a component. It also cleans up automatically when the component unmounts.
+#### `useEvent` hook
 
-```tsx
+Creates a listener that will return a stateful value that can be used in a component. It also cleans up automatically when the component unmounts.
+
+```tsx useEvent
 import { useEvent } from 'expo';
 // ... Other imports, definition of the component, creating the player etc.
 
@@ -135,9 +137,11 @@ const { status, error } = useEvent(player, 'statusChange', { status: player.stat
 // Rest of the component...
 ```
 
-- `useEventListener` hook: built around the `Player.addListener` and `Player.removeListener` methods, creates an event listener with automatic cleanup.
+#### `useEventListener` hook
 
-```tsx
+Built around the `Player.addListener` and `Player.removeListener` methods, creates an event listener with automatic cleanup.
+
+```tsx useEventListener
 import { useEventListener } from 'expo';
 // ...Other imports, definition of the component, creating the player etc.
 
@@ -149,9 +153,11 @@ useEventListener(player, 'statusChange', ({ status, error }) => {
 // Rest of the component...
 ```
 
-- `Player.addListener` method: this is the most flexible way to listen to events, but requires manual cleanup and more boilerplate code.
+#### `Player.addListener` method
 
-```tsx
+Most flexible way to listen to events, but requires manual cleanup and more boilerplate code.
+
+```tsx Player.addListener
 // ...Imports, definition of the component, creating the player etc.
 
 useEffect(() => {
@@ -172,7 +178,7 @@ useEffect(() => {
 
 `expo-video` supports playing local media loaded using the `require` function. You can use the result as a source directly, or assign it to the `assetId` parameter of a [`VideoSource`](#videosource) if you also want to configure other properties.
 
-```tsx
+```tsx Playing local media
 import { VideoSource } from 'expo-video';
 
 const assetId = require('./assets/bigbuckbunny.mp4');
@@ -199,7 +205,7 @@ In some cases, it is beneficial to preload a video later in the screen lifecycle
 
 Here is an example of how to preload a video:
 
-<SnackInline label='Video' dependencies={['expo-video']}>
+<SnackInline label='Preloading videos' dependencies={['expo-video']}>
 
 ```tsx
 import { useVideoPlayer, VideoView, VideoSource } from 'expo-video';
@@ -281,9 +287,9 @@ const styles = StyleSheet.create({
 ### Using the VideoPlayer directly
 
 In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
-In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#createvideoplayer) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
+In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
-```tsx
+```tsx Creating player instance
 import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -125,9 +125,11 @@ const styles = StyleSheet.create({
 The changes in properties of the [`VideoPlayer`](#videoplayer) do not update the React state. Therefore, to display the information about the current state of the `VideoPlayer`, it is necessary to listen to the [events](#videoplayerevents) it emits.
 The event system is based on the [`EventEmitter`](../sdk/expo/#eventemitter) class and [hooks](../sdk/expo/#hooks) from the [`expo`](../sdk/expo) package. There are a few ways to listen to events:
 
-- `useEvent` hook: it creates a listener that will return a stateful value that can be used in a component. It also cleans up automatically when the component unmounts.
+#### `useEvent` hook
 
-```tsx
+Creates a listener that will return a stateful value that can be used in a component. It also cleans up automatically when the component unmounts.
+
+```tsx useEvent
 import { useEvent } from 'expo';
 // ... Other imports, definition of the component, creating the player etc.
 
@@ -135,9 +137,11 @@ const { status, error } = useEvent(player, 'statusChange', { status: player.stat
 // Rest of the component...
 ```
 
-- `useEventListener` hook: built around the `Player.addListener` and `Player.removeListener` methods, creates an event listener with automatic cleanup.
+#### `useEventListener` hook
 
-```tsx
+Built around the `Player.addListener` and `Player.removeListener` methods, creates an event listener with automatic cleanup.
+
+```tsx useEventListener
 import { useEventListener } from 'expo';
 // ...Other imports, definition of the component, creating the player etc.
 
@@ -149,9 +153,11 @@ useEventListener(player, 'statusChange', ({ status, error }) => {
 // Rest of the component...
 ```
 
-- `Player.addListener` method: this is the most flexible way to listen to events, but requires manual cleanup and more boilerplate code.
+#### `Player.addListener` method
 
-```tsx
+Most flexible way to listen to events, but requires manual cleanup and more boilerplate code.
+
+```tsx Player.addListener
 // ...Imports, definition of the component, creating the player etc.
 
 useEffect(() => {
@@ -172,7 +178,7 @@ useEffect(() => {
 
 `expo-video` supports playing local media loaded using the `require` function. You can use the result as a source directly, or assign it to the `assetId` parameter of a [`VideoSource`](#videosource) if you also want to configure other properties.
 
-```tsx
+```tsx Playing local media
 import { VideoSource } from 'expo-video';
 
 const assetId = require('./assets/bigbuckbunny.mp4');
@@ -199,7 +205,7 @@ In some cases, it is beneficial to preload a video later in the screen lifecycle
 
 Here is an example of how to preload a video:
 
-<SnackInline label='Video' dependencies={['expo-video']}>
+<SnackInline label='Preloading videos' dependencies={['expo-video']}>
 
 ```tsx
 import { useVideoPlayer, VideoView, VideoSource } from 'expo-video';
@@ -281,9 +287,9 @@ const styles = StyleSheet.create({
 ### Using the VideoPlayer directly
 
 In most cases, the [`useVideoPlayer`](#usevideoplayersource-setup) hook should be used to create a `VideoPlayer` instance. It manages the player's lifecycle and ensures that it is properly disposed of when the component is unmounted. However, in some advanced use cases, it might be necessary to create a `VideoPlayer` that does not get automatically destroyed when the component is unmounted.
-In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#createvideoplayer) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
+In those cases, the `VideoPlayer` can be created using the [`createVideoPlayer`](#videocreatevideoplayersource) function. You need be aware of the risks that come with this approach, as it is your responsibility to call the [`release()`](../sdk/expo/#release) method when the player is no longer needed. If not handled properly, this approach may lead to memory leaks.
 
-```tsx
+```tsx Creating player instance
 import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```


### PR DESCRIPTION
# Why

Spotted few thing to improve when doing overall reference pages audit.

# How

Tweak formatting, add few code block titles, fix broken link. Backport changes to SDK 52.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-12-10 at 14 02 28](https://github.com/user-attachments/assets/f32594ae-7b11-40cd-a399-b831a4248846)

