### PR TITLE
[fingerprint] fix console.log cli accident change

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `expo-modules-autolinking` resolving issue on PNPM isolated mode. ([#33818](https://github.com/expo/expo/pull/33818) by [@kudo](https://github.com/kudo))
 - Fixed `ExpoConfigLoader` error when people has `console.log` in their `app.config.js` or `app.config.ts`. ([#33821](https://github.com/expo/expo/pull/33821) by [@kudo](https://github.com/kudo))
 - Fixed absolute paths inside `aarProjects` autolinking data. ([#33826](https://github.com/expo/expo/pull/33826) by [@kudo](https://github.com/kudo))
+- Fixed CLI `console.log` regression. ([#33828](https://github.com/expo/expo/pull/33828) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/fingerprint/cli/build/utils/withConsoleDisabledAsync.js
+++ b/packages/@expo/fingerprint/cli/build/utils/withConsoleDisabledAsync.js
@@ -8,7 +8,7 @@ async function withConsoleDisabledAsync(block) {
         error: console.error,
     };
     // Disable logging for this command since the only thing printed to stdout should be the JSON output.
-    // console.log = function () {};
+    console.log = function () { };
     console.warn = function () { };
     console.error = function () { };
     try {

--- a/packages/@expo/fingerprint/cli/src/utils/withConsoleDisabledAsync.ts
+++ b/packages/@expo/fingerprint/cli/src/utils/withConsoleDisabledAsync.ts
@@ -5,7 +5,7 @@ export async function withConsoleDisabledAsync<T>(block: () => Promise<T>): Prom
     error: console.error,
   };
   // Disable logging for this command since the only thing printed to stdout should be the JSON output.
-  // console.log = function () {};
+  console.log = function () {};
   console.warn = function () {};
   console.error = function () {};
 


### PR DESCRIPTION
# Why

revert my accident console.log change from #33821

# How

revert the console.log change

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
