### PR TITLE
[docs] Adds "EAS" to "Workflows"

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -294,7 +294,7 @@ const general = [
     makePage('eas/environment-variables.mdx'),
     makePage('eas/using-environment-variables.mdx'),
   ]),
-  makeSection('Workflows', [
+  makeSection('EAS Workflows', [
     makePage('workflows/get-started.mdx'),
     makePage('workflows/triggers.mdx'),
     makePage('workflows/jobs.mdx'),

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -8,7 +8,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [Environment variables in Expo](/guides/environment-variables) describe how to use environment variables with the Expo framework and **.env** files to set environment variables that can be inlined in your JavaScript code. Expo CLI will substitute prefixed variables in your code (for example, `process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files on your development machine.
 
-Since EAS Build and Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
+Since EAS Build and EAS Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
 
 Additionally, you may want to use environment variables outside of your project code to customize your app binary at build time, like setting a bundle identifier or a private key for an error reporting service.
 To accommodate for those needs we have a separate (but compatible) mechanism for managing environment variables in EAS, which is focused on storing and managing environment variables on EAS servers and synchronizing them for local development.
@@ -30,7 +30,7 @@ They are available in jobs that run on EAS servers and updates, together with pr
 Currently EAS supports three environments for environment variables: `development`, `preview` and `production`.
 Environments are independent sets of environment variables that can be used to customize your app in different contexts.
 For example, you might want to use different API keys for development and production, or different bundle identifiers for different App Store releases.
-Environments allows you to do so. Every EAS Build and Workflows job runs using environment variables from one of the available environments.
+Environments allows you to do so. Every EAS Build and EAS Workflows job runs using environment variables from one of the available environments.
 You can also use environments for updates, allowing you to use the same set of environment variables for your build jobs. You can do this when publishing an update by providing the `--environment` flag.
 
 Environment variables can be assigned to multiple environments and have the same value across all of them, or be created for a single environment, so that you can set a specific value for a single environment.
@@ -39,19 +39,19 @@ Environment variables can be assigned to multiple environments and have the same
 
 There are three different visibility settings:
 
-| Visibility | Description                                                                                                                              |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                         |
-| Sensitive  | Obfuscated in build and Workflows jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
-| Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and Workflows jobs logs.  |
+| Visibility | Description                                                                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                             |
+| Sensitive  | Obfuscated in build and EAS Workflows jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
+| Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and EAS Workflows jobs logs.  |
 
-> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
+> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or EAS Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
 
 ## File environment variables
 
 In addition to setting strings as values, you can also upload files as the value of an environment variable.
 
-One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job. During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`). For example, you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or Workflows job.
+One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job. During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`). For example, you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or EAS Workflows job.
 
 ```js app.config.js
 export default {
@@ -104,7 +104,7 @@ Using `eas update` is the one exception to this rule. By default, for backward c
 
 To ensure that you can use the same environment variables in your updates as your build jobs, you can use the `--environment` flag with the `eas update` command to force it to use **only** the environment variables set on the EAS servers instead of the **.env** files present in your project directory. It will ignore environment variables from **.env**.
 
-## EAS Build and Workflows job runs
+## EAS Build and EAS Workflows job runs
 
 ### Setting the environment for your builds
 

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -43,7 +43,7 @@ There are three different visibility settings:
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                             |
 | Sensitive  | Obfuscated in build and workflow jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
-| Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and EAS Workflows jobs logs.  |
+| Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and workflow jobs logs.  |
 
 > **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or EAS Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
 

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -42,7 +42,7 @@ There are three different visibility settings:
 | Visibility | Description                                                                                                                                  |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                             |
-| Sensitive  | Obfuscated in build and EAS Workflows jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
+| Sensitive  | Obfuscated in build and workflow jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
 | Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and EAS Workflows jobs logs.  |
 
 > **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or EAS Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -45,7 +45,7 @@ There are three different visibility settings:
 | Sensitive  | Obfuscated in build and workflow jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
 | Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and workflow jobs logs.  |
 
-> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or EAS Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
+> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. Secret type environment variables are intended to be used to provide values to an EAS Build or Workflows job so that they may be used to alter how a job runs. For example, a good use case is setting an `NPM_TOKEN` to install private packages from npm, or a setting a Sentry API key to create a release and upload your source maps. Secrets do not provide any additional security for values that you end up embedding in your application itself.
 
 ## File environment variables
 

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -104,7 +104,7 @@ Using `eas update` is the one exception to this rule. By default, for backward c
 
 To ensure that you can use the same environment variables in your updates as your build jobs, you can use the `--environment` flag with the `eas update` command to force it to use **only** the environment variables set on the EAS servers instead of the **.env** files present in your project directory. It will ignore environment variables from **.env**.
 
-## EAS Build and EAS Workflows job runs
+## EAS Build and Workflows job runs
 
 ### Setting the environment for your builds
 

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -30,7 +30,7 @@ They are available in jobs that run on EAS servers and updates, together with pr
 Currently EAS supports three environments for environment variables: `development`, `preview` and `production`.
 Environments are independent sets of environment variables that can be used to customize your app in different contexts.
 For example, you might want to use different API keys for development and production, or different bundle identifiers for different App Store releases.
-Environments allows you to do so. Every EAS Build and EAS Workflows job runs using environment variables from one of the available environments.
+Environments allows you to do so. Every EAS Build and Workflows job runs using environment variables from one of the available environments.
 You can also use environments for updates, allowing you to use the same set of environment variables for your build jobs. You can do this when publishing an update by providing the `--environment` flag.
 
 Environment variables can be assigned to multiple environments and have the same value across all of them, or be created for a single environment, so that you can set a specific value for a single environment.

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -8,7 +8,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [Environment variables in Expo](/guides/environment-variables) describe how to use environment variables with the Expo framework and **.env** files to set environment variables that can be inlined in your JavaScript code. Expo CLI will substitute prefixed variables in your code (for example, `process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files on your development machine.
 
-Since EAS Build and EAS Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
+Since EAS Build and Workflows jobs run on a remote server, **.env** files may not be available. For instance, if **.env** files are excluded from your project because they are listed in **.gitignore** or not committed to your local version control system.
 
 Additionally, you may want to use environment variables outside of your project code to customize your app binary at build time, like setting a bundle identifier or a private key for an error reporting service.
 To accommodate for those needs we have a separate (but compatible) mechanism for managing environment variables in EAS, which is focused on storing and managing environment variables on EAS servers and synchronizing them for local development.

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -39,9 +39,9 @@ Environment variables can be assigned to multiple environments and have the same
 
 There are three different visibility settings:
 
-| Visibility | Description                                                                                                                                  |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                             |
+| Visibility | Description                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Plain text | Visible on the website, in EAS CLI, and in logs.                                                                                        |
 | Sensitive  | Obfuscated in build and workflow jobs logs. You can use a toggle to make them visible on the website. They're also readable in EAS CLI. |
 | Secret     | Not readable outside of the EAS servers, including on the website and in EAS CLI. They are obfuscated in build and workflow jobs logs.  |
 

--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -51,7 +51,7 @@ There are three different visibility settings:
 
 In addition to setting strings as values, you can also upload files as the value of an environment variable.
 
-One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job. During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`). For example, you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or EAS Workflows job.
+One common use case of using file environment variable is passing a git ignored **google-services.json** configuration file to a build job. During the job run, the file will be created in a location outside of the project directory and the path to the file will be assigned to the environment variable (`GOOGLE_SERVICES_JSON=/path/to/google-services.json`). For example, you can then set `android.googleServicesFile` in your app config to the value of the `GOOGLE_SERVICES_JSON` environment variable to use this file when executing the build or workflow job.
 
 ```js app.config.js
 export default {

--- a/docs/pages/workflows/control-flow.mdx
+++ b/docs/pages/workflows/control-flow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Control flow
-description: Learn how to control the flow of Workflows with conditions that run certain jobs based on the result of previous jobs.
+description: Learn how to control the flow of EAS Workflows with conditions that run certain jobs based on the result of previous jobs.
 ---
 
 You can control the flow of your workflows with conditions that run certain jobs based on the result of previous jobs.

--- a/docs/pages/workflows/get-started.mdx
+++ b/docs/pages/workflows/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_title: Get started
-title: Get started with Workflows
-description: Learn how to use Workflows to automate your development and release processes.
+title: Get started with EAS Workflows
+description: Learn how to use EAS Workflows to automate your development and release processes.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -12,19 +12,19 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
 <Callout type="info">
-  Workflows are currently in preview. We may introduce breaking changes in the coming weeks. Got
+  EAS Workflows are currently in preview. We may introduce breaking changes in the coming weeks. Got
   feedback? Send us an email at workflows@expo.dev.
 </Callout>
 
-Builds, submissions, updates, and more are all a part of delivering your app to users. Workflows consist of a sequence of jobs, which help you and your team get things done. With workflows, you can build your project, run end-to-end tests, submit that build to the app stores, and then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate your and your team's release process.
+Builds, submissions, updates, and more are all a part of delivering your app to users. EAS Workflows consist of a sequence of jobs, which help you and your team get things done. With workflows, you can build your project, run end-to-end tests, submit that build to the app stores, and then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate your and your team's release process.
 
 <Collapsible summary="How do workflows compare to other CI services?">
 
-Workflows on EAS are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that can build, submit, update, run Maestro tests, and more. All job types run on EAS, so you'll only have to manage one set of YAML files, and all the artifacts from your job runs will appear on [expo.dev](https://expo.dev/).
+EAS Workflows are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that can build, submit, update, run Maestro tests, and more. All job types run on EAS, so you'll only have to manage one set of YAML files, and all the artifacts from your job runs will appear on [expo.dev](https://expo.dev/).
 
 Other CI services, like CircleCI and GitHub Actions, are more generalized and have the ability to do more than workflows. However, those services also require you to understand more about the implementation of each job. While that is necessary in some cases, workflows help you get common tasks done quickly by pre-packaging the most essential types of jobs for app developers. In addition, workflows are designed to provide you with the fastest possible cloud machine for the task at hand, and we're constantly updating those for you.
 
-Workflows are great for operations related to your Expo apps, while other CICD services will provide a better experience for other types of workflows.
+EAS Workflows are great for operations related to your Expo apps, while other CICD services will provide a better experience for other types of workflows.
 
 </Collapsible>
 
@@ -126,7 +126,7 @@ Learn more about the building blocks of workflows:
 />
 <BoxLink
   title="Jobs"
-  description="Learn which pre-packaged and custom jobs you can run with Workflows."
+  description="Learn which pre-packaged and custom jobs you can run with EAS Workflows."
   href="/workflows/jobs"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/workflows/jobs.mdx
+++ b/docs/pages/workflows/jobs.mdx
@@ -1,9 +1,9 @@
 ---
 title: Jobs
-description: Learn which pre-packaged and custom jobs you can run with Workflows.
+description: Learn which pre-packaged and custom jobs you can run with EAS Workflows.
 ---
 
-Workflows sequence jobs together to automate your development and release processes. You can run two types of jobs: pre-packaged jobs and custom jobs.
+EAS Workflows sequence jobs together to automate your development and release processes. You can run two types of jobs: pre-packaged jobs and custom jobs.
 
 Expo provides pre-packaged jobs that meet common use cases for developers, such as building, submitting, and running end-to-end tests. Since they are provided by Expo, they are continuously maintained and updated.
 

--- a/docs/pages/workflows/triggers.mdx
+++ b/docs/pages/workflows/triggers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Triggers
-description: Learn which triggers are available to work with Workflows.
+description: Learn which triggers are available to work with EAS Workflows.
 ---
 
 Triggers define when a workflow should kick off. When its conditions are met, the workflow will start.
@@ -42,7 +42,7 @@ jobs:
 
 ## More
 
-Workflows also support triggering on all branches, on both push and pull request events:
+EAS Workflows also support triggering on all branches, on both push and pull request events:
 
 ```yaml .eas/workflows/hello-world.yaml
 name: Hello World

--- a/docs/pages/workflows/variables.mdx
+++ b/docs/pages/workflows/variables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Variables
-description: Learn how to pass data between jobs or steps or set conditionals using variables in Workflows.
+description: Learn how to pass data between jobs or steps or set conditionals using variables in EAS Workflows.
 hideTOC: true
 ---
 

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -9,6 +9,7 @@ import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Ico
 import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
+import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 import { Phone01Icon } from '@expo/styleguide-icons/outline/Phone01Icon';
@@ -205,6 +206,8 @@ function getIconElement(iconName?: string) {
       return EasMetadataIcon;
     case 'EAS Insights':
       return DataIcon;
+    case 'EAS Workflows':
+      return Dataflow01Icon;
     case 'Expo Modules API':
       return CpuChip01Icon;
     case 'Expo Router':


### PR DESCRIPTION
# Why

Based on a conversation in this doc: https://www.notion.so/expo/EAS-wording-157e5b57352480cdb5e0d9accf2634e7?pvs=4, we decided to prepend Workflows with "EAS", to be specific about the service, and to have a less generic name than "workflows".

# How

Added "EAS" to all the instances of "Workflows" that were referring to EAS' service.

# Test Plan

In guides, make sure that the EAS Workflows docs make sense and are consistent with our other services like EAS Build.