### PR TITLE
[config-types] sync 52.0.0 schema

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -157,6 +157,12 @@ export interface ExpoConfig {
         [k: string]: any;
     };
     /**
+     * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
+     */
+    packagerOpts?: {
+        [k: string]: any;
+    };
+    /**
      * Configuration for the expo-updates library
      */
     updates?: {
@@ -525,6 +531,10 @@ export interface IOS {
     runtimeVersion?: string | {
         policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprint';
     };
+    /**
+     * Your iOS app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `ios.buildNumber` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `CFBundleShortVersionString`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
+     */
+    version?: string;
 }
 /**
  * Configuration that is specific to the iOS platform icons.
@@ -773,6 +783,10 @@ export interface Android {
     runtimeVersion?: string | {
         policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprint';
     };
+    /**
+     * Your android app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
+     */
+    version?: string;
 }
 export interface AndroidIntentFiltersData {
     /**

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -157,12 +157,6 @@ export interface ExpoConfig {
         [k: string]: any;
     };
     /**
-     * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
-     */
-    packagerOpts?: {
-        [k: string]: any;
-    };
-    /**
      * Configuration for the expo-updates library
      */
     updates?: {

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -159,12 +159,6 @@ export interface ExpoConfig {
     [k: string]: any;
   };
   /**
-   * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
-   */
-  packagerOpts?: {
-    [k: string]: any;
-  };
-  /**
    * Configuration for the expo-updates library
    */
   updates?: {

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -159,6 +159,12 @@ export interface ExpoConfig {
     [k: string]: any;
   };
   /**
+   * @deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.dev/guides/customizing-metro/)
+   */
+  packagerOpts?: {
+    [k: string]: any;
+  };
+  /**
    * Configuration for the expo-updates library
    */
   updates?: {
@@ -529,6 +535,10 @@ export interface IOS {
   runtimeVersion?:
     | string
     | { policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprint' };
+  /**
+   * Your iOS app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `ios.buildNumber` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `CFBundleShortVersionString`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
+   */
+  version?: string;
 }
 /**
  * Configuration that is specific to the iOS platform icons.
@@ -777,6 +787,10 @@ export interface Android {
   runtimeVersion?:
     | string
     | { policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprint' };
+  /**
+   * Your android app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
+   */
+  version?: string;
 }
 export interface AndroidIntentFiltersData {
   /**


### PR DESCRIPTION
# Why

following up #33637 and now to sync the schema

# How

`yarn generate && yarn lint --fix && yarn prepare` 
manually remove the synced `packagerOpts` which is deprecated already

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
