### PR TITLE
[env-info] add expo-updates

### DIFF
--- a/packages/expo-env-info/CHANGELOG.md
+++ b/packages/expo-env-info/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `expo-updates` to list of packages. ([#33613](https://github.com/expo/expo/pull/33613) by [@betomoedano](https://github.com/betomoedano))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-env-info/src/diagnosticsAsync.ts
+++ b/packages/expo-env-info/src/diagnosticsAsync.ts
@@ -17,6 +17,7 @@ function getEnvironmentInfoAsync(): Promise<string> {
       npmPackages: [
         'expo',
         'expo-router',
+        'expo-updates',
         'react',
         'react-dom',
         'react-native',


### PR DESCRIPTION
# Why

[ENG-13780 Add eas-cli version to expo-env-info command](https://linear.app/expo/issue/ENG-13780/add-eas-cli-version-to-expo-env-info-command)

# How

Added `expo-updates` to the list of packages

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
