### PR TITLE
[dev-menu] fix perf monitor on ios

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed performance monitor does not show on iOS. ([#33855](https://github.com/expo/expo/pull/33855) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -73,7 +73,16 @@ class DevMenuDevOptionsDelegate {
     }
 
     DispatchQueue.main.async {
-      devSettings.isPerfMonitorShown ? perfMonitor.hide() : perfMonitor.show()
+      devSettings.isPerfMonitorShown ? perfMonitor.hide() : {
+        let devMenuWindow = DevMenuManager.shared.window
+        // RCTPerfMonitor adds its view to the window using RCTKeyWindow().
+        // The key window when the dev menu is shown is actually the DevMenuWindow.
+        // To prevent RCTPerfMonitor from adding its view to the incorrect window,
+        // we temporarily hide and resign the key status of the DevMenuWindow.
+        devMenuWindow?.isHidden = true
+        perfMonitor.show()
+        devMenuWindow?.isHidden = false
+      }()
       devSettings.isPerfMonitorShown = !devSettings.isPerfMonitorShown
     }
     #endif

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -73,7 +73,9 @@ class DevMenuDevOptionsDelegate {
     }
 
     DispatchQueue.main.async {
-      devSettings.isPerfMonitorShown ? perfMonitor.hide() : {
+      if devSettings.isPerfMonitorShown {
+        perfMonitor.hide()
+      } else {
         let devMenuWindow = DevMenuManager.shared.window
         // RCTPerfMonitor adds its view to the window using RCTKeyWindow().
         // The key window when the dev menu is shown is actually the DevMenuWindow.
@@ -82,7 +84,7 @@ class DevMenuDevOptionsDelegate {
         devMenuWindow?.isHidden = true
         perfMonitor.show()
         devMenuWindow?.isHidden = false
-      }()
+      }
       devSettings.isPerfMonitorShown = !devSettings.isPerfMonitorShown
     }
     #endif


### PR DESCRIPTION
# Why

fix performance monitor ui dismissed right immediately after toggling on.
close ENG-14589

# How

as @alanjhughes pointed out, the root cause is from https://github.com/facebook/react-native/commit/16775215d5a734288da7147db348824395198407. this pr tries to hide and resign the DevMenuWindow key status temporarily during show the performance monitor.

people should not see the hidden flickering

https://github.com/user-attachments/assets/512d4163-e26c-4e74-a4de-19ff8252cbec

# Test Plan

test on a blank project and toggle performance monitor

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
