### PR TITLE
[expo-modules-core] Ensure `uuid.v4` and `uuid.v5` imports available on old architecture

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Ensure `uuid.v4`and`uuid.v5` is available on old react native architecture. ([#33621](https://github.com/expo/expo/pull/33621) by [@andrejpavlovic](https://github.com/andrejpavlovic))
 - Changed `import` to `import type` for TS type declarations. ([#33447](https://github.com/expo/expo/pull/33447) by [@j-piasecki](https://github.com/j-piasecki))
 
 ### 💡 Others

--- a/packages/expo-modules-core/build/uuid/uuid.d.ts.map
+++ b/packages/expo-modules-core/build/uuid/uuid.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"uuid.d.ts","sourceRoot":"","sources":["../../src/uuid/uuid.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAmB,MAAM,cAAc,CAAC;AA+BrD,QAAA,MAAM,IAAI,EAAE,IAIX,CAAC;AACF,eAAe,IAAI,CAAC"}
+{"version":3,"file":"uuid.d.ts","sourceRoot":"","sources":["../../src/uuid/uuid.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,IAAI,EAAmB,MAAM,cAAc,CAAC;AAgCrD,QAAA,MAAM,IAAI,EAAE,IAIX,CAAC;AACF,eAAe,IAAI,CAAC"}

--- a/packages/expo-modules-core/src/uuid/uuid.ts
+++ b/packages/expo-modules-core/src/uuid/uuid.ts
@@ -1,10 +1,9 @@
 import bytesToUuid from './lib/bytesToUuid';
 import { UUID, Uuidv5Namespace } from './uuid.types';
 
-const nativeUuidv4 = globalThis?.expo?.uuidv4;
-const nativeUuidv5 = globalThis?.expo?.uuidv5;
-
 function uuidv4(): string {
+  const nativeUuidv4 = globalThis?.expo?.uuidv4;
+
   if (!nativeUuidv4) {
     throw Error(
       "Native UUID version 4 generator implementation wasn't found in `expo-modules-core`"
@@ -22,6 +21,8 @@ function uuidv5(name: string, namespace: string | number[]) {
   if (Array.isArray(parsedNamespace)) {
     throw new Error('`namespace` must be a valid UUID string or an Array of 16 byte values');
   }
+
+  const nativeUuidv5 = globalThis?.expo?.uuidv5;
 
   if (!nativeUuidv5) {
     throw Error("Native UUID type 5 generator implementation wasn't found in `expo-modules-core`");


### PR DESCRIPTION
# Why

It seems that `globalThis?.expo?.uuidv4` is undefined on iOS when this module is loaded. As a result, when trying to call `uuid.v4` later in the code, it keeps throwing `Native UUID version 4 generator implementation wasn't found in 'expo-modules-core'` even though `globalThis?.expo?.uuidv4` at that point is available.

I'm assuming in new architecture `globalThis?.expo?.uuidv4` is set synchronously, so this would not be an issue. In old architecture however, it would be best to reference this value when executing `v4` or `v5` calls themselves.

# How

Use direct reference to `globalThis?.expo?.uuidv4` from inside `uuidv4()` functions to avoid referencing a stale value.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

On iOS the error stops being thrown when calling `uuid.v4` within a component.

```typescript
import { uuid } from 'expo-modules-core'

export const MyComponent = () => {
  useEffect(() => {
    console.log(uuid.v4())
  }, [])
  return null
}
```

# Checklist

- [*] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [*] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [*] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
