### PR TITLE
[web][video] add warn

### DIFF
--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -271,6 +271,18 @@ export default class VideoPlayerWeb
   }
 
   play(): void {
+    if (this._mountedVideos.size === 0) {
+      console.warn(
+        '[expo-video] Cannot play video - VideoView is not mounted yet.\n' +
+        'To fix this:\n' +
+        '1. Move player.play() to useEffect:\n' +
+        '   useEffect(() => {\n' +
+        '     if (player) player.play()\n' +
+        '   }, [player])\n' +
+        '2. Or wait for user interaction to play'
+      )
+    }
+    
     this._mountedVideos.forEach((video) => {
       video.play();
     });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In web, mountVideoView is invoked after the component mounts (useEffect). Therefore, the play() function in the setup function does not work as intended.

This discrepancy can be confusing for cross-platform development.

```
const player = useVideoPlayer(bigBuckBunnySource, player => {
    player.loop = true
    player.muted = true

    // not works in web
    player.play()
  })
```