### PR TITLE
[screen-orientation][ios] Fix crash with multiple threads accessing member

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed crash when multiple thread access same member in swift
+- [iOS] Fixed crash when multiple thread access same member in swift ([#33572](https://github.com/expo/expo/pull/33572) by [@chrfalch](https://github.com/chrfalch))
 - Fixed event listeners on web. ([#33361](https://github.com/expo/expo/pull/33361) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed crash when multiple thread access same member in swift
 - Fixed event listeners on web. ([#33361](https://github.com/expo/expo/pull/33361) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed crash when multiple thread access same member in swift ([#33572](https://github.com/expo/expo/pull/33572) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Fixed crash when multiple threads access same member in swift ([#33572](https://github.com/expo/expo/pull/33572) by [@chrfalch](https://github.com/chrfalch))
 - Fixed event listeners on web. ([#33361](https://github.com/expo/expo/pull/33361) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -17,8 +17,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   public var currentScreenOrientation: UIInterfaceOrientation
   var orientationControllers: [ScreenOrientationController] = []
   var controllerInterfaceMasks: [ObjectIdentifier: UIInterfaceOrientationMask] = [:]
-  private let queue = DispatchQueue(label: "expo.screenorientationregistry.controllerInterfaceMasks", attributes: .concurrent)
-  
+  private let queue = DispatchQueue(label: "expo.screenorientationregistry", attributes: .concurrent)
   @objc
   public var currentTraitCollection: UITraitCollection?
   var lastOrientationMask: UIInterfaceOrientationMask
@@ -136,7 +135,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
       for moduleMask in controllerInterfaceMasks {
         mask = mask.intersection(moduleMask.value)
       }
-      
+
       return mask
     }
   }
@@ -207,7 +206,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   func screenOrientationDidChange(_ newScreenOrientation: UIInterfaceOrientation) {
     queue.async(flags: .barrier) {
       self.currentScreenOrientation = newScreenOrientation
-      
+
       for controller in self.orientationControllers {
         controller.screenOrientationDidChange(newScreenOrientation)
       }

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -128,7 +128,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
       if controllerInterfaceMasks.isEmpty {
         return []
       }
-        
+
       // We want to apply an orientation mask which is an intersection of locks applied by the modules.
       var mask = doesDeviceHaveNotch ? UIInterfaceOrientationMask.allButUpsideDown : UIInterfaceOrientationMask.all
 


### PR DESCRIPTION
# Why

We've received a Sentry crash (that happens frequently when using expo-screen-orientation) when calling `ScreenOrientation.lockAsync(...)` in app startup.

This never happened in development builds, so I started looking around. The crash report crashed in `Dictionary.isEmpty.getter` in swift - which made me think about concurrent access to the dictionary.

Closes #33376

# How

After creating a tight loop that thried to call `ScreenOrientation.lockAsync(...)` 10.000 times after each other (without waiting), I could consistently see the error.

The problem is that while we're reading the dictionary from the main thread, we're writing to it from the module queue's thread.

This commit fixes this by protecting access to the members that aren't thread safe (arrays and dictionaries) using a DispatchQueue that can protect such access.

# Test Plan

I was able to reproduce the error with calling the following function (also in development mode):

```ts
const callLockAsyncMultipleTimes = async () => {
    for (let i = 0; i < 100000; i++) {
      ScreenOrientation.lockAsync(
        ScreenOrientation.OrientationLock.PORTRAIT_UP
      );
    }
  }
```

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
