### PR TITLE
[patch-project] remove explicit expo peerDep

### DIFF
--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Uses `*` version for the `expo` peerDependencies. ([#33763](https://github.com/expo/expo/pull/33763) by [@kudo](https://github.com/kudo))
+
 ## 0.1.22 - 2024-12-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/patch-project/package.json
+++ b/packages/patch-project/package.json
@@ -59,6 +59,6 @@
     "resolve-from": "^5.0.0"
   },
   "peerDependencies": {
-    "expo": "52.0.11"
+    "expo": "*"
   }
 }


### PR DESCRIPTION
# Why

because of the explicit peerDep. we have a lot of unnecessary patch-project publishing

# How

patch-project is available from expo sdk 51 and it's experimental. it would be fine to use `*` for expo peerDep now.

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
