### PR TITLE
[docs] reduce the font size of API reference elements, few tweaks

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`APISection expo-apple-authentication 1`] = `
   >
     Component
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#component"
       id="component"
     >
@@ -59,7 +59,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           AppleAuthenticationButton
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationbutton"
           id="appleauthenticationbutton"
         >
@@ -68,7 +68,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -95,11 +95,11 @@ exports[`APISection expo-apple-authentication 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       <span
-        class="leading-[1.6154] font-medium text-secondary"
+        class="text-xs font-medium text-tertiary"
         data-text="true"
       >
         Type:
@@ -121,7 +121,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -132,7 +132,7 @@ available via the provided properties.
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -141,7 +141,7 @@ available via the provided properties.
         href="#appleauthenticationisavailableasync"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -150,7 +150,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         true
@@ -158,7 +158,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         __DEV__ === true
@@ -168,12 +168,12 @@ a warning in development mode (
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         View
@@ -181,21 +181,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         style
@@ -203,7 +203,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         buttonStyle
@@ -211,7 +211,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         cornerRadius
@@ -222,7 +222,7 @@ button.
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
@@ -257,7 +257,7 @@ not appear on the screen.
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -332,7 +332,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -401,14 +401,14 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -477,14 +477,14 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -549,13 +549,13 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             style.borderRadius
@@ -564,7 +564,7 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -639,7 +639,7 @@ for more details.
           </code>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -648,7 +648,7 @@ for more details.
             href="#appleauthenticationisavailableasync"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -659,7 +659,7 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0 !pb-4 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -782,19 +782,19 @@ in here.
           </code>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             borderRadius
@@ -873,7 +873,7 @@ properties.
   >
     Methods
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#methods"
       id="methods"
     >
@@ -908,7 +908,7 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -918,13 +918,13 @@ properties.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           formatFullName(fullName, formatStyle)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#formatfullnamefullname-formatstyle"
           id="formatfullnamefullname-formatstyle"
         >
@@ -933,7 +933,7 @@ properties.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -960,7 +960,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -996,7 +996,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 fullName
@@ -1021,7 +1021,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 The full name object with the tokenized portions
@@ -1035,7 +1035,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 formatStyle
@@ -1065,7 +1065,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 The style in which the name should be formatted
@@ -1077,7 +1077,7 @@ properties.
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Creates a locale-aware string representation of a person's name from an object representing the tokenized portions of a user's full name
@@ -1124,7 +1124,7 @@ properties.
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A locale-aware string representation of a person's name
@@ -1132,7 +1132,7 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1142,13 +1142,13 @@ properties.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           getCredentialStateAsync(user)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#getcredentialstateasyncuser"
           id="getcredentialstateasyncuser"
         >
@@ -1157,7 +1157,7 @@ properties.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1184,7 +1184,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1220,7 +1220,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 user
@@ -1240,7 +1240,7 @@ properties.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
@@ -1250,7 +1250,7 @@ This should come from the user field of an
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1265,7 +1265,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1273,7 +1273,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
+      class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
       data-testid="callout-container"
     >
       <div
@@ -1303,7 +1303,7 @@ This should come from the user field of an
         
 
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -1385,7 +1385,7 @@ This should come from the user field of an
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1394,7 +1394,7 @@ This should come from the user field of an
           href="#appleauthenticationcredentialstate"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -1406,7 +1406,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1416,13 +1416,13 @@ value depending on the state of the credential.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           isAvailableAsync()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#isavailableasync"
           id="isavailableasync"
         >
@@ -1431,7 +1431,7 @@ value depending on the state of the credential.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1458,7 +1458,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
@@ -1525,19 +1525,19 @@ value depending on the state of the credential.
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A promise that fulfills with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           false
@@ -1547,7 +1547,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1557,13 +1557,13 @@ value depending on the state of the credential.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           refreshAsync(options)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#refreshasyncoptions"
           id="refreshasyncoptions"
         >
@@ -1572,7 +1572,7 @@ value depending on the state of the credential.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1599,7 +1599,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1635,7 +1635,7 @@ value depending on the state of the credential.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 options
@@ -1660,7 +1660,7 @@ value depending on the state of the credential.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An 
@@ -1669,7 +1669,7 @@ value depending on the state of the credential.
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1684,7 +1684,7 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1757,7 +1757,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1766,7 +1766,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -1775,7 +1775,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -1786,7 +1786,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1796,13 +1796,13 @@ refresh operation.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           signInAsync(options)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#signinasyncoptions"
           id="signinasyncoptions"
         >
@@ -1811,7 +1811,7 @@ refresh operation.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -1838,7 +1838,7 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1874,7 +1874,7 @@ refresh operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 options
@@ -1904,7 +1904,7 @@ refresh operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An optional 
@@ -1913,7 +1913,7 @@ refresh operation.
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1928,7 +1928,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1937,7 +1937,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1947,7 +1947,7 @@ of these options at runtime.
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1966,7 +1966,7 @@ You can use
         href="#appleauthenticationcredential"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -2042,7 +2042,7 @@ the user, since this remains the same for apps released by the same developer.
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -2051,7 +2051,7 @@ the user, since this remains the same for apps released by the same developer.
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2060,7 +2060,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2071,7 +2071,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2081,13 +2081,13 @@ sign-in operation.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           signOutAsync(options)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#signoutasyncoptions"
           id="signoutasyncoptions"
         >
@@ -2096,7 +2096,7 @@ sign-in operation.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -2123,7 +2123,7 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2159,7 +2159,7 @@ sign-in operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 options
@@ -2184,7 +2184,7 @@ sign-in operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An 
@@ -2193,7 +2193,7 @@ sign-in operation.
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -2208,7 +2208,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -2217,7 +2217,7 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2228,7 +2228,7 @@ from using
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           signInAsync
@@ -2240,7 +2240,7 @@ from using
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           refreshAsync
@@ -2315,7 +2315,7 @@ from using
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -2324,7 +2324,7 @@ from using
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2333,7 +2333,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           ERR_REQUEST_CANCELED
@@ -2349,7 +2349,7 @@ sign-out operation.
   >
     Event Subscriptions
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#event-subscriptions"
       id="event-subscriptions"
     >
@@ -2384,7 +2384,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2394,13 +2394,13 @@ sign-out operation.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           addRevokeListener(listener)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#addrevokelistenerlistener"
           id="addrevokelistenerlistener"
         >
@@ -2409,7 +2409,7 @@ sign-out operation.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -2436,7 +2436,7 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2467,7 +2467,7 @@ sign-out operation.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 listener
@@ -2539,7 +2539,7 @@ sign-out operation.
   >
     Types
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#types"
       id="types"
     >
@@ -2584,13 +2584,13 @@ sign-out operation.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationCredential
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationcredential"
           id="appleauthenticationcredential"
         >
@@ -2599,7 +2599,7 @@ sign-out operation.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -2626,7 +2626,7 @@ sign-out operation.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2635,7 +2635,7 @@ sign-out operation.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2648,7 +2648,7 @@ sign-out operation.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2660,7 +2660,7 @@ sign-out operation.
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2698,7 +2698,7 @@ which contains all of the pertinent user and credential information.
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -2759,7 +2759,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 authorizationCode
@@ -2789,13 +2789,13 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   user
@@ -2811,7 +2811,7 @@ the app's server counterpart. Unlike
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 email
@@ -2841,12 +2841,12 @@ the app's server counterpart. Unlike
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   EMAIL
@@ -2865,7 +2865,7 @@ an Apple domain.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 fullName
@@ -2900,26 +2900,26 @@ an Apple domain.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 The user's name. May be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   FULL_NAME
@@ -2937,7 +2937,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 identityToken
@@ -2967,7 +2967,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -2981,7 +2981,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 realUserStatus
@@ -3006,7 +3006,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -3020,7 +3020,7 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 state
@@ -3050,12 +3050,12 @@ your app.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   state
@@ -3064,7 +3064,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   state
@@ -3072,7 +3072,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
@@ -3088,7 +3088,7 @@ will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 user
@@ -3108,7 +3108,7 @@ will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -3133,13 +3133,13 @@ developers.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationFullName
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationfullname"
           id="appleauthenticationfullname"
         >
@@ -3148,7 +3148,7 @@ developers.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -3175,13 +3175,13 @@ developers.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         null
@@ -3225,7 +3225,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 familyName
@@ -3268,7 +3268,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 givenName
@@ -3311,7 +3311,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 middleName
@@ -3354,7 +3354,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 namePrefix
@@ -3397,7 +3397,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 nameSuffix
@@ -3440,7 +3440,7 @@ may be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 nickname
@@ -3491,13 +3491,13 @@ may be
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationFullNameFormatStyle
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationfullnameformatstyle"
           id="appleauthenticationfullnameformatstyle"
         >
@@ -3506,7 +3506,7 @@ may be
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -3549,7 +3549,7 @@ may be
       </code>
     </p>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       A value to specify the style for formatting a name.
@@ -3583,7 +3583,7 @@ may be
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -3676,13 +3676,13 @@ for more details.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationRefreshOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationrefreshoptions"
           id="appleauthenticationrefreshoptions"
         >
@@ -3691,7 +3691,7 @@ for more details.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -3718,7 +3718,7 @@ for more details.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3727,7 +3727,7 @@ for more details.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3765,7 +3765,7 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -3826,7 +3826,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 requestedScopes
@@ -3857,14 +3857,14 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
@@ -3873,14 +3873,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   []
@@ -3896,7 +3896,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 state
@@ -3921,7 +3921,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3947,7 +3947,7 @@ OAuth 2.0 protocol
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 user
@@ -3988,13 +3988,13 @@ OAuth 2.0 protocol
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationSignInOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationsigninoptions"
           id="appleauthenticationsigninoptions"
         >
@@ -4003,7 +4003,7 @@ OAuth 2.0 protocol
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -4030,7 +4030,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4039,7 +4039,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -4077,7 +4077,7 @@ None of these options are required.
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -4138,7 +4138,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 nonce
@@ -4163,7 +4163,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
@@ -4187,7 +4187,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 requestedScopes
@@ -4218,14 +4218,14 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
@@ -4234,14 +4234,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                   data-text="true"
                 >
                   []
@@ -4257,7 +4257,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 state
@@ -4282,7 +4282,7 @@ requests they will be
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4316,13 +4316,13 @@ OAuth 2.0 protocol
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           AppleAuthenticationSignOutOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationsignoutoptions"
           id="appleauthenticationsignoutoptions"
         >
@@ -4331,7 +4331,7 @@ OAuth 2.0 protocol
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -4358,7 +4358,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4367,7 +4367,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -4405,7 +4405,7 @@ You must include the ID string of the user to sign out.
         class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
       >
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           <span
@@ -4466,7 +4466,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 state
@@ -4491,7 +4491,7 @@ for more details.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4517,7 +4517,7 @@ OAuth 2.0 protocol
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 user
@@ -4558,13 +4558,13 @@ OAuth 2.0 protocol
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#subscription"
           id="subscription"
         >
@@ -4573,7 +4573,7 @@ OAuth 2.0 protocol
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -4600,7 +4600,7 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -4642,7 +4642,7 @@ OAuth 2.0 protocol
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 remove
@@ -4673,7 +4673,7 @@ OAuth 2.0 protocol
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -4691,7 +4691,7 @@ After calling this function, the listener will no longer receive any events from
   >
     Enums
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#enums"
       id="enums"
     >
@@ -4729,23 +4729,23 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationButtonStyle
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationbuttonstyle"
             id="appleauthenticationbuttonstyle"
           >
@@ -4754,7 +4754,7 @@ After calling this function, the listener will no longer receive any events from
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -4781,7 +4781,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4790,7 +4790,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -4800,7 +4800,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4810,13 +4810,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             WHITE
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#white"
             id="white"
           >
@@ -4852,20 +4852,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         White button with black text.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4875,13 +4875,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             WHITE_OUTLINE
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#white_outline"
             id="white_outline"
           >
@@ -4917,20 +4917,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         White button with a black outline and black text.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4940,13 +4940,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             BLACK
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#black"
             id="black"
           >
@@ -4982,13 +4982,13 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Black button with white text.
@@ -4999,23 +4999,23 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationButtonType
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationbuttontype"
             id="appleauthenticationbuttontype"
           >
@@ -5024,7 +5024,7 @@ After calling this function, the listener will no longer receive any events from
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -5051,7 +5051,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
@@ -5060,7 +5060,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5070,7 +5070,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5080,13 +5080,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             SIGN_IN
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#sign_in"
             id="sign_in"
           >
@@ -5122,20 +5122,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         "Sign in with Apple"
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5145,13 +5145,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             CONTINUE
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#continue"
             id="continue"
           >
@@ -5187,20 +5187,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         "Continue with Apple"
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5210,13 +5210,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             SIGN_UP
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#sign_up"
             id="sign_up"
           >
@@ -5251,7 +5251,7 @@ After calling this function, the listener will no longer receive any events from
           </a>
         </h4>
         <div
-          class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
+          class="flex flex-row items-start [table_&]:mb-2.5 mb-1"
         >
           <span
             class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -5286,13 +5286,13 @@ After calling this function, the listener will no longer receive any events from
         </div>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         "Sign up with Apple"
@@ -5303,23 +5303,23 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationCredentialState
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationcredentialstate"
             id="appleauthenticationcredentialstate"
           >
@@ -5328,7 +5328,7 @@ After calling this function, the listener will no longer receive any events from
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -5355,7 +5355,7 @@ After calling this function, the listener will no longer receive any events from
         </h3>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
@@ -5364,7 +5364,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -5401,7 +5401,7 @@ After calling this function, the listener will no longer receive any events from
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             <span
@@ -5427,7 +5427,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5437,13 +5437,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             REVOKED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#revoked"
             id="revoked"
           >
@@ -5479,14 +5479,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5496,13 +5496,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             AUTHORIZED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#authorized"
             id="authorized"
           >
@@ -5538,14 +5538,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5555,13 +5555,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             NOT_FOUND
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#not_found"
             id="not_found"
           >
@@ -5597,14 +5597,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5614,13 +5614,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             TRANSFERRED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#transferred"
             id="transferred"
           >
@@ -5656,7 +5656,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5667,23 +5667,23 @@ for more details.
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationOperation
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationoperation"
             id="appleauthenticationoperation"
           >
@@ -5692,7 +5692,7 @@ for more details.
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -5720,7 +5720,7 @@ for more details.
       </div>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5730,13 +5730,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             IMPLICIT
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#implicit"
             id="implicit"
           >
@@ -5772,20 +5772,20 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5795,13 +5795,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             LOGIN
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#login"
             id="login"
           >
@@ -5837,14 +5837,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5854,13 +5854,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             REFRESH
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#refresh"
             id="refresh"
           >
@@ -5896,14 +5896,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5913,13 +5913,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             LOGOUT
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#logout"
             id="logout"
           >
@@ -5955,7 +5955,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5966,23 +5966,23 @@ for more details.
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationScope
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationscope"
             id="appleauthenticationscope"
           >
@@ -5991,7 +5991,7 @@ for more details.
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -6018,7 +6018,7 @@ for more details.
         </h3>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
@@ -6027,7 +6027,7 @@ for more details.
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -6038,7 +6038,7 @@ for more details.
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
+        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
         data-testid="callout-container"
       >
         <div
@@ -6068,7 +6068,7 @@ for more details.
           
 
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -6107,7 +6107,7 @@ You will still need to handle null values for any fields you request.
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             <span
@@ -6133,7 +6133,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6143,13 +6143,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             FULL_NAME
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#full_name"
             id="full_name"
           >
@@ -6185,14 +6185,14 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
       </code>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6202,13 +6202,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             EMAIL
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#email"
             id="email"
           >
@@ -6244,7 +6244,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6255,23 +6255,23 @@ for more details.
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             AppleAuthenticationUserDetectionStatus
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#appleauthenticationuserdetectionstatus"
             id="appleauthenticationuserdetectionstatus"
           >
@@ -6280,7 +6280,7 @@ for more details.
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -6307,7 +6307,7 @@ for more details.
         </h3>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
@@ -6341,7 +6341,7 @@ for more details.
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             <span
@@ -6367,7 +6367,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6377,13 +6377,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             UNSUPPORTED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#unsupported"
             id="unsupported"
           >
@@ -6419,20 +6419,20 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         The system does not support this determination and there is no data.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6442,13 +6442,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             UNKNOWN
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#unknown"
             id="unknown"
           >
@@ -6484,20 +6484,20 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6507,13 +6507,13 @@ for more details.
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             LIKELY_REAL
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#likely_real"
             id="likely_real"
           >
@@ -6549,13 +6549,13 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6573,7 +6573,7 @@ exports[`APISection expo-pedometer 1`] = `
   >
     Methods
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#methods"
       id="methods"
     >
@@ -6608,7 +6608,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6618,13 +6618,13 @@ exports[`APISection expo-pedometer 1`] = `
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           getPermissionsAsync()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#getpermissionsasync"
           id="getpermissionsasync"
         >
@@ -6633,7 +6633,7 @@ exports[`APISection expo-pedometer 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6660,7 +6660,7 @@ exports[`APISection expo-pedometer 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
@@ -6730,7 +6730,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6740,13 +6740,13 @@ exports[`APISection expo-pedometer 1`] = `
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           getStepCountAsync(start, end)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#getstepcountasyncstart-end"
           id="getstepcountasyncstart-end"
         >
@@ -6755,7 +6755,7 @@ exports[`APISection expo-pedometer 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6816,7 +6816,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -6852,7 +6852,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 start
@@ -6879,7 +6879,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -6893,7 +6893,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 end
@@ -6920,7 +6920,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -6932,7 +6932,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Get the step count between two dates.
@@ -7004,7 +7004,7 @@ exports[`APISection expo-pedometer 1`] = `
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Returns a promise that fulfills with a 
@@ -7013,7 +7013,7 @@ exports[`APISection expo-pedometer 1`] = `
           href="#pedometerresult"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             PedometerResult
@@ -7024,7 +7024,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         As 
@@ -7041,7 +7041,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
+        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
         data-testid="callout-container"
       >
         <div
@@ -7071,7 +7071,7 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -7084,7 +7084,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7094,13 +7094,13 @@ a start date that is more than seven days in the past returns only the available
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           isAvailableAsync()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#isavailableasync"
           id="isavailableasync"
         >
@@ -7109,7 +7109,7 @@ a start date that is more than seven days in the past returns only the available
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -7136,7 +7136,7 @@ a start date that is more than seven days in the past returns only the available
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
@@ -7203,12 +7203,12 @@ a start date that is more than seven days in the past returns only the available
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           boolean
@@ -7219,7 +7219,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7229,13 +7229,13 @@ available on this device.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           requestPermissionsAsync()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#requestpermissionsasync"
           id="requestpermissionsasync"
         >
@@ -7244,7 +7244,7 @@ available on this device.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -7271,7 +7271,7 @@ available on this device.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
@@ -7341,7 +7341,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7351,13 +7351,13 @@ available on this device.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           watchStepCount(callback)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#watchstepcountcallback"
           id="watchstepcountcallback"
         >
@@ -7366,7 +7366,7 @@ available on this device.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -7393,7 +7393,7 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7429,7 +7429,7 @@ available on this device.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 callback
@@ -7454,7 +7454,7 @@ available on this device.
               class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
@@ -7464,7 +7464,7 @@ provided with a single argument that is
                   href="#pedometerresult"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                     data-text="true"
                   >
                     PedometerResult
@@ -7479,7 +7479,7 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Subscribe to pedometer updates.
@@ -7526,7 +7526,7 @@ provided with a single argument that is
       class="mb-1 mt-1.5 flex flex-col pl-6"
     >
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Returns a 
@@ -7535,7 +7535,7 @@ provided with a single argument that is
           href="#subscription"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             Subscription
@@ -7544,7 +7544,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
           remove()
@@ -7554,7 +7554,7 @@ provided with a single argument that is
       
 
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none"
+        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
         data-testid="callout-container"
       >
         <div
@@ -7584,7 +7584,7 @@ provided with a single argument that is
           
 
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
@@ -7596,7 +7596,7 @@ provided with a single argument that is
               target="_blank"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                 data-text="true"
               >
                 Health Connect API
@@ -7605,7 +7605,7 @@ provided with a single argument that is
             .
 On iOS, the 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
               data-text="true"
             >
               getStepCountAsync
@@ -7624,7 +7624,7 @@ On iOS, the
   >
     Interfaces
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#interfaces"
       id="interfaces"
     >
@@ -7659,7 +7659,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7669,13 +7669,13 @@ On iOS, the
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
           data-text="true"
         >
           PermissionResponse
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#permissionresponse"
           id="permissionresponse"
         >
@@ -7684,7 +7684,7 @@ On iOS, the
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -7711,7 +7711,7 @@ On iOS, the
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
@@ -7798,7 +7798,7 @@ On iOS, the
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 canAskAgain
@@ -7818,7 +7818,7 @@ On iOS, the
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -7834,7 +7834,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 expires
@@ -7859,7 +7859,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -7873,7 +7873,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 granted
@@ -7893,7 +7893,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -7907,7 +7907,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 status
@@ -7932,7 +7932,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -7950,7 +7950,7 @@ in order to enable/disable the permission.
   >
     Types
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#types"
       id="types"
     >
@@ -7995,13 +7995,13 @@ in order to enable/disable the permission.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           PedometerResult
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#pedometerresult"
           id="pedometerresult"
         >
@@ -8010,7 +8010,7 @@ in order to enable/disable the permission.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -8073,7 +8073,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 steps
@@ -8093,7 +8093,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -8115,14 +8115,13 @@ in order to enable/disable the permission.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
-          PedometerUpdateCallback
-          ()
+          PedometerUpdateCallback()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#pedometerupdatecallback"
           id="pedometerupdatecallback"
         >
@@ -8131,7 +8130,7 @@ in order to enable/disable the permission.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -8158,14 +8157,14 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Callback function providing event result as an argument.
     </p>
     <div>
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
       >
         <table
           class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8196,7 +8195,7 @@ in order to enable/disable the permission.
                 class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
               >
                 <span
-                  class="leading-[1.6154] text-default font-semibold"
+                  class="leading-[1.6154] text-default font-medium"
                   data-text="true"
                 >
                   result
@@ -8277,13 +8276,13 @@ in order to enable/disable the permission.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           PermissionExpiration
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#permissionexpiration"
           id="permissionexpiration"
         >
@@ -8292,7 +8291,7 @@ in order to enable/disable the permission.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -8330,7 +8329,7 @@ in order to enable/disable the permission.
       multiple types
     </p>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
@@ -8371,13 +8370,13 @@ in order to enable/disable the permission.
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8 break-words wrap-anywhere"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#subscription"
           id="subscription"
         >
@@ -8386,7 +8385,7 @@ in order to enable/disable the permission.
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -8413,7 +8412,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-base [&_strong]:break-words mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -8455,7 +8454,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <span
-                class="leading-[1.6154] text-default font-semibold"
+                class="leading-[1.6154] text-default font-medium"
                 data-text="true"
               >
                 remove
@@ -8486,7 +8485,7 @@ in order to enable/disable the permission.
               class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
             >
               <p
-                class="text-default font-normal text-base [&_strong]:break-words mb-3"
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -8504,7 +8503,7 @@ After calling this function, the listener will no longer receive any events from
   >
     Enums
     <a
-      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
+      class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-5"
       href="#enums"
       id="enums"
     >
@@ -8542,23 +8541,23 @@ After calling this function, the listener will no longer receive any events from
     class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
-      class="min-h-[56px] px-5 pt-3"
+      class="min-h-[46px] px-5 pt-3"
     >
       <div
-        class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col"
+        class="flex flex-wrap justify-between max-md-gutters:flex-col"
       >
         <h3
           class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default font-medium wrap-anywhere"
+            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
             data-text="true"
           >
             PermissionStatus
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
             href="#permissionstatus"
             id="permissionstatus"
           >
@@ -8567,7 +8566,7 @@ After calling this function, the listener will no longer receive any events from
             >
               <svg
                 aria-label="permalink"
-                class="icon-sm shrink-0"
+                class="shrink-0 icon-xs"
                 fill="none"
                 height="24"
                 viewBox="0 0 24 24"
@@ -8595,7 +8594,7 @@ After calling this function, the listener will no longer receive any events from
       </div>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8605,13 +8604,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             DENIED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#denied"
             id="denied"
           >
@@ -8647,20 +8646,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         User has denied the permission.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8670,13 +8669,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             GRANTED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#granted"
             id="granted"
           >
@@ -8712,20 +8711,20 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         User has granted the permission.
       </p>
     </div>
     <div
-      class="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8735,13 +8734,13 @@ After calling this function, the listener will no longer receive any events from
           data-heading="true"
         >
           <code
-            class="leading-[1.6154] text-default !text-inherit"
+            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
             data-text="true"
           >
             UNDETERMINED
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 !font-medium"
             href="#undetermined"
             id="undetermined"
           >
@@ -8777,13 +8776,13 @@ After calling this function, the listener will no longer receive any events from
         </h4>
       </div>
       <code
-        class="text-secondary mb-2 inline-flex text-2xs"
+        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !shadow-none"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !shadow-none"
   >
     <div
       class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
@@ -233,7 +233,7 @@ not appear on the screen.
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -332,7 +332,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -408,7 +408,7 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -484,7 +484,7 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -564,7 +564,7 @@ for more details.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -659,7 +659,7 @@ in here.
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
       >
         <div
           class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -908,7 +908,7 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1132,7 +1132,7 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1277,7 +1277,7 @@ This should come from the user field of an
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-default"
@@ -1406,7 +1406,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1547,7 +1547,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -1786,7 +1786,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2071,7 +2071,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2384,7 +2384,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2574,7 +2574,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -2590,7 +2590,7 @@ sign-out operation.
           AppleAuthenticationCredential
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationcredential"
           id="appleauthenticationcredential"
         >
@@ -2674,7 +2674,7 @@ which contains all of the pertinent user and credential information.
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -3123,7 +3123,7 @@ developers.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3139,7 +3139,7 @@ developers.
           AppleAuthenticationFullName
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationfullname"
           id="appleauthenticationfullname"
         >
@@ -3481,7 +3481,7 @@ may be
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3497,7 +3497,7 @@ may be
           AppleAuthenticationFullNameFormatStyle
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationfullnameformatstyle"
           id="appleauthenticationfullnameformatstyle"
         >
@@ -3559,7 +3559,7 @@ may be
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -3666,7 +3666,7 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3682,7 +3682,7 @@ for more details.
           AppleAuthenticationRefreshOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationrefreshoptions"
           id="appleauthenticationrefreshoptions"
         >
@@ -3741,7 +3741,7 @@ You must include the ID string of the user whose credentials you'd like to refre
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -3978,7 +3978,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -3994,7 +3994,7 @@ OAuth 2.0 protocol
           AppleAuthenticationSignInOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationsigninoptions"
           id="appleauthenticationsigninoptions"
         >
@@ -4053,7 +4053,7 @@ None of these options are required.
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -4306,7 +4306,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4322,7 +4322,7 @@ OAuth 2.0 protocol
           AppleAuthenticationSignOutOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#appleauthenticationsignoutoptions"
           id="appleauthenticationsignoutoptions"
         >
@@ -4381,7 +4381,7 @@ You must include the ID string of the user to sign out.
       data-testid="callout-container"
     >
       <div
-        class="select-none [table_&]:mt-0.5 mt-1"
+        class="select-none mt-1"
       >
         <svg
           class="translate-z icon-xs text-icon-secondary"
@@ -4548,7 +4548,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4564,7 +4564,7 @@ OAuth 2.0 protocol
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#subscription"
           id="subscription"
         >
@@ -4726,7 +4726,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -4745,7 +4745,7 @@ After calling this function, the listener will no longer receive any events from
             AppleAuthenticationButtonStyle
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationbuttonstyle"
             id="appleauthenticationbuttonstyle"
           >
@@ -4996,7 +4996,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -5015,7 +5015,7 @@ After calling this function, the listener will no longer receive any events from
             AppleAuthenticationButtonType
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationbuttontype"
             id="appleauthenticationbuttontype"
           >
@@ -5300,7 +5300,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -5319,7 +5319,7 @@ After calling this function, the listener will no longer receive any events from
             AppleAuthenticationCredentialState
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationcredentialstate"
             id="appleauthenticationcredentialstate"
           >
@@ -5377,7 +5377,7 @@ After calling this function, the listener will no longer receive any events from
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-secondary"
@@ -5664,7 +5664,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -5683,7 +5683,7 @@ for more details.
             AppleAuthenticationOperation
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationoperation"
             id="appleauthenticationoperation"
           >
@@ -5963,7 +5963,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -5982,7 +5982,7 @@ for more details.
             AppleAuthenticationScope
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationscope"
             id="appleauthenticationscope"
           >
@@ -6042,7 +6042,7 @@ for more details.
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-default"
@@ -6083,7 +6083,7 @@ You will still need to handle null values for any fields you request.
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-secondary"
@@ -6252,7 +6252,7 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -6271,7 +6271,7 @@ for more details.
             AppleAuthenticationUserDetectionStatus
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#appleauthenticationuserdetectionstatus"
             id="appleauthenticationuserdetectionstatus"
           >
@@ -6317,7 +6317,7 @@ for more details.
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-secondary"
@@ -6608,7 +6608,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6730,7 +6730,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7045,7 +7045,7 @@ exports[`APISection expo-pedometer 1`] = `
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-default"
@@ -7084,7 +7084,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7219,7 +7219,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7341,7 +7341,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7558,7 +7558,7 @@ provided with a single argument that is
         data-testid="callout-container"
       >
         <div
-          class="select-none [table_&]:mt-0.5 mt-1"
+          class="select-none mt-1"
         >
           <svg
             class="translate-z icon-xs text-icon-default"
@@ -7659,7 +7659,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 py-4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -7985,7 +7985,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8001,7 +8001,7 @@ in order to enable/disable the permission.
           PedometerResult
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#pedometerresult"
           id="pedometerresult"
         >
@@ -8105,7 +8105,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8121,7 +8121,7 @@ in order to enable/disable the permission.
           PedometerUpdateCallback()
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#pedometerupdatecallback"
           id="pedometerupdatecallback"
         >
@@ -8266,7 +8266,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8282,7 +8282,7 @@ in order to enable/disable the permission.
           PermissionExpiration
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#permissionexpiration"
           id="permissionexpiration"
         >
@@ -8360,7 +8360,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
   >
     <div
       class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8376,7 +8376,7 @@ in order to enable/disable the permission.
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
           href="#subscription"
           id="subscription"
         >
@@ -8538,7 +8538,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
   >
     <div
       class="min-h-[46px] px-5 pt-3"
@@ -8557,7 +8557,7 @@ After calling this function, the listener will no longer receive any events from
             PermissionStatus
           </code>
           <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
             href="#permissionstatus"
             id="permissionstatus"
           >

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
 import { APISectionPlatformTags } from '~/components/plugins/api/components/APISectionPlatformTags';
-import { H2, DEMI, P, CODE, MONOSPACE } from '~/ui/components/Text';
+import { H2, DEMI, CODE, MONOSPACE, CALLOUT } from '~/ui/components/Text';
 
 import {
   CommentData,
@@ -19,7 +19,7 @@ import {
   getPossibleComponentPropsNames,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { ELEMENT_SPACING, STYLES_APIBOX } from './styles';
+import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY } from './styles';
 
 export type APISectionComponentsProps = {
   data: GeneratedData[];
@@ -73,8 +73,8 @@ const renderComponent = (
         <APISectionPlatformTags comment={comment} />
       </div>
       {resolvedType && resolvedTypeParameters && (
-        <P className={ELEMENT_SPACING}>
-          <DEMI theme="secondary">Type:</DEMI>{' '}
+        <CALLOUT className={ELEMENT_SPACING}>
+          <DEMI className={STYLES_SECONDARY}>Type:</DEMI>{' '}
           <CODE>
             {extendedTypes ? (
               <>React.{resolveTypeName(resolvedTypeParameters, sdkVersion)}</>
@@ -84,7 +84,7 @@ const renderComponent = (
               </>
             )}
           </CODE>
-        </P>
+        </CALLOUT>
       )}
       <APICommentTextBlock comment={extractedComment} />
       {componentsProps?.length ? (

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -27,7 +27,7 @@ const renderConstant = (
     <APISectionDeprecationNote comment={comment} sticky />
     <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
       <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
+        <MONOSPACE weight="medium" className="wrap-anywhere !heading-base">
           {apiName ? `${apiName}.` : ''}
           {name}
         </MONOSPACE>

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -34,7 +34,7 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
         className={mergeClasses(
           'border-palette-yellow5',
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
+          sticky && 'mb-3 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
         )}>
         {content.length ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -1,10 +1,10 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { H2, H4, MONOSPACE } from '~/ui/components/Text';
 
 import { EnumDefinitionData, EnumValueData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
-import { getTagNamesList, H3Code } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { STYLES_APIBOX } from './styles';
@@ -30,31 +30,25 @@ const renderEnumValue = (value: any, fallback?: string) =>
 function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefinitionData }) {
   return (
     <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
-      <div className="min-h-[56px] px-5 pt-3">
-        <APISectionDeprecationNote comment={comment} />
-        <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+      <div className="min-h-[46px] px-5 pt-3">
+        <APISectionDeprecationNote comment={comment} sticky />
+        <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
       </div>
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div
-          className="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+          className="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-
           <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-            <H4 hideInSidebar>
-              <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
+            <H4 hideInSidebar className="!font-medium">
+              <MONOSPACE className="!wrap-anywhere !text-sm !font-medium">
+                {enumValue.name}
+              </MONOSPACE>
             </H4>
-            <APISectionPlatformTags comment={enumValue.comment} disableFallback />
+            <APISectionPlatformTags comment={enumValue.comment} disableFallback className="mb-1" />
           </div>
-          <MONOSPACE theme="secondary" className="mb-2 inline-flex text-2xs">
+          <MONOSPACE className="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -47,7 +47,6 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           className="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-
           <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
             <H4 hideInSidebar>
               <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -47,6 +47,7 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
           className="border-t border-t-secondary px-5 pb-0 pt-3 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
+
           <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
             <H4 hideInSidebar>
               <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -2,7 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, CALLOUT, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
+import { H2, CALLOUT, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
 
 import {
   CommentData,
@@ -96,7 +96,7 @@ const renderInterfacePropertyRow = (
   return (
     <Row key={name}>
       <Cell fitContent>
-        <BOLD>{name}</BOLD>
+        <DEMI>{name}</DEMI>
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell fitContent>
@@ -127,7 +127,7 @@ const renderInterface = (
       <APISectionDeprecationNote comment={comment} sticky />
       <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
+          <MONOSPACE weight="medium" className="wrap-anywhere !text-base">
             {name}
           </MONOSPACE>
         </H3Code>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -75,8 +75,8 @@ export const renderMethod = (
             <MONOSPACE
               weight="medium"
               className={mergeClasses(
-                'wrap-anywhere',
-                !exposeInSidebar && 'mb-1 inline-block prose-code:mb-0'
+                'wrap-anywhere !text-base',
+                !exposeInSidebar && 'mb-1 inline-block'
               )}>
               {getMethodName(
                 method as MethodDefinitionData,

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -114,7 +114,7 @@ export const renderProp = (
   return (
     <div
       key={`prop-entry-${name}`}
-      className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!pb-4 [&>*:last-child]:!mb-0')}>
+      className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!py-3 [&>*:last-child]:!mb-0')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
       <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
         <HeaderComponent tags={getTagNamesList(comment)}>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -3,8 +3,9 @@ import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRi
 import { Fragment, ReactNode } from 'react';
 
 import { APIBox } from '~/components/plugins/APIBox';
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, CODE, MONOSPACE, CALLOUT, RawH4 } from '~/ui/components/Text';
+import { H2, CODE, MONOSPACE, CALLOUT, RawH4, DEMI } from '~/ui/components/Text';
 
 import {
   PropData,
@@ -23,15 +24,12 @@ import {
   renderParams,
   renderDefaultValue,
   renderIndexSignature,
-  getTagNamesList,
-  H3Code,
   getCommentContent,
   listParams,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
 import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { APITypeOrSignatureType } from './components/APITypeOrSignatureType';
 import { STYLES_APIBOX, STYLES_SECONDARY } from './styles';
 
@@ -112,7 +110,7 @@ const renderTypePropertyRow = (
   return (
     <Row key={name}>
       <Cell fitContent>
-        <BOLD>{name}</BOLD>
+        <DEMI>{name}</DEMI>
         {renderFlags(flags, initValue)}
         {kind && renderIndexSignature(kind)}
       </Cell>
@@ -146,15 +144,10 @@ const renderType = (
     return (
       <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
-            <MONOSPACE weight="medium">
-              {name}
-              {type.declaration.signatures ? '()' : ''}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader
+          name={`${name}${type.declaration.signatures ? '()' : ''}`}
+          comment={comment}
+        />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         {type.declaration.children && renderTypeDeclarationTable(type.declaration, sdkVersion)}
         {type.declaration.signatures
@@ -185,12 +178,7 @@ const renderType = (
     return (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)} className="break-words wrap-anywhere">
-            <MONOSPACE weight="medium">{name}</MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT className={STYLES_SECONDARY}>
           Tuple: <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
@@ -211,14 +199,7 @@ const renderType = (
       return (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-            <H3Code tags={getTagNamesList(comment)}>
-              <MONOSPACE weight="medium" className="wrap-anywhere">
-                {name}
-              </MONOSPACE>
-            </H3Code>
-            <APISectionPlatformTags comment={comment} />
-          </div>
+          <APIBoxHeader name={name} comment={comment} />
           <APICommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
@@ -262,14 +243,7 @@ const renderType = (
       return (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
-          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-            <H3Code tags={getTagNamesList(comment)}>
-              <MONOSPACE weight="medium" className="wrap-anywhere">
-                {name}
-              </MONOSPACE>
-            </H3Code>
-            <APISectionPlatformTags comment={comment} />
-          </div>
+          <APIBoxHeader name={name} comment={comment} />
           <CALLOUT className="mb-3">
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
@@ -298,14 +272,7 @@ const renderType = (
         key={`record-definition-${name}`}
         className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader name={name} comment={comment} />
         <CALLOUT className="mb-3">
           <span className={STYLES_SECONDARY}>Type: </span>
           <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
@@ -317,14 +284,7 @@ const renderType = (
     return (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <span className={STYLES_SECONDARY}>Type: </span>
@@ -336,14 +296,7 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}&lt;{type.checkType.name}&gt;
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader name={`${name}<${type.checkType.name}>`} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           <span className={STYLES_SECONDARY}>Generic: </span>
@@ -379,14 +332,7 @@ const renderType = (
     return (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <H3Code tags={getTagNamesList(comment)}>
-            <MONOSPACE weight="medium" className="wrap-anywhere">
-              {name}
-            </MONOSPACE>
-          </H3Code>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         <CALLOUT>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { slug } from 'github-slugger';
 import { type ComponentType, type ReactNode } from 'react';
 
@@ -8,12 +9,12 @@ import { HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import {
   A,
   BOLD,
+  CALLOUT,
   CODE,
   createPermalinkedComponent,
   H4,
   LI,
   OL,
-  P,
   RawH3,
   UL,
 } from '~/ui/components/Text';
@@ -54,7 +55,7 @@ const getInvalidLinkMessage = (href: string) =>
 
 export const mdComponents: MDComponents = {
   blockquote: ({ children }) => (
-    <InlineHelp size="sm" className="shadow-none">
+    <InlineHelp size="sm" className={mergeClasses('shadow-none', ELEMENT_SPACING)}>
       {children}
     </InlineHelp>
   ),
@@ -64,14 +65,14 @@ export const mdComponents: MDComponents = {
         {children}
       </PrismCodeBlock>
     ) : (
-      <CODE className="break-words !inline">{children}</CODE>
+      <CODE className="break-words !inline py-0">{children}</CODE>
     );
   },
   pre: ({ children }) => <>{children}</>,
   h1: ({ children }) => <H4 hideInSidebar>{children}</H4>,
   ul: ({ children }) => <UL className={ELEMENT_SPACING}>{children}</UL>,
   ol: ({ children }) => <OL className={ELEMENT_SPACING}>{children}</OL>,
-  li: ({ children }) => <LI>{children}</LI>,
+  li: ({ children }) => <LI className="text-sm">{children}</LI>,
   a: ({ href, children }) => {
     if (
       href?.startsWith('../') &&
@@ -86,7 +87,8 @@ export const mdComponents: MDComponents = {
     }
     return <A href={href}>{children}</A>;
   },
-  p: ({ children }) => (children ? <P className={ELEMENT_SPACING}>{children}</P> : null),
+  p: ({ children }) =>
+    children ? <CALLOUT className={ELEMENT_SPACING}>{children}</CALLOUT> : null,
   strong: ({ children }) => <BOLD>{children}</BOLD>,
   span: ({ children }) => (children ? <span>{children}</span> : null),
   table: ({ children }) => <Table>{children}</Table>,
@@ -381,7 +383,7 @@ export const parseParamName = (name: string) => (name.startsWith('__') ? name.su
 export const renderParams = (parameters: MethodParamData[], sdkVersion: string) => {
   const hasDescription = Boolean(parameters.some(param => param.comment));
   return (
-    <Table>
+    <Table containerClassName="mt-0.5">
       <APIParamsTableHeadRow hasDescription={hasDescription} mainCellLabel="Parameter" />
       <tbody>
         {parameters?.map(param => (

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -1,0 +1,23 @@
+import { MONOSPACE } from '~/ui/components/Text';
+
+import { CommentData } from '../APIDataTypes';
+import { getTagNamesList, H3Code } from '../APISectionUtils';
+import { APISectionPlatformTags } from './APISectionPlatformTags';
+
+type Props = {
+  name: string;
+  comment?: CommentData;
+};
+
+export function APIBoxHeader({ name, comment }: Props) {
+  return (
+    <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
+      <H3Code tags={getTagNamesList(comment)}>
+        <MONOSPACE weight="medium" className="!wrap-anywhere !text-base">
+          {name}
+        </MONOSPACE>
+      </H3Code>
+      <APISectionPlatformTags comment={comment} />
+    </div>
+  );
+}

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function APIBoxHeader({ name, comment }: Props) {
   return (
     <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-      <H3Code tags={getTagNamesList(comment)}>
+      <H3Code tags={getTagNamesList(comment)} className="mb-0">
         <MONOSPACE weight="medium" className="!wrap-anywhere !text-base">
           {name}
         </MONOSPACE>

--- a/docs/components/plugins/api/components/APIParamRow.tsx
+++ b/docs/components/plugins/api/components/APIParamRow.tsx
@@ -10,7 +10,7 @@ import {
 import { APICommentTextBlock } from '~/components/plugins/api/components/APICommentTextBlock';
 import { APIDataType } from '~/components/plugins/api/components/APIDataType';
 import { Cell, Row } from '~/ui/components/Table';
-import { BOLD } from '~/ui/components/Text';
+import { DEMI } from '~/ui/components/Text';
 
 type Props = {
   param: MethodParamData;
@@ -30,10 +30,10 @@ export function APIParamRow({
   return (
     <Row key={`param-${name}`}>
       <Cell>
-        <BOLD>
+        <DEMI>
           {flags?.isRest ? '...' : ''}
           {parseParamName(name)}
-        </BOLD>
+        </DEMI>
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell>

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APICommentTextBlock basic comment 1`] = `
 <div>
   <p
-    class="text-default font-normal text-base [&_strong]:break-words mb-3"
+    class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
     data-text="true"
   >
     This is the basic comment.
@@ -48,7 +48,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
     </span>
   </div>
   <p
-    class="text-default font-normal text-base [&_strong]:break-words mb-3"
+    class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
@@ -59,7 +59,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
       target="_blank"
     >
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
         data-text="true"
       >
         Install Referrer API

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -17,7 +17,7 @@ export const STYLES_APIBOX = mergeClasses(
   'max-lg-gutters:px-4'
 );
 
-export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 px-5 pb-0 pt-4 shadow-none [&_h4]:mt-0');
+export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0');
 
 export const STYLES_APIBOX_WRAPPER = mergeClasses(
   'mb-3.5 px-5 pt-4',

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -7,7 +7,7 @@ export const STYLES_SECONDARY = mergeClasses('text-xs font-medium text-tertiary'
 export const STYLES_OPTIONAL = mergeClasses('flex !text-3xs text-tertiary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-5 rounded-lg border border-palette-gray4 px-5 py-4 shadow-xs',
+  'mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
   '[&_li]:mb-0',

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           name
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#name"
           id="name"
         >
@@ -25,7 +25,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -68,7 +68,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Name of your app.
@@ -142,7 +142,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Edit the 'Display Name' field in Xcode
@@ -163,7 +163,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           androidNavigationBar
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#androidnavigationbar"
           id="androidnavigationbar"
         >
@@ -172,7 +172,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -215,7 +215,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
@@ -289,7 +289,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Set this property using AppConstants.java.
@@ -365,7 +365,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Set this property using just Xcode
@@ -451,7 +451,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
@@ -525,7 +525,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
             <p
-              class="text-default font-normal text-base [&_strong]:break-words mb-3"
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
               data-text="true"
             >
               Set this property using Xcode.
@@ -611,7 +611,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
           </div>
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             Test sub-sub-property
@@ -697,7 +697,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -705,12 +705,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 break-words !inline"
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
             '#000000'
@@ -731,7 +731,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           intentFilters
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 scroll-m-8"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#intentfilters"
           id="intentfilters"
         >
@@ -740,7 +740,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             <svg
               aria-label="permalink"
-              class="icon-sm shrink-0"
+              class="shrink-0 icon-xs"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -783,7 +783,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-base [&_strong]:break-words mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
@@ -857,7 +857,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-base [&_strong]:break-words mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
             data-text="true"
           >
             This is set in AndroidManifest.xml directly.
@@ -971,7 +971,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-base [&_strong]:break-words mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -151,7 +151,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -373,7 +373,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -533,7 +533,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -719,7 +719,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -893,7 +893,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -978,7 +978,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -1056,7 +1056,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-palette-gray4 py-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -56,8 +56,7 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
         className
       )}
       data-testid="callout-container">
-      <div
-        className={mergeClasses('mt-1 select-none', '[table_&]:mt-0.5', size === 'sm' && 'mt-1')}>
+      <div className={mergeClasses('mt-1 select-none', size === 'sm' && 'mt-1')}>
         {typeof icon === 'string' ? (
           icon
         ) : (

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -31,7 +31,7 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
     props.id
   );
 
-  const isDeepNested = props.nestingLevel >= 4;
+  const isDeepNested = props.nestingLevel >= 3;
 
   return (
     <PermalinkBase component={component} className="group flex gap-1">
@@ -39,7 +39,7 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
       <Button
         theme="quaternary"
         className={mergeClasses(
-          'relative my-auto inline-flex size-[26px] justify-center p-0 transition-all duration-default',
+          'relative my-auto inline-flex size-[25px] justify-center p-0 transition-all duration-default',
           'invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100',
           isDeepNested && 'size-[22px]',
           props.additionalProps?.sidebarType === 'text' ? 'scroll-m-5' : 'scroll-m-8',

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -8,10 +8,21 @@ type TableProps = PropsWithChildren<{
   headers?: string[];
   headersAlign?: TextAlign[];
   className?: string;
+  containerClassName?: string;
 }>;
 
-export const Table = ({ children, headers = [], headersAlign, className }: TableProps) => (
-  <div className="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs">
+export const Table = ({
+  children,
+  headers = [],
+  headersAlign,
+  className,
+  containerClassName,
+}: TableProps) => (
+  <div
+    className={mergeClasses(
+      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs',
+      containerClassName
+    )}>
     <table
       className={mergeClasses(
         'w-full rounded-none border-0 text-xs text-default',


### PR DESCRIPTION
# Why

Stacked on:
* #33695

# How

This part focuses mostly on typography part, includes the general text component font size reduction across all API Reference elements. This might looks a bit off at the first sight, since we so far don't use the various font sizes that much in the content part, but the reduction tight up all previous changes and it feels like tights everything together, also reducing quite a bit the vertical space size which each entity takes.

The changeset also includes few small appearance tweaks for minor things missed previous, or spotted when browsing some of the generated reference docs.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-12-16 at 21 15 33](https://github.com/user-attachments/assets/ce3f42b4-b49d-4c25-ad5e-acb296ebde8c)
![Screenshot 2024-12-16 at 21 01 51](https://github.com/user-attachments/assets/280cabbd-a94c-42c1-a46a-8a9da199ca94)
![Screenshot 2024-12-16 at 21 00 50](https://github.com/user-attachments/assets/f8f608c1-feb8-40dc-88a8-4d7cd32364bb)
![Screenshot 2024-12-16 at 20 57 58](https://github.com/user-attachments/assets/9fba933a-9510-4e8e-848b-d9b2ffd8ecf4)