### PR TITLE
[media-library][ios] Fix `unknown` file type being returned for video files

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `unknown` file type being returned for video files. ([#33589](https://github.com/expo/expo/pull/33589) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 17.0.3 — 2024-11-22

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -267,13 +267,13 @@ func assetType(for localUri: URL) -> PHAssetMediaType {
   switch type {
   case .image:
     return .image
-  case .video:
+  case .video, .movie:
     return .video
   case .audio:
     return .audio
   case _ where type.conforms(to: .image):
     return .image
-  case _ where type.conforms(to: .video):
+  case _ where type.conforms(to: .video) || type.conforms(to: .movie):
     return .video
   case _ where type.conforms(to: .audio):
     return .audio


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33537

iOS returns the `.movie` UTType for some video files instead of the `.video` type. Moreover the `.movie` type does not conform to `.video` type.

# How

Return `.video` for both iOS `.video` and `.movie` types

# Test Plan

Tested in BareExpo in iOS simulator
