### PR TITLE
[updates] Prevent ANRs from `launchFallbackUpdateFromDisk`

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- `launchFallbackUpdateFromDisk` should be called from a background thread.
+- Fix an issue where `launchFallbackUpdateFromDisk` is called from a background thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- `launchFallbackUpdateFromDisk` should be called from a background thread.
+
 ### 💡 Others
 
 ## 0.26.10 - 2024-12-05

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix an issue where `launchFallbackUpdateFromDisk` is called from a background thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -294,56 +294,66 @@ class LoaderTask(
   }
 
   private fun launchFallbackUpdateFromDisk(diskUpdateCallback: LaunchUpdateCallback) {
-    val database = databaseHolder.database
-    val launcher = DatabaseLauncher(context, configuration, directory, fileDownloader, selectionPolicy, logger)
-    candidateLauncher = launcher
-    val launcherCallback: LauncherCallback = object : LauncherCallback {
-      override fun onFailure(e: Exception) {
-        databaseHolder.releaseDatabase()
-        diskUpdateCallback.onFailure(e)
+    AsyncTask.execute {
+      val database = databaseHolder.database
+      val launcher =
+        DatabaseLauncher(context, configuration, directory, fileDownloader, selectionPolicy, logger)
+      candidateLauncher = launcher
+      val launcherCallback: LauncherCallback = object : LauncherCallback {
+        override fun onFailure(e: Exception) {
+          databaseHolder.releaseDatabase()
+          diskUpdateCallback.onFailure(e)
+        }
+
+        override fun onSuccess() {
+          databaseHolder.releaseDatabase()
+          diskUpdateCallback.onSuccess()
+        }
       }
+      if (configuration.hasEmbeddedUpdate) {
+        // if the embedded update should be launched (e.g. if it's newer than any other update we have
+        // in the database, which can happen if the app binary is updated), load it into the database
+        // so we can launch it
+        val embeddedUpdate =
+          EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)!!.updateEntity
+        val launchableUpdate = launcher.getLaunchableUpdate(database)
+        val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
+        if (selectionPolicy.shouldLoadNewUpdate(
+            embeddedUpdate,
+            launchableUpdate,
+            manifestFilters
+          )
+        ) {
+          EmbeddedLoader(context, configuration, logger, database, directory).start(object :
+            LoaderCallback {
+            override fun onFailure(e: Exception) {
+              logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
+              launcher.launch(database, launcherCallback)
+            }
 
-      override fun onSuccess() {
-        databaseHolder.releaseDatabase()
-        diskUpdateCallback.onSuccess()
-      }
-    }
-    if (configuration.hasEmbeddedUpdate) {
-      // if the embedded update should be launched (e.g. if it's newer than any other update we have
-      // in the database, which can happen if the app binary is updated), load it into the database
-      // so we can launch it
-      val embeddedUpdate = EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)!!.updateEntity
-      val launchableUpdate = launcher.getLaunchableUpdate(database)
-      val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
-      if (selectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, manifestFilters)) {
-        EmbeddedLoader(context, configuration, logger, database, directory).start(object : LoaderCallback {
-          override fun onFailure(e: Exception) {
-            logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
-            launcher.launch(database, launcherCallback)
-          }
+            override fun onSuccess(loaderResult: Loader.LoaderResult) {
+              launcher.launch(database, launcherCallback)
+            }
 
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
-            launcher.launch(database, launcherCallback)
-          }
+            override fun onAssetLoaded(
+              asset: AssetEntity,
+              successfulAssetCount: Int,
+              failedAssetCount: Int,
+              totalAssetCount: Int
+            ) {
+              // do nothing
+            }
 
-          override fun onAssetLoaded(
-            asset: AssetEntity,
-            successfulAssetCount: Int,
-            failedAssetCount: Int,
-            totalAssetCount: Int
-          ) {
-            // do nothing
-          }
-
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
-          }
-        })
+            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+              return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+            }
+          })
+        } else {
+          launcher.launch(database, launcherCallback)
+        }
       } else {
         launcher.launch(database, launcherCallback)
       }
-    } else {
-      launcher.launch(database, launcherCallback)
     }
   }
 


### PR DESCRIPTION
# Why
We experience a significant number of ANRs when calling the `launchFallbackUpdateFromDisk` method on the `LoaderTask`. This occurs because the method is called on the main thread and accesses the database, whose getter implementation is:
```kotlin
val database: UpdatesDatabase
  get() {
    while (isInUse) {
      try {
        (this as java.lang.Object).wait()
      } catch (e: InterruptedException) {
        Log.e(TAG, "Interrupted while waiting for database", e)
      }
    }
```

Closes ENG-12782.

# How
We should not be blocking the main thread to do this. For now, I've wrapped the call in an `AsyncTask` similar to what other methods in `LoaderTask` are doing but everything here should be migrated to use coroutines. `AsyncTask` has been deprecated for a long time.

# Test Plan
expo-go. The app behaves as normal. 
