### PR TITLE
[expo-location][ios] `startLocationUpdatesAsync` should not require background permissions

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)
+
 ### 💡 Others
 
 ## 18.0.4 - 2024-12-10

--- a/packages/expo-location/ios/LocationModule.swift
+++ b/packages/expo-location/ios/LocationModule.swift
@@ -147,9 +147,13 @@ public final class LocationModule: Module {
     // Background location
 
     AsyncFunction("startLocationUpdatesAsync") { (taskName: String, options: [String: Any]) in
+      // There are two ways of starting this service.
+      // 1. As a background location service, this requires the background location permission.
+      // 2. As a user-initiated foreground service, this does NOT require the background location permission.
+      // Unfortunately, we cannot distinguish between those cases.
+      // So we only check foreground permission which needs to be granted in both cases.
       try ensureLocationServicesEnabled()
       try ensureForegroundLocationPermissions(appContext)
-      try ensureBackgroundLocationPermissions(appContext)
 
       guard CLLocationManager.significantLocationChangeMonitoringAvailable() else {
         throw Exceptions.LocationUpdatesUnavailable()


### PR DESCRIPTION
# Why

It looks like migration of code to Swift caused a regression where a background location permissions check was added to `startLocationUpdatesAsync` where it was not required before.

Before the rewrite (good):
https://github.com/expo/expo/blob/a2eab18fa91f04e884e2ea90079c3a28e85b5617/packages/expo-location/ios/EXLocation/EXLocation.m#L398-L405

After the rewrite (regression):
https://github.com/expo/expo/blob/b68e5216d26513415934ce28b2188442866a0167/packages/expo-location/ios/LocationModule.swift#L149-L152

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

To reverse the regression, I've removed the background permission check and added back in the comments that were there in the pre-swift code.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After requesting foreground permissions via `Location.useForegroundPermissions()`, calling `Location.startLocationUpdatesAsync` no longer throws `Background location permission is required to do this operation` error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [*] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [*] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [*] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
