### PR TITLE
[router] Fix array styles with Link children

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### 🐛 Bug fixes
 
 - Fix initial URL when using Expo Go ([#34596](https://github.com/expo/expo/pull/34596) by [@marklawlor](https://github.com/marklawlor))
+- Prevent base url from being appended to external links. ([#31420](https://github.com/expo/expo/pull/31420) by [@6TELOIV](https://github.com/6teloiv))
+- Fix baseURL being removed when refreshing the app on web. ([#33481](https://github.com/expo/expo/pull/33481) by [@marklawlor](https://github.com/marklawlor))
+- Fix navigation when using browser back/forward ([#33524](https://github.com/expo/expo/pull/33524) by [@stephentuso](https://github.com/stephentuso))
+- Fix array styles with `<Link asChild>` children.
 
 ### 💡 Others
 

--- a/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
@@ -141,6 +141,7 @@ it('strips web-only href attributes', () => {
   );
 });
 
+<<<<<<< HEAD
 it('can preserve the initialRoute', () => {
   renderRouter({
     index: function MyIndexRoute() {
@@ -201,4 +202,30 @@ it('can preserve the initialRoute with shared groups', () => {
   expect(screen.getByTestId('orange')).toBeDefined();
   act(() => router.back());
   expect(screen.getByTestId('link')).toBeDefined();
+=======
+it('supports array styles', () => {
+  const { getByTestId } = render(
+    <Link testID="link" href="https://www.example.com/foo" style={[{ color: 'red' }]}>
+      Foo
+    </Link>
+  );
+  const node = getByTestId('link');
+  expect(node.props.style).toStrictEqual([{ color: 'red' }]);
+});
+
+it('children supports array styles', () => {
+  const { getByTestId } = render(
+    <Link
+      testID="link"
+      href="https://www.example.com/foo"
+      asChild
+      style={[{ borderColor: 'blue' }]}>
+      <Pressable style={[{ backgroundColor: 'red' }]}>
+        <Text>Foo</Text>
+      </Pressable>
+    </Link>
+  );
+  const node = getByTestId('link');
+  expect(node.props.style).toStrictEqual({ backgroundColor: 'red', borderColor: 'blue' });
+>>>>>>> d1ebb6f7e9 ([router] Fix array styles with Link children)
 });

--- a/packages/expo-router/src/link/__tests__/Link.test.web.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.web.tsx
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 import { render } from '@testing-library/react';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Link } from '../Link';
 
@@ -188,4 +188,26 @@ describe('base url relative links', () => {
     const node = getByTestId('link');
     expect(node.getAttribute('href')).toBe('https://www.example.com/foo');
   });
+});
+
+it('supports array styles', () => {
+  const { getByTestId } = render(
+    <Link testID="link" href="https://www.example.com/foo" style={[{ color: 'red' }]}>
+      Foo
+    </Link>
+  );
+  const node = getByTestId('link');
+  expect(node.getAttribute('style')).toBe('color: rgb(255, 0, 0);');
+});
+
+it('children supports array styles', () => {
+  const { getByTestId } = render(
+    <Link testID="link" href="https://www.example.com/foo" asChild>
+      <Pressable style={[{ backgroundColor: 'red' }]}>
+        <Text>Foo</Text>
+      </Pressable>
+    </Link>
+  );
+  const node = getByTestId('link');
+  expect(node.getAttribute('style')).toBe('background-color: rgb(255, 0, 0);');
 });

--- a/packages/expo-router/src/ui/Slot.tsx
+++ b/packages/expo-router/src/ui/Slot.tsx
@@ -1,5 +1,5 @@
 import { Slot as RUISlot } from '@radix-ui/react-slot';
-import { forwardRef, useMemo } from 'react';
+import { cloneElement, forwardRef, isValidElement, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 
 /**
@@ -16,9 +16,21 @@ import { StyleSheet } from 'react-native';
  * @returns
  */
 function ShimSlotForReactNative(Component: typeof RUISlot): typeof RUISlot {
-  return forwardRef(function RNSlotHOC({ style, ...props }, ref) {
-    style = useMemo(() => StyleSheet.flatten(style), [style]);
-    return <Component ref={ref} {...props} style={style} />;
+  return forwardRef(function RNSlotHOC({ style, children, ...props }, ref) {
+    const [flatStyle, childrenWithFlatStyle] = useMemo(() => {
+      if (isValidElement(children) && Array.isArray(children.props?.style)) {
+        children = cloneElement<any>(children, {
+          style: StyleSheet.flatten(children.props.style),
+        });
+      }
+      return [StyleSheet.flatten(style), children];
+    }, [style, children]);
+
+    return (
+      <Component ref={ref} {...props} style={flatStyle}>
+        {childrenWithFlatStyle}
+      </Component>
+    );
   });
 }
 

--- a/packages/expo-router/src/views/Screen.tsx
+++ b/packages/expo-router/src/views/Screen.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 
+import { Href } from '../types';
 import { useNavigation } from '../useNavigation';
 
 export type ScreenProps<TOptions extends Record<string, any> = Record<string, any>> = {
@@ -12,6 +13,7 @@ export type ScreenProps<TOptions extends Record<string, any> = Record<string, an
    * @example `/(root)` maps to a layout route `/app/(root).tsx`.
    */
   name?: string;
+  href?: Href;
   initialParams?: Record<string, any>;
   options?: TOptions;
 };
@@ -19,8 +21,12 @@ export type ScreenProps<TOptions extends Record<string, any> = Record<string, an
 const useLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : function () {};
 
 /** Component for setting the current screen's options dynamically. */
-export function Screen<TOptions extends object = object>({ name, options }: ScreenProps<TOptions>) {
-  const navigation = useNavigation(name);
+export function Screen<TOptions extends object = object>({
+  name,
+  href,
+  options,
+}: ScreenProps<TOptions>) {
+  const navigation = useNavigation(href || name);
 
   useLayoutEffect(() => {
     if (


### PR DESCRIPTION
# Why

Fix #31990 #32775

Fix style merging on the the children of components using `<Slot asChild />`. This include `<Link />` and the `<Tabs />` components from `expo-router/ui`

# How

Previously we only flattened the styles on the component. This change also flattens the styles on the props.children

# Test Plan

Added tests for native and web. Tested on device

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
