### PR TITLE
[docs] Fix diff file name used in EAS Updates getting started guide

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -101,7 +101,7 @@ The `EXPO_UPDATE_URL` value should contain your project's ID.
 
 Inside **android/app/src/main/res/values/strings.xml**, you'll see the `expo_runtime_version` string entry in the `resources` object:
 
-<DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />
+<DiffBlock source="/static/diffs/expo-updates-strings-xml.diff" />
 
 #### iOS
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix diff file name used in EAS Updates getting started guide in the `DiffBlock`. This resolves the missing diffblock not shown in the guide and the hydration error.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-12-13 at 00 31 12@2x](https://github.com/user-attachments/assets/4c567888-d7fa-4e4f-badb-eb473b044130)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
