### PR TITLE
chore(expo-router): Add less aggressive babel plugin migration warning.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Add less aggressive babel plugin migration warning.
+
 ### 🐛 Bug fixes
 
 - Fix regex on `expo-router/matcher` `matchLastGroupName` allows to use it on `IOS < 16.4` ([#33350](https://github.com/expo/expo/pull/33350) by [@antonio-serrat](https://github.com/Antonio-Serat))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- Add less aggressive babel plugin migration warning.
+- Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -1,3 +1,17 @@
-throw new Error(
-  'expo-router/babel is deprecated in favor of babel-preset-expo in SDK 50. To fix the issue, remove "expo-router/babel" from "plugins" in your babel.config.js file.'
-);
+let hasWarned = false;
+
+module.exports = (api) => {
+  return {
+    name: 'expo-router-babel-deprecated',
+    visitor: {
+      Program() {
+        if (!hasWarned) {
+          hasWarned = true;
+          console.warn(
+            'expo-router/babel is deprecated in favor of babel-preset-expo in SDK 50. To fix the issue, remove "expo-router/babel" from "plugins" in your babel.config.js file.'
+          );
+        }
+      },
+    },
+  };
+};


### PR DESCRIPTION
# Why

- Make it a bit easier for users upgrading from older versions of Expo Router (v2 to v4+)
