### PR TITLE
[ios][video] Background mode playback fix

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Fix `sourceLoad` event not being emitted. ([#39023](https://github.com/expo/expo/pull/39023) by [@behenate](https://github.com/behenate))
 - [Web] Fix audio not playing due to conflicting CORS and AudioNode settings. ([#39039](https://github.com/expo/expo/pull/39039) by [@behenate](https://github.com/behenate))
+- [iOS] Background mode playback fix. ([#33706](https://github.com/expo/expo/pull/33706) by [@hromovp](https://github.com/hromovp))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -54,6 +54,7 @@ class VideoManager {
       if player.staysActiveInBackground == true {
         player.pointer.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
       } else if !videoView.isInPictureInPicture {
+        player.ref.audiovisualBackgroundPlaybackPolicy = .pauses
         player.pointer.pause()
       }
     }

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -53,7 +53,7 @@ class VideoManager {
       }
       if player.staysActiveInBackground == true {
         player.ref.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
-      } else if !videoView.isInPictureInPicture {
+      } else if !videoView.playerViewController.isInPictureInPicture {
         player.ref.audiovisualBackgroundPlaybackPolicy = .pauses
         player.ref.pause()
       }

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -44,11 +44,7 @@ class VideoManager {
     videoViews.remove(videoView)
   }
 
-  func onAppForegrounded() {
-    for videoPlayer in videoPlayers.allObjects {
-      videoPlayer.setTracksEnabled(true)
-    }
-  }
+  func onAppForegrounded() {}
 
   func onAppBackgrounded() {
     for videoView in videoViews.allObjects {
@@ -56,9 +52,9 @@ class VideoManager {
         continue
       }
       if player.staysActiveInBackground == true {
-        player.setTracksEnabled(videoView.playerViewController.isInPictureInPicture)
-      } else if !videoView.playerViewController.isInPictureInPicture {
-        player.ref.pause()
+        player.pointer.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+      } else if !videoView.isInPictureInPicture {
+        player.pointer.pause()
       }
     }
   }

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -52,10 +52,10 @@ class VideoManager {
         continue
       }
       if player.staysActiveInBackground == true {
-        player.pointer.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+        player.ref.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
       } else if !videoView.isInPictureInPicture {
         player.ref.audiovisualBackgroundPlaybackPolicy = .pauses
-        player.pointer.pause()
+        player.ref.pause()
       }
     }
   }

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -272,23 +272,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     return
   }
 
-  /**
-   * iOS automatically pauses videos when the app enters the background. Only way to avoid this is to detach the player from the playerLayer.
-   * Typical way of doing this for `AVPlayerViewController` is setting `playerViewController.player = nil`, but that makes the
-   * video invisible for around a second after foregrounding, disabling the tracks requires more code, but works a lot faster.
-   */
-  func setTracksEnabled(_ enabled: Bool) {
-    ref.currentItem?.tracks.forEach({ track in
-      guard let assetTrack = track.assetTrack else {
-        return
-      }
-
-      if assetTrack.hasMediaCharacteristic(AVMediaCharacteristic.visual) {
-        track.isEnabled = enabled
-      }
-    })
-  }
-
   private func getBufferedPosition() -> Double {
     guard let currentItem = ref.currentItem else {
       return -1


### PR DESCRIPTION
# Why

When using background mode in iOS, app behavior is not necessary logical. e.g

1. When using `player.staysActiveInBackground = true` and `allowsPictureInPicture={false}` for `VideoView`:
    - upon locking screen with app in foreground **video stops**;
    - upon moving app to the background **video stops**;
2. When using `player.staysActiveInBackground = true` and `allowsPictureInPicture={true}` for `VideoView`:
    - upon moving app to the background PiP mode turns on and **video is playing**;
    - when locking screen while PiP mode is on - **audio is playing**;
    - upon locking screen with app in foreground **video stops**;

Considering there is more elegant way to handle background audio playback, configuration could be updated.

# How

- If using `player.staysActiveInBackground = true` set `audiovisualBackgroundPlaybackPolicy = .continuesIfPossible`
- Remove setTracksEnabled function

# Test Plan
1. In example video app, when using `player.staysActiveInBackground = true`  and `allowsPictureInPicture={false}` for `VideoView`:
    - upon locking screen with app in foreground **audio is playing** without PiP;
    - upon moving app to the background **audio is playing** without PiP;
2. When using `player.staysActiveInBackground = true` and `allowsPictureInPicture={true}` for `VideoView`:
    - upon moving app to the background PiP mode turns on and **video is playing**;
    - when locking screen while PiP mode is on - **video is playing**;
    - upon locking screen with app in foreground **audio is playing**;

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
