### PR TITLE
[docs] Update multiple docs to highlight different keywords

### DIFF
--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use existing credentials
+title: Using existing credentials
+sidebar_title: Existing credentials
 description: Learn about different options for supplying your app signing credentials to EAS Build.
 hideTOC: true
 ---

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use local credentials
+title: Using local credentials
+sidebar_title: Local credentials
 description: Learn how to configure and use local credentials when using EAS.
 ---
 

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use automatically managed credentials
+title: Using automatically managed credentials
+sidebar_title: Automatically managed credentials
 description: Learn how to automatically manage your app credentials with EAS.
 ---
 

--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use Git Submodules
+title: Using Git submodules
+sidebar_title: Git submodules
 description: Learn how to configure EAS Build to use git submodules.
 hideTOC: true
 ---

--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use npm cache with Yarn 1 (Classic)
+title: Using npm cache with Yarn 1 (Classic)
+sidebar_label: npm cache with Yarn 1 (Classic)
 hideTOC: true
 description: Learn how to use npm cache by overriding the registry in Yarn 1 (Classic).
 ---

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use private npm packages
+title: Using private npm packages
+sidebar_label: Private npm packages
 description: Learn how to configure EAS Build to use private npm packages.
 ---
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use EAS Update
+title: Using EAS Update
 description: Learn how to use EAS Update with EAS Build.
 ---
 

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Animation
-description: Learn how to integrate the react-native-reanimated library and use it in your Expo project.
+description: Learn how to integrate React Native animations and use it in your Expo project.
 ---
 
 import { Terminal, SnackInline } from '~/ui/components/Snippet';

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Facebook authentication
+title: Using Facebook authentication
 description: A guide on using react-native-fbsdk-next library to integrate Facebook authentication in your Expo project.
 ---
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Google authentication
+title: Using Google authentication
 description: A guide on using @react-native-google-signin/google-signin library to integrate Google authentication in your Expo project.
 ---
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -1,6 +1,6 @@
 ---
-title: Icons
-description: Learn how to use various types of icons in your Expo app, including vector icons, custom icon fonts, icon images, and icon buttons.
+title: Expo Vector Icons
+description: Learn how to use various types of icons in your Expo app, including react native vector icons, custom icon fonts, icon images, and icon buttons.
 ---
 
 import { SnackInline } from '~/ui/components/Snippet';

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use In-app purchase
+title: Using In-app purchase
 description: Learn about how to use in-app purchases in your Expo app.
 hideTOC: true
 ---

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -1,5 +1,6 @@
 ---
-title: New Architecture
+title: React Native's New Architecture
+sidebar_title: New Architecture
 description: Learn about React Native's "New Architecture" and how and why to migrate to it.
 ---
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use TypeScript
+title: Using TypeScript
 description: An in-depth guide on configuring an Expo project with TypeScript.
 ---
 

--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Native analytics SDKs and libraries
-sidebar_title: Use Analytics
+sidebar_title: Using Analytics
 hideTOC: true
 description: An overview of analytics services available in the Expo and React Native ecosystem.
 ---

--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use Analytics
+title: React Native analytics SDKs and libraries
+sidebar_title: Use Analytics
 hideTOC: true
 description: An overview of analytics services available in the Expo and React Native ecosystem.
 ---

--- a/docs/pages/guides/using-bugsnag.mdx
+++ b/docs/pages/guides/using-bugsnag.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use BugSnag
+title: Using BugSnag
 description: A guide on installing and configuring BugSnag for end-to-end error reporting and analytics.
 hideTOC: true
 ---

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Bun
+title: Using Bun
 description: A guide on using Bun with Expo and EAS.
 ---
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use ESLint and Prettier
+title: Using ESLint and Prettier
 description: A guide on configuring ESLint and Prettier to format Expo apps.
 ---
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Firebase
+title: Using Firebase
 maxHeadingDepth: 4
 description: A guide on getting started and using Firebase JS SDK and React Native Firebase library.
 ---

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use Hermes Engine
-sidebar_title: Use Hermes
+title: Using Hermes Engine
+sidebar_title: Using Hermes
 description: A guide on configuring Hermes for both Android and iOS in an Expo project.
 ---
 

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use Next.js with Expo for Web
-sidebar_title: Use Next.js
+title: Using Next.js with Expo for Web
+sidebar_title: Using Next.js
 description: A guide for integrating Next.js with Expo for the web.
 ---
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Sentry
+title: Using Sentry
 maxHeadingDepth: 4
 hideTOC: true
 description: A guide on installing and configuring Sentry for crash reporting.

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Supabase
+title: Using Supabase
 description: Add a Postgres Database and user authentication to your React Native app with Supabase.
 ---
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Linking into your app
 sidebar_title: Into your app
-description: Learn how to handle an incoming URL in your app by creating a deep link.
+description: Learn how to handle an incoming URL in your React Native and Expo app by creating a deep link.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Push notifications: Overview'
+title: 'Expo push notifications: Overview'
 sidebar_title: Overview
 description: An overview of Expo push notification service.
 hideTOC: true

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Push notifications setup
+title: Expo push notifications setup
 description: Learn how to set up push notifications, get credentials for development and production, and send a testing push notification.
 ---
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -26,15 +26,13 @@ It brings the best file-system routing concepts from the web to a universal appl
 - **Universal**: Android, iOS, and web share a unified navigation structure, with the ability to drop-down to platform-specific APIs at the route level.
 - **Discoverable**: Expo Router enables build-time static rendering on web, and universal linking to native. Meaning your app content can be indexed by search engines.
 
-## Common questions
+### Using a different navigation library
 
-<Collapsible summary="Can I use a different navigation library?">
-
-You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, we recommend using Expo Router for all the features described above. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
+You can use any other navigation library, like [React Navigation](https://reactnavigation.org/docs/getting-started#installation), in your Expo project. However, if you are building a new app, **we recommend using Expo Router for all the features described above**. With other navigation libraries, you might have to implement your own strategies for some of these features, such as shareable links or handling web and native navigation in the same project.
 
 If you are looking to use [React Native Navigation by Wix](https://github.com/wix/react-native-navigation), it is not available in Expo Go and is not yet compatible with `expo-dev-client`. We recommend using [`createNativeStackNavigator`](https://reactnavigation.org/docs/native-stack-navigator) from React Navigation to use Android and iOS native navigation APIs.
 
-</Collapsible>
+## Common questions
 
 <Collapsible summary="Expo Router versus Expo versus React Native CLI">
 

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use URL parameters
+title: Using URL parameters
 description: Learn how to access and modify route and search parameters in your app.
 sidebar_title: URL parameters
 ---

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create a modal
-description: In this tutorial, learn how to create a modal from React Native to select an image.
+description: In this tutorial, learn how to create a React Native modal to select an image.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Expo Tutorial: Introduction'
+title: 'Tutorial: Using React Native and Expo'
 sidebar_title: Introduction
-description: An introduction to a tutorial on how to build a universal app that runs on Android, iOS and the web using Expo.
+description: An introduction to a React Native tutorial on how to build a universal app that runs on Android, iOS and the web using Expo.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 We're about to embark on a journey of building universal apps. In this tutorial, we'll create an Expo app that runs on Android, iOS, and web; all with a single codebase. Let's get started!
 
-## About this tutorial
+## About React Native and Expo tutorial
 
 The objective of this tutorial is to get started with Expo and become familiar with the Expo SDK. It'll cover the following topics:
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -1,5 +1,6 @@
 ---
-title: GestureHandler
+title: React Native Gesture Handler
+sidebar_title: GestureHandler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -1,5 +1,6 @@
 ---
-title: Picker
+title: React Native Picker
+sidebar_title: Picker
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native Reanimated
+sidebar_title: Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reanimated
+title: React Native Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -1,5 +1,6 @@
 ---
-title: SafeAreaContext
+title: React Native Safe Area Context
+sidebar_title: SafeAreaContext
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -1,5 +1,6 @@
 ---
-title: Svg
+title: React Native SVG
+sidebar_title: Svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebView
+title: React Native WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native WebView
+sidebar_title: WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
@@ -1,5 +1,6 @@
 ---
-title: GestureHandler
+title: React Native Gesture Handler
+sidebar_title: GestureHandler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'

--- a/docs/pages/versions/v50.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/picker.mdx
@@ -1,5 +1,6 @@
 ---
-title: Picker
+title: React Native Picker
+sidebar_title: Picker
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native Reanimated
+sidebar_title: Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reanimated
+title: React Native Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -1,5 +1,6 @@
 ---
-title: SafeAreaContext
+title: React Native Safe Area Context
+sidebar_title: SafeAreaContext
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'

--- a/docs/pages/versions/v50.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/svg.mdx
@@ -1,5 +1,6 @@
 ---
-title: Svg
+title: React Native SVG
+sidebar_title: Svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'

--- a/docs/pages/versions/v50.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webview.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native WebView
+sidebar_title: WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v50.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webview.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebView
+title: React Native WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
@@ -1,5 +1,6 @@
 ---
-title: GestureHandler
+title: React Native Gesture Handler
+sidebar_title: GestureHandler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'

--- a/docs/pages/versions/v51.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/picker.mdx
@@ -1,5 +1,6 @@
 ---
-title: Picker
+title: React Native Picker
+sidebar_title: Picker
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'

--- a/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native Reanimated
+sidebar_title: Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reanimated
+title: React Native Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -1,5 +1,6 @@
 ---
-title: SafeAreaContext
+title: React Native Safe Area Context
+sidebar_title: SafeAreaContext
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'

--- a/docs/pages/versions/v51.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/svg.mdx
@@ -1,5 +1,6 @@
 ---
-title: Svg
+title: React Native SVG
+sidebar_title: Svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'

--- a/docs/pages/versions/v51.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/webview.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebView
+title: React Native WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v51.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/webview.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native WebView
+sidebar_title: WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v52.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/gesture-handler.mdx
@@ -1,5 +1,6 @@
 ---
-title: GestureHandler
+title: React Native Gesture Handler
+sidebar_title: GestureHandler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'

--- a/docs/pages/versions/v52.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/picker.mdx
@@ -1,5 +1,6 @@
 ---
-title: Picker
+title: React Native Picker
+sidebar_title: Picker
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'

--- a/docs/pages/versions/v52.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/reanimated.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native Reanimated
+sidebar_title: Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v52.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/reanimated.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reanimated
+title: React Native Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'

--- a/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
@@ -1,5 +1,6 @@
 ---
-title: SafeAreaContext
+title: React Native Safe Area Context
+sidebar_title: SafeAreaContext
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'

--- a/docs/pages/versions/v52.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/svg.mdx
@@ -1,5 +1,6 @@
 ---
-title: Svg
+title: React Native SVG
+sidebar_title: Svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'

--- a/docs/pages/versions/v52.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/webview.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebView
+title: React Native WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/versions/v52.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/webview.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Native WebView
+sidebar_title: WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -1,6 +1,7 @@
 ---
-title: Use libraries
-description: Learn how to use libraries based on React Native, Expo SDK and third-party in your project.
+title: Using Expo SDK, React Native, and third-party libraries
+sidebar_title: Using libraries
+description: Learn how to use Expo SDK, React Native libraries, and other third-party npm packages in your project.
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-14412

# How

<!--
How did you build this feature or fix this bug and why?
-->

By re-purposing/updating content and metadata description on multiple pages as discussed in SEO sync with @dankelly2040 .

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See the diff and check each page manually by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
