### PR TITLE
[typescript] Create tsconfig.next.json

### DIFF
--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -33,6 +33,7 @@
     "@expo/npm-proofread": "^1.0.1",
     "@testing-library/react-native": "^12.5.2",
     "@tsconfig/node18": "^18.2.2",
+    "@tsconfig/react-native": "^3.0.5",
     "@types/jest": "^29.2.1",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-preset-expo": "~12.0.0",

--- a/packages/expo-module-scripts/tsconfig.next.json
+++ b/packages/expo-module-scripts/tsconfig.next.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "include": [
+    "./src"
+  ],
+  "compilerOptions": {
+    "outDir": "./build",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    // Only load types from these directories. If you have required types in nested node_modules, you should upgrade the dependency so it is no longer nested.
+    "typeRoots": [
+      "./ts-declarations",
+      "./node_modules/@types",
+      "../../node_modules/@types",
+    ],
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,7 +3210,7 @@
   dependencies:
     color "^4.2.3"
 
-"@react-navigation/native-stack@7.0.0", "@react-navigation/native-stack@^7.0.0":
+"@react-navigation/native-stack@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.0.0.tgz#8f5a50919d8e58548053743a697e90a177976946"
   integrity sha512-OZEvXaQDZesWnib+XD7PgWaVeS95/oD/gCSmDXXQZLTtGBXutmLycGtvjunFHRAkQ8u3TB89oOhs9YxDBAXl5Q==
@@ -3218,7 +3218,7 @@
     "@react-navigation/elements" "^2.0.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@7.0.0", "@react-navigation/native@^7.0.0":
+"@react-navigation/native@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.0.0.tgz#d3efaca481bef01cde89c2397f4b0815682f9137"
   integrity sha512-OkfVzQNAuvy6WduON+4ctLImQWybBnOEycVpEEFA3y8nheLuo4hT+ObyyYu2DVqtslltUlTNGcd2G7pbB7y/bA==
@@ -3229,7 +3229,7 @@
     nanoid "3.3.7"
     use-latest-callback "^0.2.1"
 
-"@react-navigation/routers@7.0.0", "@react-navigation/routers@^7.0.0":
+"@react-navigation/routers@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.0.0.tgz#fb55a4d70a14e16b630c386fd09ba43664cc7409"
   integrity sha512-b2ehNmgAfDziTd0EERm0C9JI9JH1kdRS4SNBWbKQOVPv23WG+5ExovwWet26sGtMabLJ5lxSE8Z2/fByfggjNQ==
@@ -3660,6 +3660,11 @@
   version "20.1.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node20/-/node20-20.1.2.tgz#b93128c411d38e9507035255195bc8a6718541e3"
   integrity sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==
+
+"@tsconfig/react-native@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@tsconfig/react-native/-/react-native-3.0.5.tgz#c4971b1eca2e8cdf7b0d25f40193a782039c1abd"
+  integrity sha512-0+pmYzHccvwWpFz2Tv5AJxp6UroLALmAy+SX34tKlwaCie1mNbtCv6uOJp7x8pKchgNA9/n6BGrx7uLQvw8p9A==
 
 "@tsd/typescript@~5.0.2":
   version "5.0.4"
@@ -9455,6 +9460,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 ini@~1.3.0:
   version "1.3.8"
@@ -16226,7 +16236,14 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@^0.10.3, util@^0.12.0, util@^0.12.3, util@~0.12.4:
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.12.0, util@^0.12.3:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==


### PR DESCRIPTION
# Why

[React Contributors discord request](https://discord.com/channels/514829729862516747/896089100199788604/1316801255036813433)

This the first step of many upgrade Expo's SDK to the latest TypeScript and align our `tsconfig.json` with the recommended settings.

- Extended from `@tsconfig/react-native`
- `@tsconfig/react-native` enables `strict: true` so the partial strict options were removed
- Add `noUnusedLocals`
- Remove `inlineSource`, I don't believe this is needed with the new debugger.
- Remove `types` override. Where we using`"jest-require"`? Modules that do not run on device should override this setting
- Remove `lib` override. Modules that do not run on device (or in multiple environments) should override this setting
- Modules are compiled by default (`build` folder output). Modules will need to disable this if they do not perform a build step, or have alternative build tooling (cli). 
- While Metro is signalling that they would prefer that packages were not precompiled, the ecosystem is clearing moving towards things being precompiled. For example, `react-native-builder-bob` / `react-native-reanimated` / `react-native-navigation` all ship precompiled. https://bsky.app/profile/satya164.page/post/3ldf4egm2jk2q

All-in-all, when a module switches to this `tsconfig` we will need to
- Check for module specific overrides
- Fix the new strict mode errors
- Commit or disable the `build` dir being

This `tsconfig` does not yet include the changes to `module`. I suspect the changes to `strict` are enough work for now.  The `react-native` repro just switched to `esnext` [this week](https://github.com/facebook/react-native/pull/48230).