### PR TITLE
[expo-font][ios] fix crash when accessing dictionary from multiple threads

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix crash when accessing resource from multiple threads
+- [iOS] Fix crash when accessing resource from multiple threads ([#33574](https://github.com/expo/expo/pull/33574) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash when accessing resource from multiple threads
+
 ### 💡 Others
 
 ## 13.0.1 — 2024-11-05

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -11,6 +11,11 @@ private var fontFamilyAliases = [String: String]()
 private var hasSwizzled = false
 
 /**
+ Queue to protect shared resources
+ */
+private let queue = DispatchQueue(label: "expo.fontfamilyaliasmanager", attributes: .concurrent)
+
+/**
  Manages the font family aliases and swizzles the `UIFont` class.
  */
 internal struct FontFamilyAliasManager {
@@ -18,7 +23,9 @@ internal struct FontFamilyAliasManager {
    Whether the given alias has already been set.
    */
   internal static func hasAlias(_ familyNameAlias: String) -> Bool {
-    return fontFamilyAliases[familyNameAlias] != nil
+    return queue.sync {
+      fontFamilyAliases[familyNameAlias] != nil
+    }
   }
 
   /**
@@ -27,14 +34,18 @@ internal struct FontFamilyAliasManager {
    */
   internal static func setAlias(_ familyNameAlias: String, forFont font: String) {
     maybeSwizzleUIFont()
-    fontFamilyAliases[familyNameAlias] = font
+    queue.sync {
+      fontFamilyAliases[familyNameAlias] = font
+    }
   }
 
   /**
    Returns the family name for the given alias or `nil` when it's not set yet.
    */
   internal static func familyName(forAlias familyNameAlias: String) -> String? {
-    return fontFamilyAliases[familyNameAlias]
+    return queue.sync {
+      fontFamilyAliases[familyNameAlias]
+    }
   }
 }
 


### PR DESCRIPTION
# Why

We've received a Sentry crash that was evident for a lot of the client's users.

It wasn't reproducible in development builds, so I started looking around. The crash report crashed in Dictionary.subscript.getter in swift - which made me think about concurrent access to the dictionary.

Closes #31563
Closes #33552 

# How

The fix here protects accessing the `fontFamilyAliases` member by using a DispatchQueue.

# Test Plan

Follow Sentry reports

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
