### PR TITLE
[docs] APISection: fix API entities categorization

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -66,10 +66,10 @@ const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) => {
   } else if (extendedTypes?.length) {
     return extendedTypes[0].name === 'Component' || extendedTypes[0].name === 'PureComponent';
   } else if (signatures?.length) {
+    const mainSignature = signatures[0];
     if (
-      signatures[0].type.name === 'Element' ||
-      signatures[0].type.types?.map(t => t.name).includes('Element') ||
-      (signatures[0].parameters && signatures[0].parameters[0].name === 'props')
+      (mainSignature.parameters && mainSignature.parameters[0].name === 'props') ||
+      (mainSignature.parameters && mainSignature.parameters[0].name === '__namedParameters')
     ) {
       return true;
     }


### PR DESCRIPTION
# Why

Spotted small issue on the Expo router page since SDK 52.

# How

Fix categorization rules, so `Redirect` is correctly rendered as component.

# Test Plan

The changes have been reviewed by running docs locally.

I have also checked most of the APIs to verify that all components are still categorized correctly.

# Preview

![Screenshot 2024-12-19 at 18 31 44](https://github.com/user-attachments/assets/e033620f-14e6-4c71-9d0e-edfcda190b02)
