### PR TITLE
[android][audio] Accept null source in audio player

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Expose `isMeteringEnabled` to `JS`. ([#33713](https://github.com/expo/expo/pull/33713) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, allow player to accept a `null` audio source.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Expose `isMeteringEnabled` to `JS`. ([#33713](https://github.com/expo/expo/pull/33713) by [@alanjhughes](https://github.com/alanjhughes))
-- On `Android`, allow player to accept a `null` audio source.
+- On `Android`, allow player to accept a `null` audio source. ([#33854](https://github.com/expo/expo/pull/33854) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -239,7 +239,7 @@ class AudioModule : Module() {
           ref.player.volume
         }
       }.set { ref, volume: Float ->
-        appContext.mainQueue.launch {
+        runOnMain {
           ref.player.volume = volume
         }
       }
@@ -249,21 +249,23 @@ class AudioModule : Module() {
           Log.e(TAG, "Audio has been disabled. Re-enable to start playing")
           return@Function
         }
-        appContext.mainQueue.launch {
+        runOnMain {
           ref.player.play()
         }
       }
 
       Function("pause") { ref: AudioPlayer ->
-        appContext.mainQueue.launch {
+        runOnMain {
           ref.player.pause()
         }
       }
 
-      Function("replace") { ref: AudioPlayer, source: AudioSource ->
+      Function("replace") { ref: AudioPlayer, source: AudioSource? ->
         if (ref.player.availableCommands.contains(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
           val mediaSource = createMediaItem(source)
-          ref.player.replaceMediaItem(0, mediaSource.mediaItem)
+          mediaSource?.let {
+            ref.player.replaceMediaItem(0, it.mediaItem)
+          }
         }
       }
 
@@ -355,21 +357,26 @@ class AudioModule : Module() {
     }
   }
 
-  private fun createMediaItem(source: AudioSource?): MediaSource {
-    val isLocal = Util.isLocalFileUri(Uri.parse(source?.uri))
-    val factory = if (isLocal) {
+  private fun createMediaItem(source: AudioSource?): MediaSource? = source?.let {
+    val factory = createDataSourceFactory(it)
+    it.uri?.let { uri ->
+      val item = MediaItem.fromUri(uri)
+      buildMediaSourceFactory(factory, item)
+    }
+  }
+
+  private fun createDataSourceFactory(audioSource: AudioSource): DataSource.Factory {
+    val isLocal = Util.isLocalFileUri(Uri.parse(audioSource.uri))
+    return if (isLocal) {
       DefaultDataSource.Factory(context)
     } else {
       OkHttpDataSource.Factory(httpClient).apply {
-        source?.headers?.let {
-          setDefaultRequestProperties(it)
+        audioSource.headers?.let { headers ->
+          setDefaultRequestProperties(headers)
         }
         DefaultDataSource.Factory(context, this)
       }
     }
-
-    val item = MediaItem.fromUri(source?.uri ?: "")
-    return buildMediaSourceFactory(factory, item)
   }
 
   private fun updatePlaySoundThroughEarpiece(playThroughEarpiece: Boolean) {
@@ -384,7 +391,7 @@ class AudioModule : Module() {
     mediaItem: MediaItem
   ): MediaSource {
     val uri = mediaItem.localConfiguration?.uri
-    val newFactory = when (val type = retrieveStreamType(uri!!)) {
+    val newFactory = when (val type = uri?.let { retrieveStreamType(it) }) {
       CONTENT_TYPE_SS -> SsMediaSource.Factory(factory)
       CONTENT_TYPE_DASH -> DashMediaSource.Factory(factory)
       CONTENT_TYPE_HLS -> HlsMediaSource.Factory(factory)

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -7,6 +7,7 @@ import android.media.audiofx.Visualizer
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -29,14 +30,16 @@ private const val AUDIO_SAMPLE_UPDATE = "audioSampleUpdate"
 class AudioPlayer(
   context: Context,
   appContext: AppContext,
-  source: MediaSource,
+  source: MediaSource?,
   updateInterval: Double
 ) : SharedRef<ExoPlayer>(
   ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
     .build()
     .apply {
-      setMediaSource(source)
+      source?.let {
+        setMediaSource(it)
+      }
       setAudioAttributes(AudioAttributes.DEFAULT, true)
       prepare()
     },
@@ -52,7 +55,7 @@ class AudioPlayer(
   private var visualizer: Visualizer? = null
 
   val currentTime get() = player.currentPosition / 1000
-  val duration get() = player.duration / 1000
+  val duration get() = if (player.duration != C.TIME_UNSET) player.duration / 1000 else 0
 
   init {
     addPlayerListeners()
@@ -175,7 +178,8 @@ class AudioPlayer(
               }
             }
 
-            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) = Unit
+            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) =
+              Unit
           },
           Visualizer.getMaxCaptureRate() / 2,
           true,

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -178,8 +178,7 @@ class AudioPlayer(
               }
             }
 
-            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) =
-              Unit
+            override fun onFftDataCapture(visualizer: Visualizer?, fft: ByteArray?, samplingRate: Int) = Unit
           },
           Visualizer.getMaxCaptureRate() / 2,
           true,


### PR DESCRIPTION
# Why
Closes #33822

# How
The player should accept a null source. We can do this by only creating the media item if possible and leaving it unset otherwise. 

# Test Plan
Bare-expo. 
```typescript
const player = useAudioPlayer(null)
```
works as expected.

