### PR TITLE
[core][Android] Add module extension

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/Version.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/Version.kt
@@ -1,0 +1,13 @@
+package expo.modules.plugin
+
+data class Version(
+  val major: Int,
+  val minor: Int,
+  val patch: Int
+) {
+  fun isAtLeast(other: Version): Boolean {
+    return major > other.major ||
+      (major == other.major && minor > other.minor) ||
+      (major == other.major && minor == other.minor && patch >= other.patch)
+  }
+}

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoGradleHelperExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoGradleHelperExtension.kt
@@ -1,0 +1,78 @@
+package expo.modules.plugin.gradle
+
+import org.gradle.api.Project
+import java.util.Properties
+import java.io.File
+import java.io.FileInputStream
+import expo.modules.plugin.Version
+
+/**
+ * An extension for the Gradle instance that stores data in a cache,
+ * reducing the number of times it needs to be recomputed.
+ *
+ * For example, to resolve the React Native directory, we need to run an external process.
+ * This can add up - it's better to run it once and cache the result.
+ */
+open class ExpoGradleHelperExtension {
+  /**
+   * Cached React Native directory
+   */
+  private lateinit var reactNativeDir: File
+
+  /**
+   * Cached React Native properties
+   */
+  private lateinit var reactNativeProperties: Properties
+
+  /**
+   * Cached React Native version
+   */
+  private lateinit var reactNativeVersion: Version
+
+  fun getReactNativeDir(project: Project): File = synchronized(this) {
+    if (::reactNativeDir.isInitialized) {
+      return reactNativeDir
+    }
+
+    // When building from source, the ReactAndroid project is available
+    val reactNativeDirFromSource = project
+      .findProject(":packages:react-native:ReactAndroid")
+      ?.projectDir
+      ?.parentFile
+
+    reactNativeDir = reactNativeDirFromSource ?: File(
+      project.providers.exec { env ->
+        env.workingDir(project.rootDir)
+        env.commandLine("node", "--print", "require.resolve('react-native/package.json')")
+      }.standardOutput.asText.get().trim()
+    ).parentFile
+
+    return reactNativeDir
+  }
+
+  fun getReactNativeProperties(project: Project): Properties = synchronized(this) {
+    if (::reactNativeProperties.isInitialized) {
+      return reactNativeProperties
+    }
+
+    val reactPropertiesFile = File(getReactNativeDir(project), "ReactAndroid/gradle.properties")
+    reactNativeProperties = Properties().also { properties ->
+      FileInputStream(reactPropertiesFile).use {
+        properties.load(it)
+      }
+      properties.load(reactPropertiesFile.inputStream())
+    }
+    return reactNativeProperties
+  }
+
+  fun getReactNativeVersion(project: Project): Version = synchronized(this) {
+    if (::reactNativeVersion.isInitialized) {
+      return reactNativeVersion
+    }
+
+    val version = getReactNativeProperties(project).getProperty("VERSION_NAME")
+    val (major, minor, patch) = version.split(".").map { it.toInt() }
+    reactNativeVersion = Version(major, minor, patch)
+    return reactNativeVersion
+  }
+}

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -1,0 +1,24 @@
+package expo.modules.plugin.gradle
+
+import org.gradle.api.Project
+import java.io.File
+import java.util.Properties
+import expo.modules.plugin.Version
+
+/**
+ * An user-facing interface to interact with the `ExpoGradleHelperExtension`.
+ */
+open class ExpoModuleExtension(val project: Project) {
+  private val gradleHelper by lazy {
+    project.gradle.extensions.getByType(ExpoGradleHelperExtension::class.java)
+  }
+
+  val reactNativeDir: File
+    get() = gradleHelper.getReactNativeDir(project)
+
+  val reactNativeProperties: Properties
+    get() = gradleHelper.getReactNativeProperties(project)
+
+  val reactNativeVersion: Version
+    get() = gradleHelper.getReactNativeVersion(project)
+}


### PR DESCRIPTION
# Why

Adds a module extension.

# How

Resolving information about your project, like the React Native version, is a common task across many of our packages. This PR aims to enhance this typical pattern by calculating information once and sharing it across multiple packages.

I have added two new extensions: one for Gradle and one for the project. The first extension holds and calculates information about your app, while the second provides an improved API.

For instance, now you can access React Native directory in module like this:
```groovy
println(expoModule.reactNativeDir)
```

# Test Plan

- bare-expo ✅ 