### PR TITLE
Update plugins-and-mods.mdx typo

### DIFF
--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -352,7 +352,7 @@ If an **app.plugin.js** file is present in the root of a Node module's folder, i
   files={[
     ['app.config.js', <code>import "expo-splash-screen"</code>],
     ['node_modules/expo-splash-screen', 'Node module'],
-    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
+    ['node_modules/expo-splash-screen/package.json', <code>"main": "./app.plugin.js"</code>],
     [
       'node_modules/expo-splash-screen/app.plugin.js',
       <>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In this example, the author wants to point out that users should choose app.plugin.js instead of build/index.js, so the entry file should be modified to app.plugin.js.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
