### PR TITLE
[docs] Add info about tvOS support in expo-status-bar

### DIFF
--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -16,7 +16,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **tvOS and web support**
 >
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
+> For **tvOS**, the `expo-status-bar` code will compile and run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
 

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -5,7 +5,7 @@ description: A library that provides the same interface as the React Native Stat
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-status-bar'
 packageName: 'expo-status-bar'
 iconUrl: '/static/images/packages/expo-status-bar.png'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -14,9 +14,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web support**
+> **Web and tvOS support**
 >
-> There is no API available on the web for controlling the operating system status bar, so `expo-status-bar` will no-op, so it will do nothing and will **not** error.
+> For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -14,10 +14,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web and tvOS support**
+> **tvOS and web support**
+>
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
@@ -16,7 +16,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **tvOS and web support**
 >
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
+> For **tvOS**, the `expo-status-bar` code will compile and run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
 

--- a/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
@@ -14,10 +14,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web and tvOS support**
+> **tvOS and web support**
+>
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/status-bar.mdx
@@ -5,7 +5,7 @@ description: A library that provides the same interface as the React Native Stat
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-status-bar'
 packageName: 'expo-status-bar'
 iconUrl: '/static/images/packages/expo-status-bar.png'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -14,9 +14,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web support**
+> **Web and tvOS support**
 >
-> There is no API available on the web for controlling the operating system status bar, so `expo-status-bar` will no-op, so it will do nothing and will **not** error.
+> For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
@@ -16,7 +16,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **tvOS and web support**
 >
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
+> For **tvOS**, the `expo-status-bar` code will compile and run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
 

--- a/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
@@ -5,7 +5,7 @@ description: A library that provides the same interface as the React Native Stat
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-status-bar'
 packageName: 'expo-status-bar'
 iconUrl: '/static/images/packages/expo-status-bar.png'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -14,9 +14,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web support**
+> **Web and tvOS support**
 >
-> There is no API available on the web for controlling the operating system status bar, so `expo-status-bar` will no-op, so it will do nothing and will **not** error.
+> For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/status-bar.mdx
@@ -14,10 +14,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
-> **Web and tvOS support**
+> **tvOS and web support**
+>
+> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 >
 > For **web**, there is no API available to control the operating system's status bar, so `expo-status-bar` will do nothing and won't throw an error.
-> For **tvOS**, the `expo-status-bar` code will compile an run, but no status bar will show.
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #33571

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update current callout for `tvOS` support in Expo StatusBar API reference.
- Update platform order as per our writing style guide to reference web as the last platform in Expo StatusBar reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2024-12-11 at 00 11 38](https://github.com/user-attachments/assets/c50834d1-9e56-4631-8a7b-e8fcbc56a9d4)


![CleanShot 2024-12-11 at 00 06 06](https://github.com/user-attachments/assets/adecae2f-f278-4fe0-bf86-180f8bf8dd7a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
