### PR TITLE
[core][iOS] Fix ExpoAppDelegate lifecycle events with scenes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Ensure `uuid.v4`and`uuid.v5` is available on old react native architecture. ([#33621](https://github.com/expo/expo/pull/33621) by [@andrejpavlovic](https://github.com/andrejpavlovic))
 - Changed `import` to `import type` for TS type declarations. ([#33447](https://github.com/expo/expo/pull/33447) by [@j-piasecki](https://github.com/j-piasecki))
 - [macOS] Allow SwiftUI views to work on macOS ([#33506](https://github.com/expo/expo/pull/33506) by [@hassankhan](https://github.com/hassankhan))
+- [iOS] Fix `ExpoAppDelegate` lifecycle events with scenes ([#33691](https://github.com/expo/expo/pull/33691) by [@alextoudic](https://github.com/alextoudic))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -21,6 +21,47 @@ open class ExpoAppDelegate: ExpoAppInstance {
   public var shouldCallReactNativeSetup: Bool = true
 
   #if os(iOS) || os(tvOS)
+
+  override public init() {
+    super.init()
+
+    let notifications = [
+      UIApplication.didBecomeActiveNotification,
+      UIApplication.willResignActiveNotification,
+      UIApplication.didEnterBackgroundNotification,
+      UIApplication.willEnterForegroundNotification
+    ]
+    notifications.forEach { name in
+      NotificationCenter.default.addObserver(self, selector: #selector(handleClientAppNotification(_:)), name: name, object: nil)
+    }
+  }
+
+  /**
+   Cleans things up before deallocation.
+   */
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  /**
+   Handles app's (`UIApplication`) lifecycle notifications
+   */
+  @objc
+  private func handleClientAppNotification(_ notification: Notification) {
+    switch notification.name {
+    case UIApplication.didBecomeActiveNotification:
+      handleDidBecomeActive()
+    case UIApplication.willResignActiveNotification:
+      handleWillResignActive()
+    case UIApplication.didEnterBackgroundNotification:
+      handleDidEnterBackground()
+    case UIApplication.willEnterForegroundNotification:
+      handleWillEnterForeground()
+    default:
+      return
+    }
+  }
+
   // MARK: - Initializing the App
 
   open override func application(
@@ -62,23 +103,20 @@ open class ExpoAppDelegate: ExpoAppInstance {
 
   // MARK: - Responding to App Life-Cycle Events
 
-  @objc
-  open override func applicationDidBecomeActive(_ application: UIApplication) {
-    subscribers.forEach { $0.applicationDidBecomeActive?(application) }
+  func handleDidBecomeActive() {
+    subscribers.forEach { $0.applicationDidBecomeActive?(UIApplication.shared) }
   }
 
-  @objc
-  open override func applicationWillResignActive(_ application: UIApplication) {
-    subscribers.forEach { $0.applicationWillResignActive?(application) }
+  func handleWillResignActive() {
+    subscribers.forEach { $0.applicationWillResignActive?(UIApplication.shared) }
   }
 
-  @objc
-  open override func applicationDidEnterBackground(_ application: UIApplication) {
-    subscribers.forEach { $0.applicationDidEnterBackground?(application) }
+  func handleDidEnterBackground() {
+    subscribers.forEach { $0.applicationDidEnterBackground?(UIApplication.shared) }
   }
 
-  open override func applicationWillEnterForeground(_ application: UIApplication) {
-    subscribers.forEach { $0.applicationWillEnterForeground?(application) }
+  func handleWillEnterForeground() {
+    subscribers.forEach { $0.applicationWillEnterForeground?(UIApplication.shared) }
   }
 
   open override func applicationWillTerminate(_ application: UIApplication) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Currently events subscription described in https://docs.expo.dev/modules/appdelegate-subscribers/ isn't working due to scenes usage as described on https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:)#Discussion

# How

<!--
How did you build this feature or fix this bug and why?
-->
Took inspiration from https://github.com/expo/expo/blob/a1e7001a88ebad709560624f0a2f8b59bdb73cbd/packages/expo-modules-core/ios/Core/AppContext.swift to rely on UIKit's notifications

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Patched a local implementation to make sure changes address the initial issue

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
