### PR TITLE
[bare-expo] fix search navigation

### DIFF
--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -1,11 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import {
-  Link,
-  NavigationAction,
-  StackActions,
-  useLinkBuilder,
-  useLinkProps,
-} from '@react-navigation/native';
+import { Link, NavigationAction, useLinkBuilder, useLinkProps } from '@react-navigation/native';
 import React from 'react';
 import {
   FlatList,
@@ -47,10 +41,7 @@ function LinkButton({
   screenName?: string;
 }) {
   const { buildAction } = useLinkBuilder();
-  let action: NavigationAction = buildAction(href);
-  if (screenName) {
-    action = StackActions.push(screenName);
-  }
+  const action: NavigationAction = buildAction(href);
 
   const { onPress, ...props } = useLinkProps({ href, action });
 

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -32,13 +32,11 @@ interface Props {
 function LinkButton({
   href,
   children,
-  screenName,
   ...rest
 }: Omit<React.ComponentProps<typeof Link>, 'action'> & {
   href: string;
   disabled?: boolean;
   children?: React.ReactNode;
-  screenName?: string;
 }) {
   const { buildAction } = useLinkBuilder();
   const action: NavigationAction = buildAction(href);
@@ -95,7 +93,6 @@ export default function ComponentListScreen(props: Props) {
       <LinkButton
         disabled={!isAvailable}
         href={route ?? screenName ?? exampleName}
-        screenName={screenName ?? exampleName}
         style={[styles.rowTouchable]}>
         <View
           pointerEvents="none"


### PR DESCRIPTION
# Why

The navigation via the search screen of the `bare-expo` app is not working. Seems like a regression from #31992 during upgrading `@react-navigation`.

# How

Was setting up the local development environment to get familiar with the internals and noticed this when trying to navigate through the components and APIs.

# Test Plan

<details>
<summary>Recording before the fix</summary>


https://github.com/user-attachments/assets/1665c222-d8fa-402c-ad10-96a90a6b9a27


</details>

<details>
<summary>Recording after the fix</summary>


https://github.com/user-attachments/assets/0374c16a-495f-44c9-a1fe-f4285502c258


</details>

I've also verified the normal navigation still works as expected.

