### PR TITLE
[ios][splashscreen] Show splashscreen on reload

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, show the splashscreen again when the app is reloaded.
+
 ### 💡 Others
 
 ## 0.29.18 - 2024-12-10

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, show the splashscreen again when the app is reloaded.
+- On `iOS`, show the splashscreen again when the app is reloaded. ([#33793](https://github.com/expo/expo/pull/33793) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -20,12 +20,13 @@ class SplashScreenModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoSplashScreen")
 
-    AsyncFunction<Unit>("preventAutoHideAsync") {
+    AsyncFunction<Boolean>("preventAutoHideAsync") {
       // The user has manually invoked prevent autohide, this is used to allow libraries
       // such as expo-router to know whether it's safe to hide or if they should wait for
       // the user to do it.
       userControlledAutoHideEnabled = true
       SplashScreenManager.preventAutoHideCalled = true
+      return@AsyncFunction true
     }
 
     AsyncFunction<Unit>("internalPreventAutoHideAsync") {

--- a/packages/expo-splash-screen/ios/SplashScreenManager.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenManager.swift
@@ -2,7 +2,7 @@ import React
 import UIKit
 import ExpoModulesCore
 
-public class SplashScreenManager: NSObject {
+public class SplashScreenManager: NSObject, RCTReloadListener {
   @objc public static let shared = SplashScreenManager()
   private var loadingView: UIView?
   private var rootView: UIView?
@@ -17,27 +17,7 @@ public class SplashScreenManager: NSObject {
     }
 
     self.rootView = rootView
-    if let vc = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController() {
-      loadingView = vc.view
-      loadingView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-
-      if let bounds = self.rootView?.bounds {
-        loadingView?.frame = bounds
-        loadingView?.center = CGPoint(x: bounds.midX, y: bounds.midY)
-      }
-      loadingView?.isHidden = false
-#if RCT_NEW_ARCH_ENABLED
-      if let hostView = rootView as? RCTSurfaceHostingProxyRootView, let loadingView {
-        hostView.disableActivityIndicatorAutoHide(true)
-        hostView.loadingView = loadingView
-      }
-#else
-      if let loadingView {
-        self.rootView?.addSubview(loadingView)
-      }
-#endif
-    }
-
+    showSplashScreen()
     NotificationCenter.default.addObserver(self, selector: #selector(onAppReady), name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
   }
 
@@ -76,6 +56,33 @@ public class SplashScreenManager: NSObject {
     self.options = options
   }
 
+  private func showSplashScreen() {
+    if let vc = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController() {
+      loadingView = vc.view
+      loadingView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+      if let bounds = self.rootView?.bounds {
+        loadingView?.frame = bounds
+        loadingView?.center = CGPoint(x: bounds.midX, y: bounds.midY)
+      }
+      loadingView?.isHidden = false
+#if RCT_NEW_ARCH_ENABLED
+      if let hostView = rootView as? RCTSurfaceHostingProxyRootView, let loadingView {
+        hostView.disableActivityIndicatorAutoHide(true)
+        hostView.loadingView = loadingView
+      }
+#else
+      if let loadingView {
+        self.rootView?.addSubview(loadingView)
+      }
+#endif
+    }
+  }
+
+  public func didReceiveReloadCommand() {
+    showSplashScreen()
+  }
+
   private func isLoadingViewVisible() -> Bool {
     guard let loadingView else {
       return false
@@ -86,6 +93,5 @@ public class SplashScreenManager: NSObject {
 
   func removeObservers() {
     NotificationCenter.default.removeObserver(self, name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
-    NotificationCenter.default.removeObserver(self, name: Notification.Name.RCTJavaScriptDidLoad, object: nil)
   }
 }

--- a/packages/expo-splash-screen/ios/SplashScreenModule.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenModule.swift
@@ -30,6 +30,7 @@ public class SplashScreenModule: Module {
       // the user to do it.
       userControlledAutoHideEnabled = true
       SplashScreenManager.shared.preventAutoHideCalled = true
+      return true
     }
 
     AsyncFunction("internalPreventAutoHideAsync") {


### PR DESCRIPTION
# Why
Addresses two issues
1. The return value of `preventAutoHideAsync` is typed as a boolean but we are not returning anything from native. 
2. On ios, when the app reloads the splashscreen may briefly show but disappear immediately even if you have called `preventAutoHideAsync` and should be in control of it. 

# How
For the first issue we just return `true`. This function cannot fail but we should do this for backward compatibility.

For the second issue, this will only have an effect in development. Production apps work as expected but this is a pretty janky experience in dev. The reason it is happening is we are not taking control of the splashscreen again on reload so react native hides it immediately when ready. To fix it, we can register as an `RCTReloadListener` and take control of the splashscreen again. This will make testing the splashscreen easier on iOS at least. We can't do anything about this on Android as there is no api to show the splashscreen again.

# Test Plan

### Before
https://github.com/user-attachments/assets/6718734b-40e1-49f0-8683-5d8b3cdddda6

### After
https://github.com/user-attachments/assets/78491974-72b0-4111-9660-9fd7dc5b9e77
