### PR TITLE
[fingerprint] add markers to read correct json from stdout (#33798)

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed ignorePaths does not ignore files inside local modules. ([#33597](https://github.com/expo/expo/pull/33597) by [@kudo](https://github.com/kudo))
 - Fixed unstable fingerprint on Windows. ([#33627](https://github.com/expo/expo/pull/33627) by [@kudo](https://github.com/kudo))
 - Fixed negate `!` pattern ignore all paths in `.fingerprintignore`. ([#33671](https://github.com/expo/expo/pull/33671) by [@kudo](https://github.com/kudo))
+- Fixed issue where console logs in `app.config.js` caused errors when loading the config. ([#33800](https://github.com/expo/expo/pull/33800) by [@joelyourstone](https://github.com/joelyourstone))  
 
 ### 💡 Others
 

--- a/packages/@expo/fingerprint/src/Options.ts
+++ b/packages/@expo/fingerprint/src/Options.ts
@@ -10,6 +10,8 @@ import { SourceSkips } from './sourcer/SourceSkips';
 import { buildDirMatchObjects, buildPathMatchObjects } from './utils/Path';
 
 export const FINGERPRINT_IGNORE_FILENAME = '.fingerprintignore';
+export const FINGERPRINT_CONFIG_OUTPUT_START_MARKER = '@expo-fingerprint-config-output-start-marker-f8c7d9e1';
+export const FINGERPRINT_CONFIG_OUTPUT_END_MARKER = '@expo-fingerprint-config-output-end-marker-f8c7d9e1';
 
 export const DEFAULT_IGNORE_PATHS = [
   FINGERPRINT_IGNORE_FILENAME,

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -12,6 +12,7 @@ import { SourceSkips } from './SourceSkips';
 import { getFileBasedHashSourceAsync, stringifyJsonSorted } from './Utils';
 import type { HashSource, NormalizedOptions } from '../Fingerprint.types';
 import { toPosixPath } from '../utils/Path';
+import { FINGERPRINT_CONFIG_OUTPUT_START_MARKER, FINGERPRINT_CONFIG_OUTPUT_END_MARKER } from '../Options';
 
 const debug = require('debug')('expo:fingerprint:sourcer:Expo');
 
@@ -39,7 +40,15 @@ export async function getExpoConfigSourcesAsync(
       [getExpoConfigLoaderPath(), path.resolve(projectRoot), ignoredFile],
       { cwd: projectRoot }
     );
-    const stdoutJson = JSON.parse(stdout);
+
+    // Find the content between the start and end markers, as to not include other output in stdout
+    const startMarker = FINGERPRINT_CONFIG_OUTPUT_START_MARKER;
+    const endMarker = FINGERPRINT_CONFIG_OUTPUT_END_MARKER;
+    const startIndex = stdout.indexOf(startMarker);
+    const endIndex = stdout.indexOf(endMarker);
+    const configContent = stdout.slice(startIndex + startMarker.length, endIndex).trim();
+
+    const stdoutJson = JSON.parse(configContent);
     config = stdoutJson.config;
     expoConfig = normalizeExpoConfig(config.exp, options);
     loadedModules = stdoutJson.loadedModules;

--- a/packages/@expo/fingerprint/src/sourcer/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/sourcer/ExpoConfigLoader.ts
@@ -7,7 +7,7 @@ import module from 'module';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
-import { DEFAULT_IGNORE_PATHS } from '../Options';
+import { DEFAULT_IGNORE_PATHS, FINGERPRINT_CONFIG_OUTPUT_END_MARKER, FINGERPRINT_CONFIG_OUTPUT_START_MARKER } from '../Options';
 import { isIgnoredPath } from '../utils/Path';
 
 async function runAsync(programName: string, args: string[] = []) {
@@ -33,7 +33,11 @@ async function runAsync(programName: string, args: string[] = []) {
   const filteredLoadedModules = loadedModules.filter(
     (modulePath) => !isIgnoredPath(modulePath, ignoredPaths)
   );
+  // Since we're using stdout to read this output and we cannot always control the entire output
+  // (e.g. config.app.js having a console.log), we'll add a start and end marker to the output
+  console.log(FINGERPRINT_CONFIG_OUTPUT_START_MARKER);
   console.log(JSON.stringify({ config, loadedModules: filteredLoadedModules }));
+  console.log(FINGERPRINT_CONFIG_OUTPUT_END_MARKER);
 }
 
 // If running from the command line


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33798

# How

Dug around in node_modules to understand why I got errors, found why I got errors. Modified the built javascript file until I found a solution. Then build that solution in an expo fork, refactored a bit to not be a proof of concept.

See https://github.com/expo/expo/issues/33798 for more details about the issue and how to reproduce it.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
### Either

`node C:\tempo\ExpoFingerprintStdoutRepro\node_modules\@expo\fingerprint\build\sourcer\ExpoConfigLoader.js C:\tempo\ExpoFingerprintStdoutRepro C:\Users\joely\AppData\Local\Temp\expo-fingerprint-66QHtS\.fingerprintignore 2> $null`

This is emulating the code that is running in https://github.com/expo/expo/blob/main/packages/%40expo/fingerprint/src/sourcer/Expo.ts#L37
Change paths so it fits your project, also change the `2>$null` to whatever makes stderr not output for you, this was for powershell.

### or

Run `npx @expo/fingerprint .` in an expo project with this fix.

## Test ideas
* Make sure the fingerprint hash is the same before & after this code is applied
* Make sure it works and fingerprint hash is the same for projects running app.json, app.config.js or app.config.ts


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


This is my first PR to expo & my first open source contribution, meaning I have **surely** missed a lot of things, apologies for that! 
<img src="https://github.com/user-attachments/assets/3ae4d6c6-cc5c-46de-9ec7-9afed52793c7" width="300">