### PR TITLE
[docs] APISectionClasses: display methods using nested presentation

### DIFF
--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -1,6 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
-import ReactMarkdown from 'react-markdown';
 
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
@@ -12,9 +11,7 @@ import { renderMethod } from './APISectionMethods';
 import { renderProp } from './APISectionProps';
 import {
   getTagData,
-  mdComponents,
   resolveTypeName,
-  getCommentContent,
   DEFAULT_BASE_NESTING_LEVEL,
   extractDefaultPropValue,
 } from './APISectionUtils';
@@ -126,14 +123,17 @@ const renderClass = (
         includePlatforms={false}
         afterContent={
           returnComment && (
-            <div className="flex flex-col items-start gap-2">
+            <div className="flex flex-col items-start">
               <div className="flex flex-row items-center gap-2">
                 <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
                 <span className={STYLES_SECONDARY}>Returns</span>
               </div>
-              <ReactMarkdown components={mdComponents}>
-                {getCommentContent(returnComment.content)}
-              </ReactMarkdown>
+              <div className="mb-1 mt-1.5 flex flex-col pl-6">
+                <APICommentTextBlock
+                  comment={{ summary: returnComment.content }}
+                  includeSpacing={false}
+                />
+              </div>
             </div>
           )
         }
@@ -167,15 +167,14 @@ const renderClass = (
             exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
-          <div className={mergeClasses(VERTICAL_SPACING, 'mt-4')}>
-            {methods.map(method =>
-              renderMethod(method, {
-                exposeInSidebar: true,
-                baseNestingLevel: linksNestingLevel,
-                sdkVersion,
-              })
-            )}
-          </div>
+          {methods.map(method =>
+            renderMethod(method, {
+              exposeInSidebar: true,
+              nested: true,
+              baseNestingLevel: linksNestingLevel,
+              sdkVersion,
+            })
+          )}
         </>
       )}
     </div>

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -11,9 +11,10 @@ import { ELEMENT_SPACING } from './styles';
 type Props = {
   comment?: CommentData;
   sticky?: boolean;
+  className?: string;
 };
 
-export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) => {
+export const APISectionDeprecationNote = ({ comment, className, sticky = false }: Props) => {
   const deprecation = getTagData('deprecated', comment);
 
   if (!deprecation) {
@@ -34,7 +35,8 @@ export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) =>
         className={mergeClasses(
           'border-palette-yellow5',
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'mb-0 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4'
+          sticky && 'mb-0 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4',
+          className
         )}>
         {content.length ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -70,9 +70,9 @@ export const renderMethod = (
         className={mergeClasses(
           !nested && STYLES_APIBOX,
           !nested && STYLES_APIBOX_NESTED,
-          nested && 'border-b border-palette-gray4'
+          nested && 'border-b border-palette-gray4 last:border-b-0'
         )}>
-        <APISectionDeprecationNote comment={comment} sticky />
+        <APISectionDeprecationNote comment={comment} sticky className="!rounded-t-none" />
         <APIBoxHeader
           name={getMethodName(
             method as MethodDefinitionData,


### PR DESCRIPTION
# Why

Small follow up for recent APISection changes.

# How

Use nested presentation to render class methods. This would align the display with regular class properties.

# Test Plan

The changes have been reviewed by running app locally.

# Preview

![Screenshot 2024-12-23 at 18 37 17](https://github.com/user-attachments/assets/d8d54604-c551-4b32-8f2d-63f7e25ad96c)

