### PR TITLE
Fix @react-native-firebase/messaging overriding Expo

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix @react-native-firebase/messaging overriding Expo Notifications
+- [Android] Fix @react-native-firebase/messaging overriding Expo Notifications ([#33666](https://github.com/expo/expo/pull/33666) by [@scarlac](https://github.com/scarlac))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix @react-native-firebase/messaging overriding Expo Notifications
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <service
       android:name=".service.ExpoFirebaseMessagingService"
       android:exported="false">
-      <intent-filter android:priority="-1">
+      <intent-filter android:priority="100">
         <action android:name="com.google.firebase.MESSAGING_EVENT" />
       </intent-filter>
     </service>


### PR DESCRIPTION
 Fix @react-native-firebase/messaging overriding Expo Notifications, originally attempted in PR #8175

# Why

If @react-native-firebase/messaging is installed on Android it will block Expo's ability to catch notifications while the app is in the foreground. This is because there can only be one service that handles the message, and by default Expo sets its priority to -1, which was introduced in PR #8175 as what seems to be a bug.
The default priority is 0, and any HIGHER priorities will take precedence.
The author of PR 8175 wrote "register ExpoFcmMessagingService with higher priority", but instead they put a lower priority.
This PR fixes that, and enables Expo to handle foreground notifications as intended.

# How

<!--
How did you build this feature or fix this bug and why?
-->
AndroidManifest.xml was simply modified to a sufficiently high priority value.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I have tested this change locally and it worked. I undid the change and Firebase took over again, then I re-applied the change and confirmed that it indeed did work (a classic triple check to ensure it's not a fluke).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
