### PR TITLE
[expo-updates] Fix expo-updates breaking filesystem on API24-25

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix expo-updates breaking filesystem on Android API 24 and 25. ([#33694](https://github.com/expo/expo/pull/33694) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 18.0.6 - 2024-12-16

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -291,9 +291,19 @@ open class FileSystemModule : Module() {
           val from = fromUri.toFile()
           val to = toUri.toFile()
           if (from.isDirectory) {
-            FileUtils.copyDirectory(from, to)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              FileUtils.copyDirectory(from, to)
+            } else {
+              // to be removed once Android SDK 25 support is dropped
+              from.copyRecursively(to, overwrite = true)
+            }
           } else {
-            FileUtils.copyFile(from, to)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              FileUtils.copyFile(from, to)
+            } else {
+              // to be removed once Android SDK 25 support is dropped
+              from.copyTo(to, overwrite = true)
+            }
           }
         }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/33520
Closes ENG-14513

# How

expo-file-system relies on `commons-io:commons-io:1.4` for the `copyFile` path.
expo-updates uses `commons-io:commons-io:2.16.1`.

Gradle won't allow us to use two versions of a same dependency imo, and both the old one and the latest one don't work for both our usecases.

~To fix this issue in the least invasive way IMO I would just downgrade the version in expo-updates to the latest one that correctly supports `copyFile` on API24 and 25 and also has the new stuff you're using in updates. Gradle will pick the latest one of two, but just for clarity I also bumped the version in filesystem.~

I added a check for API24 and 25 similarly to existing code in filesystem and I'm using kotlin SDK functions.

# Test Plan

Tested the original repro. Let's see if updates tests pass correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
…DK24