### PR TITLE
[docs] Add React Native Devtools section to router troubleshooting

### DIFF
--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -13,7 +13,7 @@ This can happen if your Chrome DevTools has exclusions within its ignore list. T
 2. Open **Settings** by clicking the gear icon
 3. Under **Extensions**, click **Restore defaults and reload**
 4. Open **Settings** again, and go to **Ignore List** tab
-5. Remove any exclusions with `node_modules`
+5. Uncheck any exclusions for `/node_modules/`
 
 ## `EXPO_ROUTER_APP_ROOT` not defined
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -11,7 +11,7 @@ This can happen if your Chrome DevTools has exclusions within its ignore list. T
 
 1. Start the React Native DevTools
 2. Open **Settings** by clicking the gear icon
-3. Press "restore defaults and reload"
+3. Under **Extensions**, click **Restore defaults and reload**
 4. Open settings again, and click the "ignore list" tab
 5. Remove any exclusions with `node_modules`
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -12,7 +12,7 @@ This can happen if your Chrome DevTools has exclusions within its ignore list. T
 1. Start the React Native DevTools by pressing <kbd>J</kbd> from the development server running in the terminal window
 2. Open **Settings** by clicking the gear icon
 3. Under **Extensions**, click **Restore defaults and reload**
-4. Open settings again, and click the "ignore list" tab
+4. Open **Settings** again, and go to **Ignore List** tab
 5. Remove any exclusions with `node_modules`
 
 ## `EXPO_ROUTER_APP_ROOT` not defined

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -5,7 +5,7 @@ description: Fixing common issues with Expo Router setup.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-## Missing files / source maps in React Native DevTools
+## Missing files or source maps in React Native DevTools
 
 This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ## Missing files or source maps in React Native DevTools
 
-This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue
+This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue, use [React Native DevTools](https://reactnative.dev/docs/react-native-devtools):
 
 1. Start the React Native DevTools
 2. Open **Settings** by clicking the gear icon

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -5,6 +5,16 @@ description: Fixing common issues with Expo Router setup.
 
 import { Terminal } from '~/ui/components/Snippet';
 
+## Missing files / source maps in React Native DevTools
+
+This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue
+
+1. Start the React Native DevTools
+2. Open settings by pressing the gear icon
+3. Press "restore defaults and reload"
+4. Open settings again, and click the "ignore list" tab
+5. Remove any exclusions with `node_modules`
+
 ## `EXPO_ROUTER_APP_ROOT` not defined
 
 If `process.env.EXPO_ROUTER_APP_ROOT` is not defined you'll see the following error:

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue
 
 1. Start the React Native DevTools
-2. Open settings by pressing the gear icon
+2. Open **Settings** by clicking the gear icon
 3. Press "restore defaults and reload"
 4. Open settings again, and click the "ignore list" tab
 5. Remove any exclusions with `node_modules`

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue, use [React Native DevTools](https://reactnative.dev/docs/react-native-devtools):
 
-1. Start the React Native DevTools
+1. Start the React Native DevTools by pressing <kbd>J</kbd> from the development server running in the terminal window
 2. Open **Settings** by clicking the gear icon
 3. Under **Extensions**, click **Restore defaults and reload**
 4. Open settings again, and click the "ignore list" tab


### PR DESCRIPTION
# Why

Fix: #33189 

# How

Chrome DevTools shares settings across projects. If the developer launches the dev tools using a web framework, it may setup exclusions that cause Expo Router to stop showing sourcemaps