### PR TITLE
[expo-go] Stub out iOS notification code until Swift conversion complete

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+/*
 #if __has_include(<EXNotifications/EXNotificationBuilder.h>)
 
 #import <EXNotifications/EXNotificationBuilder.h>
@@ -17,3 +19,4 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 #endif
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+/*
 #import "EXScopedNotificationBuilder.h"
 #import "EXScopedNotificationsUtils.h"
 
@@ -42,3 +44,4 @@
 }
 
 @end
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+/*
 #if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)
 
 #import <EXNotifications/EXNotificationPresentationModule.h>
@@ -15,3 +17,4 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 #endif
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -1,5 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+
+/*
 #import "EXScopedNotificationPresentationModule.h"
 #import "EXScopedNotificationsUtils.h"
 #import "EXScopedNotificationSerializer.h"
@@ -69,3 +72,4 @@
 }
 
 @end
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
@@ -1,5 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+
+/*
 #if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
 
 #import <EXNotifications/EXNotificationSchedulerModule.h>
@@ -15,3 +18,4 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 #endif
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -1,5 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+// TODO: rework the new Swift Notification code for ExpoGo
+
+/*
 #import "EXScopedNotificationSchedulerModule.h"
 #import "EXScopedNotificationsUtils.h"
 #import "EXScopedNotificationSerializer.h"
@@ -66,3 +69,4 @@
 }
 
 @end
+ */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -14,13 +14,14 @@
 
 #import "EXScopedReactNativeAdapter.h"
 #import "EXExpoUserNotificationCenterProxy.h"
-
+/*
 #import "EXScopedNotificationsEmitter.h"
 #import "EXScopedNotificationsHandlerModule.h"
 #import "EXScopedNotificationBuilder.h"
 #import "EXScopedNotificationSchedulerModule.h"
 #import "EXScopedNotificationPresentationModule.h"
 #import "EXScopedNotificationCategoriesModule.h"
+ */
 #import "EXScopedServerRegistrationModule.h"
 
 #if __has_include(<EXTaskManager/EXTaskManager.h>)
@@ -73,6 +74,9 @@ if (params[@"fileSystemDirectories"]) {
   [moduleRegistry registerExportedModule:taskManagerModule];
 #endif
 
+  // TODO: rework the new Swift Notification code for ExpoGo
+
+/*
 #if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
   EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithScopeKey:scopeKey];
   [moduleRegistry registerExportedModule:notificationsEmmitter];
@@ -105,6 +109,7 @@ if (params[@"fileSystemDirectories"]) {
   [EXScopedNotificationCategoriesModule maybeMigrateLegacyCategoryIdentifiersForProjectWithExperienceStableLegacyId:experienceStableLegacyId
                                                                                                            scopeKey:scopeKey];
 #endif
+ */
 
 #if __has_include(<EXNotifications/EXServerRegistrationModule.h>)
   EXScopedServerRegistrationModule *serverRegistrationModule = [[EXScopedServerRegistrationModule alloc] initWithScopeKey:scopeKey];


### PR DESCRIPTION
# Why

Existing scoped notifications modules in Expo Go are still written in Objective C with the old module API, and are not compatible with the new Swift implementation.

# How

Stubbing these out for now so that Expo Go CI can pass.

# Test Plan

CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
