### PR TITLE
[docs] Update description for Router UI reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Router UI
-description: An Expo Router submodule that provides headless UI navigators to create custom layouts.
+description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router-ui'
 platforms: ['android', 'ios', 'web']
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-`expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
+`expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom tab layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
 
 > See the [Expo Router](./router) reference for more information about the file-based routing library for native and web app.
 

--- a/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Router UI
-description: An Expo Router submodule that provides headless UI navigators to create custom layouts.
+description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router-ui'
 platforms: ['android', 'ios', 'web']
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-`expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
+`expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom tab layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
 
 > See the [Expo Router](./router) reference for more information about the file-based routing library for native and web app.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on [feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1733924954558699) and discussion with @marklawlor.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update Router UI reference description to indicate that this package is meant to be used to create custom tab layouts.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-12-12 at 17 55 23@2x](https://github.com/user-attachments/assets/d0deb2a5-dda3-47cd-ad5b-1cff2c6eb0fc)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
