### PR TITLE
[cli] Reduce the number of evaluations needed to open dev tools

### DIFF
--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -97,10 +97,18 @@ export async function queryAllInspectorAppsAsync(
     if (!pageIsSupported(app)) {
       continue;
     }
-    // Hide targets that are marked as hidden from the inspector, e.g. instances from expo-dev-menu and expo-dev-launcher.
-    if (await appShouldBeIgnoredAsync(app)) {
+
+    try {
+      // Hide targets that are marked as hidden from the inspector, e.g. instances from expo-dev-menu and expo-dev-launcher.
+      if (await appShouldBeIgnoredAsync(app)) {
+        continue;
+      }
+    } catch (e: unknown) {
+      // If we can't evaluate the JS, we just ignore the error and skips the target.
+      debug(`Can't evaluate the JS on the app:`, JSON.stringify(e, null, 2));
       continue;
     }
+
     results.push(app);
   }
   return results;

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -89,7 +89,8 @@ export async function queryAllInspectorAppsAsync(
   metroServerOrigin: string
 ): Promise<MetroInspectorProxyApp[]> {
   const resp = await fetch(`${metroServerOrigin}/json/list`);
-  // The newst runtime will be at the end of the list, that's why we reverse it.
+  // The newest runtime will be at the end of the list,
+  // reversing the result would save time from try-error.
   const apps: MetroInspectorProxyApp[] = transformApps(await resp.json()).reverse();
   const results: MetroInspectorProxyApp[] = [];
   for (const app of apps) {

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -89,7 +89,8 @@ export async function queryAllInspectorAppsAsync(
   metroServerOrigin: string
 ): Promise<MetroInspectorProxyApp[]> {
   const resp = await fetch(`${metroServerOrigin}/json/list`);
-  const apps: MetroInspectorProxyApp[] = transformApps(await resp.json());
+  // The newst runtime will be at the end of the list, that's why we reverse it.
+  const apps: MetroInspectorProxyApp[] = transformApps(await resp.json()).reverse();
   const results: MetroInspectorProxyApp[] = [];
   for (const app of apps) {
     // Only use targets with better reloading support

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
@@ -33,7 +33,7 @@ describe(queryAllInspectorAppsAsync, () => {
       .get('/json/list')
       .reply(200, METRO_INSPECTOR_RESPONSE_FIXTURE);
 
-    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter(pageIsSupported);
+    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter(pageIsSupported).reverse();
 
     const result = await queryAllInspectorAppsAsync('http://localhost:8081');
 

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
@@ -50,7 +50,9 @@ describe(queryAllInspectorAppsAsync, () => {
       .get('/json/list')
       .reply(200, METRO_INSPECTOR_RESPONSE_FIXTURE);
 
-    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter((app) => pageIsSupported(app));
+    const entities = METRO_INSPECTOR_RESPONSE_FIXTURE.filter((app) =>
+      pageIsSupported(app)
+    ).reverse();
 
     const result = await queryAllInspectorAppsAsync('http://localhost:8081');
     expect(result.length).toBe(entities.length);


### PR DESCRIPTION
# Why

Reduces the number of evaluations needed to open dev tools.
Fixes:
<img width="545" alt="image" src="https://github.com/user-attachments/assets/48d148d1-14fb-421e-b2ca-6db0effd6218" />

# How

The newest runtime should be at the end of the list so we can reduce the number of checks.
Also, I've added a try-catch block to catch `Error: Runtime.evaluate`. Currently, Expo Go on Android is leaking, leaving some phantom runtimes in the memory that can't execute code anymore. 

For instance, here is an output of `/json/list` after opening, closing, and opening an experience:
```json
[
  {
    "id": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c-1",
    "title": "React Native Bridgeless [C++ connection]",
    "description": "host.exp.exponent",
    "type": "node",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=192.168.82.182%3A8081%2Finspector%2Fdebug%3Fdevice%3D60640a5fbd89a15bab67c6df9f8e96afe88ca40c%26page%3D1",
    "webSocketDebuggerUrl": "ws://192.168.82.182:8081/inspector/debug?device=60640a5fbd89a15bab67c6df9f8e96afe88ca40c&page=1",
    "deviceName": "sdk_gphone64_arm64 - 15 - API 35",
    "reactNative": {
      "logicalDeviceId": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c",
      "capabilities": {
        "prefersFuseboxFrontend": true,
        "nativeSourceCodeFetching": false,
        "nativePageReloads": true
      }
    }
  },
  {
    "id": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c-3",
    "title": "React Native Bridgeless [C++ connection]",
    "description": "host.exp.exponent",
    "type": "node",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=192.168.82.182%3A8081%2Finspector%2Fdebug%3Fdevice%3D60640a5fbd89a15bab67c6df9f8e96afe88ca40c%26page%3D3",
    "webSocketDebuggerUrl": "ws://192.168.82.182:8081/inspector/debug?device=60640a5fbd89a15bab67c6df9f8e96afe88ca40c&page=3",
    "deviceName": "sdk_gphone64_arm64 - 15 - API 35",
    "reactNative": {
      "logicalDeviceId": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c",
      "capabilities": {
        "prefersFuseboxFrontend": true,
        "nativeSourceCodeFetching": false,
        "nativePageReloads": true
      }
    }
  },
  {
    "id": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c-5",
    "title": "React Native Bridgeless [C++ connection]",
    "description": "host.exp.exponent",
    "type": "node",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=192.168.82.182%3A8081%2Finspector%2Fdebug%3Fdevice%3D60640a5fbd89a15bab67c6df9f8e96afe88ca40c%26page%3D5",
    "webSocketDebuggerUrl": "ws://192.168.82.182:8081/inspector/debug?device=60640a5fbd89a15bab67c6df9f8e96afe88ca40c&page=5",
    "deviceName": "sdk_gphone64_arm64 - 15 - API 35",
    "reactNative": {
      "logicalDeviceId": "60640a5fbd89a15bab67c6df9f8e96afe88ca40c",
      "capabilities": {
        "prefersFuseboxFrontend": true,
        "nativeSourceCodeFetching": false,
        "nativePageReloads": true
      }
    }
  }
]
```

# Test Plan

- testing with fresh app running SDK 52 on both Android and iOS ✅ 