### PR TITLE
chore: Remove "shortcut" from `rel="icon"` from favicon injection.

### DIFF
--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -57,10 +57,7 @@ export async function getVirtualFaviconAssetsAsync(
     if (!html.includes('</head>')) {
       return html;
     }
-    return html.replace(
-      '</head>',
-      `<link rel="shortcut icon" href="${baseUrl}/favicon.ico" /></head>`
-    );
+    return html.replace('</head>', `<link rel="icon" href="${baseUrl}/favicon.ico" /></head>`);
   }
 
   return injectFaviconTag;

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### 💡 Others
 
-- Remove "shortcut" from `rel="icon"` from favicon injection.
+- Remove "shortcut" from `rel="icon"` from favicon injection. ([#33696](https://github.com/expo/expo/pull/33696) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 52.0.18 - 2024-12-10
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### 💡 Others
 
+- Remove "shortcut" from `rel="icon"` from favicon injection.
+
 ## 52.0.18 - 2024-12-10
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why

- mirror https://github.com/expo/expo/pull/28094 since I can't make changes to that PR.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
