### PR TITLE
[docs] small tweaks and fixes for platform tags

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -5264,7 +5264,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h4>
       <div
-        class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
+        class="flex flex-row items-start [table_&]:mb-2.5 mb-1"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -6755,7 +6755,7 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
       <div
-        class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
+        class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -50,7 +50,12 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           <H4 hideInSidebar>
             <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
           </H4>
-          <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" disableFallback />
+          <APISectionPlatformTags
+            comment={enumValue.comment}
+            prefix="Only for:"
+            className="mb-1"
+            disableFallback
+          />
           <MONOSPACE theme="secondary" className="mb-2 inline-flex text-xs">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <div
-    class="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5"
+    class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
   >
     <span
       class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -1,3 +1,5 @@
+import { mergeClasses } from '@expo/styleguide';
+
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
@@ -13,6 +15,7 @@ type Props = {
   platforms?: CommentTagData[];
   userProvidedPlatforms?: string[];
   disableFallback?: boolean;
+  className?: string;
 };
 
 export const APISectionPlatformTags = ({
@@ -20,6 +23,7 @@ export const APISectionPlatformTags = ({
   platforms,
   prefix,
   userProvidedPlatforms,
+  className,
   disableFallback = false,
 }: Props) => {
   const { platforms: defaultPlatforms } = usePageMetadata();
@@ -42,7 +46,7 @@ export const APISectionPlatformTags = ({
   }
 
   return (
-    <div className="flex flex-row items-start max-md-gutters:mb-2.5 [table_&]:mb-2.5">
+    <div className={mergeClasses('mb-3 flex flex-row items-start [table_&]:mb-2.5', className)}>
       {experimentalData.length > 0 && (
         <CALLOUT tag="span" theme="secondary" className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function PagePlatformTags({ platforms }: Props) {
   return (
-    <div className="mt-3 inline-flex flex-wrap gap-2">
+    <div className="mt-3 inline-flex flex-wrap">
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {


### PR DESCRIPTION
# Why

Spotted some edge-cases after shipping platform label changes, let's address them.

# How

Add missing spacing if layout overflows on desktop viewport size, tweak page-level tags gaps, fix for platform tags sizing when used in MDX headers.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2024-12-12 at 19 48 04](https://github.com/user-attachments/assets/87460db1-55a2-4a2c-b726-567c5492f5a3)
