### PR TITLE
[expo-go] Prevent crash from `EXErrorView`

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -115,10 +115,11 @@
   }
 
   UIFont *font = _txtErrorDetail.font;
-  NSAttributedString *attributedErrorString =[[NSAttributedString alloc] initWithString:errorDetail];
-  attributedErrorString = [EXManifestResource parseUrlsAndBoldInAttributedString:attributedErrorString withFont:font];
-
-  _txtErrorDetail.attributedText = attributedErrorString;
+  if (errorDetail != nil) {
+    NSAttributedString *attributedErrorString =[[NSAttributedString alloc] initWithString:errorDetail];
+    attributedErrorString = [EXManifestResource parseUrlsAndBoldInAttributedString:attributedErrorString withFont:font];
+    _txtErrorDetail.attributedText = attributedErrorString;
+  }
   _txtErrorDetail.textColor = [UIColor colorNamed:@"textDefault"];
 
   if (errorFixInstructions != nil) {


### PR DESCRIPTION
# Why
Fixes a common crash seen in crashlytics. The `localizedDescription` on `NSError` can potentially be nil. This causes a crash when trying to create an attributed string with this value.

# How
Check if the value is nil before attempting to create the attributed string.

# Test Plan
expo-go

