### PR TITLE
Update build-with-monorepos.mdx

### DIFF
--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -9,7 +9,7 @@ To set up EAS Build with a monorepo, you need to follow the standard process as 
 - Run all EAS CLI commands from the root of the app directory. For example, if your project exists inside your git repository at **apps/my-app**, then run `eas build` from there.
 - All files related to EAS Build, such as **eas.json** and **credentials.json**, should be in the root of the app directory. If you have multiple apps that use EAS Build in your monorepo, each app directory will have its own copy of these files.
 - **If you are building a managed project in a monorepo**, see [Working with Monorepos](/guides/monorepos) guide.
-- If your project needs additional setup beyond what is provided, use one of the `eas-build-*` lifecycle hooks to **package.json** in your project that builds all necessary dependencies in other workspaces. For example:
+- If your project needs additional setup beyond what is provided, use one of the `eas-build-*` [lifecycle hooks](https://docs.expo.dev/build-reference/npm-hooks/#eas-build-lifecycle-hooks) in **package.json** of your project that builds all necessary dependencies in other workspaces. For example:
 
 ```json package.json
 {

--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -9,12 +9,12 @@ To set up EAS Build with a monorepo, you need to follow the standard process as 
 - Run all EAS CLI commands from the root of the app directory. For example, if your project exists inside your git repository at **apps/my-app**, then run `eas build` from there.
 - All files related to EAS Build, such as **eas.json** and **credentials.json**, should be in the root of the app directory. If you have multiple apps that use EAS Build in your monorepo, each app directory will have its own copy of these files.
 - **If you are building a managed project in a monorepo**, see [Working with Monorepos](/guides/monorepos) guide.
-- If your project needs additional setup beyond what is provided, add a `postinstall` step to **package.json** in your project that builds all necessary dependencies in other workspaces. For example:
+- If your project needs additional setup beyond what is provided, use one of the `eas-build-*` lifecycle hooks to **package.json** in your project that builds all necessary dependencies in other workspaces. For example:
 
 ```json package.json
 {
   "scripts": {
-    "postinstall": "cd ../.. && yarn build"
+    "eas-build-post-install": "cd ../.. && yarn build"
   }
 }
 ```


### PR DESCRIPTION
eas-build commands seem better than using generic postinstall script.

# Why

using eas-build hooks is cleaner than postinstall

# How

Updated doc

# Test Plan


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
