### PR TITLE
[docs] further refactor and streamline API reference presentation

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,17 +43,17 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !shadow-none"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none !shadow-none"
   >
     <div
-      class="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationButton
@@ -95,7 +95,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0 mx-4"
       data-text="true"
     >
       <span
@@ -120,170 +120,174 @@ exports[`APISection expo-apple-authentication 1`] = `
         &gt;
       </code>
     </p>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
 your screen. The App Store Guidelines require you to use this component to start the
 authentication process instead of a custom button. Limited customization of the button is
 available via the provided properties.
-    </p>
-    
+      </p>
+      
 
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      You should only attempt to render this if 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationisavailableasync"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
+        You should only attempt to render this if 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationisavailableasync"
+        >
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            data-text="true"
+          >
+            AppleAuthentication.isAvailableAsync()
+          </code>
+        </a>
+        
+resolves to 
         <code
           class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
-          AppleAuthentication.isAvailableAsync()
+          true
         </code>
-      </a>
-      
-resolves to 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        true
-      </code>
-      . This component will render nothing if it is not available, and you will get
+        . This component will render nothing if it is not available, and you will get
 a warning in development mode (
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        __DEV__ === true
-      </code>
-      ).
-    </p>
-    
-
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      The properties of this component extend from 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        View
-      </code>
-      ; however, you should not attempt to set
-
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        backgroundColor
-      </code>
-       or 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        borderRadius
-      </code>
-       with the 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        style
-      </code>
-       property. This will not work and is against
-the App Store Guidelines. Instead, you should use the 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        buttonStyle
-      </code>
-       property to choose one of the
-predefined color styles and the 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        cornerRadius
-      </code>
-       property to change the border radius of the
-button.
-    </p>
-    
-
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Make sure to attach height and width via the style props as without these styles, the button will
-not appear on the screen.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
           data-text="true"
         >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          __DEV__ === true
+        </code>
+        ).
+      </p>
+      
+
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        The properties of this component extend from 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          View
+        </code>
+        ; however, you should not attempt to set
+
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          backgroundColor
+        </code>
+         or 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          borderRadius
+        </code>
+         with the 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          style
+        </code>
+         property. This will not work and is against
+the App Store Guidelines. Instead, you should use the 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          buttonStyle
+        </code>
+         property to choose one of the
+predefined color styles and the 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          cornerRadius
+        </code>
+         property to change the border radius of the
+button.
+      </p>
+      
+
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        Make sure to attach height and width via the style props as without these styles, the button will
+not appear on the screen.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
+        >
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Apple
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <div>
       <p
-        class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4"
+        class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary"
         data-text="true"
       >
         <span
@@ -329,20 +333,20 @@ for more details.
       </p>
     </div>
     <div
-      class="[&>*:last-child]:!mb-0"
+      class="[&>*]:last:!mb-0"
     >
       <div
-        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="flex flex-wrap justify-between max-md-gutters:flex-col"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
               data-text="true"
             >
               buttonStyle
@@ -384,7 +388,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mb-2.5"
+          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
         >
           Type:
            
@@ -400,25 +404,29 @@ for more details.
             </a>
           </code>
         </div>
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+        <div
+          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
         >
-          The Apple-defined color scheme to use to display the button.
-        </p>
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            The Apple-defined color scheme to use to display the button.
+          </p>
+        </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="flex flex-wrap justify-between max-md-gutters:flex-col"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
               data-text="true"
             >
               buttonType
@@ -460,7 +468,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mb-2.5"
+          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
         >
           Type:
            
@@ -476,25 +484,29 @@ for more details.
             </a>
           </code>
         </div>
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+        <div
+          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
         >
-          The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
-        </p>
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
+          </p>
+        </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="flex flex-wrap justify-between max-md-gutters:flex-col"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
               data-text="true"
             >
               cornerRadius
@@ -536,7 +548,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mb-2.5"
+          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
         >
           Optional • 
           Type:
@@ -548,33 +560,37 @@ for more details.
             number
           </code>
         </div>
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+        <div
+          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
         >
-          The border radius to use when rendering the button. This works similarly to
-
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            style.borderRadius
-          </code>
-           in other Views.
-        </p>
+            The border radius to use when rendering the button. This works similarly to
+
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              style.borderRadius
+            </code>
+             in other Views.
+          </p>
+        </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="flex flex-wrap justify-between max-md-gutters:flex-col"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
               data-text="true"
             >
               onPress
@@ -616,7 +632,7 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mb-2.5"
+          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
         >
           Type:
            
@@ -638,38 +654,42 @@ for more details.
             void
           </code>
         </div>
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+        <div
+          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
         >
-          The method to call when the user presses the button. You should call 
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#appleauthenticationisavailableasync"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
           >
-            <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-              data-text="true"
+            The method to call when the user presses the button. You should call 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationisavailableasync"
             >
-              AppleAuthentication.signInAsync
-            </code>
-          </a>
-          
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                AppleAuthentication.signInAsync
+              </code>
+            </a>
+            
 in here.
-        </p>
+          </p>
+        </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0 !py-3 [&>*:last-child]:!mb-0"
+        class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="flex flex-wrap justify-between max-md-gutters:flex-col"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
             data-heading="true"
           >
             <code
-              class="leading-[1.6154] text-default font-medium wrap-anywhere !heading-base inline-block prose-code:mb-0"
+              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
               data-text="true"
             >
               style
@@ -711,7 +731,7 @@ in here.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mb-2.5"
+          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
         >
           Optional • 
           Type:
@@ -781,90 +801,98 @@ in here.
             </span>
           </code>
         </div>
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+        <div
+          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
         >
-          The custom style to apply to the button. Should not include 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            backgroundColor
-          </code>
-           or 
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-            data-text="true"
-          >
-            borderRadius
-          </code>
-          
+            The custom style to apply to the button. Should not include 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              backgroundColor
+            </code>
+             or 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              borderRadius
+            </code>
+            
 properties.
-        </p>
+          </p>
+        </div>
       </div>
-      <h4
-        class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
-        data-heading="true"
+      <div
+        class="border-t border-palette-gray4 px-4 py-3"
       >
-        Inherited Props
-        <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
-          href="#inherited-props"
-          id="inherited-props"
+        <h4
+          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1"
+          data-heading="true"
         >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
+          Inherited Props
+          <a
+            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5"
+            href="#inherited-props"
+            id="inherited-props"
           >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              class="flex self-center text-inherit leading-none select-none"
             >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-      <ul
-        class="leading-[1.6154] text-default list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
-      >
-        <li
-          class="text-default text-base font-normal leading-relaxed mb-2"
-          data-text="true"
+              <svg
+                aria-label="permalink"
+                class="shrink-0 icon-xs"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+        <ul
+          class="leading-[1.6154] text-default list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
         >
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+          <li
+            class="text-default text-base font-normal leading-relaxed mb-2"
             data-text="true"
           >
-            <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="https://reactnative.dev/docs/view#props"
-              rel="noopener noreferrer"
-              target="_blank"
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              data-text="true"
             >
-              ViewProps
-            </a>
-          </code>
-        </li>
-      </ul>
+              <a
+                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                href="https://reactnative.dev/docs/view#props"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                ViewProps
+              </a>
+            </code>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <h2
@@ -908,17 +936,17 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           formatFullName(fullName, formatStyle)
@@ -960,7 +988,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -969,7 +997,7 @@ properties.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -990,10 +1018,10 @@ properties.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -1003,7 +1031,7 @@ properties.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1018,21 +1046,25 @@ properties.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                The full name object with the tokenized portions
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  The full name object with the tokenized portions
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -1047,7 +1079,7 @@ properties.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1062,87 +1094,99 @@ properties.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                The style in which the name should be formatted
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  The style in which the name should be formatted
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Creates a locale-aware string representation of a person's name from an object representing the tokenized portions of a user's full name
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        string
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A locale-aware string representation of a person's name
+        Creates a locale-aware string representation of a person's name from an object representing the tokenized portions of a user's full name
       </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
+        >
+          string
+        </code>
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A locale-aware string representation of a person's name
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           getCredentialStateAsync(user)
@@ -1184,7 +1228,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1193,7 +1237,7 @@ properties.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -1214,10 +1258,10 @@ properties.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -1227,7 +1271,7 @@ properties.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1237,186 +1281,198 @@ properties.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                The unique identifier for the user whose credential state you'd like to check.
-This should come from the user field of an 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationcredentialstate"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                    data-text="true"
+                  The unique identifier for the user whose credential state you'd like to check.
+This should come from the user field of an 
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationcredentialstate"
                   >
-                    AppleAuthenticationCredential
-                  </code>
-                </a>
-                 object.
-              </p>
+                    <code
+                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      data-text="true"
+                    >
+                      AppleAuthenticationCredential
+                    </code>
+                  </a>
+                   object.
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
-    </p>
-    
-
-    <blockquote
-      class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        
-
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
-            data-text="true"
-          >
-            Note:
-          </span>
-           This method must be tested on a real device. On the iOS simulator it always throws an error.
-        </p>
-        
-
-      </div>
-    </blockquote>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#appleauthenticationcredentialstate"
-          >
-            AppleAuthenticationCredentialState
-          </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A promise that fulfills with an 
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="#appleauthenticationcredentialstate"
+        Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
+      </p>
+      
+
+      <blockquote
+        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
         >
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          <svg
+            class="translate-z icon-xs text-icon-default"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          
+
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            AppleAuthenticationCredentialState
-          </code>
-        </a>
-        
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              Note:
+            </span>
+             This method must be tested on a real device. On the iOS simulator it always throws an error.
+          </p>
+          
+
+        </div>
+      </blockquote>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
+        >
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredentialstate"
+            >
+              AppleAuthenticationCredentialState
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
+        </code>
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A promise that fulfills with an 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredentialstate"
+            >
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                AppleAuthenticationCredentialState
+              </code>
+            </a>
+            
 value depending on the state of the credential.
-      </p>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           isAvailableAsync()
@@ -1457,107 +1513,115 @@ value depending on the state of the credential.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Determine if the current device's operating system supports Apple authentication.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          boolean
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A promise that fulfills with 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          true
-        </code>
-         if the system supports Apple authentication, and 
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          false
-        </code>
-         otherwise.
+        Determine if the current device's operating system supports Apple authentication.
       </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
+        >
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            boolean
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
+        </code>
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A promise that fulfills with 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              true
+            </code>
+             if the system supports Apple authentication, and 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              false
+            </code>
+             otherwise.
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           refreshAsync(options)
@@ -1599,7 +1663,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1608,7 +1672,7 @@ value depending on the state of the credential.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -1629,10 +1693,10 @@ value depending on the state of the credential.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -1642,7 +1706,7 @@ value depending on the state of the credential.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1657,146 +1721,158 @@ value depending on the state of the credential.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationrefreshoptions"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                    data-text="true"
+                  An 
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationrefreshoptions"
                   >
-                    AppleAuthenticationRefreshOptions
-                  </code>
-                </a>
-                 object
-              </p>
+                    <code
+                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      data-text="true"
+                    >
+                      AppleAuthenticationRefreshOptions
+                    </code>
+                  </a>
+                   object
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      An operation that refreshes the logged-in user’s credentials.
-Calling this method will show the sign in modal before actually refreshing the user credentials.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#appleauthenticationcredential"
-          >
-            AppleAuthenticationCredential
-          </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A promise that fulfills with an 
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="#appleauthenticationcredential"
+        An operation that refreshes the logged-in user’s credentials.
+Calling this method will show the sign in modal before actually refreshing the user credentials.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
         >
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-            data-text="true"
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            AppleAuthenticationCredential
-          </code>
-        </a>
-        
-object after a successful authentication, and rejects with 
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
-          ERR_REQUEST_CANCELED
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              AppleAuthenticationCredential
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
-         if the user cancels the
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A promise that fulfills with an 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                AppleAuthenticationCredential
+              </code>
+            </a>
+            
+object after a successful authentication, and rejects with 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              ERR_REQUEST_CANCELED
+            </code>
+             if the user cancels the
 refresh operation.
-      </p>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           signInAsync(options)
@@ -1838,7 +1914,7 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1847,7 +1923,7 @@ refresh operation.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -1868,10 +1944,10 @@ refresh operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -1886,7 +1962,7 @@ refresh operation.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -1901,151 +1977,73 @@ refresh operation.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An optional 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationsigninoptions"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                    data-text="true"
+                  An optional 
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationsigninoptions"
                   >
-                    AppleAuthenticationSignInOptions
-                  </code>
-                </a>
-                 object
-              </p>
+                    <code
+                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      data-text="true"
+                    >
+                      AppleAuthenticationSignInOptions
+                    </code>
+                  </a>
+                   object
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Sends a request to the operating system to initiate the Apple authentication flow, which will
-present a modal to the user over your app and allow them to sign in.
-    </p>
-    
-
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      You can request access to the user's full name and email address in this method, which allows you
-to personalize your UI for signed in users. However, users can deny access to either or both
-of these options at runtime.
-    </p>
-    
-
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Additionally, you will only receive Apple Authentication Credentials the first time users sign
-into your app, so you must store it for later use. It's best to store this information either
-server-side, or using 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="./securestore"
-      >
-        SecureStore
-      </a>
-      , so that the data persists across app installs.
-You can use 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationcredential"
-      >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          AppleAuthenticationCredential.user
-        </code>
-      </a>
-       to identify
-the user, since this remains the same for apps released by the same developer.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#appleauthenticationcredential"
-          >
-            AppleAuthenticationCredential
-          </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A promise that fulfills with an 
+        Sends a request to the operating system to initiate the Apple authentication flow, which will
+present a modal to the user over your app and allow them to sign in.
+      </p>
+      
+
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        You can request access to the user's full name and email address in this method, which allows you
+to personalize your UI for signed in users. However, users can deny access to either or both
+of these options at runtime.
+      </p>
+      
+
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        Additionally, you will only receive Apple Authentication Credentials the first time users sign
+into your app, so you must store it for later use. It's best to store this information either
+server-side, or using 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="./securestore"
+        >
+          SecureStore
+        </a>
+        , so that the data persists across app installs.
+You can use 
         <a
           class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredential"
@@ -2054,34 +2052,124 @@ the user, since this remains the same for apps released by the same developer.
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            AppleAuthenticationCredential
+            AppleAuthenticationCredential.user
           </code>
         </a>
-        
-object after a successful authentication, and rejects with 
+         to identify
+the user, since this remains the same for apps released by the same developer.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
-          ERR_REQUEST_CANCELED
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              AppleAuthenticationCredential
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
-         if the user cancels the
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A promise that fulfills with an 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                AppleAuthenticationCredential
+              </code>
+            </a>
+            
+object after a successful authentication, and rejects with 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              ERR_REQUEST_CANCELED
+            </code>
+             if the user cancels the
 sign-in operation.
-      </p>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           signOutAsync(options)
@@ -2123,7 +2211,7 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2132,7 +2220,7 @@ sign-in operation.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -2153,10 +2241,10 @@ sign-in operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2166,7 +2254,7 @@ sign-in operation.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2181,166 +2269,178 @@ sign-in operation.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationsignoutoptions"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                    data-text="true"
+                  An 
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationsignoutoptions"
                   >
-                    AppleAuthenticationSignOutOptions
-                  </code>
-                </a>
-                 object
-              </p>
+                    <code
+                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      data-text="true"
+                    >
+                      AppleAuthenticationSignOutOptions
+                    </code>
+                  </a>
+                   object
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      An operation that ends the authenticated session.
-Calling this method will show the sign in modal before actually signing the user out.
-    </p>
-    
-
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      It is not recommended to use this method to sign out the user as it works counterintuitively.
-Instead of using this method it is recommended to simply clear all the user's data collected
-from using 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationsigninasyncoptions"
-      >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          signInAsync
-        </code>
-      </a>
-       or 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationrefreshasyncoptions"
-      >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          refreshAsync
-        </code>
-      </a>
-       methods.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#appleauthenticationcredential"
-          >
-            AppleAuthenticationCredential
-          </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        A promise that fulfills with an 
+        An operation that ends the authenticated session.
+Calling this method will show the sign in modal before actually signing the user out.
+      </p>
+      
+
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        It is not recommended to use this method to sign out the user as it works counterintuitively.
+Instead of using this method it is recommended to simply clear all the user's data collected
+from using 
         <a
           class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="#appleauthenticationcredential"
+          href="#appleauthenticationsigninasyncoptions"
         >
           <code
             class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            AppleAuthenticationCredential
+            signInAsync
           </code>
         </a>
-        
-object after a successful authentication, and rejects with 
+         or 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationrefreshasyncoptions"
+        >
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            data-text="true"
+          >
+            refreshAsync
+          </code>
+        </a>
+         methods.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
-          ERR_REQUEST_CANCELED
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              AppleAuthenticationCredential
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
-         if the user cancels the
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            A promise that fulfills with an 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#appleauthenticationcredential"
+            >
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                AppleAuthenticationCredential
+              </code>
+            </a>
+            
+object after a successful authentication, and rejects with 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              ERR_REQUEST_CANCELED
+            </code>
+             if the user cancels the
 sign-out operation.
-      </p>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <h2
@@ -2384,17 +2484,17 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           addRevokeListener(listener)
@@ -2436,7 +2536,7 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2445,7 +2545,7 @@ sign-out operation.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -2461,10 +2561,10 @@ sign-out operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2474,7 +2574,7 @@ sign-out operation.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2495,42 +2595,46 @@ sign-out operation.
     </div>
     <br />
     <div
-      class="flex flex-row items-start gap-2 mb-3"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <div
-        class="flex flex-row items-center gap-2"
+        class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"
       >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+        <div
+          class="flex flex-row items-center gap-2"
         >
-          <g
-            id="corner-down-right-outline-icon"
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
         >
-          Returns:
-        </span>
+          EventSubscription
+        </code>
       </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        EventSubscription
-      </code>
     </div>
   </div>
   <h2
@@ -2574,23 +2678,23 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationCredential
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationcredential"
           id="appleauthenticationcredential"
         >
@@ -2625,105 +2729,112 @@ sign-out operation.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      The object type returned from a successful call to 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationsigninasyncoptions"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
+        The object type returned from a successful call to 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationsigninasyncoptions"
         >
-          AppleAuthentication.signInAsync()
-        </code>
-      </a>
-      ,
-
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationrefreshasyncoptions"
-      >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          AppleAuthentication.refreshAsync()
-        </code>
-      </a>
-      , or 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationsignoutasyncoptions"
-      >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          AppleAuthentication.signOutAsync()
-        </code>
-      </a>
-      
-which contains all of the pertinent user and credential information.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
-            rel="noopener noreferrer"
-            target="_blank"
+            AppleAuthentication.signInAsync()
+          </code>
+        </a>
+        ,
+
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationrefreshasyncoptions"
+        >
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            data-text="true"
           >
-            Apple
+            AppleAuthentication.refreshAsync()
+          </code>
+        </a>
+        , or 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationsignoutasyncoptions"
+        >
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            data-text="true"
+          >
+            AppleAuthentication.signOutAsync()
+          </code>
+        </a>
+        
+which contains all of the pertinent user and credential information.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
+        >
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2732,7 +2843,7 @@ for more details.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -2753,10 +2864,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2766,7 +2877,7 @@ for more details.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2786,29 +2897,33 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A short-lived session token used by your app for proof of authorization when interacting with
-the app's server counterpart. Unlike 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
-                  user
-                </code>
-                , this is ephemeral and will change each session.
-              </p>
+                  A short-lived session token used by your app for proof of authorization when interacting with
+the app's server counterpart. Unlike 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    user
+                  </code>
+                  , this is ephemeral and will change each session.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2818,7 +2933,7 @@ the app's server counterpart. Unlike
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2838,31 +2953,35 @@ the app's server counterpart. Unlike
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                The user's email address. Might not be present if you didn't request the 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
-                  EMAIL
-                </code>
-                 scope. May
+                  The user's email address. Might not be present if you didn't request the 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    EMAIL
+                  </code>
+                   scope. May
 also be null if this is not the first time the user has signed into your app. If the user chose
 to withhold their email address, this field will instead contain an obscured email address with
 an Apple domain.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2872,7 +2991,7 @@ an Apple domain.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2897,44 +3016,48 @@ an Apple domain.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                The user's name. May be 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
-                  null
-                </code>
-                 or contain 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                 values if you didn't request the 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  FULL_NAME
-                </code>
-                
+                  The user's name. May be 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                   or contain 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                   values if you didn't request the 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    FULL_NAME
+                  </code>
+                  
 scope, if the user denied access, or if this is not the first time the user has signed into
 your app.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2944,7 +3067,7 @@ your app.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -2964,21 +3087,25 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A JSON Web Token (JWT) that securely communicates information about the user to your app.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  A JSON Web Token (JWT) that securely communicates information about the user to your app.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -2988,7 +3115,7 @@ your app.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3003,21 +3130,25 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A value that indicates whether the user appears to the system to be a real person.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  A value that indicates whether the user appears to the system to be a real person.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3027,7 +3158,7 @@ your app.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3047,45 +3178,49 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An arbitrary string that your app provided as 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
-                  state
-                </code>
-                 in the request that generated the
+                  An arbitrary string that your app provided as 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    state
+                  </code>
+                   in the request that generated the
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  state
-                </code>
-                 when making the sign-in request, this field
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    state
+                  </code>
+                   when making the sign-in request, this field
 will be 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                .
-              </p>
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3095,7 +3230,7 @@ will be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3105,17 +3240,21 @@ will be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An identifier associated with the authenticated user. You can use this to check if the user is
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  An identifier associated with the authenticated user. You can use this to check if the user is
 still authenticated later. This is stable and can be shared across apps released under the same
 development team. The same user will have a different identifier for apps released by other
 developers.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -3123,23 +3262,23 @@ developers.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationFullName
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationfullname"
           id="appleauthenticationfullname"
         >
@@ -3174,22 +3313,29 @@ developers.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      An object representing the tokenized portions of the user's full name. Any of all of the fields
-may be 
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        null
-      </code>
-      . Only applicable fields that the user has allowed your app to access will be nonnull.
-    </p>
+        An object representing the tokenized portions of the user's full name. Any of all of the fields
+may be 
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          null
+        </code>
+        . Only applicable fields that the user has allowed your app to access will be nonnull.
+      </p>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3198,7 +3344,7 @@ may be
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -3219,10 +3365,10 @@ may be
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3232,7 +3378,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3252,7 +3398,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3262,10 +3408,10 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3275,7 +3421,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3295,7 +3441,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3305,10 +3451,10 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3318,7 +3464,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3338,7 +3484,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3348,10 +3494,10 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3361,7 +3507,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3381,7 +3527,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3391,10 +3537,10 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3404,7 +3550,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3424,7 +3570,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3434,10 +3580,10 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3447,7 +3593,7 @@ may be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3467,7 +3613,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3481,23 +3627,23 @@ may be
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationFullNameFormatStyle
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationfullnameformatstyle"
           id="appleauthenticationfullnameformatstyle"
         >
@@ -3533,7 +3679,7 @@ may be
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-3"
       data-text="true"
     >
       <span
@@ -3548,67 +3694,71 @@ may be
         string
       </code>
     </p>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      A value to specify the style for formatting a name.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
+        A value to specify the style for formatting a name.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
         >
-          <g
-            id="info-circle-solid-icon"
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
           >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/foundation/personnamecomponentsformatter"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Apple
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/foundation/personnamecomponentsformatter"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <p
-      class="tracking-[-0.006rem] text-xs font-medium text-tertiary"
+      class="tracking-[-0.006rem] text-xs font-medium text-tertiary mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
@@ -3666,23 +3816,23 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationRefreshOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationrefreshoptions"
           id="appleauthenticationrefreshoptions"
         >
@@ -3717,80 +3867,87 @@ for more details.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      The options you can supply when making a call to 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationrefreshasyncoptions"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
+        The options you can supply when making a call to 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationrefreshasyncoptions"
         >
-          AppleAuthentication.refreshAsync()
-        </code>
-      </a>
-      .
-You must include the ID string of the user whose credentials you'd like to refresh.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
-            rel="noopener noreferrer"
-            target="_blank"
+            AppleAuthentication.refreshAsync()
+          </code>
+        </a>
+        .
+You must include the ID string of the user whose credentials you'd like to refresh.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
+        >
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
           >
-            Apple
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3799,7 +3956,7 @@ for more details.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -3820,10 +3977,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3838,7 +3995,7 @@ for more details.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3854,46 +4011,50 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Array of user information scopes to which your app is requesting access. Note that the user can
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                 values for any scopes you request. Additionally, note that the requested scopes
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                   values for any scopes you request. Additionally, note that the requested scopes
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                . Defaults to 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  []
-                </code>
-                 (no scopes).
-              </p>
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                  . Defaults to 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    []
+                  </code>
+                   (no scopes).
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3908,7 +4069,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3918,33 +4079,37 @@ requests they will be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An arbitrary string that is returned unmodified in the corresponding credential after a
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  RFC6749
-                </a>
-                .
-              </p>
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    RFC6749
+                  </a>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -3954,7 +4119,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -3964,7 +4129,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -3978,23 +4143,23 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationSignInOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationsigninoptions"
           id="appleauthenticationsigninoptions"
         >
@@ -4029,80 +4194,87 @@ OAuth 2.0 protocol
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      The options you can supply when making a call to 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationsigninasyncoptions"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
+        The options you can supply when making a call to 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationsigninasyncoptions"
         >
-          AppleAuthentication.signInAsync()
-        </code>
-      </a>
-      .
-None of these options are required.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
-            rel="noopener noreferrer"
-            target="_blank"
+            AppleAuthentication.signInAsync()
+          </code>
+        </a>
+        .
+None of these options are required.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
+        >
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
           >
-            Apple
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4111,7 +4283,7 @@ for more details.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -4132,10 +4304,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4150,7 +4322,7 @@ for more details.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4160,31 +4332,35 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An arbitrary string that is used to prevent replay attacks. See more information on this in the
-
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
-                  rel="noopener noreferrer"
-                  target="_blank"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  OpenID Connect specification
-                </a>
-                .
-              </p>
+                  An arbitrary string that is used to prevent replay attacks. See more information on this in the
+
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    OpenID Connect specification
+                  </a>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4199,7 +4375,7 @@ for more details.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4215,46 +4391,50 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Array of user information scopes to which your app is requesting access. Note that the user can
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                 values for any scopes you request. Additionally, note that the requested scopes
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                   values for any scopes you request. Additionally, note that the requested scopes
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  null
-                </code>
-                . Defaults to 
-                <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                  data-text="true"
-                >
-                  []
-                </code>
-                 (no scopes).
-              </p>
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    null
+                  </code>
+                  . Defaults to 
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    []
+                  </code>
+                   (no scopes).
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4269,7 +4449,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4279,26 +4459,30 @@ requests they will be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An arbitrary string that is returned unmodified in the corresponding credential after a
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  RFC6749
-                </a>
-                .
-              </p>
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    RFC6749
+                  </a>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -4306,23 +4490,23 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           AppleAuthenticationSignOutOptions
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#appleauthenticationsignoutoptions"
           id="appleauthenticationsignoutoptions"
         >
@@ -4357,80 +4541,87 @@ OAuth 2.0 protocol
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      The options you can supply when making a call to 
-      <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-        href="#appleauthenticationsignoutasyncoptions"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
       >
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
+        The options you can supply when making a call to 
+        <a
+          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          href="#appleauthenticationsignoutasyncoptions"
         >
-          AppleAuthentication.signOutAsync()
-        </code>
-      </a>
-      .
-You must include the ID string of the user to sign out.
-    </p>
-    <blockquote
-      class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
-      data-testid="callout-container"
-    >
-      <div
-        class="select-none mt-1"
-      >
-        <svg
-          class="translate-z icon-xs text-icon-secondary"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
-      >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-          data-text="true"
-        >
-          <span
-            class="leading-[1.6154] text-default font-semibold"
+          <code
+            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
             data-text="true"
           >
-            See:
-          </span>
-           
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
-            rel="noopener noreferrer"
-            target="_blank"
+            AppleAuthentication.signOutAsync()
+          </code>
+        </a>
+        .
+You must include the ID string of the user to sign out.
+      </p>
+      <blockquote
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        data-testid="callout-container"
+      >
+        <div
+          class="select-none mt-1"
+        >
+          <svg
+            class="translate-z icon-xs text-icon-secondary"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
           >
-            Apple
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            <span
+              class="leading-[1.6154] text-default font-semibold"
+              data-text="true"
+            >
+              See:
+            </span>
+             
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4439,7 +4630,7 @@ for more details.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -4460,10 +4651,10 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4478,7 +4669,7 @@ for more details.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4488,33 +4679,37 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                An arbitrary string that is returned unmodified in the corresponding credential after a
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  RFC6749
-                </a>
-                .
-              </p>
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    RFC6749
+                  </a>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4524,7 +4719,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -4534,7 +4729,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="text-quaternary"
@@ -4548,23 +4743,23 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#subscription"
           id="subscription"
         >
@@ -4599,14 +4794,21 @@ OAuth 2.0 protocol
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      A subscription object that allows to conveniently remove an event listener from the emitter.
-    </p>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        A subscription object that allows to conveniently remove an event listener from the emitter.
+      </p>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4615,7 +4817,7 @@ OAuth 2.0 protocol
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -4636,10 +4838,10 @@ OAuth 2.0 protocol
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -4649,7 +4851,7 @@ OAuth 2.0 protocol
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -4670,15 +4872,19 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Removes an event listener for which the subscription has been created.
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Removes an event listener for which the subscription has been created.
 After calling this function, the listener will no longer receive any events from the emitter.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -4726,62 +4932,62 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationButtonStyle
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationbuttonstyle"
+          id="appleauthenticationbuttonstyle"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationButtonStyle
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationbuttonstyle"
-            id="appleauthenticationbuttonstyle"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4800,7 +5006,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4857,15 +5063,19 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        White button with black text.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          White button with black text.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4922,15 +5132,19 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        White button with a black outline and black text.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          White button with a black outline and black text.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -4987,71 +5201,75 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        Black button with white text.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          Black button with white text.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationButtonType
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationbuttontype"
+          id="appleauthenticationbuttontype"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationButtonType
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationbuttontype"
-            id="appleauthenticationbuttontype"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
@@ -5070,7 +5288,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5127,15 +5345,19 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        "Sign in with Apple"
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          "Sign in with Apple"
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5192,15 +5414,19 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        "Continue with Apple"
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          "Continue with Apple"
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5291,71 +5517,75 @@ After calling this function, the listener will no longer receive any events from
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        "Sign up with Apple"
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          "Sign up with Apple"
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationCredentialState
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationcredentialstate"
+          id="appleauthenticationcredentialstate"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationCredentialState
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationcredentialstate"
-            id="appleauthenticationcredentialstate"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
@@ -5373,7 +5603,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <div
@@ -5401,7 +5631,7 @@ After calling this function, the listener will no longer receive any events from
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
@@ -5427,7 +5657,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5484,9 +5714,12 @@ for more details.
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5543,9 +5776,12 @@ for more details.
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5602,9 +5838,12 @@ for more details.
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5661,66 +5900,68 @@ for more details.
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
       </code>
+      <div
+        class=""
+      />
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationOperation
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationoperation"
+          id="appleauthenticationoperation"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationOperation
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationoperation"
-            id="appleauthenticationoperation"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5777,15 +6018,19 @@ for more details.
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        An operation that depends on the particular kind of credential provider.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          An operation that depends on the particular kind of credential provider.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5842,9 +6087,12 @@ for more details.
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5901,9 +6149,12 @@ for more details.
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -5960,65 +6211,68 @@ for more details.
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
       </code>
+      <div
+        class=""
+      />
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationScope
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationscope"
+          id="appleauthenticationscope"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationScope
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationscope"
-            id="appleauthenticationscope"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
@@ -6038,7 +6292,7 @@ for more details.
       
 
       <blockquote
-        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
+        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <div
@@ -6068,7 +6322,7 @@ for more details.
           
 
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -6079,7 +6333,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <div
@@ -6107,7 +6361,7 @@ You will still need to handle null values for any fields you request.
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
@@ -6133,7 +6387,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6190,9 +6444,12 @@ for more details.
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
       </code>
+      <div
+        class=""
+      />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6249,71 +6506,74 @@ for more details.
       >
         AppleAuthenticationScope.EMAIL ＝ 1
       </code>
+      <div
+        class=""
+      />
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          AppleAuthenticationUserDetectionStatus
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#appleauthenticationuserdetectionstatus"
+          id="appleauthenticationuserdetectionstatus"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            AppleAuthenticationUserDetectionStatus
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#appleauthenticationuserdetectionstatus"
-            id="appleauthenticationuserdetectionstatus"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-3"
+        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <div
@@ -6341,7 +6601,7 @@ for more details.
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
@@ -6367,7 +6627,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6424,15 +6684,19 @@ for more details.
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        The system does not support this determination and there is no data.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          The system does not support this determination and there is no data.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6489,15 +6753,19 @@ for more details.
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        The system has not determined whether the user might be a real person.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          The system has not determined whether the user might be a real person.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -6554,12 +6822,16 @@ for more details.
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        The user appears to be a real person.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          The user appears to be a real person.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -6608,17 +6880,17 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           getPermissionsAsync()
@@ -6659,88 +6931,92 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Checks user's permissions for accessing pedometer.
-    </p>
     <div
-      class="flex flex-row items-start gap-2 mb-3"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
+        Checks user's permissions for accessing pedometer.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
         >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
         >
-          &lt;
-        </span>
-        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#permissionresponse"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            PermissionResponse
+            Promise
           </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#permissionresponse"
+            >
+              PermissionResponse
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
+        </code>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           getStepCountAsync(start, end)
@@ -6781,7 +7057,7 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </h3>
       <div
-        class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
+        class="flex flex-row items-start [table_&]:mb-2.5 mb-0"
       >
         <span
           class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
@@ -6816,7 +7092,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -6825,7 +7101,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -6846,10 +7122,10 @@ exports[`APISection expo-pedometer 1`] = `
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -6859,7 +7135,7 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -6876,21 +7152,25 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A date indicating the start of the range over which to measure steps.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  A date indicating the start of the range over which to measure steps.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -6900,7 +7180,7 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -6917,184 +7197,196 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A date indicating the end of the range over which to measure steps.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  A date indicating the end of the range over which to measure steps.
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Get the step count between two dates.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        Get the step count between two dates.
+      </p>
       <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#pedometerresult"
-          >
-            PedometerResult
-          </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
-    >
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
-      >
-        Returns a promise that fulfills with a 
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="#pedometerresult"
-        >
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-            data-text="true"
-          >
-            PedometerResult
-          </code>
-        </a>
-        .
-      </p>
-      
-
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
-      >
-        As 
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Apple documentation states
-        </a>
-        :
-      </p>
-      
-
-      <blockquote
-        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
-        data-testid="callout-container"
+        class="flex flex-row items-start gap-2"
       >
         <div
-          class="select-none mt-1"
+          class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-xs text-icon-default"
-            fill="currentColor"
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
             role="img"
+            stroke="currentColor"
             viewBox="0 0 24 24"
           >
             <g
-              id="info-circle-solid-icon"
+              id="corner-down-right-outline-icon"
             >
               <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
               />
             </g>
           </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
         </div>
-        <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
         >
-          
-
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#pedometerresult"
+            >
+              PedometerResult
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
+        </code>
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            Only the past seven days worth of data is stored and available for you to retrieve. Specifying
-a start date that is more than seven days in the past returns only the available data.
+            Returns a promise that fulfills with a 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#pedometerresult"
+            >
+              <code
+                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                data-text="true"
+              >
+                PedometerResult
+              </code>
+            </a>
+            .
           </p>
           
 
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            As 
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple documentation states
+            </a>
+            :
+          </p>
+          
+
+          <blockquote
+            class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            data-testid="callout-container"
+          >
+            <div
+              class="select-none mt-1"
+            >
+              <svg
+                class="translate-z icon-xs text-icon-default"
+                fill="currentColor"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <g
+                  id="info-circle-solid-icon"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                    fill-rule="evenodd"
+                    id="Solid"
+                  />
+                </g>
+              </svg>
+            </div>
+            <div
+              class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+            >
+              
+
+              <p
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                data-text="true"
+              >
+                Only the past seven days worth of data is stored and available for you to retrieve. Specifying
+a start date that is more than seven days in the past returns only the available data.
+              </p>
+              
+
+            </div>
+          </blockquote>
         </div>
-      </blockquote>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           isAvailableAsync()
@@ -7135,101 +7427,109 @@ a start date that is more than seven days in the past returns only the available
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Returns whether the pedometer is enabled on the device.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
-        >
-          &lt;
-        </span>
-        <span>
-          boolean
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        Returns a promise that fulfills with a 
+        Returns whether the pedometer is enabled on the device.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
+        >
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
           data-text="true"
         >
-          boolean
+          <a
+            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Promise
+          </a>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            boolean
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
-        , indicating whether the pedometer is
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            data-text="true"
+          >
+            Returns a promise that fulfills with a 
+            <code
+              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              data-text="true"
+            >
+              boolean
+            </code>
+            , indicating whether the pedometer is
 available on this device.
-      </p>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           requestPermissionsAsync()
@@ -7270,88 +7570,92 @@ available on this device.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Asks the user to grant permissions for accessing pedometer.
-    </p>
     <div
-      class="flex flex-row items-start gap-2 mb-3"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
-          rel="noopener noreferrer"
-          target="_blank"
+        Asks the user to grant permissions for accessing pedometer.
+      </p>
+      <div
+        class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"
+      >
+        <div
+          class="flex flex-row items-center gap-2"
         >
-          Promise
-        </a>
-        <span
-          class="text-quaternary"
+          <svg
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="corner-down-right-outline-icon"
+            >
+              <path
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
+        </div>
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
         >
-          &lt;
-        </span>
-        <span>
           <a
             class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-            href="#permissionresponse"
+            href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            PermissionResponse
+            Promise
           </a>
-        </span>
-        <span
-          class="text-quaternary"
-        >
-          &gt;
-        </span>
-      </code>
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
+          <span>
+            <a
+              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              href="#permissionresponse"
+            >
+              PermissionResponse
+            </a>
+          </span>
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
+        </code>
+      </div>
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           watchStepCount(callback)
@@ -7393,7 +7697,7 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7402,7 +7706,7 @@ available on this device.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -7423,10 +7727,10 @@ available on this device.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -7436,7 +7740,7 @@ available on this device.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7451,171 +7755,183 @@ available on this device.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A callback that is invoked when new step count data is available. The callback is
-provided with a single argument that is 
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#pedometerresult"
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
                 >
-                  <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-                    data-text="true"
+                  A callback that is invoked when new step count data is available. The callback is
+provided with a single argument that is 
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#pedometerresult"
                   >
-                    PedometerResult
-                  </code>
-                </a>
-                .
-              </p>
+                    <code
+                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      data-text="true"
+                    >
+                      PedometerResult
+                    </code>
+                  </a>
+                  .
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      Subscribe to pedometer updates.
-    </p>
     <div
-      class="flex flex-row items-start gap-2"
-    >
-      <div
-        class="flex flex-row items-center gap-2"
-      >
-        <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="corner-down-right-outline-icon"
-          >
-            <path
-              d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        <span
-          class="text-xs font-medium text-tertiary"
-        >
-          Returns:
-        </span>
-      </div>
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
-        data-text="true"
-      >
-        EventSubscription
-      </code>
-    </div>
-    <div
-      class="mb-1 mt-1.5 flex flex-col pl-6"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        Returns a 
-        <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-          href="#subscription"
-        >
-          <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-            data-text="true"
-          >
-            Subscription
-          </code>
-        </a>
-         that enables you to call
-
-        <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-          data-text="true"
-        >
-          remove()
-        </code>
-         when you would like to unsubscribe the listener.
+        Subscribe to pedometer updates.
       </p>
-      
-
-      <blockquote
-        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-3"
-        data-testid="callout-container"
+      <div
+        class="flex flex-row items-start gap-2"
       >
         <div
-          class="select-none mt-1"
+          class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-xs text-icon-default"
-            fill="currentColor"
+            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            fill="none"
             role="img"
+            stroke="currentColor"
             viewBox="0 0 24 24"
           >
             <g
-              id="info-circle-solid-icon"
+              id="corner-down-right-outline-icon"
             >
               <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
+                d="M4 4V5.4C4 8.76031 4 10.4405 4.65396 11.7239C5.2292 12.8529 6.14708 13.7708 7.27606 14.346C8.55953 15 10.2397 15 13.6 15H20M20 15L15 10M20 15L15 20"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
               />
             </g>
           </svg>
+          <span
+            class="text-xs font-medium text-tertiary"
+          >
+            Returns:
+          </span>
         </div>
-        <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          data-text="true"
         >
-          
-
+          EventSubscription
+        </code>
+      </div>
+      <div
+        class="mb-1 mt-1.5 flex flex-col pl-6"
+      >
+        <div
+          class=""
+        >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
-            Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
-
+            Returns a 
             <a
               class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-              href="https://developer.android.com/health-and-fitness/guides/health-connect"
-              rel="noopener noreferrer"
-              target="_blank"
+              href="#subscription"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
                 data-text="true"
               >
-                Health Connect API
+                Subscription
               </code>
             </a>
-            .
-On iOS, the 
+             that enables you to call
+
             <code
               class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
               data-text="true"
             >
-              getStepCountAsync
+              remove()
             </code>
-             method can be used to get the step count between two dates.
+             when you would like to unsubscribe the listener.
           </p>
           
 
+          <blockquote
+            class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            data-testid="callout-container"
+          >
+            <div
+              class="select-none mt-1"
+            >
+              <svg
+                class="translate-z icon-xs text-icon-default"
+                fill="currentColor"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <g
+                  id="info-circle-solid-icon"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                    fill-rule="evenodd"
+                    id="Solid"
+                  />
+                </g>
+              </svg>
+            </div>
+            <div
+              class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+            >
+              
+
+              <p
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                data-text="true"
+              >
+                Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
+
+                <a
+                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  href="https://developer.android.com/health-and-fitness/guides/health-connect"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <code
+                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    data-text="true"
+                  >
+                    Health Connect API
+                  </code>
+                </a>
+                .
+On iOS, the 
+                <code
+                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                  data-text="true"
+                >
+                  getStepCountAsync
+                </code>
+                 method can be used to get the step count between two dates.
+              </p>
+              
+
+            </div>
+          </blockquote>
         </div>
-      </blockquote>
+      </div>
     </div>
   </div>
   <h2
@@ -7659,17 +7975,17 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           PermissionResponse
@@ -7710,59 +8026,18 @@ On iOS, the
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      An object obtained by permissions get and request functions.
-    </p>
-    <p
-      class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4"
-      data-text="true"
-    >
-      <span
-        class="leading-[1.6154] text-inherit items-center group flex gap-1"
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
-        PermissionResponse Properties
-        <a
-          class="border border-solid rounded-md whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-5 flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
-          href="#permissionresponse-properties"
-          id="permissionresponse-properties"
-        >
-          <span
-            class="flex self-center text-inherit leading-none select-none"
-          >
-            <svg
-              aria-label="permalink"
-              class="shrink-0 icon-xs"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </span>
-    </p>
+        An object obtained by permissions get and request functions.
+      </p>
+    </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7771,12 +8046,12 @@ On iOS, the
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
-              Name
+              Property
             </th>
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -7792,10 +8067,10 @@ On iOS, the
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -7805,7 +8080,7 @@ On iOS, the
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7815,23 +8090,27 @@ On iOS, the
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Indicates if user can be asked again for specific permission.
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Indicates if user can be asked again for specific permission.
 If not, one should be directed to the Settings app
 in order to enable/disable the permission.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -7841,7 +8120,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7856,21 +8135,25 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Determines time when the permission expires.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Determines time when the permission expires.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -7880,7 +8163,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7890,21 +8173,25 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                A convenience boolean that indicates if the permission is granted.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  A convenience boolean that indicates if the permission is granted.
+                </p>
+              </div>
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -7914,7 +8201,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -7929,20 +8216,23 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Determines the status of the permission.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Determines the status of the permission.
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
-    <br />
   </div>
   <h2
     class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1"
@@ -7985,23 +8275,23 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           PedometerResult
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#pedometerresult"
           id="pedometerresult"
         >
@@ -8037,7 +8327,13 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8046,7 +8342,7 @@ in order to enable/disable the permission.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -8067,10 +8363,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -8080,7 +8376,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -8090,14 +8386,18 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Number of steps taken between the given dates.
-              </p>
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Number of steps taken between the given dates.
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -8105,25 +8405,25 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
-          PedometerUpdateCallback()
+          PedometerUpdateCallback(result)
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-          href="#pedometerupdatecallback"
-          id="pedometerupdatecallback"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#pedometerupdatecallbackresult"
+          id="pedometerupdatecallbackresult"
         >
           <span
             class="flex self-center text-inherit leading-none select-none"
@@ -8156,15 +8456,22 @@ in order to enable/disable the permission.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      Callback function providing event result as an argument.
-    </p>
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        Callback function providing event result as an argument.
+      </p>
+    </div>
     <div>
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mt-0.5"
+        class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      />
+      <div
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
       >
         <table
           class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8173,7 +8480,7 @@ in order to enable/disable the permission.
             class="border-b border-b-default bg-subtle"
           >
             <tr
-              class="even:bg-subtle even:[&_summary]:bg-element"
+              class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
             >
               <th
                 class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -8189,10 +8496,10 @@ in order to enable/disable the permission.
           </thead>
           <tbody>
             <tr
-              class="even:bg-subtle even:[&_summary]:bg-element"
+              class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
             >
               <td
-                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
                 <span
                   class="leading-[1.6154] text-default font-medium"
@@ -8202,7 +8509,7 @@ in order to enable/disable the permission.
                 </span>
               </td>
               <td
-                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*:last-child]:!mb-0"
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
                 <code
                   class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
@@ -8222,7 +8529,7 @@ in order to enable/disable the permission.
       </div>
     </div>
     <div
-      class="mt-3.5 flex flex-row items-start gap-2"
+      class="mx-4 mb-2.5 [table_&]:last:mb-0 mt-3.5 flex flex-row items-start gap-2"
     >
       <div
         class="flex flex-row items-center gap-2"
@@ -8266,23 +8573,23 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           PermissionExpiration
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#permissionexpiration"
           id="permissionexpiration"
         >
@@ -8318,7 +8625,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-3"
       data-text="true"
     >
       <span
@@ -8328,14 +8635,18 @@ in order to enable/disable the permission.
       </span>
       multiple types
     </p>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
-      Permission expiration time. Currently, all permissions are granted permanently.
-    </p>
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        Permission expiration time. Currently, all permissions are granted permanently.
+      </p>
+    </div>
     <p
-      class="tracking-[-0.006rem] text-xs font-medium text-tertiary"
+      class="tracking-[-0.006rem] text-xs font-medium text-tertiary mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
@@ -8360,23 +8671,23 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
         data-heading="true"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
           href="#subscription"
           id="subscription"
         >
@@ -8411,14 +8722,21 @@ in order to enable/disable the permission.
         </a>
       </h3>
     </div>
-    <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-      data-text="true"
-    >
-      A subscription object that allows to conveniently remove an event listener from the emitter.
-    </p>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    >
+      <p
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        data-text="true"
+      >
+        A subscription object that allows to conveniently remove an event listener from the emitter.
+      </p>
+    </div>
+    <div
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8427,7 +8745,7 @@ in order to enable/disable the permission.
           class="border-b border-b-default bg-subtle"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <th
               class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
@@ -8448,10 +8766,10 @@ in order to enable/disable the permission.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element"
+            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
           >
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <span
                 class="leading-[1.6154] text-default font-medium"
@@ -8461,7 +8779,7 @@ in order to enable/disable the permission.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
               <code
                 class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
@@ -8482,15 +8800,19 @@ in order to enable/disable the permission.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left w-fit last:border-r-0 [&>*:last-child]:!mb-0"
+              class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-                data-text="true"
+              <div
+                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
               >
-                Removes an event listener for which the subscription has been created.
+                <p
+                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  data-text="true"
+                >
+                  Removes an event listener for which the subscription has been created.
 After calling this function, the listener will no longer receive any events from the emitter.
-              </p>
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -8538,63 +8860,62 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 !p-0"
+    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="min-h-[46px] px-5 pt-3"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
     >
-      <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+      <h3
+        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
+        data-heading="true"
       >
-        <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
-          data-heading="true"
+        <code
+          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          data-text="true"
         >
-          <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base"
-            data-text="true"
+          PermissionStatus
+        </code>
+        <a
+          class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8"
+          href="#permissionstatus"
+          id="permissionstatus"
+        >
+          <span
+            class="flex self-center text-inherit leading-none select-none"
           >
-            PermissionStatus
-          </code>
-          <a
-            class="border border-solid rounded-md font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] scroll-m-8 mb-0"
-            href="#permissionstatus"
-            id="permissionstatus"
-          >
-            <span
-              class="flex self-center text-inherit leading-none select-none"
+            <svg
+              aria-label="permalink"
+              class="shrink-0 icon-xs"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-label="permalink"
-                class="shrink-0 icon-xs"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </h3>
-      </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    />
+    <div
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8651,15 +8972,19 @@ After calling this function, the listener will no longer receive any events from
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        User has denied the permission.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          User has denied the permission.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8716,15 +9041,19 @@ After calling this function, the listener will no longer receive any events from
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        User has granted the permission.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          User has granted the permission.
+        </p>
+      </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
     >
       <div
         class="flex flex-wrap justify-between max-md-gutters:flex-col"
@@ -8781,12 +9110,16 @@ After calling this function, the listener will no longer receive any events from
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-        data-text="true"
+      <div
+        class=""
       >
-        User hasn't granted or denied the permission yet.
-      </p>
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          data-text="true"
+        >
+          User hasn't granted or denied the permission yet.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,10 +43,10 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none !shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none !shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -339,7 +339,7 @@ for more details.
         class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -419,7 +419,7 @@ for more details.
         class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -499,7 +499,7 @@ for more details.
         class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -583,7 +583,7 @@ for more details.
         class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -682,7 +682,7 @@ in here.
         class="border-t border-palette-gray4 first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
         >
           <h3
             class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -936,10 +936,10 @@ properties.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -988,7 +988,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1176,10 +1176,10 @@ properties.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -1228,7 +1228,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1462,10 +1462,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -1611,10 +1611,10 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -1663,7 +1663,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1862,10 +1862,10 @@ refresh operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -1914,7 +1914,7 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2159,10 +2159,10 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -2211,7 +2211,7 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2484,10 +2484,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -2536,7 +2536,7 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2678,10 +2678,10 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -2834,7 +2834,7 @@ for more details.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3262,10 +3262,10 @@ developers.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -3335,7 +3335,7 @@ may be
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3627,10 +3627,10 @@ may be
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -3679,7 +3679,7 @@ may be
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
       data-text="true"
     >
       <span
@@ -3816,10 +3816,10 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -3947,7 +3947,7 @@ for more details.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4143,10 +4143,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -4274,7 +4274,7 @@ for more details.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4490,10 +4490,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -4621,7 +4621,7 @@ for more details.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4743,10 +4743,10 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -4808,7 +4808,7 @@ OAuth 2.0 protocol
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4932,10 +4932,10 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -5214,10 +5214,10 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -5530,10 +5530,10 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -5906,10 +5906,10 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -6217,10 +6217,10 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -6512,10 +6512,10 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -6880,10 +6880,10 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -7006,10 +7006,10 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -7092,7 +7092,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7376,10 +7376,10 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -7519,10 +7519,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -7645,10 +7645,10 @@ available on this device.
     </div>
   </div>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -7697,7 +7697,7 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7975,10 +7975,10 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
+    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -8037,7 +8037,7 @@ On iOS, the
       </p>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8275,10 +8275,10 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -8333,7 +8333,7 @@ in order to enable/disable the permission.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8405,10 +8405,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -8471,7 +8471,7 @@ in order to enable/disable the permission.
         class="px-4 [table_&]:!mb-0 [table_&]:px-0"
       />
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4"
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
       >
         <table
           class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8573,10 +8573,10 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -8625,7 +8625,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-3"
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
       data-text="true"
     >
       <span
@@ -8671,10 +8671,10 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"
@@ -8736,7 +8736,7 @@ in order to enable/disable the permission.
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8860,10 +8860,10 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
+    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
     >
       <h3
         class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1"

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -233,7 +233,7 @@ export type TypeDeclarationContentData = {
   kind?: TypeDocKind;
   indexSignature?: TypeSignaturesData;
   signatures?: TypeSignaturesData[];
-  parameters?: PropData[];
+  parameters?: MethodParamData[];
   children?: PropData[];
   comment?: CommentData;
 };

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -2,17 +2,16 @@ import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 import ReactMarkdown from 'react-markdown';
 
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
-import { H2, CODE, MONOSPACE, CALLOUT, SPAN } from '~/ui/components/Text';
+import { H2, CODE, CALLOUT } from '~/ui/components/Text';
 
 import { ClassDefinitionData, GeneratedData, PropData, TypeDocKind } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import { renderMethod } from './APISectionMethods';
 import { renderProp } from './APISectionProps';
 import {
-  H3Code,
   getTagData,
-  getTagNamesList,
   mdComponents,
   resolveTypeName,
   getCommentContent,
@@ -20,8 +19,7 @@ import {
   extractDefaultPropValue,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
-import { STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
+import { STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
@@ -96,27 +94,14 @@ const renderClass = (
       key={`class-definition-${name}`}
       className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
-      </div>
+      <APIBoxHeader name={name} comment={comment} />
       {(extendedTypes?.length || implementedTypes?.length) && (
-        <CALLOUT className="mb-3">
-          <SPAN theme="secondary" weight="medium">
-            Type:{' '}
-          </SPAN>
-          {type ? (
-            <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
-          ) : (
-            <SPAN theme="secondary">Class</SPAN>
-          )}
+        <CALLOUT className={mergeClasses('mb-3 !font-normal', STYLES_SECONDARY, VERTICAL_SPACING)}>
+          <span className="font-medium">Type: </span>
+          {type ? <CODE>{resolveTypeName(type, sdkVersion)}</CODE> : <span>Class</span>}
           {extendedTypes?.length && (
             <>
-              <SPAN theme="secondary"> extends </SPAN>
+              <span> extends </span>
               {extendedTypes.map(extendedType => (
                 <CODE key={`extends-${extendedType.name}`}>
                   {resolveTypeName(extendedType, sdkVersion)}
@@ -126,7 +111,7 @@ const renderClass = (
           )}
           {implementedTypes?.length && (
             <>
-              <SPAN theme="secondary"> implements </SPAN>
+              <span> implements </span>
               {implementedTypes.map(implementedType => (
                 <CODE key={`implements-${implementedType.name}`}>
                   {resolveTypeName(implementedType, sdkVersion)}
@@ -182,13 +167,15 @@ const renderClass = (
             exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
-          {methods.map(method =>
-            renderMethod(method, {
-              exposeInSidebar: true,
-              baseNestingLevel: linksNestingLevel,
-              sdkVersion,
-            })
-          )}
+          <div className={mergeClasses(VERTICAL_SPACING, 'mt-4')}>
+            {methods.map(method =>
+              renderMethod(method, {
+                exposeInSidebar: true,
+                baseNestingLevel: linksNestingLevel,
+                sdkVersion,
+              })
+            )}
+          </div>
         </>
       )}
     </div>

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
-import { APISectionPlatformTags } from '~/components/plugins/api/components/APISectionPlatformTags';
-import { H2, DEMI, CODE, MONOSPACE, CALLOUT } from '~/ui/components/Text';
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
+import { H2, DEMI, CODE, CALLOUT } from '~/ui/components/Text';
 
 import {
   CommentData,
@@ -14,12 +14,10 @@ import APISectionProps from './APISectionProps';
 import {
   resolveTypeName,
   getComponentName,
-  getTagNamesList,
-  H3Code,
   getPossibleComponentPropsNames,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY } from './styles';
+import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionComponentsProps = {
   data: GeneratedData[];
@@ -64,16 +62,9 @@ const renderComponent = (
       key={`component-definition-${resolvedName}`}
       className={mergeClasses(STYLES_APIBOX, '!shadow-none')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <div className="flex flex-wrap items-baseline justify-between max-md-gutters:flex-col [&_h3]:mb-0">
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {resolvedName}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
-      </div>
+      <APIBoxHeader name={resolvedName} comment={extractedComment} />
       {resolvedType && resolvedTypeParameters && (
-        <CALLOUT className={ELEMENT_SPACING}>
+        <CALLOUT className={mergeClasses(ELEMENT_SPACING, VERTICAL_SPACING)}>
           <DEMI className={STYLES_SECONDARY}>Type:</DEMI>{' '}
           <CODE>
             {extendedTypes ? (

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -1,14 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
 
-import { H2, P, MONOSPACE } from '~/ui/components/Text';
+import { CALLOUT, H2 } from '~/ui/components/Text';
 
 import { ConstantDefinitionData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
-import { getTagNamesList, H3Code } from './APISectionUtils';
+import { APIBoxHeader } from './components/APIBoxHeader';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
-import { STYLES_APIBOX, STYLES_SECONDARY } from './styles';
+import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
@@ -21,27 +20,15 @@ const renderConstant = (
   sdkVersion: string,
   apiName?: string
 ): JSX.Element => (
-  <div
-    key={`constant-definition-${name}`}
-    className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
+  <div key={`constant-definition-${name}`} className={STYLES_APIBOX}>
     <APISectionDeprecationNote comment={comment} sticky />
-    <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere !heading-base">
-          {apiName ? `${apiName}.` : ''}
-          {name}
-        </MONOSPACE>
-      </H3Code>
-      <APISectionPlatformTags comment={comment} />
-    </div>
+    <APIBoxHeader name={`${apiName ? `${apiName}.` : ''}${name}`} comment={comment} />
     {type && (
-      <P className={STYLES_SECONDARY}>
+      <CALLOUT className={mergeClasses(STYLES_SECONDARY, ELEMENT_SPACING, VERTICAL_SPACING)}>
         Type: <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
-      </P>
+      </CALLOUT>
     )}
-    {comment && (
-      <APICommentTextBlock comment={comment} includePlatforms={false} beforeContent={<br />} />
-    )}
+    {comment && <APICommentTextBlock comment={comment} includePlatforms={false} inlineHeaders />}
   </div>
 );
 

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -25,7 +25,7 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
     <div
       className={mergeClasses(
         `[table_&]:mt-0 [table_&]:${ELEMENT_SPACING} [table_&]:last:mb-0`,
-        sticky && 'mx-[-21px] mt-[-21px] max-lg-gutters:mx-[-17px]'
+        sticky && '-mx-px -mt-px'
       )}>
       <InlineHelp
         size="sm"
@@ -34,7 +34,7 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
         className={mergeClasses(
           'border-palette-yellow5',
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'mb-3 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
+          sticky && 'mb-0 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
         )}>
         {content.length ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -29,15 +29,13 @@ const renderEnumValue = (value: any, fallback?: string) =>
 
 function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefinitionData }) {
   return (
-    <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX, '!p-0')}>
-      <div className="min-h-[46px] px-5 pt-3">
-        <APISectionDeprecationNote comment={comment} sticky />
-        <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
-      </div>
+    <div key={`enum-definition-${name}`} className={mergeClasses(STYLES_APIBOX)}>
+      <APISectionDeprecationNote comment={comment} sticky />
+      <APIBoxHeader name={name} comment={comment} />
+      <APICommentTextBlock comment={comment} includePlatforms={false} />
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div
-          className="border-t border-t-palette-gray4 px-5 pb-0 pt-3 [&_h4]:mb-0.5"
+          className="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
           <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
@@ -54,7 +52,11 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
               enumValue.type.name
             )}`}
           </MONOSPACE>
-          <APICommentTextBlock comment={enumValue.comment} includePlatforms={false} />
+          <APICommentTextBlock
+            comment={enumValue.comment}
+            includePlatforms={false}
+            includeSpacing={false}
+          />
         </div>
       ))}
     </div>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -1,8 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, CALLOUT, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
+import { H2, CALLOUT, CODE, DEMI } from '~/ui/components/Text';
 
 import {
   CommentData,
@@ -18,15 +17,14 @@ import {
   renderFlags,
   resolveTypeName,
   renderDefaultValue,
-  getTagNamesList,
-  H3Code,
   getCommentContent,
 } from './APISectionUtils';
+import { APIBoxHeader } from './components/APIBoxHeader';
+import { APIBoxSectionHeader } from './components/APIBoxSectionHeader';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
 import { APIParamRow } from './components/APIParamRow';
 import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
 
 export type APISectionInterfacesProps = {
@@ -78,7 +76,7 @@ const renderInterfaceComment = (
           inlineHeaders
           comment={comment}
           afterContent={renderDefaultValue(initValue)}
-          emptyCommentFallback="-"
+          emptyCommentFallback={getTagData('deprecated', comment) ? '' : '-'}
         />
       </>
     );
@@ -95,14 +93,14 @@ const renderInterfacePropertyRow = (
   );
   return (
     <Row key={name}>
-      <Cell fitContent>
+      <Cell>
         <DEMI>{name}</DEMI>
         {renderFlags(flags, initValue)}
       </Cell>
-      <Cell fitContent>
+      <Cell>
         <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </Cell>
-      <Cell fitContent>{renderInterfaceComment(sdkVersion, comment, signatures, initValue)}</Cell>
+      <Cell>{renderInterfaceComment(sdkVersion, comment, signatures, initValue)}</Cell>
     </Row>
   );
 };
@@ -123,16 +121,9 @@ const renderInterface = (
   return (
     <div
       key={`interface-definition-${name}`}
-      className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
+      className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, 'overflow-hidden')}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere !text-base">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
-      </div>
+      <APIBoxHeader name={name} comment={comment} />
       {extendedTypes?.length ? (
         <CALLOUT className={ELEMENT_SPACING}>
           <span className={STYLES_SECONDARY}>Extends: </span>
@@ -154,14 +145,12 @@ const renderInterface = (
       )}
       {interfaceFields.length > 0 && (
         <>
-          <APIBoxSectionHeader text={`${name} Properties`} exposeInSidebar baseNestingLevel={99} />
-          <Table>
-            <APIParamsTableHeadRow />
+          <Table containerClassName="rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4">
+            <APIParamsTableHeadRow mainCellLabel="Property" />
             <tbody>
               {interfaceFields.map(field => renderInterfacePropertyRow(field, sdkVersion))}
             </tbody>
           </Table>
-          <br />
         </>
       )}
     </div>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -145,7 +145,7 @@ const renderInterface = (
       )}
       {interfaceFields.length > 0 && (
         <>
-          <Table containerClassName="rounded-none border-0 border-t border-palette-gray4 [&_thead]:border-palette-gray4">
+          <Table containerClassName="rounded-none border-0 border-t">
             <APIParamsTableHeadRow mainCellLabel="Property" />
             <tbody>
               {interfaceFields.map(field => renderInterfacePropertyRow(field, sdkVersion))}

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -1,7 +1,8 @@
 import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { H2, MONOSPACE, RawH3 } from '~/ui/components/Text';
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
+import { H2 } from '~/ui/components/Text';
 
 import { AccessorDefinitionData, MethodDefinitionData, PropData } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
@@ -9,13 +10,11 @@ import {
   getMethodName,
   renderParams,
   resolveTypeName,
-  getCodeHeadingWithBaseNestingLevel,
   getTagData,
   getAllTagData,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
 
 export type APISectionMethodsProps = {
@@ -30,6 +29,7 @@ export type RenderMethodOptions = {
   apiName?: string;
   sdkVersion: string;
   header?: string;
+  nested?: boolean;
   exposeInSidebar?: boolean;
   baseNestingLevel?: number;
 };
@@ -57,38 +57,33 @@ function getMethodRootSignatures(method: MethodDefinitionData | AccessorDefiniti
 
 export const renderMethod = (
   method: MethodDefinitionData | AccessorDefinitionData | PropData,
-  { apiName, exposeInSidebar = true, sdkVersion, ...options }: RenderMethodOptions
+  { apiName, exposeInSidebar = true, nested = false, sdkVersion, ...options }: RenderMethodOptions
 ) => {
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
-  const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
 
   return signatures.map(({ name, parameters, comment, type, typeParameter }) => {
     const returnComment = getTagData('returns', comment);
     return (
       <div
         key={`method-signature-${method.name || name}-${parameters?.length ?? 0}`}
-        className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED)}>
+        className={mergeClasses(
+          !nested && STYLES_APIBOX,
+          !nested && STYLES_APIBOX_NESTED,
+          nested && 'border-b border-palette-gray4'
+        )}>
         <APISectionDeprecationNote comment={comment} sticky />
-        <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-          <HeaderComponent>
-            <MONOSPACE
-              weight="medium"
-              className={mergeClasses(
-                'wrap-anywhere !text-base',
-                !exposeInSidebar && 'mb-1 inline-block'
-              )}>
-              {getMethodName(
-                method as MethodDefinitionData,
-                apiName,
-                name,
-                parameters,
-                typeParameter
-              )}
-            </MONOSPACE>
-          </HeaderComponent>
-          <APISectionPlatformTags comment={comment} />
-        </div>
+        <APIBoxHeader
+          name={getMethodName(
+            method as MethodDefinitionData,
+            apiName,
+            name,
+            parameters,
+            typeParameter
+          )}
+          comment={comment}
+          baseNestingLevel={baseNestingLevel}
+        />
         {parameters && parameters.length > 0 && (
           <>
             {renderParams(parameters, sdkVersion)}
@@ -114,7 +109,10 @@ export const renderMethod = (
                 </div>
                 {returnComment ? (
                   <div className="mb-1 mt-1.5 flex flex-col pl-6">
-                    <APICommentTextBlock comment={{ summary: returnComment.content }} />
+                    <APICommentTextBlock
+                      comment={{ summary: returnComment.content }}
+                      includeSpacing={false}
+                    />
                   </div>
                 ) : undefined}
               </>

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -1,20 +1,14 @@
 import ReactMarkdown from 'react-markdown';
 
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
-import { H2, MONOSPACE } from '~/ui/components/Text';
+import { H2 } from '~/ui/components/Text';
 
 import { ClassDefinitionData, GeneratedData, PropData, TypeDocKind } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import { renderMethod } from './APISectionMethods';
-import {
-  getTagData,
-  getTagNamesList,
-  mdComponents,
-  H3Code,
-  getCommentContent,
-} from './APISectionUtils';
+import { getTagData, mdComponents, getCommentContent } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
 import { STYLES_APIBOX } from './styles';
 
 export type APISectionNamespacesProps = {
@@ -44,14 +38,7 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
   return (
     <div key={`class-definition-${name}`} className={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} sticky />
-      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-        <H3Code tags={getTagNamesList(comment)}>
-          <MONOSPACE weight="medium" className="wrap-anywhere">
-            {name}
-          </MONOSPACE>
-        </H3Code>
-        <APISectionPlatformTags comment={comment} />
-      </div>
+      <APIBoxHeader name={name} comment={comment} />
       <APICommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -1,8 +1,9 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { APITypeOrSignatureType } from '~/components/plugins/api/components/APITypeOrSignatureType';
-import { CODE, H2, H3, H4, LI, MONOSPACE, RawH3, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, UL } from '~/ui/components/Text';
 
 import {
   DefaultPropsDefinitionData,
@@ -15,13 +16,10 @@ import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import {
   extractDefaultPropValue,
   getCommentOrSignatureComment,
-  getCodeHeadingWithBaseNestingLevel,
-  getTagNamesList,
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { APISectionPlatformTags } from './components/APISectionPlatformTags';
-import { STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
+import { STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -54,10 +52,10 @@ const renderInheritedProps = (
     inheritedData.filter((ip: TypeDefinitionData) => ip.type === 'reference') ?? [];
   if (inheritedProps.length) {
     return (
-      <>
+      <div className={mergeClasses('border-t border-palette-gray4 px-4 py-3')}>
         {exposeInSidebar ? <H3>Inherited Props</H3> : <H4>Inherited Props</H4>}
         <UL>{inheritedProps.map(prop => renderInheritedProp(prop, sdkVersion))}</UL>
-      </>
+      </div>
     );
   }
   return undefined;
@@ -86,7 +84,7 @@ const renderProps = (
     .filter((dec, i, arr) => arr.findIndex(t => t?.name === dec?.name) === i);
 
   return (
-    <div key={`props-definition-${def.name}`} className="[&>*:last-child]:!mb-0">
+    <div key={`props-definition-${def.name}`} className="[&>*]:last:!mb-0">
       {propsDeclarations?.map(prop =>
         prop
           ? renderProp(prop, sdkVersion, extractDefaultPropValue(prop, defaultValues), {
@@ -107,29 +105,16 @@ export const renderProp = (
 ) => {
   const { comment, name, type, flags, signatures } = { ...propData, ...propData.getSignature };
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
-  const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
   const extractedSignatures = signatures ?? type?.declaration?.signatures;
   const extractedComment = getCommentOrSignatureComment(comment, extractedSignatures);
 
   return (
     <div
       key={`prop-entry-${name}`}
-      className={mergeClasses(STYLES_APIBOX, STYLES_APIBOX_NESTED, '!py-3 [&>*:last-child]:!mb-0')}>
+      className={mergeClasses('border-t border-palette-gray4 first:border-t-0')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
-      <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-        <HeaderComponent tags={getTagNamesList(comment)}>
-          <MONOSPACE
-            weight="medium"
-            className={mergeClasses(
-              'wrap-anywhere !heading-base',
-              !exposeInSidebar && 'inline-block prose-code:mb-0'
-            )}>
-            {name}
-          </MONOSPACE>
-        </HeaderComponent>
-        <APISectionPlatformTags comment={comment} />
-      </div>
-      <div className={mergeClasses(STYLES_SECONDARY, extractedComment && 'mb-2.5')}>
+      <APIBoxHeader name={name} comment={extractedComment} baseNestingLevel={baseNestingLevel} />
+      <div className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}
         Type:{' '}
@@ -144,7 +129,7 @@ export const renderProp = (
           </>
         )}
       </div>
-      <APICommentTextBlock comment={extractedComment} includePlatforms={false} />
+      <APICommentTextBlock comment={extractedComment} includePlatforms={false} inlineHeaders />
     </div>
   );
 };

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -68,11 +68,7 @@ const renderTypeDeclarationTable = (
       </CALLOUT>
     ) : undefined}
     <APICommentTextBlock comment={comment} />
-    <Table
-      containerClassName={mergeClasses(
-        'mt-0.5 rounded-none border-0 border-t border-palette-gray4',
-        '[&_thead]:border-palette-gray4'
-      )}>
+    <Table containerClassName={mergeClasses('mt-0.5 rounded-none border-0 border-t')}>
       <APIParamsTableHeadRow mainCellLabel="Property" />
       <tbody>
         {children?.map(prop => renderTypePropertyRow(prop, sdkVersion))}
@@ -231,11 +227,17 @@ const renderType = (
                     {type.type === 'union' ? ' or ' : ' '}
                   </Fragment>
                 ))}
-              {type.type === 'union'
-                ? propMethodDefinitions.length > 2
-                  ? 'An anonymous method defined as described below'
-                  : 'Object shaped as below'
-                : 'extended by'}
+              {type.type === 'union' ? (
+                propMethodDefinitions.length > 2 ? (
+                  'An anonymous method defined as described below'
+                ) : (
+                  <>
+                    <CODE className="text-default">object</CODE> shaped as below
+                  </>
+                )
+              ) : (
+                'extended by'
+              )}
               :
             </CALLOUT>
           ) : null}
@@ -256,7 +258,7 @@ const renderType = (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
           <APIBoxHeader name={name} comment={comment} />
-          <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-3')}>
+          <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-1.5')}>
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
@@ -308,14 +310,14 @@ const renderType = (
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={`${name}<${type.checkType.name}>`} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT className={VERTICAL_SPACING}>
+        <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-1')}>
           <span className={STYLES_SECONDARY}>Generic: </span>
           <CODE>
             {type.checkType.name}
             {typeParameter && <> extends {resolveTypeName(typeParameter[0].type, sdkVersion)}</>}
           </CODE>
         </CALLOUT>
-        <CALLOUT className={VERTICAL_SPACING}>
+        <CALLOUT className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>
             {type.checkType.name}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -12,7 +12,6 @@ import {
   TypeDeclarationContentData,
   TypeDefinitionData,
   TypeGeneralData,
-  TypeSignaturesData,
 } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import {
@@ -31,7 +30,7 @@ import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
 import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
 import { APITypeOrSignatureType } from './components/APITypeOrSignatureType';
-import { STYLES_APIBOX, STYLES_SECONDARY } from './styles';
+import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
@@ -62,9 +61,18 @@ const renderTypeDeclarationTable = (
   index?: number
 ): ReactNode => (
   <Fragment key={`type-declaration-table-${children?.map(child => child.name).join('-')}`}>
-    {index && index > 0 ? <br /> : undefined}
+    {index && index > 0 ? (
+      <CALLOUT
+        className={mergeClasses(STYLES_SECONDARY, 'border-t border-palette-gray4 px-4 py-3')}>
+        Or object shaped as below:
+      </CALLOUT>
+    ) : undefined}
     <APICommentTextBlock comment={comment} />
-    <Table>
+    <Table
+      containerClassName={mergeClasses(
+        'mt-0.5 rounded-none border-0 border-t border-palette-gray4',
+        '[&_thead]:border-palette-gray4'
+      )}>
       <APIParamsTableHeadRow mainCellLabel="Property" />
       <tbody>
         {children?.map(prop => renderTypePropertyRow(prop, sdkVersion))}
@@ -117,12 +125,12 @@ const renderTypePropertyRow = (
   const hasDeprecationNote = Boolean(getTagData('deprecated', comment));
   return (
     <Row key={name}>
-      <Cell fitContent>
+      <Cell>
         <DEMI>{name}</DEMI>
         {renderFlags(flags, initValue)}
         {kind && renderIndexSignature(kind)}
       </Cell>
-      <Cell fitContent>
+      <Cell>
         <APITypeOrSignatureType
           allowBlock
           type={type}
@@ -130,7 +138,7 @@ const renderTypePropertyRow = (
           sdkVersion={sdkVersion}
         />
       </Cell>
-      <Cell fitContent>
+      <Cell>
         <APISectionDeprecationNote comment={comment} />
         <APICommentTextBlock
           inlineHeaders
@@ -149,34 +157,35 @@ const renderType = (
 ): ReactNode => {
   if (type.declaration) {
     // Object Types
+    const signature = type?.declaration?.signatures?.[0];
     return (
       <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader
-          name={`${name}${type.declaration.signatures ? '()' : ''}`}
+          name={`${name}${signature ? `(${signature.parameters ? listParams(signature.parameters) : ''})` : ''}`}
           comment={comment}
         />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
         {type.declaration.children && renderTypeDeclarationTable(type.declaration, sdkVersion)}
-        {type.declaration.signatures
-          ? type.declaration.signatures.map(({ parameters, comment }: TypeSignaturesData) => (
-              <div key={`type-definition-signature-${name}`}>
-                <APICommentTextBlock comment={comment} />
-                {parameters && renderParams(parameters, sdkVersion)}
-              </div>
-            ))
-          : null}
-        {type.declaration.signatures?.[0].type && (
-          <div className="mt-3.5 flex flex-row items-start gap-2">
+        {signature ? (
+          <div key={`type-definition-signature-${signature.name}`}>
+            <APICommentTextBlock comment={signature.comment} />
+            {signature.parameters && renderParams(signature.parameters, sdkVersion)}
+          </div>
+        ) : null}
+        {signature?.type && (
+          <div
+            className={mergeClasses(
+              VERTICAL_SPACING,
+              ELEMENT_SPACING,
+              'mt-3.5 flex flex-row items-start gap-2'
+            )}>
             <div className="flex flex-row items-center gap-2">
               <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
               <span className={STYLES_SECONDARY}>Returns:</span>
             </div>
             <CALLOUT>
-              <APIDataType
-                typeDefinition={type.declaration.signatures[0].type}
-                sdkVersion={sdkVersion}
-              />
+              <APIDataType typeDefinition={signature.type} sdkVersion={sdkVersion} />
             </CALLOUT>
           </div>
         )}
@@ -188,7 +197,7 @@ const renderType = (
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT className={STYLES_SECONDARY}>
+        <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING)}>
           Tuple: <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
         </CALLOUT>
       </div>
@@ -210,30 +219,25 @@ const renderType = (
           <APIBoxHeader name={name} comment={comment} />
           <APICommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
-            <>
-              <CALLOUT className={STYLES_SECONDARY}>
-                Type:{' '}
-                {type.types
-                  .filter(type =>
-                    ['reference', 'union', 'intersection', 'intrinsic', 'literal'].includes(
-                      type.type
-                    )
-                  )
-                  .map(validType => (
-                    <Fragment key={`nested-reference-type-${validType.name}`}>
-                      <CODE className="text-default">{resolveTypeName(validType, sdkVersion)}</CODE>
-                      {type.type === 'union' ? ' or ' : ' '}
-                    </Fragment>
-                  ))}
-                {type.type === 'union'
-                  ? propMethodDefinitions.length > 2
-                    ? 'an anonymous method defined as described below'
-                    : 'object shaped as below'
-                  : 'extended by'}
-                :
-              </CALLOUT>
-              <br />
-            </>
+            <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
+              Type:{' '}
+              {type.types
+                .filter(type =>
+                  ['reference', 'union', 'intersection', 'intrinsic', 'literal'].includes(type.type)
+                )
+                .map(validType => (
+                  <Fragment key={`nested-reference-type-${validType.name}`}>
+                    <CODE className="text-default">{resolveTypeName(validType, sdkVersion)}</CODE>
+                    {type.type === 'union' ? ' or ' : ' '}
+                  </Fragment>
+                ))}
+              {type.type === 'union'
+                ? propMethodDefinitions.length > 2
+                  ? 'An anonymous method defined as described below'
+                  : 'Object shaped as below'
+                : 'extended by'}
+              :
+            </CALLOUT>
           ) : null}
           {propObjectDefinitions.map(
             (propType, index) =>
@@ -252,12 +256,12 @@ const renderType = (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
           <APIBoxHeader name={name} comment={comment} />
-          <CALLOUT className="mb-3">
+          <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-3')}>
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
           <APICommentTextBlock comment={comment} includePlatforms={false} />
-          <CALLOUT className={STYLES_SECONDARY}>
+          <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
             Acceptable values are:{' '}
             {literalTypes.map((lt, index) => (
               <Fragment key={`${name}-literal-type-${index}`}>
@@ -276,12 +280,10 @@ const renderType = (
     ['array', 'reference'].includes(type.type)
   ) {
     return (
-      <div
-        key={`record-definition-${name}`}
-        className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:!mb-0')}>
+      <div key={`record-definition-${name}`} className={mergeClasses(STYLES_APIBOX)}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <CALLOUT className="mb-3">
+        <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-3')}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
         </CALLOUT>
@@ -294,7 +296,7 @@ const renderType = (
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT>
+        <CALLOUT className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>{type.name}</CODE>
         </CALLOUT>
@@ -306,14 +308,14 @@ const renderType = (
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={`${name}<${type.checkType.name}>`} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT>
+        <CALLOUT className={VERTICAL_SPACING}>
           <span className={STYLES_SECONDARY}>Generic: </span>
           <CODE>
             {type.checkType.name}
             {typeParameter && <> extends {resolveTypeName(typeParameter[0].type, sdkVersion)}</>}
           </CODE>
         </CALLOUT>
-        <CALLOUT>
+        <CALLOUT className={VERTICAL_SPACING}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>
             {type.checkType.name}
@@ -342,7 +344,7 @@ const renderType = (
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
         <APICommentTextBlock comment={comment} includePlatforms={false} />
-        <CALLOUT>
+        <CALLOUT className={VERTICAL_SPACING}>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.
         </CALLOUT>
       </div>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -43,7 +43,7 @@ import {
 } from './APIStaticData';
 import { APIParamRow } from './components/APIParamRow';
 import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
-import { ELEMENT_SPACING, STYLES_OPTIONAL, STYLES_SECONDARY } from './styles';
+import { ELEMENT_SPACING, STYLES_OPTIONAL, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 import { CodeComponentProps, MDComponents } from './types';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -396,7 +396,11 @@ export const parseParamName = (name: string) => (name.startsWith('__') ? name.su
 export const renderParams = (parameters: MethodParamData[], sdkVersion: string) => {
   const hasDescription = Boolean(parameters.some(param => param.comment));
   return (
-    <Table containerClassName="mt-0.5">
+    <Table
+      containerClassName={mergeClasses(
+        VERTICAL_SPACING,
+        'mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4'
+      )}>
       <APIParamsTableHeadRow hasDescription={hasDescription} mainCellLabel="Parameter" />
       <tbody>
         {parameters?.map(param => (

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -396,11 +396,7 @@ export const parseParamName = (name: string) => (name.startsWith('__') ? name.su
 export const renderParams = (parameters: MethodParamData[], sdkVersion: string) => {
   const hasDescription = Boolean(parameters.some(param => param.comment));
   return (
-    <Table
-      containerClassName={mergeClasses(
-        VERTICAL_SPACING,
-        'mt-0.5 border-palette-gray4 [&_thead]:border-palette-gray4'
-      )}>
+    <Table containerClassName={mergeClasses(VERTICAL_SPACING, 'mt-0.5')}>
       <APIParamsTableHeadRow hasDescription={hasDescription} mainCellLabel="Parameter" />
       <tbody>
         {parameters?.map(param => (

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -1,23 +1,32 @@
-import { MONOSPACE } from '~/ui/components/Text';
+import { mergeClasses } from '@expo/styleguide';
+
+import { MONOSPACE, RawH3 } from '~/ui/components/Text';
 
 import { CommentData } from '../APIDataTypes';
-import { getTagNamesList, H3Code } from '../APISectionUtils';
+import { getCodeHeadingWithBaseNestingLevel, getTagNamesList } from '../APISectionUtils';
 import { APISectionPlatformTags } from './APISectionPlatformTags';
 
 type Props = {
   name: string;
   comment?: CommentData;
+  baseNestingLevel?: number;
 };
 
-export function APIBoxHeader({ name, comment }: Props) {
+export function APIBoxHeader({ name, comment, baseNestingLevel = 3 }: Props) {
+  const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
   return (
-    <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-      <H3Code tags={getTagNamesList(comment)} className="mb-0">
-        <MONOSPACE weight="medium" className="!wrap-anywhere !text-base">
+    <div
+      className={mergeClasses(
+        'mb-2.5 flex flex-wrap justify-between px-4 pt-3',
+        'max-md-gutters:flex-col',
+        '[&_h3]:!mb-0'
+      )}>
+      <HeaderComponent tags={getTagNamesList(comment)}>
+        <MONOSPACE weight="medium" className="!wrap-anywhere !text-base !leading-snug">
           {name}
         </MONOSPACE>
-      </H3Code>
-      <APISectionPlatformTags comment={comment} />
+      </HeaderComponent>
+      <APISectionPlatformTags comment={comment} className="mb-0" />
     </div>
   );
 }

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -18,7 +18,7 @@ export function APIBoxHeader({ name, comment, baseNestingLevel = 3 }: Props) {
     <div
       className={mergeClasses(
         'mb-2.5 flex flex-wrap justify-between px-4 pt-3',
-        'max-md-gutters:flex-col',
+        'max-md-gutters:flex-col max-md-gutters:gap-y-1.5',
         '[&_h3]:!mb-0'
       )}>
       <HeaderComponent tags={getTagNamesList(comment)}>

--- a/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
@@ -28,8 +28,7 @@ export const APIBoxSectionHeader = ({
   return (
     <CALLOUT
       className={mergeClasses(
-        '-mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary',
-        'max-lg-gutters:-mx-4',
+        'flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary',
         className
       )}>
       <TextWrapper className="flex flex-row items-center gap-2 text-2xs font-medium text-tertiary">

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -7,7 +7,7 @@ import remarkSupsub from 'remark-supersub';
 import { InlineHelp } from 'ui/components/InlineHelp';
 
 import { Tag } from '~/ui/components/Tag/Tag';
-import { DEMI } from '~/ui/components/Text';
+import { CALLOUT } from '~/ui/components/Text';
 
 import { MDComponents } from '../types';
 import { APIBoxSectionHeader } from './APIBoxSectionHeader';
@@ -28,6 +28,7 @@ type Props = {
   beforeContent?: ReactNode;
   afterContent?: ReactNode;
   includePlatforms?: boolean;
+  includeSpacing?: boolean;
   inlineHeaders?: boolean;
   emptyCommentFallback?: string;
 };
@@ -37,6 +38,7 @@ export const APICommentTextBlock = ({
   beforeContent,
   afterContent,
   includePlatforms = true,
+  includeSpacing = true,
   inlineHeaders = false,
   emptyCommentFallback,
 }: Props) => {
@@ -55,14 +57,14 @@ export const APICommentTextBlock = ({
 
   const examples = getAllTagData('example', comment);
   const exampleText = examples?.map((example, index) => (
-    <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:mb-0')}>
+    <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:!mb-0')}>
       {inlineHeaders ? (
-        <DEMI className="mb-1.5 flex flex-row items-center gap-1.5 text-secondary">
-          <CodeSquare01Icon className="icon-sm" />
+        <CALLOUT className="my-1.5 flex flex-row items-center gap-1.5 font-medium text-tertiary">
+          <CodeSquare01Icon className="icon-sm -mt-px text-icon-tertiary" />
           Example
-        </DEMI>
+        </CALLOUT>
       ) : (
-        <APIBoxSectionHeader text="Example" className="!mb-3 !mt-1" Icon={CodeSquare01Icon} />
+        <APIBoxSectionHeader text="Example" className="-mx-4 mb-3 mt-1" Icon={CodeSquare01Icon} />
       )}
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
         {getCommentContent(example.content ?? example.name)}
@@ -85,7 +87,7 @@ export const APICommentTextBlock = ({
   const hasPlatforms = (getAllTagData('platform', comment)?.length || 0) > 0;
 
   return (
-    <>
+    <div className={mergeClasses(includeSpacing && 'px-4 [table_&]:!mb-0 [table_&]:px-0')}>
       {includePlatforms && hasPlatforms && (
         <APISectionPlatformTags
           comment={comment}
@@ -106,7 +108,7 @@ export const APICommentTextBlock = ({
       {afterContent && !exampleText && <br />}
       {seeText}
       {exampleText}
-    </>
+    </div>
   );
 };
 

--- a/docs/components/plugins/api/components/APIParamRow.tsx
+++ b/docs/components/plugins/api/components/APIParamRow.tsx
@@ -40,7 +40,7 @@ export function APIParamRow({
         <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </Cell>
       {showDescription && (
-        <Cell>
+        <Cell className="[&>*]:last:!mb-0">
           <APICommentTextBlock
             comment={comment}
             afterContent={renderDefaultValue(initValue)}

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -2,156 +2,170 @@
 
 exports[`APICommentTextBlock basic comment 1`] = `
 <div>
-  <p
-    class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-    data-text="true"
+  <div
+    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
   >
-    This is the basic comment.
-  </p>
+    <p
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+      data-text="true"
+    >
+      This is the basic comment.
+    </p>
+  </div>
 </div>
 `;
 
 exports[`APICommentTextBlock comment with example 1`] = `
 <div>
   <div
-    class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
+    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
   >
-    <span
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
-      data-text="true"
-    >
-      <div
-        class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
-      >
-        <svg
-          class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80"
-          fill="none"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <g
-            id="android-custom-icon"
-          >
-            <path
-              d="M17.0628 15.073C16.5576 15.073 16.1467 14.6605 16.1467 14.1537C16.1467 13.6469 16.5576 13.2347 17.0628 13.2347C17.5679 13.2347 17.9788 13.6469 17.9788 14.1537C17.9788 14.6605 17.5679 15.073 17.0628 15.073ZM6.9372 15.073C6.43204 15.073 6.02116 14.6605 6.02116 14.1537C6.02116 13.6469 6.43204 13.2347 6.9372 13.2347C7.44234 13.2347 7.85325 13.6469 7.85325 14.1537C7.85325 14.6605 7.44234 15.073 6.9372 15.073ZM17.3913 9.53705L19.2222 6.35598C19.3272 6.17313 19.2647 5.93959 19.0828 5.834C18.9008 5.72871 18.6677 5.79135 18.5624 5.97389L16.7087 9.19523C15.291 8.54619 13.6989 8.18468 12 8.18468C10.3011 8.18468 8.70893 8.54619 7.29131 9.19523L5.43751 5.97389C5.33226 5.79135 5.09916 5.72871 4.9172 5.834C4.73524 5.93959 4.67251 6.17313 4.77776 6.35598L6.60865 9.53705C3.46479 11.2524 1.31456 14.4454 1 18.2177H23C22.6851 14.4454 20.5349 11.2524 17.3913 9.53705Z"
-              fill="currentColor"
-              id="Vector"
-            />
-          </g>
-        </svg>
-        <span
-          class="whitespace-nowrap !text-3xs font-normal !leading-none"
-        >
-          Android
-        </span>
-      </div>
-    </span>
-  </div>
-  <p
-    class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
-    data-text="true"
-  >
-    Gets the referrer URL of the installed app with the 
-    <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-      href="https://developer.android.com/google/play/installreferrer"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
-        data-text="true"
-      >
-        Install Referrer API
-      </code>
-    </a>
-    
-from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
-  </p>
-  <div
-    class="mb-3 last:[&>*]:mb-0"
-  >
-    <p
-      class="tracking-[-0.006rem] -mx-5 my-4 flex border-y border-palette-gray4 bg-subtle px-5 py-2 text-2xs font-medium text-tertiary max-lg-gutters:-mx-4 !mb-3 !mt-1"
-      data-text="true"
+    <div
+      class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
     >
       <span
-        class="tracking-[-0.006rem] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
         data-text="true"
       >
-        <svg
-          class="translate-z icon-sm text-icon-secondary"
-          fill="none"
-          role="img"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+        <div
+          class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
         >
-          <g
-            id="code-square-01-outline-icon"
+          <svg
+            class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80"
+            fill="none"
+            role="img"
+            viewBox="0 0 24 24"
           >
-            <path
-              d="M14.5 15L17.5 12L14.5 9M9.5 9L6.5 12L9.5 15M7.8 21H16.2C17.8802 21 18.7202 21 19.362 20.673C19.9265 20.3854 20.3854 19.9265 20.673 19.362C21 18.7202 21 17.8802 21 16.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V16.2C3 17.8802 3 18.7202 3.32698 19.362C3.6146 19.9265 4.07354 20.3854 4.63803 20.673C5.27976 21 6.11984 21 7.8 21Z"
-              id="Icon"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </g>
-        </svg>
-        Example
+            <g
+              id="android-custom-icon"
+            >
+              <path
+                d="M17.0628 15.073C16.5576 15.073 16.1467 14.6605 16.1467 14.1537C16.1467 13.6469 16.5576 13.2347 17.0628 13.2347C17.5679 13.2347 17.9788 13.6469 17.9788 14.1537C17.9788 14.6605 17.5679 15.073 17.0628 15.073ZM6.9372 15.073C6.43204 15.073 6.02116 14.6605 6.02116 14.1537C6.02116 13.6469 6.43204 13.2347 6.9372 13.2347C7.44234 13.2347 7.85325 13.6469 7.85325 14.1537C7.85325 14.6605 7.44234 15.073 6.9372 15.073ZM17.3913 9.53705L19.2222 6.35598C19.3272 6.17313 19.2647 5.93959 19.0828 5.834C18.9008 5.72871 18.6677 5.79135 18.5624 5.97389L16.7087 9.19523C15.291 8.54619 13.6989 8.18468 12 8.18468C10.3011 8.18468 8.70893 8.54619 7.29131 9.19523L5.43751 5.97389C5.33226 5.79135 5.09916 5.72871 4.9172 5.834C4.73524 5.93959 4.67251 6.17313 4.77776 6.35598L6.60865 9.53705C3.46479 11.2524 1.31456 14.4454 1 18.2177H23C22.6851 14.4454 20.5349 11.2524 17.3913 9.53705Z"
+                fill="currentColor"
+                id="Vector"
+              />
+            </g>
+          </svg>
+          <span
+            class="whitespace-nowrap !text-3xs font-normal !leading-none"
+          >
+            Android
+          </span>
+        </div>
       </span>
-    </p>
-    <pre
-      class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4 [p+&]:mt-0"
+    </div>
+    <p
+      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
-      <code
-        class="text-2xs text-default"
+      Gets the referrer URL of the installed app with the 
+      <a
+        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+        href="https://developer.android.com/google/play/installreferrer"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <code
+          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          data-text="true"
+        >
+          Install Referrer API
+        </code>
+      </a>
+      
+from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
+    </p>
+    <div
+      class="mb-2.5 [table_&]:last:mb-0 last:[&>*]:!mb-0"
+    >
+      <p
+        class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary -mx-4 mb-3 mt-1"
+        data-text="true"
       >
         <span
-          class="token keyword"
+          class="tracking-[-0.006rem] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+          data-text="true"
         >
-          await
+          <svg
+            class="translate-z icon-sm text-icon-secondary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <g
+              id="code-square-01-outline-icon"
+            >
+              <path
+                d="M14.5 15L17.5 12L14.5 9M9.5 9L6.5 12L9.5 15M7.8 21H16.2C17.8802 21 18.7202 21 19.362 20.673C19.9265 20.3854 20.3854 19.9265 20.673 19.362C21 18.7202 21 17.8802 21 16.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V16.2C3 17.8802 3 18.7202 3.32698 19.362C3.6146 19.9265 4.07354 20.3854 4.63803 20.673C5.27976 21 6.11984 21 7.8 21Z"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          Example
         </span>
-         Application
-        <span
-          class="token punctuation"
+      </p>
+      <pre
+        class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4 [p+&]:mt-0"
+        data-text="true"
+      >
+        <code
+          class="text-2xs text-default"
         >
-          .
-        </span>
-        <span
-          class="token function"
-        >
-          getInstallReferrerAsync
-        </span>
-        <span
-          class="token punctuation"
-        >
-          (
-        </span>
-        <span
-          class="token punctuation"
-        >
-          )
-        </span>
-        <span
-          class="token punctuation"
-        >
-          ;
-        </span>
-        
+          <span
+            class="token keyword"
+          >
+            await
+          </span>
+           Application
+          <span
+            class="token punctuation"
+          >
+            .
+          </span>
+          <span
+            class="token function"
+          >
+            getInstallReferrerAsync
+          </span>
+          <span
+            class="token punctuation"
+          >
+            (
+          </span>
+          <span
+            class="token punctuation"
+          >
+            )
+          </span>
+          <span
+            class="token punctuation"
+          >
+            ;
+          </span>
+          
 
-        <span
-          class="token comment"
-        >
-          // "utm_source=google-play&utm_medium=organic"
-        </span>
-        
+          <span
+            class="token comment"
+          >
+            // "utm_source=google-play&utm_medium=organic"
+          </span>
+          
 
-      </code>
-    </pre>
+        </code>
+      </pre>
+    </div>
   </div>
 </div>
 `;
 
-exports[`APICommentTextBlock no comment 1`] = `<div />`;
+exports[`APICommentTextBlock no comment 1`] = `
+<div>
+  <div
+    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+  />
+</div>
+`;

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -8,14 +8,15 @@ export const STYLES_SECONDARY = mergeClasses('text-xs font-medium text-tertiary'
 export const STYLES_OPTIONAL = mergeClasses('flex !text-3xs text-tertiary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-5 rounded-lg border border-palette-gray4 shadow-xs',
+  'mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
   '[&_h4]:mb-0',
   '[&_li]:mb-0',
+  '[&_thead]:border-palette-gray4',
   '[&_th]:px-4 [&_th]:text-tertiary',
-  '[&_td]:py-3',
-  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none'
+  '[&_td]:border-palette-gray4 [&_td]:py-3',
+  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none'
 );
 
 export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 shadow-none [&_h4]:mt-0');

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -1,25 +1,23 @@
 import { mergeClasses } from '@expo/styleguide';
 
-export const ELEMENT_SPACING = mergeClasses('mb-3');
+export const ELEMENT_SPACING = mergeClasses('mb-2.5 [table_&]:last:mb-0');
+export const VERTICAL_SPACING = mergeClasses('mx-4');
 
 export const STYLES_SECONDARY = mergeClasses('text-xs font-medium text-tertiary');
 
 export const STYLES_OPTIONAL = mergeClasses('flex !text-3xs text-tertiary');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-5 rounded-lg border border-palette-gray4 px-5 pb-4 pt-3 shadow-xs',
+  'mb-5 rounded-lg border border-palette-gray4 shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
+  '[&_h4]:mb-0',
   '[&_li]:mb-0',
   '[&_th]:px-4 [&_th]:text-tertiary',
   '[&_td]:py-3',
-  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none',
-  'max-lg-gutters:px-4'
+  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none'
 );
 
-export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 px-5 pb-0 pt-3 shadow-none [&_h4]:mt-0');
+export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 shadow-none [&_h4]:mt-0');
 
-export const STYLES_APIBOX_WRAPPER = mergeClasses(
-  'mb-3.5 px-5 pt-4',
-  '[&_.table-wrapper]:last:mb-4'
-);
+export const STYLES_APIBOX_WRAPPER = mergeClasses('mb-3.5', '[&_.table-wrapper]:last:mb-4');

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -68,7 +68,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Name of your app.
@@ -142,7 +142,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Edit the 'Display Name' field in Xcode
@@ -151,7 +151,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -215,7 +215,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
@@ -289,7 +289,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Set this property using AppConstants.java.
@@ -365,7 +365,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Set this property using just Xcode
@@ -373,7 +373,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -451,7 +451,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
@@ -525,7 +525,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
             <p
-              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
               data-text="true"
             >
               Set this property using Xcode.
@@ -533,7 +533,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -611,7 +611,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
           </div>
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Test sub-sub-property
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -697,7 +697,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -705,7 +705,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           6 character long hex color string, eg: 
@@ -719,7 +719,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -783,7 +783,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
@@ -857,7 +857,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             This is set in AndroidManifest.xml directly.
@@ -893,7 +893,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -971,14 +971,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-3"
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -1056,7 +1056,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-palette-gray4 pb-4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none max-lg-gutters:px-4 mb-3.5 px-5 pt-4 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -151,7 +151,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -373,7 +373,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -533,7 +533,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </details>
         <div
-          class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -719,7 +719,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
     >
       <p
         class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -893,7 +893,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -978,7 +978,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
       <div
-        class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
       >
         <p
           class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"
@@ -1056,7 +1056,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_th]:px-4 [&_th]:text-tertiary [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
+          class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default !pb-4 last:[&>*]:!mb-1"
         >
           <p
             class="text-default font-normal text-base [&_strong]:break-words group flex gap-1"

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -8,16 +8,23 @@ type CellProps = PropsWithChildren<{
   fitContent?: boolean;
   align?: TextAlign | 'char';
   colSpan?: number;
+  className?: string;
 }>;
 
-export const Cell = ({ children, colSpan, fitContent = false, align = 'left' }: CellProps) => (
+export const Cell = ({
+  children,
+  colSpan,
+  className,
+  fitContent = false,
+  align = 'left',
+}: CellProps) => (
   <td
     className={mergeClasses(
       'border-r border-secondary p-4',
       convertAlignToClass(align),
       fitContent && 'w-fit',
       'last:border-r-0',
-      '[&>*:last-child]:!mb-0'
+      className
     )}
     colSpan={colSpan}>
     {children}

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -7,16 +7,23 @@ import { convertAlignToClass } from './utils';
 type HeaderCellProps = PropsWithChildren<{
   align?: TextAlign | 'char';
   size?: 'md' | 'sm';
+  className?: string;
 }>;
 
-export const HeaderCell = ({ children, align = 'left', size = 'md' }: HeaderCellProps) => (
+export const HeaderCell = ({
+  children,
+  className,
+  align = 'left',
+  size = 'md',
+}: HeaderCellProps) => (
   <th
     className={mergeClasses(
       'border-r border-secondary px-4 py-3.5 text-2xs font-medium text-secondary',
       convertAlignToClass(align),
       size === 'sm' && 'py-2 text-3xs',
       '[&_code]:text-3xs [&_code]:text-secondary',
-      'last:border-r-0'
+      'last:border-r-0',
+      className
     )}>
     {children}
   </th>

--- a/docs/ui/components/Table/Row.tsx
+++ b/docs/ui/components/Table/Row.tsx
@@ -10,6 +10,7 @@ export const Row = ({ children, subtle }: RowProps) => (
     className={mergeClasses(
       'even:bg-subtle',
       'even:[&_summary]:bg-element',
+      'even:[&_blockquote]:bg-default',
       subtle && 'opacity-50'
     )}>
     {children}


### PR DESCRIPTION
# Why

Further refactor and streamline API reference elements presentation.

# How

Refactor how we manage spacing in APIBoxes, almost fully rely on APIBoxHeader, stretch out table where possible, display props in rows form, tweak spacing in multiple cases.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-12-17 at 22 51 24](https://github.com/user-attachments/assets/8c715f44-1fb5-42bf-924e-29483c08878c)
![Screenshot 2024-12-17 at 22 49 03](https://github.com/user-attachments/assets/d5ba7720-6218-4d3f-a9b3-1665c0235bec)
![Screenshot 2024-12-17 at 22 50 13](https://github.com/user-attachments/assets/7b82c204-1eff-4ebf-9b1a-3e6bbbea2fed)
![Screenshot 2024-12-17 at 22 47 05](https://github.com/user-attachments/assets/ffc05e1b-e132-4e25-80ba-c868bcd05db3)

