### PR TITLE
[ios][core] Fix view managers not deallocating

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Ensure `uuid.v4`and`uuid.v5` is available on old react native architecture. ([#33621](https://github.com/expo/expo/pull/33621) by [@andrejpavlovic](https://github.com/andrejpavlovic))
 - Changed `import` to `import type` for TS type declarations. ([#33447](https://github.com/expo/expo/pull/33447) by [@j-piasecki](https://github.com/j-piasecki))
 - [macOS] Allow SwiftUI views to work on macOS ([#33506](https://github.com/expo/expo/pull/33506) by [@hassankhan](https://github.com/hassankhan))
+- [iOS] Fixes view managers not deallocating when reloading.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Ensure `uuid.v4`and`uuid.v5` is available on old react native architecture. ([#33621](https://github.com/expo/expo/pull/33621) by [@andrejpavlovic](https://github.com/andrejpavlovic))
 - Changed `import` to `import type` for TS type declarations. ([#33447](https://github.com/expo/expo/pull/33447) by [@j-piasecki](https://github.com/j-piasecki))
 - [macOS] Allow SwiftUI views to work on macOS ([#33506](https://github.com/expo/expo/pull/33506) by [@hassankhan](https://github.com/hassankhan))
-- [iOS] Fixes view managers not deallocating when reloading.
+- [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -4,9 +4,6 @@
  A converter associated with the specific app context that delegates value conversions to the dynamic type converters.
  */
 public struct MainValueConverter {
-  /**
-   It holds a strong reference as the AppContext is the only owner of the converter.
-   */
   private(set) weak var appContext: AppContext?
 
   /**

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -7,7 +7,7 @@ public struct MainValueConverter {
   /**
    It holds a strong reference as the AppContext is the only owner of the converter.
    */
-  internal let appContext: AppContext
+  private(set) weak var appContext: AppContext?
 
   /**
    Casts the given JavaScriptValue to a non-JS value.
@@ -15,6 +15,9 @@ public struct MainValueConverter {
    */
   public func toNative(_ value: JavaScriptValue, _ type: AnyDynamicType) throws -> Any {
     // Preliminary cast from JS value to a common native type.
+    guard let appContext else {
+      throw Exceptions.AppContextLost()
+    }
     let rawValue = try type.cast(jsValue: value, appContext: appContext)
 
     // Cast common native type to more complex types (e.g. records, convertibles, enumerables, shared objects).
@@ -46,6 +49,9 @@ public struct MainValueConverter {
    Converts the given value to the type compatible with JavaScript.
    */
   public func toJS<ValueType>(_ value: ValueType, _ type: AnyDynamicType) throws -> JavaScriptValue {
+    guard let appContext else {
+      throw Exceptions.AppContextLost()
+    }
     let result = Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: type)
     return try type.castToJS(result, appContext: appContext)
   }

--- a/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
@@ -18,7 +18,7 @@ public final class ComponentData: RCTComponentDataSwiftAdapter {
    */
   @objc
   public init(viewModule: ViewModuleWrapper, managerClass: ViewModuleWrapper.Type, bridge: RCTBridge) {
-    self.moduleHolder = viewModule.wrappedModuleHolder
+    self.moduleHolder = viewModule.moduleHolder
     super.init(managerClass: managerClass, bridge: bridge, eventDispatcher: bridge.eventDispatcher())
   }
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -57,6 +57,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func name() -> String {
+    // swiftlint:disable:next force_cast
     return wrappedModuleHolder!.name
   }
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -20,7 +20,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    A reference to the module holder that stores the module definition.
    Enforced unwrapping is required since it can be set right after the object is initialized.
    */
-  var wrappedModuleHolder: ModuleHolder!
+  weak var wrappedModuleHolder: ModuleHolder?
 
   /**
    The designated initializer. At first, we use this base class to hide `ModuleHolder` from Objective-C runtime.
@@ -57,7 +57,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func name() -> String {
-    return wrappedModuleHolder.name
+    return wrappedModuleHolder!.name
   }
 
   /**
@@ -83,10 +83,10 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public override func view() -> UIView! {
-    guard let appContext = wrappedModuleHolder.appContext else {
+    guard let appContext = wrappedModuleHolder?.appContext else {
       fatalError(Exceptions.AppContextLost().reason)
     }
-    guard let view = wrappedModuleHolder.definition.view?.createView(appContext: appContext) else {
+    guard let view = wrappedModuleHolder?.definition.view?.createView(appContext: appContext) else {
       fatalError("Cannot create a view from module '\(String(describing: self.name))'")
     }
     return view

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -57,7 +57,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func name() -> String {
-    // swiftlint:disable:next force_cast
+    // swiftlint:disable:next force_unwrapping
     return wrappedModuleHolder!.name
   }
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -18,15 +18,14 @@ protocol DynamicModuleWrapperProtocol {
 public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtocol {
   /**
    A reference to the module holder that stores the module definition.
-   Enforced unwrapping is required since it can be set right after the object is initialized.
    */
-  weak var wrappedModuleHolder: ModuleHolder?
+  weak var moduleHolder: ModuleHolder?
 
   /**
    The designated initializer. At first, we use this base class to hide `ModuleHolder` from Objective-C runtime.
    */
-  public init(_ wrappedModuleHolder: ModuleHolder) {
-    self.wrappedModuleHolder = wrappedModuleHolder
+  public init(_ moduleHolder: ModuleHolder) {
+    self.moduleHolder = moduleHolder
   }
 
   /**
@@ -41,7 +40,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
     guard let module = (self as DynamicModuleWrapperProtocol).wrappedModule?() else {
       return
     }
-    self.wrappedModuleHolder = module.wrappedModuleHolder
+    self.moduleHolder = module.moduleHolder
   }
 
   /**
@@ -57,8 +56,10 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func name() -> String {
-    // swiftlint:disable:next force_unwrapping
-    return wrappedModuleHolder!.name
+    guard let moduleHolder else {
+      fatalError("Failed to create ModuleHolder")
+    }
+    return moduleHolder.name
   }
 
   /**
@@ -84,10 +85,10 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public override func view() -> UIView! {
-    guard let appContext = wrappedModuleHolder?.appContext else {
+    guard let appContext = moduleHolder?.appContext else {
       fatalError(Exceptions.AppContextLost().reason)
     }
-    guard let view = wrappedModuleHolder?.definition.view?.createView(appContext: appContext) else {
+    guard let view = moduleHolder?.definition.view?.createView(appContext: appContext) else {
       fatalError("Cannot create a view from module '\(String(describing: self.name))'")
     }
     return view


### PR DESCRIPTION
# Why
Closes #33655

# How
Attempts to fix two memory leaks
- The `MainValueConverter` holds a strong reference to the `AppContext` causing it not to deallocate
- The `ModuleHolder` will not deallocate when the definition exports a view because the `ViewModuleWrapper` strongly references it.

# Test Plan
Bare-expo. The lifecycle methods `OnDestroy`, and `OnAppContextDestroys` are called correctly when the app is reloaded.

