### PR TITLE
[docs] Whitelist global tutorial code annotation class in eslint config

### DIFF
--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -145,6 +145,7 @@ module.exports = {
               'dialog-.+',
               'terminal-snippet',
               'table-wrapper',
+              'tutorial-code-annotation',
             ],
             ...TAILWIND_DEFAULTS,
           },


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

![CleanShot 2024-12-26 at 19 19 32](https://github.com/user-attachments/assets/67deebdb-a333-4cf5-979a-3d909f372de8)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Whitelist `tutorial-code-annotation` class under `tailwindcss/no-custom-classname` in `.eslintrc.cjs` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint`, and there will be no warnings anymore.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
