### PR TITLE
[video][ios] Fix now playing notification being always on

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix empty notification showing on iOS when `showNowPlayingNotification` is set to false.
+- [iOS] Fix empty notification showing on iOS when `showNowPlayingNotification` is set to false. ([#33698](https://github.com/expo/expo/pull/33698) by [@behenate](https://github.com/behenate))
 - [iOS] Dispatch current player item changes on main queue to fix KVO-related crashes. ([#33123](https://github.com/expo/expo/pull/33123) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix empty notification showing on iOS when `showNowPlayingNotification` is set to false.
 - [iOS] Dispatch current player item changes on main queue to fix KVO-related crashes. ([#33123](https://github.com/expo/expo/pull/33123) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -84,6 +84,10 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
 
     removeExistingTargets(commandCenter: commandCenter)
 
+    guard self.mostRecentInteractionPlayer != nil else {
+      return
+    }
+
     playTarget = commandCenter.playCommand.addTarget { [weak self] _ in
       guard let self, let player = self.mostRecentInteractionPlayer else {
         return .commandFailed


### PR DESCRIPTION
# Why

Reported by a person from Software Mansion, seems to be a regression, most likely caused by https://github.com/expo/expo/pull/32428

# How

Make sure not to setup the controls when there is no player registered

# Test Plan

Tested in BareExpo on a physical iOS18 device
