### PR TITLE
[docs] further tweaks and improvements for API reference rendering

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState, createRef, type PropsWithChildren, useRef } from 'react';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
 import * as RoutesUtils from '~/common/routes';
 import { appendSectionToRoute, isRouteActive } from '~/common/routes';
@@ -12,7 +13,6 @@ import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScr
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { PageMetadata } from '~/types/common';
-import { Callout } from '~/ui/components/Callout';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { PagePlatformTags } from '~/ui/components/PagePlatformTags';
@@ -146,11 +146,11 @@ export default function DocumentationPage({
           'max-lg-gutters:px-4 max-lg-gutters:pb-12 max-lg-gutters:pt-5'
         )}>
         {version && version === 'unversioned' && (
-          <Callout type="default" size="sm" className="!mb-5 !inline-flex w-full">
+          <InlineHelp type="default" size="sm" className="!mb-5 !inline-flex w-full">
             This is documentation for the next SDK version. For up-to-date documentation, see the{' '}
             <A href={pathname.replace('unversioned', 'latest')}>latest version</A> (
             {versionToText(LATEST_VERSION)}).
-          </Callout>
+          </InlineHelp>
         )}
         {title && (
           <PageTitle

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
-import { getH3CodeWithBaseNestingLevel } from '~/components/plugins/api/APISectionUtils';
+import { getCodeHeadingWithBaseNestingLevel } from '~/components/plugins/api/APISectionUtils';
 import { APISectionPlatformTags } from '~/components/plugins/api/components/APISectionPlatformTags';
 import {
   STYLES_APIBOX,
@@ -9,7 +9,7 @@ import {
   STYLES_APIBOX_WRAPPER,
 } from '~/components/plugins/api/styles';
 import { PlatformName } from '~/types/common';
-import { MONOSPACE } from '~/ui/components/Text';
+import { MONOSPACE, RawH3 } from '~/ui/components/Text';
 
 type APIBoxProps = PropsWithChildren<{
   header?: string;
@@ -25,7 +25,7 @@ export const APIBox = ({
   className,
   headerNestingLevel = 3,
 }: APIBoxProps) => {
-  const HeadingElement = getH3CodeWithBaseNestingLevel(headerNestingLevel);
+  const HeadingElement = getCodeHeadingWithBaseNestingLevel(headerNestingLevel, RawH3);
   return (
     <div
       className={mergeClasses(

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !shadow-none"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !shadow-none"
   >
     <div
       class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
@@ -95,7 +95,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       <span
@@ -121,7 +121,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -132,7 +132,7 @@ available via the provided properties.
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -141,7 +141,7 @@ available via the provided properties.
         href="#appleauthenticationisavailableasync"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -150,7 +150,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         true
@@ -158,7 +158,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         __DEV__ === true
@@ -168,12 +168,12 @@ a warning in development mode (
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         View
@@ -181,21 +181,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         style
@@ -203,7 +203,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         buttonStyle
@@ -211,7 +211,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         cornerRadius
@@ -222,21 +222,21 @@ button.
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -254,10 +254,10 @@ not appear on the screen.
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -283,11 +283,11 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4"
+        class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4"
         data-text="true"
       >
         <span
-          class="leading-[1.6154] text-inherit group flex gap-1"
+          class="leading-[1.6154] text-inherit items-center group flex gap-1"
           data-text="true"
         >
           AppleAuthenticationButtonProps
@@ -332,7 +332,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -342,7 +342,7 @@ for more details.
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
               data-text="true"
             >
               buttonStyle
@@ -401,14 +401,14 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -418,7 +418,7 @@ for more details.
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
               data-text="true"
             >
               buttonType
@@ -477,14 +477,14 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -494,7 +494,7 @@ for more details.
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
               data-text="true"
             >
               cornerRadius
@@ -549,13 +549,13 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             style.borderRadius
@@ -564,7 +564,7 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -574,7 +574,7 @@ for more details.
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
               data-text="true"
             >
               onPress
@@ -639,7 +639,7 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -648,7 +648,7 @@ for more details.
             href="#appleauthenticationisavailableasync"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -659,7 +659,7 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -669,7 +669,7 @@ in here.
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
               data-text="true"
             >
               style
@@ -782,19 +782,19 @@ in here.
           </code>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             borderRadius
@@ -847,7 +847,7 @@ properties.
         class="leading-[1.6154] text-default list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
       >
         <li
-          class="text-default text-[16px] font-normal leading-relaxed tracking-[-0.011rem] mb-2"
+          class="text-default text-base font-normal leading-relaxed mb-2"
           data-text="true"
         >
           <code
@@ -908,7 +908,7 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1021,7 +1021,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 The full name object with the tokenized portions
@@ -1065,7 +1065,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 The style in which the name should be formatted
@@ -1077,7 +1077,7 @@ properties.
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Creates a locale-aware string representation of a person's name from an object representing the tokenized portions of a user's full name
@@ -1113,23 +1113,18 @@ properties.
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
-        >
-          string
-        </code>
-      </p>
+        string
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A locale-aware string representation of a person's name
@@ -1137,7 +1132,7 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1245,7 +1240,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
@@ -1255,7 +1250,7 @@ This should come from the user field of an
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1270,7 +1265,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1278,14 +1273,14 @@ This should come from the user field of an
     
 
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-default"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -1308,7 +1303,7 @@ This should come from the user field of an
         
 
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -1354,48 +1349,43 @@ This should come from the user field of an
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#appleauthenticationcredentialstate"
           >
-            Promise
+            AppleAuthenticationCredentialState
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#appleauthenticationcredentialstate"
-            >
-              AppleAuthenticationCredentialState
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1404,7 +1394,7 @@ This should come from the user field of an
           href="#appleauthenticationcredentialstate"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -1416,7 +1406,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1468,7 +1458,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
@@ -1504,55 +1494,50 @@ value depending on the state of the credential.
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Promise
-          </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            boolean
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
+          boolean
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A promise that fulfills with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           false
@@ -1562,7 +1547,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1675,7 +1660,7 @@ value depending on the state of the credential.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An 
@@ -1684,7 +1669,7 @@ value depending on the state of the credential.
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1699,7 +1684,7 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1736,48 +1721,43 @@ Calling this method will show the sign in modal before actually refreshing the u
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#appleauthenticationcredential"
           >
-            Promise
+            AppleAuthenticationCredential
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#appleauthenticationcredential"
-            >
-              AppleAuthenticationCredential
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1786,7 +1766,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1795,7 +1775,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1806,7 +1786,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1924,7 +1904,7 @@ refresh operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An optional 
@@ -1933,7 +1913,7 @@ refresh operation.
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1948,7 +1928,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1957,7 +1937,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1967,7 +1947,7 @@ of these options at runtime.
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1986,7 +1966,7 @@ You can use
         href="#appleauthenticationcredential"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -2026,48 +2006,43 @@ the user, since this remains the same for apps released by the same developer.
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#appleauthenticationcredential"
           >
-            Promise
+            AppleAuthenticationCredential
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#appleauthenticationcredential"
-            >
-              AppleAuthenticationCredential
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -2076,7 +2051,7 @@ the user, since this remains the same for apps released by the same developer.
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2085,7 +2060,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2096,7 +2071,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2209,7 +2184,7 @@ sign-in operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An 
@@ -2218,7 +2193,7 @@ sign-in operation.
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -2233,7 +2208,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -2242,7 +2217,7 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2253,7 +2228,7 @@ from using
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           signInAsync
@@ -2265,7 +2240,7 @@ from using
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           refreshAsync
@@ -2304,48 +2279,43 @@ from using
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#appleauthenticationcredential"
           >
-            Promise
+            AppleAuthenticationCredential
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#appleauthenticationcredential"
-            >
-              AppleAuthenticationCredential
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -2354,7 +2324,7 @@ from using
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2363,7 +2333,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2414,7 +2384,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2555,17 +2525,12 @@ sign-out operation.
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
-        >
-          EventSubscription
-        </code>
-      </p>
+        EventSubscription
+      </code>
     </div>
   </div>
   <h2
@@ -2609,7 +2574,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2661,7 +2626,7 @@ sign-out operation.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2670,7 +2635,7 @@ sign-out operation.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2683,7 +2648,7 @@ sign-out operation.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2695,7 +2660,7 @@ sign-out operation.
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2705,14 +2670,14 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -2730,10 +2695,10 @@ which contains all of the pertinent user and credential information.
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -2824,13 +2789,13 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   user
@@ -2876,12 +2841,12 @@ the app's server counterpart. Unlike
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   EMAIL
@@ -2935,26 +2900,26 @@ an Apple domain.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 The user's name. May be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   FULL_NAME
@@ -3002,7 +2967,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -3041,7 +3006,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -3085,12 +3050,12 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   state
@@ -3099,7 +3064,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   state
@@ -3107,7 +3072,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
@@ -3143,7 +3108,7 @@ will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -3158,7 +3123,7 @@ developers.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3210,13 +3175,13 @@ developers.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         null
@@ -3516,7 +3481,7 @@ may be
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3584,20 +3549,20 @@ may be
       </code>
     </p>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       A value to specify the style for formatting a name.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -3615,10 +3580,10 @@ may be
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -3701,7 +3666,7 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3753,7 +3718,7 @@ for more details.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3762,7 +3727,7 @@ for more details.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3772,14 +3737,14 @@ for more details.
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -3797,10 +3762,10 @@ You must include the ID string of the user whose credentials you'd like to refre
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -3892,14 +3857,14 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
@@ -3908,14 +3873,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   []
@@ -3956,7 +3921,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4013,7 +3978,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4065,7 +4030,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4074,7 +4039,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -4084,14 +4049,14 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -4109,10 +4074,10 @@ None of these options are required.
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -4198,7 +4163,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
@@ -4253,14 +4218,14 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
@@ -4269,14 +4234,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                   data-text="true"
                 >
                   []
@@ -4317,7 +4282,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4341,7 +4306,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4393,7 +4358,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4402,7 +4367,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -4412,14 +4377,14 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
       data-testid="callout-container"
     >
       <div
-        class="mt-1 select-none [table_&]:mt-0.5"
+        class="select-none [table_&]:mt-0.5 mt-1"
       >
         <svg
-          class="translate-z icon-sm text-icon-default"
+          class="translate-z icon-xs text-icon-secondary"
           fill="currentColor"
           role="img"
           viewBox="0 0 24 24"
@@ -4437,10 +4402,10 @@ You must include the ID string of the user to sign out.
         </svg>
       </div>
       <div
-        class="w-full leading-normal text-default last:mb-0"
+        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           <span
@@ -4526,7 +4491,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4583,7 +4548,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4635,7 +4600,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -4708,7 +4673,7 @@ OAuth 2.0 protocol
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -4761,7 +4726,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -4816,7 +4781,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4825,7 +4790,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4837,59 +4802,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          WHITE
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#white"
-          id="white"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            WHITE
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#white"
+            id="white"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         White button with black text.
@@ -4898,59 +4867,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          WHITE_OUTLINE
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#white_outline"
-          id="white_outline"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            WHITE_OUTLINE
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#white_outline"
+            id="white_outline"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4959,59 +4932,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          BLACK
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#black"
-          id="black"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            BLACK
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#black"
+            id="black"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Black button with white text.
@@ -5019,7 +4996,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -5074,7 +5051,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
@@ -5083,7 +5060,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5095,59 +5072,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          SIGN_IN
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#sign_in"
-          id="sign_in"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            SIGN_IN
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#sign_in"
+            id="sign_in"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         "Sign in with Apple"
@@ -5156,59 +5137,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          CONTINUE
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#continue"
-          id="continue"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            CONTINUE
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#continue"
+            id="continue"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         "Continue with Apple"
@@ -5217,100 +5202,97 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
-      >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
-        >
-          SIGN_UP
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#sign_up"
-          id="sign_up"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
-          >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
       <div
-        class="flex flex-row items-start [table_&]:mb-2.5 mb-1"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <span
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          <span
-            class="text-xs font-medium text-tertiary [table_&]:!text-2xs"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            Only for:
-             
-          </span>
-          <div
-            class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            SIGN_UP
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#sign_up"
+            id="sign_up"
           >
-            <svg
-              class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
-              fill="none"
-              role="img"
-              viewBox="0 0 24 24"
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <g
-                id="apple-custom-icon"
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
-                  fill="currentColor"
-                  id="Vector"
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
                 />
-              </g>
-            </svg>
-            <span
-              class="whitespace-nowrap !text-3xs font-normal !leading-none"
-            >
-              iOS 13.2+
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
             </span>
-          </div>
-          <br />
-        </span>
+          </a>
+        </h4>
+        <div
+          class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
+        >
+          <span
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+            data-text="true"
+          >
+            <div
+              class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            >
+              <svg
+                class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
+                fill="none"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <g
+                  id="apple-custom-icon"
+                >
+                  <path
+                    d="M20.4478 17.3538C20.1312 18.0852 19.7564 18.7585 19.3222 19.3775C18.7303 20.2214 18.2457 20.8055 17.8722 21.1299C17.2933 21.6623 16.673 21.935 16.0088 21.9505C15.5319 21.9505 14.9568 21.8148 14.2874 21.5395C13.6158 21.2656 12.9986 21.1299 12.4343 21.1299C11.8424 21.1299 11.2076 21.2656 10.5287 21.5395C9.84865 21.8148 9.30085 21.9582 8.88201 21.9724C8.24504 21.9996 7.61014 21.7192 6.9764 21.1299C6.57191 20.7771 6.06598 20.1723 5.45989 19.3155C4.80961 18.4005 4.27499 17.3396 3.85615 16.13C3.4076 14.8235 3.18274 13.5583 3.18274 12.3335C3.18274 10.9304 3.48591 9.72034 4.09316 8.70628C4.5704 7.89174 5.20531 7.24922 5.99994 6.77753C6.79457 6.30584 7.65317 6.06547 8.57781 6.0501C9.08374 6.0501 9.7472 6.20659 10.5717 6.51416C11.3938 6.82276 11.9217 6.97926 12.1532 6.97926C12.3262 6.97926 12.9127 6.79627 13.9068 6.43145C14.847 6.09313 15.6404 5.95304 16.2905 6.00823C18.0519 6.15038 19.3752 6.84473 20.2552 8.09567C18.6799 9.05016 17.9007 10.387 17.9162 12.102C17.9304 13.4379 18.415 14.5495 19.3674 15.4321C19.799 15.8418 20.2811 16.1584 20.8174 16.3833C20.7011 16.7206 20.5783 17.0436 20.4478 17.3538ZM16.4081 1.45728C16.4081 2.50431 16.0256 3.48192 15.2631 4.38678C14.343 5.46249 13.2301 6.08408 12.0232 5.986C12.0078 5.86039 11.9989 5.72819 11.9989 5.58926C11.9989 4.58412 12.4365 3.50841 13.2135 2.62888C13.6015 2.18355 14.0949 1.81327 14.6932 1.51789C15.2902 1.22692 15.855 1.066 16.3861 1.03845C16.4016 1.17842 16.4081 1.3184 16.4081 1.45727V1.45728Z"
+                    fill="currentColor"
+                    id="Vector"
+                  />
+                </g>
+              </svg>
+              <span
+                class="whitespace-nowrap !text-3xs font-normal !leading-none"
+              >
+                iOS 13.2+
+              </span>
+            </div>
+          </span>
+        </div>
       </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         "Sign up with Apple"
@@ -5318,7 +5300,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -5373,7 +5355,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
@@ -5382,7 +5364,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -5391,14 +5373,14 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
         data-testid="callout-container"
       >
         <div
-          class="mt-1 select-none [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -5416,10 +5398,10 @@ After calling this function, the listener will no longer receive any events from
           </svg>
         </div>
         <div
-          class="w-full leading-normal text-default last:mb-0"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             <span
@@ -5447,53 +5429,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          REVOKED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#revoked"
-          id="revoked"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            REVOKED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#revoked"
+            id="revoked"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5502,53 +5488,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          AUTHORIZED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#authorized"
-          id="authorized"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            AUTHORIZED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#authorized"
+            id="authorized"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5557,53 +5547,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          NOT_FOUND
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#not_found"
-          id="not_found"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            NOT_FOUND
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#not_found"
+            id="not_found"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5612,53 +5606,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          TRANSFERRED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#transferred"
-          id="transferred"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            TRANSFERRED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#transferred"
+            id="transferred"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5666,7 +5664,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -5724,59 +5722,63 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          IMPLICIT
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#implicit"
-          id="implicit"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            IMPLICIT
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#implicit"
+            id="implicit"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5785,53 +5787,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          LOGIN
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#login"
-          id="login"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            LOGIN
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#login"
+            id="login"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5840,53 +5846,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          REFRESH
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#refresh"
-          id="refresh"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            REFRESH
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#refresh"
+            id="refresh"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5895,53 +5905,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          LOGOUT
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#logout"
-          id="logout"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            LOGOUT
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#logout"
+            id="logout"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5949,7 +5963,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -6004,7 +6018,7 @@ for more details.
         </h3>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
@@ -6013,7 +6027,7 @@ for more details.
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -6024,14 +6038,14 @@ for more details.
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6054,7 +6068,7 @@ for more details.
           
 
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -6065,14 +6079,14 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
         data-testid="callout-container"
       >
         <div
-          class="mt-1 select-none [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6090,10 +6104,10 @@ You will still need to handle null values for any fields you request.
           </svg>
         </div>
         <div
-          class="w-full leading-normal text-default last:mb-0"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             <span
@@ -6121,53 +6135,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          FULL_NAME
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#full_name"
-          id="full_name"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            FULL_NAME
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#full_name"
+            id="full_name"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -6176,53 +6194,57 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          EMAIL
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#email"
-          id="email"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            EMAIL
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#email"
+            id="email"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6230,7 +6252,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -6285,20 +6307,20 @@ for more details.
         </h3>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
         data-testid="callout-container"
       >
         <div
-          class="mt-1 select-none [table_&]:mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6316,10 +6338,10 @@ for more details.
           </svg>
         </div>
         <div
-          class="w-full leading-normal text-default last:mb-0"
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             <span
@@ -6347,59 +6369,63 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          UNSUPPORTED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#unsupported"
-          id="unsupported"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            UNSUPPORTED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#unsupported"
+            id="unsupported"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -6408,59 +6434,63 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          UNKNOWN
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#unknown"
-          id="unknown"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            UNKNOWN
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#unknown"
+            id="unknown"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6469,59 +6499,63 @@ for more details.
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          LIKELY_REAL
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#likely_real"
-          id="likely_real"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            LIKELY_REAL
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#likely_real"
+            id="likely_real"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6574,7 +6608,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6626,7 +6660,7 @@ exports[`APISection expo-pedometer 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
@@ -6662,46 +6696,41 @@ exports[`APISection expo-pedometer 1`] = `
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#permissionresponse"
           >
-            Promise
+            PermissionResponse
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#permissionresponse"
-            >
-              PermissionResponse
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6850,7 +6879,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -6891,7 +6920,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -6903,7 +6932,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Get the step count between two dates.
@@ -6939,48 +6968,43 @@ exports[`APISection expo-pedometer 1`] = `
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#pedometerresult"
           >
-            Promise
+            PedometerResult
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#pedometerresult"
-            >
-              PedometerResult
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Returns a promise that fulfills with a 
@@ -6989,7 +7013,7 @@ exports[`APISection expo-pedometer 1`] = `
           href="#pedometerresult"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             PedometerResult
@@ -7000,7 +7024,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         As 
@@ -7017,14 +7041,14 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -7047,7 +7071,7 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -7060,7 +7084,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7112,7 +7136,7 @@ a start date that is more than seven days in the past returns only the available
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
@@ -7148,48 +7172,43 @@ a start date that is more than seven days in the past returns only the available
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Promise
-          </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            boolean
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
+          boolean
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           boolean
@@ -7200,7 +7219,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7252,7 +7271,7 @@ available on this device.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
@@ -7288,46 +7307,41 @@ available on this device.
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+          rel="noopener noreferrer"
+          target="_blank"
         >
+          Promise
+        </a>
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
+        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="#permissionresponse"
           >
-            Promise
+            PermissionResponse
           </a>
-          <span
-            class="text-quaternary"
-          >
-            &lt;
-          </span>
-          <span>
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="#permissionresponse"
-            >
-              PermissionResponse
-            </a>
-          </span>
-          <span
-            class="text-quaternary"
-          >
-            &gt;
-          </span>
-        </code>
-      </p>
+        </span>
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
+      </code>
     </div>
   </div>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7440,7 +7454,7 @@ available on this device.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
@@ -7450,7 +7464,7 @@ provided with a single argument that is
                   href="#pedometerresult"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                     data-text="true"
                   >
                     PedometerResult
@@ -7465,7 +7479,7 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Subscribe to pedometer updates.
@@ -7501,23 +7515,18 @@ provided with a single argument that is
           Returns:
         </span>
       </div>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
         data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-          data-text="true"
-        >
-          EventSubscription
-        </code>
-      </p>
+        EventSubscription
+      </code>
     </div>
     <div
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Returns a 
@@ -7526,7 +7535,7 @@ provided with a single argument that is
           href="#subscription"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             Subscription
@@ -7535,7 +7544,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
           data-text="true"
         >
           remove()
@@ -7545,14 +7554,14 @@ provided with a single argument that is
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0"
+        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-0.5"
+          class="select-none [table_&]:mt-0.5 mt-1"
         >
           <svg
-            class="translate-z icon-sm text-icon-default"
+            class="translate-z icon-xs text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -7575,7 +7584,7 @@ provided with a single argument that is
           
 
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
@@ -7587,7 +7596,7 @@ provided with a single argument that is
               target="_blank"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
                 data-text="true"
               >
                 Health Connect API
@@ -7596,7 +7605,7 @@ provided with a single argument that is
             .
 On iOS, the 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
               data-text="true"
             >
               getStepCountAsync
@@ -7650,7 +7659,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-secondary py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7702,20 +7711,54 @@ On iOS, the
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4"
+      class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4"
       data-text="true"
     >
       <span
-        class="tracking-[-0.006rem] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+        class="leading-[1.6154] text-inherit items-center group flex gap-1"
         data-text="true"
       >
         PermissionResponse Properties
+        <a
+          class="border border-solid rounded-md whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+          href="#permissionresponse-properties"
+          id="permissionresponse-properties"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
+          >
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </span>
     </p>
     <div
@@ -7775,7 +7818,7 @@ On iOS, the
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -7816,7 +7859,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -7850,7 +7893,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -7889,7 +7932,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -7942,7 +7985,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8050,7 +8093,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -8062,7 +8105,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8115,7 +8158,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Callback function providing event result as an argument.
@@ -8180,7 +8223,7 @@ in order to enable/disable the permission.
       </div>
     </div>
     <div
-      class="mt-4 flex flex-row items-start gap-2"
+      class="mt-3.5 flex flex-row items-start gap-2"
     >
       <div
         class="flex flex-row items-center gap-2"
@@ -8224,7 +8267,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8287,7 +8330,7 @@ in order to enable/disable the permission.
       multiple types
     </p>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
@@ -8318,7 +8361,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8370,7 +8413,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+      class="text-default font-normal text-base [&_strong]:break-words mb-3"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -8443,7 +8486,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+                class="text-default font-normal text-base [&_strong]:break-words mb-3"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -8496,7 +8539,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[56px] px-5 pt-3"
@@ -8554,59 +8597,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          DENIED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#denied"
-          id="denied"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            DENIED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#denied"
+            id="denied"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         User has denied the permission.
@@ -8615,59 +8662,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          GRANTED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#granted"
-          id="granted"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            GRANTED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#granted"
+            id="granted"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         User has granted the permission.
@@ -8676,59 +8727,63 @@ After calling this function, the listener will no longer receive any events from
     <div
       class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
-        <code
-          class="leading-[1.6154] text-default !text-inherit !font-medium"
-          data-text="true"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          UNDETERMINED
-        </code>
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#undetermined"
-          id="undetermined"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          <code
+            class="leading-[1.6154] text-default !text-inherit"
+            data-text="true"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            UNDETERMINED
+          </code>
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#undetermined"
+            id="undetermined"
+          >
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
       <code
-        class="text-tertiary mb-2 inline-flex text-2xs"
+        class="text-secondary mb-2 inline-flex text-2xs"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -8741,7 +8796,7 @@ After calling this function, the listener will no longer receive any events from
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words"
+    class="text-default font-normal text-base [&_strong]:break-words"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import ReactMarkdown from 'react-markdown';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
-import { Callout } from '~/ui/components/Callout';
 import { BOLD } from '~/ui/components/Text';
 
 import { CommentData } from './APIDataTypes';
@@ -27,20 +27,21 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
         `[table_&]:mt-0 [table_&]:${ELEMENT_SPACING} [table_&]:last:mb-0`,
         sticky && 'mx-[-21px] mt-[-21px] max-lg-gutters:mx-[-17px]'
       )}>
-      <Callout
+      <InlineHelp
         size="sm"
         type="warning"
         key="deprecation-note"
         className={mergeClasses(
+          'border-palette-yellow5',
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'rounded-b-none rounded-t-lg pl-6 pr-4 shadow-none max-md-gutters:px-4'
+          sticky && 'rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
         )}>
         {content.length ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>
         ) : (
           <BOLD>Deprecated</BOLD>
         )}
-      </Callout>
+      </InlineHelp>
     </div>
   );
 };

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -47,16 +47,14 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           className="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-          <H4 hideInSidebar>
-            <MONOSPACE className="!text-inherit !font-medium">{enumValue.name}</MONOSPACE>
-          </H4>
-          <APISectionPlatformTags
-            comment={enumValue.comment}
-            prefix="Only for:"
-            className="mb-1"
-            disableFallback
-          />
-          <MONOSPACE theme="tertiary" className="mb-2 inline-flex text-2xs">
+
+          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
+            <H4 hideInSidebar>
+              <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
+            </H4>
+            <APISectionPlatformTags comment={enumValue.comment} disableFallback />
+          </div>
+          <MONOSPACE theme="secondary" className="mb-2 inline-flex text-2xs">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -146,7 +146,7 @@ const renderInterface = (
       <APICommentTextBlock comment={comment} includePlatforms={false} />
       {interfaceMethods.length > 0 && (
         <>
-          <APIBoxSectionHeader text={`${name} Methods`} />
+          <APIBoxSectionHeader text={`${name} Methods`} exposeInSidebar baseNestingLevel={99} />
           {interfaceMethods.map(method =>
             renderMethod(method, { exposeInSidebar: false, sdkVersion })
           )}
@@ -154,7 +154,7 @@ const renderInterface = (
       )}
       {interfaceFields.length > 0 && (
         <>
-          <APIBoxSectionHeader text={`${name} Properties`} />
+          <APIBoxSectionHeader text={`${name} Properties`} exposeInSidebar baseNestingLevel={99} />
           <Table>
             <APIParamsTableHeadRow />
             <tbody>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { CALLOUT, H2, MONOSPACE } from '~/ui/components/Text';
+import { H2, MONOSPACE, RawH3 } from '~/ui/components/Text';
 
 import { AccessorDefinitionData, MethodDefinitionData, PropData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
@@ -9,7 +9,7 @@ import {
   getMethodName,
   renderParams,
   resolveTypeName,
-  getH3CodeWithBaseNestingLevel,
+  getCodeHeadingWithBaseNestingLevel,
   getTagData,
   getAllTagData,
 } from './APISectionUtils';
@@ -61,7 +61,7 @@ export const renderMethod = (
 ) => {
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
-  const HeaderComponent = getH3CodeWithBaseNestingLevel(baseNestingLevel);
+  const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
 
   return signatures.map(({ name, parameters, comment, type, typeParameter }) => {
     const returnComment = getTagData('returns', comment);
@@ -110,9 +110,7 @@ export const renderMethod = (
                     <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
                     <span className={STYLES_SECONDARY}>Returns:</span>
                   </div>
-                  <CALLOUT>
-                    <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
-                  </CALLOUT>
+                  <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
                 </div>
                 {returnComment ? (
                   <div className="mb-1 mt-1.5 flex flex-col pl-6">

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -2,7 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { APITypeOrSignatureType } from '~/components/plugins/api/components/APITypeOrSignatureType';
-import { CODE, H2, H3, H4, LI, MONOSPACE, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, MONOSPACE, RawH3, UL } from '~/ui/components/Text';
 
 import {
   DefaultPropsDefinitionData,
@@ -15,7 +15,7 @@ import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import {
   extractDefaultPropValue,
   getCommentOrSignatureComment,
-  getH3CodeWithBaseNestingLevel,
+  getCodeHeadingWithBaseNestingLevel,
   getTagNamesList,
   resolveTypeName,
 } from './APISectionUtils';
@@ -107,7 +107,7 @@ export const renderProp = (
 ) => {
   const { comment, name, type, flags, signatures } = { ...propData, ...propData.getSignature };
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
-  const HeaderComponent = getH3CodeWithBaseNestingLevel(baseNestingLevel);
+  const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
   const extractedSignatures = signatures ?? type?.declaration?.signatures;
   const extractedComment = getCommentOrSignatureComment(comment, extractedSignatures);
 
@@ -121,7 +121,7 @@ export const renderProp = (
           <MONOSPACE
             weight="medium"
             className={mergeClasses(
-              'wrap-anywhere',
+              'wrap-anywhere !heading-base',
               !exposeInSidebar && 'inline-block prose-code:mb-0'
             )}>
             {name}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -166,7 +166,7 @@ const renderType = (
             ))
           : null}
         {type.declaration.signatures?.[0].type && (
-          <div className="mt-4 flex flex-row items-start gap-2">
+          <div className="mt-3.5 flex flex-row items-start gap-2">
             <div className="flex flex-row items-center gap-2">
               <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
               <span className={STYLES_SECONDARY}>Returns:</span>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -3,7 +3,7 @@ import { type ComponentType, type ReactNode } from 'react';
 
 import { HeadingType } from '~/common/headingManager';
 import { Code as PrismCodeBlock } from '~/components/base/code';
-import { Callout } from '~/ui/components/Callout';
+import { InlineHelp } from '~/ui/components/InlineHelp';
 import { HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import {
   A,
@@ -53,14 +53,18 @@ const getInvalidLinkMessage = (href: string) =>
   `Using "../" when linking other packages in doc comments produce a broken link! Please use "./" instead. Problematic link:\n\t${href}`;
 
 export const mdComponents: MDComponents = {
-  blockquote: ({ children }) => <Callout size="sm">{children}</Callout>,
+  blockquote: ({ children }) => (
+    <InlineHelp size="sm" className="shadow-none">
+      {children}
+    </InlineHelp>
+  ),
   code: ({ className, children, node }: CodeComponentProps) => {
     return className ? (
       <PrismCodeBlock className={className} title={node?.data?.meta}>
         {children}
       </PrismCodeBlock>
     ) : (
-      <CODE className="!inline">{children}</CODE>
+      <CODE className="break-words !inline">{children}</CODE>
     );
   },
   pre: ({ children }) => <>{children}</>,
@@ -516,17 +520,26 @@ export const getCommentContent = (content: CommentContentData[]) => {
     .trim();
 };
 
-const getMonospaceHeader = (element: ComponentType<any>, baseNestingLevel: number) => {
+const getMonospaceHeader = (
+  element: ComponentType<any>,
+  baseNestingLevel: number,
+  className: string | undefined = undefined
+) => {
   return createPermalinkedComponent(element, {
     baseNestingLevel,
     sidebarType: HeadingType.INLINE_CODE,
+    className,
   });
 };
 
-export function getH3CodeWithBaseNestingLevel(baseNestingLevel: number) {
-  return getMonospaceHeader(RawH3, baseNestingLevel);
+export function getCodeHeadingWithBaseNestingLevel(
+  baseNestingLevel: number,
+  Element: ComponentType<any>,
+  className: string | undefined = undefined
+) {
+  return getMonospaceHeader(Element, baseNestingLevel, className);
 }
-export const H3Code = getH3CodeWithBaseNestingLevel(3);
+export const H3Code = getCodeHeadingWithBaseNestingLevel(3, RawH3);
 
 export const getComponentName = (name?: string, children: PropData[] = []) => {
   if (name && name !== 'default') {

--- a/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
@@ -28,7 +28,7 @@ export const APIBoxSectionHeader = ({
   return (
     <CALLOUT
       className={mergeClasses(
-        '-mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2',
+        '-mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary',
         'max-lg-gutters:-mx-4',
         className
       )}>
@@ -41,7 +41,10 @@ export const APIBoxSectionHeader = ({
 };
 
 function createInheritPermalink(baseNestingLevel: number) {
-  return createPermalinkedComponent(createTextComponent(TextElement.SPAN, 'text-inherit'), {
-    baseNestingLevel,
-  });
+  return createPermalinkedComponent(
+    createTextComponent(TextElement.SPAN, 'text-inherit inline-flex items-center'),
+    {
+      baseNestingLevel,
+    }
+  );
 }

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -4,8 +4,8 @@ import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkSupsub from 'remark-supersub';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
-import { Callout } from '~/ui/components/Callout';
 import { Tag } from '~/ui/components/Tag/Tag';
 import { DEMI } from '~/ui/components/Text';
 
@@ -62,7 +62,7 @@ export const APICommentTextBlock = ({
           Example
         </DEMI>
       ) : (
-        <APIBoxSectionHeader text="Example" className="!mt-1" Icon={CodeSquare01Icon} />
+        <APIBoxSectionHeader text="Example" className="!mb-3 !mt-1" Icon={CodeSquare01Icon} />
       )}
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
         {getCommentContent(example.content ?? example.name)}
@@ -72,11 +72,14 @@ export const APICommentTextBlock = ({
 
   const see = getTagData('see', comment);
   const seeText = see && (
-    <Callout className={`!${ELEMENT_SPACING}`}>
+    <InlineHelp
+      className={mergeClasses('shadow-none', `!${ELEMENT_SPACING}`)}
+      size="sm"
+      type="info-light">
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
         {`**See:** ` + getCommentContent(see.content)}
       </ReactMarkdown>
-    </Callout>
+    </InlineHelp>
   );
 
   const hasPlatforms = (getAllTagData('platform', comment)?.length || 0) > 0;

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APICommentTextBlock basic comment 1`] = `
 <div>
   <p
-    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+    class="text-default font-normal text-base [&_strong]:break-words mb-3"
     data-text="true"
   >
     This is the basic comment.
@@ -48,7 +48,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
     </span>
   </div>
   <p
-    class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+    class="text-default font-normal text-base [&_strong]:break-words mb-3"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
@@ -59,7 +59,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
       target="_blank"
     >
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
         data-text="true"
       >
         Install Referrer API
@@ -72,7 +72,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
     class="mb-3 last:[&>*]:mb-0"
   >
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] -mx-5 my-4 flex border-y border-secondary bg-subtle px-5 py-2 max-lg-gutters:-mx-4 !mt-1"
+      class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4 !mb-3 !mt-1"
       data-text="true"
     >
       <span

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -7,7 +7,7 @@ export const STYLES_SECONDARY = mergeClasses('text-xs font-medium text-tertiary'
 export const STYLES_OPTIONAL = mergeClasses('flex !text-3xs text-tertiary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-5 rounded-lg border border-secondary px-5 py-4 shadow-xs',
+  'mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
   '[&_li]:mb-0',

--- a/docs/components/plugins/permissions/AndroidPermissions.tsx
+++ b/docs/components/plugins/permissions/AndroidPermissions.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { useMemo } from 'react';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
-import { Callout } from '~/ui/components/Callout';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { CODE, P, createPermalinkedComponent } from '~/ui/components/Text';
 
@@ -63,14 +63,14 @@ function AndroidPermissionRow({
           <P className={mergeClasses((warning || explanation) && '!mb-4')}>{description}</P>
         )}
         {!!warning && (
-          <Callout className="mb-0 mt-1.5" type="warning">
+          <InlineHelp className="mb-0 mt-1.5" type="warning">
             {warning}
-          </Callout>
+          </InlineHelp>
         )}
         {explanation && !warning && (
-          <Callout className="mb-0 mt-1.5">
+          <InlineHelp className="mb-0 mt-1.5">
             <span dangerouslySetInnerHTML={{ __html: explanation }} />
-          </Callout>
+          </InlineHelp>
         )}
       </Cell>
     </Row>

--- a/docs/pages/workflows/get-started.mdx
+++ b/docs/pages/workflows/get-started.mdx
@@ -7,14 +7,11 @@ description: Learn how to use EAS Workflows to automate your development and rel
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-<Callout type="info">
-  EAS Workflows are currently in preview. We may introduce breaking changes in the coming weeks. Got
-  feedback? Send us an email at workflows@expo.dev.
-</Callout>
+> **info** EAS Workflows are currently in preview. We may introduce breaking changes in the coming weeks.
+> Got feedback? Send us an email at workflows@expo.dev.
 
 Builds, submissions, updates, and more are all a part of delivering your app to users. EAS Workflows consist of a sequence of jobs, which help you and your team get things done. With workflows, you can build your project, run end-to-end tests, submit that build to the app stores, and then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate your and your team's release process.
 

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
         data-text="true"
       >
         <code
@@ -68,7 +68,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Name of your app.
@@ -142,7 +142,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Edit the 'Display Name' field in Xcode
@@ -151,10 +151,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
         data-text="true"
       >
         <code
@@ -215,7 +215,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
@@ -289,7 +289,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Set this property using AppConstants.java.
@@ -365,7 +365,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Set this property using just Xcode
@@ -373,10 +373,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
           data-text="true"
         >
           <code
@@ -451,7 +451,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
@@ -525,7 +525,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
             <p
-              class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+              class="text-default font-normal text-base [&_strong]:break-words mb-3"
               data-text="true"
             >
               Set this property using Xcode.
@@ -533,10 +533,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+            class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
             data-text="true"
           >
             <code
@@ -611,7 +611,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
           </div>
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             Test sub-sub-property
@@ -619,10 +619,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
           data-text="true"
         >
           <code
@@ -697,7 +697,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -705,12 +705,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
             data-text="true"
           >
             '#000000'
@@ -719,10 +719,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
         data-text="true"
       >
         <code
@@ -783,7 +783,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+        class="text-default font-normal text-base [&_strong]:break-words mb-3"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
@@ -857,7 +857,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+            class="text-default font-normal text-base [&_strong]:break-words mb-3"
             data-text="true"
           >
             This is set in AndroidManifest.xml directly.
@@ -893,10 +893,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
           data-text="true"
         >
           <code
@@ -971,17 +971,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words mb-3"
+          class="text-default font-normal text-base [&_strong]:break-words mb-3"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
         </p>
       </div>
       <div
-        class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
-          class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
           data-text="true"
         >
           <code
@@ -1056,10 +1056,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-secondary py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
-            class="text-default font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words group flex gap-1"
+            class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
             data-text="true"
           >
             <code

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -3,8 +3,8 @@ import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
-import { Callout } from '~/ui/components/Callout';
 import { Input, Textarea } from '~/ui/components/Form';
 import { CALLOUT, LABEL, RawH2 } from '~/ui/components/Text';
 
@@ -133,11 +133,11 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     </div>
                   </div>
                   {errors?.length && (
-                    <Callout type="error">
+                    <InlineHelp type="error">
                       <CALLOUT>
                         {errors.map(error => ('message' in error ? error.message : '')).join('\n')}
                       </CALLOUT>
-                    </Callout>
+                    </InlineHelp>
                   )}
                 </div>
                 <div className="flex min-h-[56px] items-center justify-end gap-2 bg-subtle px-3">

--- a/docs/ui/components/InlineHelp/InlineHelp.test.tsx
+++ b/docs/ui/components/InlineHelp/InlineHelp.test.tsx
@@ -2,63 +2,63 @@ import { CheckCircleSolidIcon } from '@expo/styleguide-icons/solid/CheckCircleSo
 import { render, screen } from '@testing-library/react';
 import ReactMarkdown from 'react-markdown';
 
-import { Callout } from '.';
+import { InlineHelp } from '.';
 
-describe(Callout, () => {
-  it('renders callout with icon emoji', () => {
-    render(<Callout icon="🎨">Hello</Callout>);
+describe(InlineHelp, () => {
+  it('renders inline help with icon emoji', () => {
+    render(<InlineHelp icon="🎨">Hello</InlineHelp>);
     expect(screen.getByText('🎨')).toBeInTheDocument();
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
-  it('renders callout with icon component', () => {
-    render(<Callout icon={CheckCircleSolidIcon}>Hello</Callout>);
+  it('renders inline help with icon component', () => {
+    render(<InlineHelp icon={CheckCircleSolidIcon}>Hello</InlineHelp>);
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
-  it('renders callout with default icon from info type', () => {
-    render(<Callout type="info">Hello</Callout>);
+  it('renders inline help with default icon from info type', () => {
+    render(<InlineHelp type="info">Hello</InlineHelp>);
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('img')).toHaveClass('icon-sm text-info');
   });
 
-  it('renders callout with default icon from warning type', () => {
-    render(<Callout type="warning">Hello</Callout>);
+  it('renders inline help with default icon from warning type', () => {
+    render(<InlineHelp type="warning">Hello</InlineHelp>);
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('img')).toHaveClass('icon-sm text-warning');
   });
 
-  it('renders callout with default icon from error type', () => {
-    render(<Callout type="error">Hello</Callout>);
+  it('renders inline help with default icon from error type', () => {
+    render(<InlineHelp type="error">Hello</InlineHelp>);
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('img')).toHaveClass('icon-sm text-danger');
   });
 
-  it('renders callout with warning style from warning type', () => {
-    render(<Callout type="warning">Hello</Callout>);
+  it('renders inline help with warning style from warning type', () => {
+    render(<InlineHelp type="warning">Hello</InlineHelp>);
     expect(screen.getByTestId('callout-container')).toHaveClass('bg-warning');
   });
 
-  it('renders callout with error style from error type', () => {
-    render(<Callout type="error">Hello</Callout>);
+  it('renders inline help with error style from error type', () => {
+    render(<InlineHelp type="error">Hello</InlineHelp>);
     expect(screen.getByTestId('callout-container')).toHaveClass('bg-danger');
   });
 
-  it('renders callout with info style from info type', () => {
-    render(<Callout type="info">Hello</Callout>);
+  it('renders inline help with info style from info type', () => {
+    render(<InlineHelp type="info">Hello</InlineHelp>);
     expect(screen.getByTestId('callout-container')).toHaveClass('bg-info border-info');
   });
 
   it('renders from translated Markdown', () => {
-    render(<ReactMarkdown components={{ blockquote: Callout }}>{'> Hello'}</ReactMarkdown>);
+    render(<ReactMarkdown components={{ blockquote: InlineHelp }}>{'> Hello'}</ReactMarkdown>);
     expect(screen.getByTestId('callout-container')).toBeInTheDocument();
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('renders correct type from translated Markdown', () => {
     render(
-      <ReactMarkdown components={{ blockquote: Callout }}>{`> **warning** Hello`}</ReactMarkdown>
+      <ReactMarkdown components={{ blockquote: InlineHelp }}>{`> **warning** Hello`}</ReactMarkdown>
     );
     expect(screen.getByTestId('callout-container')).toBeInTheDocument();
     expect(screen.getByTestId('callout-container')).toHaveClass('bg-warning');
@@ -68,7 +68,7 @@ describe(Callout, () => {
 
   it('renders content starting with emphasized word which is not a type', () => {
     render(
-      <ReactMarkdown components={{ blockquote: Callout }}>{`> **Note**: Hello`}</ReactMarkdown>
+      <ReactMarkdown components={{ blockquote: InlineHelp }}>{`> **Note**: Hello`}</ReactMarkdown>
     );
     expect(screen.getByTestId('callout-container')).toBeInTheDocument();
     expect(screen.getByText('Note')).toBeInTheDocument();

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -11,9 +11,9 @@ import {
   type ReactNode,
 } from 'react';
 
-type CalloutType = 'default' | 'warning' | 'error' | 'info';
+type CalloutType = 'default' | 'warning' | 'error' | 'info' | 'info-light';
 
-type CalloutProps = PropsWithChildren<{
+type Props = PropsWithChildren<{
   type?: CalloutType;
   className?: string;
   icon?: ComponentType<HTMLAttributes<SVGSVGElement>> | string;
@@ -35,13 +35,7 @@ const extractType = (childrenArray: ReactNode[]) => {
   return false;
 };
 
-export const Callout = ({
-  type = 'default',
-  size = 'md',
-  icon,
-  children,
-  className,
-}: CalloutProps) => {
+export const InlineHelp = ({ type = 'default', size = 'md', icon, children, className }: Props) => {
   const content = Children.toArray(children).filter(child => isValidElement(child))[0];
   const contentChildren = Children.toArray(isValidElement(content) && content?.props?.children);
 
@@ -53,6 +47,7 @@ export const Callout = ({
     <blockquote
       className={mergeClasses(
         'mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs',
+        size === 'sm' && 'px-3 py-2.5',
         '[table_&]:last:mb-0',
         '[&_code]:bg-element',
         getCalloutColor(finalType),
@@ -62,11 +57,16 @@ export const Callout = ({
       )}
       data-testid="callout-container">
       <div
-        className={mergeClasses('mt-1 select-none', '[table_&]:mt-0.5', size === 'sm' && 'mt-0.5')}>
+        className={mergeClasses('mt-1 select-none', '[table_&]:mt-0.5', size === 'sm' && 'mt-1')}>
         {typeof icon === 'string' ? (
           icon
         ) : (
-          <Icon className={mergeClasses('icon-sm', getCalloutIconColor(finalType))} />
+          <Icon
+            className={mergeClasses(
+              size === 'sm' ? 'icon-xs' : 'icon-sm',
+              getCalloutIconColor(finalType)
+            )}
+          />
         )}
       </div>
       <div
@@ -102,6 +102,8 @@ function getCalloutColor(type: CalloutType) {
         `[&_code]:border-palette-blue5 [&_code]:bg-palette-blue4`,
         `dark:selection:bg-palette-yellow6`
       );
+    case 'info-light':
+      return mergeClasses('bg-default');
     default:
       return null;
   }
@@ -126,6 +128,8 @@ function getCalloutIconColor(type: CalloutType) {
       return 'text-danger';
     case 'info':
       return 'text-info';
+    case 'info-light':
+      return 'text-icon-secondary';
     default:
       return 'text-icon-default';
   }

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType, PropsWithChildren } from 'react';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
 import { Code as PrismCodeBlock } from '~/components/base/code';
-import { Callout } from '~/ui/components/Callout';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { H1, H2, H3, H4, H5, A, CODE, P, BOLD, UL, OL, LI, KBD, DEL } from '~/ui/components/Text';
 
@@ -56,7 +56,7 @@ const markdownStyles: Record<string, Config | null> = {
     className: 'border-0 bg-palette-gray6 h-px mb-[2ch] mt-12',
   },
   blockquote: {
-    Component: Callout,
+    Component: InlineHelp,
   },
   img: {
     Component: 'img',

--- a/docs/ui/components/PrereleaseNotice.tsx
+++ b/docs/ui/components/PrereleaseNotice.tsx
@@ -1,12 +1,12 @@
 import { PropsWithChildren } from 'react';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
-import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { A, CODE } from '~/ui/components/Text';
 
 export default function PrereleaseNotice({ children }: PropsWithChildren) {
   return (
-    <Callout>
+    <InlineHelp>
       {children}
       <Collapsible
         summary={
@@ -22,6 +22,6 @@ export default function PrereleaseNotice({ children }: PropsWithChildren) {
         </A>{' '}
         GitHub repository.
       </Collapsible>
-    </Callout>
+    </InlineHelp>
   );
 }

--- a/docs/ui/components/RedirectNotification.tsx
+++ b/docs/ui/components/RedirectNotification.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState, PropsWithChildren } from 'react';
-
-import { Callout } from '~/ui/components/Callout';
+import { InlineHelp } from 'ui/components/InlineHelp';
 
 type Props = PropsWithChildren<{
   showForQuery?: string;
@@ -18,7 +17,7 @@ export default function RedirectNotification({ showForQuery = 'redirected', chil
   }, [router?.query]);
 
   if (visible) {
-    return <Callout type="warning">{children}</Callout>;
+    return <InlineHelp type="warning">{children}</InlineHelp>;
   }
 
   return null;

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -195,10 +195,7 @@ export const RawH5 = createTextComponent(
   )
 );
 
-export const P = createTextComponent(
-  TextElement.P,
-  'font-normal text-[16px] leading-[1.625] tracking-[-0.011rem] [&_strong]:break-words'
-);
+export const P = createTextComponent(TextElement.P, 'font-normal text-base [&_strong]:break-words');
 export const CODE = createTextComponent(
   TextElement.CODE,
   mergeClasses(
@@ -208,12 +205,9 @@ export const CODE = createTextComponent(
 );
 export const LI = createTextComponent(
   TextElement.LI,
-  mergeClasses('text-[16px] font-normal leading-relaxed tracking-[-0.011rem]', 'mb-2')
+  mergeClasses('text-base font-normal leading-relaxed', 'mb-2')
 );
-export const HEADLINE = createTextComponent(
-  TextElement.P,
-  'font-medium text-[16px] leading-[1.625] tracking-[-0.011rem]'
-);
+export const HEADLINE = createTextComponent(TextElement.P, 'font-medium text-base');
 export const LABEL = createTextComponent(
   TextElement.SPAN,
   'font-medium text-[15px] leading-[1.6] tracking-[-0.009rem]'


### PR DESCRIPTION
# Why

Stacked on:
* #33657

# How

Further spacing and appearance tweaks for API reference section, including spacing and typography changes.

Rename `Callout` -> `InlineHelp` component to match design system naming and avoid confusion when discussing elements, add missing `info-light` theme. Use small InlineHelps inside the API entries comments.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-12-16 at 18 37 08](https://github.com/user-attachments/assets/4a9df5a6-bac8-4433-9d2d-d96897314fad)

![Screenshot 2024-12-16 at 18 58 07](https://github.com/user-attachments/assets/945e7581-702b-46c5-bd4d-5a52f9545a6b)

