### PR TITLE
[web][video] add warn

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Added a warning for when the video plays before the component mounts in web. ([#33840](https://github.com/expo/expo/pull/33840) by [@zereight(https://github.com/zereight)])
+
 ### 💡 Others
 
 - Fixed `generateThumbnailsAsync` not being available on Android in the types. ([#33491](https://github.com/expo/expo/pull/33491) by [@hirbod](https://github.com/hirbod))

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -273,13 +273,7 @@ export default class VideoPlayerWeb
   play(): void {
     if (this._mountedVideos.size === 0) {
       console.warn(
-        '[expo-video] Cannot play video - VideoView is not mounted yet.\n' +
-        'To fix this:\n' +
-        '1. Move player.play() to useEffect:\n' +
-        '   useEffect(() => {\n' +
-        '     if (player) player.play()\n' +
-        '   }, [player])\n' +
-        '2. Or wait for user interaction to play'
+        '[expo-video] Cannot play video - No mounted video found.'
       )
     }
 

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -271,6 +271,18 @@ export default class VideoPlayerWeb
   }
 
   play(): void {
+    if (this._mountedVideos.size === 0) {
+      console.warn(
+        '[expo-video] Cannot play video - VideoView is not mounted yet.\n' +
+        'To fix this:\n' +
+        '1. Move player.play() to useEffect:\n' +
+        '   useEffect(() => {\n' +
+        '     if (player) player.play()\n' +
+        '   }, [player])\n' +
+        '2. Or wait for user interaction to play'
+      )
+    }
+
     this._mountedVideos.forEach((video) => {
       video.play();
     });


### PR DESCRIPTION
In web, mountVideoView is invoked after the component mounts (useEffect). Therefore, the play() function in the setup function does not work as intended.

This discrepancy can be confusing for cross-platform development.

```
const player = useVideoPlayer(bigBuckBunnySource, player => {
    player.loop = true
    player.muted = true

    // not works in web
    player.play()
  })
```