### PR TITLE
[docs] Update page titles to "Using" under Guides

### DIFF
--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use existing credentials
+title: Using existing credentials
+sidebar_title: Existing credentials
 description: Learn about different options for supplying your app signing credentials to EAS Build.
 hideTOC: true
 ---

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use local credentials
+title: Using local credentials
+sidebar_title: Local credentials
 description: Learn how to configure and use local credentials when using EAS.
 ---
 

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use automatically managed credentials
+title: Using automatically managed credentials
+sidebar_title: Automatically managed credentials
 description: Learn how to automatically manage your app credentials with EAS.
 ---
 

--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use Git Submodules
+title: Using Git submodules
+sidebar_title: Git submodules
 description: Learn how to configure EAS Build to use git submodules.
 hideTOC: true
 ---

--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use npm cache with Yarn 1 (Classic)
+title: Using npm cache with Yarn 1 (Classic)
+sidebar_label: npm cache with Yarn 1 (Classic)
 hideTOC: true
 description: Learn how to use npm cache by overriding the registry in Yarn 1 (Classic).
 ---

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use private npm packages
+title: Using private npm packages
+sidebar_label: Private npm packages
 description: Learn how to configure EAS Build to use private npm packages.
 ---
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use EAS Update
+title: Using EAS Update
 description: Learn how to use EAS Update with EAS Build.
 ---
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Facebook authentication
+title: Using Facebook authentication
 description: A guide on using react-native-fbsdk-next library to integrate Facebook authentication in your Expo project.
 ---
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Google authentication
+title: Using Google authentication
 description: A guide on using @react-native-google-signin/google-signin library to integrate Google authentication in your Expo project.
 ---
 

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use In-app purchase
+title: Using In-app purchase
 description: Learn about how to use in-app purchases in your Expo app.
 hideTOC: true
 ---

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use TypeScript
+title: Using TypeScript
 description: An in-depth guide on configuring an Expo project with TypeScript.
 ---
 

--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Native analytics SDKs and libraries
-sidebar_title: Use Analytics
+sidebar_title: Using Analytics
 hideTOC: true
 description: An overview of analytics services available in the Expo and React Native ecosystem.
 ---

--- a/docs/pages/guides/using-bugsnag.mdx
+++ b/docs/pages/guides/using-bugsnag.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use BugSnag
+title: Using BugSnag
 description: A guide on installing and configuring BugSnag for end-to-end error reporting and analytics.
 hideTOC: true
 ---

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Bun
+title: Using Bun
 description: A guide on using Bun with Expo and EAS.
 ---
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use ESLint and Prettier
+title: Using ESLint and Prettier
 description: A guide on configuring ESLint and Prettier to format Expo apps.
 ---
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Firebase
+title: Using Firebase
 maxHeadingDepth: 4
 description: A guide on getting started and using Firebase JS SDK and React Native Firebase library.
 ---

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use Hermes Engine
-sidebar_title: Use Hermes
+title: Using Hermes Engine
+sidebar_title: Using Hermes
 description: A guide on configuring Hermes for both Android and iOS in an Expo project.
 ---
 

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use Next.js with Expo for Web
-sidebar_title: Use Next.js
+title: Using Next.js with Expo for Web
+sidebar_title: Using Next.js
 description: A guide for integrating Next.js with Expo for the web.
 ---
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Sentry
+title: Using Sentry
 maxHeadingDepth: 4
 hideTOC: true
 description: A guide on installing and configuring Sentry for crash reporting.

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use Supabase
+title: Using Supabase
 description: Add a Postgres Database and user authentication to your React Native app with Supabase.
 ---
 

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use URL parameters
+title: Using URL parameters
 description: Learn how to access and modify route and search parameters in your app.
 sidebar_title: URL parameters
 ---


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Stacked on https://github.com/expo/expo/pull/33662

Based on feedback from @brentvatne.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update page titles under Guides to prepend with "Using" since we are leaving an option for the developer to either use any of the tools/services instead of recommending them. Currently, the word "Use" directs as a recommenedation/command.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
