### PR TITLE
Fix erroneously copy pasted InvalidAudioModeException error message in AudioUtils.swift

### DIFF
--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -153,7 +153,7 @@ struct AudioUtils {
       throw InvalidAudioModeException("playsInSilentMode == false and duckOthers == true cannot be set on iOS")
     }
     if !mode.playsInSilentMode && mode.allowsRecording {
-      throw InvalidAudioModeException("playsInSilentMode == false and duckOthers == true cannot be set on iOS")
+      throw InvalidAudioModeException("playsInSilentMode == false and allowsRecording == true cannot be set on iOS")
     }
     if !mode.playsInSilentMode && mode.shouldPlayInBackground {
       throw InvalidAudioModeException("playsInSilentMode == false and staysActiveInBackground == true cannot be set on iOS.")


### PR DESCRIPTION
was confused because we never set `duckOthers`

# Why

was confused because we never set `duckOthers`

# How

matched the error message to the predicate

# Test Plan

looked at it

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
