### PR TITLE
[docs] Remove pleasantries in multiple docs

### DIFF
--- a/docs/components/plugins/permissions/data/android.json
+++ b/docs/components/plugins/permissions/data/android.json
@@ -266,7 +266,7 @@
       "explanation": null,
       "constant": "android.permission.BIND_CHOOSER_TARGET_SERVICE",
       "protection": "signature",
-      "warning": "This constant was deprecated in API level 30. For publishing direct share targets, please follow the instructions in https://developer.android.com/training/sharing/receive.html#providing-direct-share-targets instead."
+      "warning": "This constant was deprecated in API level 30. For publishing direct share targets, follow the instructions in https://developer.android.com/training/sharing/receive.html#providing-direct-share-targets instead."
     },
     "BIND_COMPANION_DEVICE_SERVICE": {
       "apiAdded": 31,
@@ -2367,7 +2367,7 @@
       "explanation": null,
       "constant": "android.permission.PERSISTENT_ACTIVITY",
       "protection": null,
-      "warning": "This constant was deprecated in API level 15. This functionality will be removed in the future; please do not use. Allow an application to make its activities persistent."
+      "warning": "This constant was deprecated in API level 15. Do not use this functionality since it will be removed in the future. Allow an application to make its activities persistent."
     },
     "POST_NOTIFICATIONS": {
       "apiAdded": 33,

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 When setting up CI or writing a script to help manage your projects, we recommend avoiding using your username and password to authenticate. With these credentials, anyone will be able to log in and use your account.
 
-Instead of providing credentials, you can generate tokens that will allow you to manage each integration point separately. Anyone who has access to these tokens will be able to perform actions against your account. Please treat them with the same care as a user password. In case something is leaked, you can revoke these tokens to block access.
+Instead of providing credentials, you can generate tokens that will allow you to manage each integration point separately. Anyone who has access to these tokens will be able to perform actions against your account. Treat them with the same care as a user password. In case something is leaked, you can revoke these tokens to block access.
 
 ## Personal access tokens
 

--- a/docs/pages/archive/classic-updates/configuring-updates.mdx
+++ b/docs/pages/archive/classic-updates/configuring-updates.mdx
@@ -2,11 +2,11 @@
 title: Configuring Updates
 ---
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
 Expo provides various settings to configure how your app receives updates. Updates allow you to publish a new version of your app JavaScript and assets without building a new version of your app and re-submitting it to app stores. ([Read more about the limitations](/archive/classic-updates/publishing/)).
 
-To create an update of your app, run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of these changes](/archive/classic-updates/publishing/#some-native-configuration-cant-be-updated-by-publishing), you'll need to rebuild your app with `eas build` and upload the binary file to the appropriate app store ([see the docs here](/build/setup)).
+To create an update of your app, run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Note** that if you wish to update the SDK version of your app, or make [any of these changes](/archive/classic-updates/publishing/#some-native-configuration-cant-be-updated-by-publishing), you'll need to rebuild your app with `eas build` and upload the binary file to the appropriate app store ([see the docs here](/build/setup)).
 
 Updates are controlled by the `updates` settings in app.json, which handle the initial app load, and the Updates SDK module, which allows you to fetch updates asynchronously from your JS.
 

--- a/docs/pages/archive/classic-updates/hosting-your-app.mdx
+++ b/docs/pages/archive/classic-updates/hosting-your-app.mdx
@@ -5,7 +5,7 @@ title: Hosting Updates on Your Servers
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
 Normally, when updates are enabled, your app will fetch updates comprising JavaScript bundles and assets from Expo's CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, updates are slow or unusable in countries that have blocked Expo's CDN providers on AWS and Google Cloud. In these cases, you can host your updates on your own servers to better suit your use cases.
 

--- a/docs/pages/archive/classic-updates/introduction.mdx
+++ b/docs/pages/archive/classic-updates/introduction.mdx
@@ -6,4 +6,4 @@ hideTOC: true
 
 Classic Updates was a service by Expo that delivered updates to end-users using Expo CLI's `expo publish` command. It was supported by Expo through August 2022, when it was replaced by [EAS Update](/eas-update).
 
-Classic Updates will be sunset gradually throughout 2023 and 2024. If your project is using Classic Updates actively, please migrate to [EAS Update](/eas-update/migrate-from-classic-updates).
+Classic Updates will be sunset gradually throughout 2023 and 2024. If your project is using Classic Updates actively, migrate to [EAS Update](/eas-update/migrate-from-classic-updates).

--- a/docs/pages/archive/classic-updates/optimizing-updates.mdx
+++ b/docs/pages/archive/classic-updates/optimizing-updates.mdx
@@ -4,7 +4,7 @@ title: Optimizing Updates
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
 ## What's in an update
 

--- a/docs/pages/archive/classic-updates/publishing.mdx
+++ b/docs/pages/archive/classic-updates/publishing.mdx
@@ -4,7 +4,7 @@ title: Publishing updates
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
 While you're developing your project, you're writing code on your
 computer, and when you use Expo CLI, a server and the Metro bundler run on your machine and bundle up all your source code and make

--- a/docs/pages/archive/classic-updates/updating-your-app.mdx
+++ b/docs/pages/archive/classic-updates/updating-your-app.mdx
@@ -3,7 +3,7 @@ title: Updating your App
 sidebar_title: Updating your App
 ---
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
 The `expo-updates` module provides a client-side implementation for loading updates in React Native apps. Updates allow you to deploy new JavaScript and assets to existing builds of your app without building a new binary.
 

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -31,10 +31,10 @@ To install and use Expo modules, the easiest way to get up and running is with t
 - <YesIcon small /> **When the command succeeds**, you will be able to add any Expo module in your
   app! Proceed to [Usage](#usage) for more information.
 
-- <NoIcon small /> **If the command fails**, please follow the manual installation instructions.
-  Updating code programmatically can be tricky, and if your project deviates significantly from a
-  default React Native project, then you need to perform manual installation and adapt the
-  instructions here to your codebase.
+- <NoIcon small /> **If the command fails**, follow the manual installation instructions. Updating
+  code programmatically can be tricky, and if your project deviates significantly from a default
+  React Native project, then you need to perform manual installation and adapt the instructions here
+  to your codebase.
 
 ## Manual installation
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -178,8 +178,8 @@ Join us on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord and Forum
 
 When you ask for troubleshooting help, be sure to share the following information:
 
-- **A link to your build page**. This can only be accessed by your team or Expo employees. If you'd like to share it more publicly, take a screenshot. If you'd like to share it more privately, send an email to secure@expo.dev and mention that in your help request on chat or forums. If you are performing this build locally with `eas build --local`, you may omit this, but please indicate this fact.
-- **Error logs**. Anything that you suspect may be related to your build or runtime error. If you can't provide this, please explain why not.
+- **A link to your build page**. This can only be accessed by your team or Expo employees. If you'd like to share it more publicly, take a screenshot. If you'd like to share it more privately, send an email to secure@expo.dev and mention that in your help request on chat or forums. If you are performing this build locally with `eas build --local`, you can omit this, but do mention this fact.
+- **Error logs**. Anything that you suspect may be related to your build or runtime error. If you can't provide this, explain why not.
 - **Minimal reproducible example or a link to your repository**. The quickest way to get a solution to your problem is to ensure that other developers can reproduce it. If you have ever worked on a team, you know this from experience. In many cases, if you can't provide a reproducible example then it may not be possible to help you, and at best the back-and-forth process of asking and answering questions will be an inefficient use of time. Learn more about how to create a reproducible example in the [manual debugging guide](https://expo.fyi/manual-debugging) and Stack Overflow's [Minimal Viable Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example) guide.
 
 Try to be clear, precise, and helpful. General guidance provided by Stack Overflow's [How to ask a good question](https://stackoverflow.com/help/how-to-ask) guide applies.

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -129,7 +129,7 @@ Alternatively, you can use `--platform all` option to build for Android and iOS 
 
 - If you have not yet generated a keystore for your app, you can let EAS CLI take care of that for you by selecting `Generate new keystore`, and then you are done. The keystore is stored securely on EAS servers.
 - If you have previously built your app with `expo build:android`, you can use the same credentials here.
-- If you want to manually generate your keystore, please see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
+- If you want to manually generate your keystore, see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
 
 #### iOS app signing credentials
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -80,7 +80,7 @@ In the example above, the `scheme` is `exp+app-slug`, and the `url` is a project
 
 ## Example workflows
 
-These are a few examples of workflows to help your team get the most out of your development build. If you come up with others that would be useful for other teams, please [submit a PR](https://github.com/expo/expo/tree/main/CONTRIBUTING.md#-updating-documentation) to share your knowledge!
+These are a few examples of workflows to help your team get the most out of your development build. If you come up with others that would be useful for other teams, [submit a PR](https://github.com/expo/expo/tree/main/CONTRIBUTING.md#-updating-documentation) to share your knowledge!
 
 ### PR previews
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -51,7 +51,7 @@ The instructions in the [EAS Update Getting Started guide](/eas-update/getting-s
 
 Since you have changed the update provider from CodePush to EAS Update, you will need to rebuild your app and submit the new build to the respective app stores (Google Play Store and Apple App Store) to ensure the update mechanism works as expected for your end-users.
 
-Please follow the respective store guidelines for submitting a new build of your application:
+Follow the respective store guidelines for submitting a new build of your application:
 
 - [Submitting to Apple App Store](/submit/ios)
 - [Submitting to Google Play Store](/submit/android)

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -199,7 +199,7 @@ Let's go back to the root and create the **packages** directory. This directory 
   cmdCopy="mkdir -p packages/cool-package && cd packages/cool-package && yarn init"
 />
 
-We won't go into too much detail in creating a package. If you are not familiar with this, please consider using a simple app without monorepos. But, to make the example complete, let's add an **index.js** file with the following content:
+We won't go into too much detail in creating a package. If you are not familiar with this, consider using a simple app without monorepos. But, to make the example complete, let's add an **index.js** file with the following content:
 
 ```js index.js
 export const greeting = 'Hello!';

--- a/docs/pages/preview/introduction.mdx
+++ b/docs/pages/preview/introduction.mdx
@@ -7,12 +7,12 @@ This section of the documentation provides a preview of experimental new feature
 
 > **info** Pages behind `/preview` are not indexed on search engines.
 
-We just ask that you please keep the following in mind when exploring preview features:
+We just ask that you keep the following in mind when exploring preview features:
 
 1. **Don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
 2. **You probably should not depend on preview features in production**. Unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
 3. **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
-4. **Please provide us with detailed feedback from your experiences using experimental features**. From documentation to API interfaces to CLI commands, we want to hear your feedback because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and feedback](#support-and-feedback).
+4. **Provide us with detailed feedback from your experiences using experimental features**. From documentation to API interfaces to CLI commands, we want to hear your feedback because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and feedback](#support-and-feedback).
 
 ## Support and feedback
 

--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -4,8 +4,6 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
-{/* Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue. */}
-
 import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
 

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Report issues you encounter to [`react-native-masked-view` GitHub repository](https://github.com/react-native-masked-view/masked-view).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -100,7 +100,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Available sensors
 
-For more information, please see the documentation for the sensor you are interested in:
+For more information, see the documentation for the sensor you are interested in:
 
 <BoxLink
   title="Accelerometer"

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -52,7 +52,7 @@ export default function App() {
         // Pre-load fonts, make any API calls you need to do here
         await Font.loadAsync(Entypo.font);
         // Artificially delay for two seconds to simulate a slow loading
-        // experience. Please remove this if you copy and paste the code!
+        // experience. Remove this if you copy and paste the code!
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (e) {
         console.warn(e);

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -86,7 +86,7 @@ import * as SQLite from 'expo-sqlite';
 const db = await SQLite.openDatabaseAsync('databaseName');
 
 // `execAsync()` is useful for bulk queries when you want to execute altogether.
-// Please note that `execAsync()` does not escape parameters and may lead to SQL injection.
+// Note that `execAsync()` does not escape parameters and may lead to SQL injection.
 await db.execAsync(`
 PRAGMA journal_mode = WAL;
 CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER);

--- a/docs/pages/versions/v50.0.0/config/app.mdx
+++ b/docs/pages/versions/v50.0.0/config/app.mdx
@@ -4,8 +4,6 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
-{/* Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue. */}
-
 import schema from '~/public/static/schemas/v50.0.0/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
 

--- a/docs/pages/versions/v50.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/masked-view.mdx
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Report issues you encounter to [`react-native-masked-view` GitHub repository](https://github.com/react-native-masked-view/masked-view).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sensors.mdx
@@ -57,7 +57,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Available sensors
 
-For more information, please see the documentation for the sensor you are interested in:
+For more information, see the documentation for the sensor you are interested in:
 
 <BoxLink
   title="Accelerometer"

--- a/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
@@ -44,7 +44,7 @@ export default function App() {
         // Pre-load fonts, make any API calls you need to do here
         await Font.loadAsync(Entypo.font);
         // Artificially delay for two seconds to simulate a slow loading
-        // experience. Please remove this if you copy and paste the code!
+        // experience. Remove this if you copy and paste the code!
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (e) {
         console.warn(e);

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -41,7 +41,7 @@ import * as SQLite from 'expo-sqlite/next';
 const db = await SQLite.openDatabaseAsync('databaseName');
 
 // `execAsync()` is useful for bulk queries when you want to execute altogether.
-// Please note that `execAsync()` does not escape parameters and may lead to SQL injection.
+// Note that `execAsync()` does not escape parameters and may lead to SQL injection.
 await db.execAsync(`
 PRAGMA journal_mode = WAL;
 CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER);

--- a/docs/pages/versions/v51.0.0/config/app.mdx
+++ b/docs/pages/versions/v51.0.0/config/app.mdx
@@ -4,8 +4,6 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
-{/* Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue. */}
-
 import schema from '~/public/static/schemas/v51.0.0/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
 

--- a/docs/pages/versions/v51.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/masked-view.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Report issues you encounter to [`react-native-masked-view` GitHub repository](https://github.com/react-native-masked-view/masked-view).
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sensors.mdx
@@ -55,7 +55,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Available sensors
 
-For more information, please see the documentation for the sensor you are interested in:
+For more information, see the documentation for the sensor you are interested in:
 
 <BoxLink
   title="Accelerometer"

--- a/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
@@ -42,7 +42,7 @@ export default function App() {
         // Pre-load fonts, make any API calls you need to do here
         await Font.loadAsync(Entypo.font);
         // Artificially delay for two seconds to simulate a slow loading
-        // experience. Please remove this if you copy and paste the code!
+        // experience. Remove this if you copy and paste the code!
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (e) {
         console.warn(e);

--- a/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
@@ -31,7 +31,7 @@ import * as SQLite from 'expo-sqlite';
 const db = await SQLite.openDatabaseAsync('databaseName');
 
 // `execAsync()` is useful for bulk queries when you want to execute altogether.
-// Please note that `execAsync()` does not escape parameters and may lead to SQL injection.
+// Note that `execAsync()` does not escape parameters and may lead to SQL injection.
 await db.execAsync(`
 PRAGMA journal_mode = WAL;
 CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER);

--- a/docs/pages/versions/v52.0.0/config/app.mdx
+++ b/docs/pages/versions/v52.0.0/config/app.mdx
@@ -4,8 +4,6 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
-{/* Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue. */}
-
 import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
 

--- a/docs/pages/versions/v52.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/masked-view.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Report issues you encounter to [`react-native-masked-view` GitHub repository](https://github.com/react-native-masked-view/masked-view).
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sensors.mdx
@@ -100,7 +100,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Available sensors
 
-For more information, please see the documentation for the sensor you are interested in:
+For more information, see the documentation for the sensor you are interested in:
 
 <BoxLink
   title="Accelerometer"

--- a/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
@@ -52,7 +52,7 @@ export default function App() {
         // Pre-load fonts, make any API calls you need to do here
         await Font.loadAsync(Entypo.font);
         // Artificially delay for two seconds to simulate a slow loading
-        // experience. Please remove this if you copy and paste the code!
+        // experience. Remove this if you copy and paste the code!
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (e) {
         console.warn(e);

--- a/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
@@ -86,7 +86,7 @@ import * as SQLite from 'expo-sqlite';
 const db = await SQLite.openDatabaseAsync('databaseName');
 
 // `execAsync()` is useful for bulk queries when you want to execute altogether.
-// Please note that `execAsync()` does not escape parameters and may lead to SQL injection.
+// Note that `execAsync()` does not escape parameters and may lead to SQL injection.
 await db.execAsync(`
 PRAGMA journal_mode = WAL;
 CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove unnecessary pleasantries from multiple docs since the documentation is provided to inform developers.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By going through multiple docs and removing words like "please" and "please note". Replace the context with appropriate verbiage (where necessary).
- Remove an older comment about opening a docs issue in this GitHub repository from app config schema page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Docs have been tested locally, and all checks are being passed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
