### PR TITLE
[sensors] Add missing permission functions to DeviceMotion modules

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -24,6 +24,8 @@ _This version does not introduce any user-facing changes._
 
 - Add missing `react-native` peer dependencies for isolated modules. ([#30482](https://github.com/expo/expo/pull/30482) by [@byCedric](https://github.com/byCedric))
 
+- [iOS] Added missing `getPermissionsAsync` and `requestPermissionsAsync` implementations to DeviceMotion module. ([#33719](https://github.com/expo/expo/pull/33719) by [@ratley](https://github.com/ratley))
+
 ### 💡 Others
 
 - Fix incorrect event emitting tests. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
 - Add missing `getPermissionsAsync` and `requestPermissionsAsync` implementations to native DeviceMotion modules. ([#33719](https://github.com/expo/expo/pull/33719) by [@ratley](https://github.com/ratley))
 
 ### 💡 Others

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Add missing `getPermissionsAsync` and `requestPermissionsAsync` implementations to native DeviceMotion modules. ([#33719](https://github.com/expo/expo/pull/33719) by [@ratley](https://github.com/ratley))
 
 ### 💡 Others
 
@@ -23,8 +24,6 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - Add missing `react-native` peer dependencies for isolated modules. ([#30482](https://github.com/expo/expo/pull/30482) by [@byCedric](https://github.com/byCedric))
-
-- [iOS] Added missing `getPermissionsAsync` and `requestPermissionsAsync` implementations to DeviceMotion module. ([#33719](https://github.com/expo/expo/pull/33719) by [@ratley](https://github.com/ratley))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -16,6 +16,9 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.sensors.SensorSubscription
 import java.lang.ref.WeakReference
+import android.Manifest
+import expo.modules.interfaces.permissions.Permissions
+import expo.modules.kotlin.Promise
 
 private val sensorTypes = arrayListOf(
   Sensor.TYPE_GYROSCOPE,
@@ -62,6 +65,32 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
 
     AsyncFunction("setUpdateInterval") { updateInterval: Float ->
       this@DeviceMotionModule.updateInterval = updateInterval
+    }
+
+    AsyncFunction("getPermissionsAsync") { promise: expo.modules.kotlin.Promise ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Permissions.getPermissionsWithPermissionsManager(
+          appContext.permissions,
+          promise,
+          Manifest.permission.ACTIVITY_RECOGNITION
+        )
+      } else {
+        // Permissions don't need to be requested on Android versions below Q
+        Permissions.getPermissionsWithPermissionsManager(appContext.permissions, promise)
+      }
+    }
+
+    AsyncFunction("requestPermissionsAsync") { promise: expo.modules.kotlin.Promise ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Permissions.askForPermissionsWithPermissionsManager(
+          appContext.permissions,
+          promise,
+          Manifest.permission.ACTIVITY_RECOGNITION
+        )
+      } else {
+        // Permissions don't need to be requested on Android versions below Q
+        Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise)
+      }
     }
 
     OnDestroy {

--- a/packages/expo-sensors/ios/DeviceMotionModule.swift
+++ b/packages/expo-sensors/ios/DeviceMotionModule.swift
@@ -31,6 +31,28 @@ public final class DeviceMotionModule: Module {
       motionManager.deviceMotionUpdateInterval = intervalMs / 1000.0
     }
 
+    AsyncFunction("getPermissionsAsync") { (promise: Promise) in
+      guard let permissionsManager = appContext?.permissions else {
+        return
+      }
+      permissionsManager.getPermissionUsingRequesterClass(
+        EXMotionPermissionRequester.self,
+        resolve: promise.resolver,
+        reject: promise.legacyRejecter
+      )
+    }
+
+    AsyncFunction("requestPermissionsAsync") { (promise: Promise) in
+      guard let permissionsManager = appContext?.permissions else {
+        return
+      }
+      permissionsManager.askForPermission(
+        usingRequesterClass: EXMotionPermissionRequester.self,
+        resolve: promise.resolver,
+        reject: promise.legacyRejecter
+      )
+    }
+
     OnStartObserving {
       startDeviceMotionUpdates()
     }
@@ -41,6 +63,13 @@ public final class DeviceMotionModule: Module {
 
     OnDestroy {
       motionManager.stopDeviceMotionUpdates()
+    }
+
+    OnCreate {
+      guard let permissionsManager = appContext?.permissions else {
+        return
+      }
+      permissionsManager.register([EXMotionPermissionRequester()])
     }
   }
 


### PR DESCRIPTION
# Why
`getPermissionsAsync` and `requestPermissionsAsync` always return the default permissions response because the functions aren't defined in `expo-sensors/ios/DeviceMotionModule.swift` and `expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt`.

# How
Added missing `getPermissionsAsync` and `requestPermissionsAsync` implementations to DeviceMotion modules.

# Test Plan
- Tested in BareExpo on physical iOS and Android devices by calling both `getPermissionsAsync()` and `requestPermissionsAsync()
- Verified that the permission dialog appears when calling `requestPermissionsAsync()`
- Verified that `getPermissionsAsync()` returns the correct permission status before and after granting/denying