### PR TITLE
[core][iOS] Support dispatching events by SwiftUI views

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Implemented dispatching events by SwiftUI views.
+
 ### 🐛 Bug fixes
 
 - [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Implemented dispatching events by SwiftUI views.
+- Implemented dispatching events by SwiftUI views. ([#33860](https://github.com/expo/expo/pull/33860) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Events/EventDispatcher.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventDispatcher.swift
@@ -77,7 +77,7 @@ internal func installEventDispatcher<ViewType>(forEvent eventName: String, onVie
 /**
  Checks whether the mirror child refers to the event dispatcher with the given event name.
  */
-private func isEventDispatcherWithName(_ mirrorChild: Mirror.Child, _ eventName: String) -> Bool {
+internal func isEventDispatcherWithName(_ mirrorChild: Mirror.Child, _ eventName: String) -> Bool {
   guard let eventDispatcher = mirrorChild.value as? EventDispatcher else {
     return false
   }

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -29,7 +29,7 @@ internal final class CoreModule: Module {
       for propName in viewDefinition.getSupportedPropNames() {
         validAttributes[propName] = true
       }
-      for eventName in viewDefinition.eventNames {
+      for eventName in viewDefinition.getSupportedEventNames() {
         guard let normalizedEventName = RCTNormalizeInputEventName(eventName) else {
           continue
         }

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -28,6 +28,11 @@ public protocol AnyViewDefinition {
   func getSupportedPropNames() -> [String]
 
   /**
+   Returns a list of event names supported by the view.
+   */
+  func getSupportedEventNames() -> [String]
+
+  /**
    Calls defined lifecycle methods with the given type.
    */
   func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: UIView)

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -85,6 +85,6 @@ internal func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
 /**
  Converts mirror's label to field's key by dropping the "_" prefix from wrapped property label.
  */
-private func convertLabelToKey(_ label: String?) -> String? {
+internal func convertLabelToKey(_ label: String?) -> String? {
   return (label != nil && label!.starts(with: "_")) ? String(label!.dropFirst()) : label
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -32,21 +32,41 @@ extension ExpoSwiftUI {
    A definition representing the native SwiftUI view to export to React.
    */
   public final class ViewDefinition<Props: ViewProps, ViewType: View<Props>>: ExpoModulesCore.ViewDefinition<HostingView<Props, ViewType>> {
+    // To obtain prop and event names from the props object we need to create a dummy instance first.
+    // This is not ideal, but RN requires us to provide all names before the view is created
+    // and there doesn't seem to be a better way to do this right now.
+    private lazy var dummyPropsMirror: Mirror = Mirror(reflecting: Props())
+
     init(_ viewType: ViewType.Type) {
       super.init(HostingView<Props, ViewType>.self, elements: [])
     }
 
     public override func createView(appContext: AppContext) -> UIView? {
       let props = Props()
-      return HostingView(viewType: ViewType.self, props: props, appContext: appContext)
+      let view = HostingView(viewType: ViewType.self, props: props, appContext: appContext)
+
+      // Set up events to call view's `dispatchEvent` method.
+      props.setUpEvents(view.dispatchEvent(_:payload:))
+
+      return view
     }
 
     public override func getSupportedPropNames() -> [String] {
-      // To obtain field names from the props object we need to create a dummy instance first.
-      // This is not ideal, but RN requires us to provide all prop names before the view is created
-      // and there doesn't seem to be a better way to do this right now.
-      let props = Props()
-      return fieldsOf(props).compactMap(\.key)
+      return dummyPropsMirror.children.compactMap { (label: String?, value: Any) in
+        guard let field = value as? AnyFieldInternal else {
+          return nil
+        }
+        return field.key ?? convertLabelToKey(label)
+      }
+    }
+
+    public override func getSupportedEventNames() -> [String] {
+      return dummyPropsMirror.children.compactMap { (label: String?, value: Any) in
+        guard let event = value as? EventDispatcher else {
+          return nil
+        }
+        return event.customName ?? convertLabelToKey(label)
+      }
     }
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -45,8 +45,11 @@ extension ExpoSwiftUI {
       let props = Props()
       let view = HostingView(viewType: ViewType.self, props: props, appContext: appContext)
 
+#if RCT_NEW_ARCH_ENABLED
       // Set up events to call view's `dispatchEvent` method.
+      // This is supported only on the new architecture, `dispatchEvent` exists only there.
       props.setUpEvents(view.dispatchEvent(_:payload:))
+#endif
 
       return view
     }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
@@ -22,5 +22,19 @@ extension ExpoSwiftUI {
       // Notify subscribed views about the change to re-render them.
       objectWillChange.send()
     }
+
+    internal func setUpEvents(_ dispatcher: @escaping (_ eventName: String, _ payload: Any) -> Void) {
+      Mirror(reflecting: self).children.forEach { (label: String?, value: Any) in
+        guard let event = value as? EventDispatcher else {
+          return
+        }
+        guard let eventName = event.customName ?? convertLabelToKey(label) else {
+          fatalError("The event has no name")
+        }
+        event.handler = { payload in
+          dispatcher(eventName, payload)
+        }
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -65,6 +65,10 @@ public class ViewDefinition<ViewType: UIView>: ObjectDefinition, AnyViewDefiniti
     return props.map(\.name)
   }
 
+  public func getSupportedEventNames() -> [String] {
+    return eventNames
+  }
+
   public func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: UIView) {
     for method in lifecycleMethods where method.type == type {
       method(view)


### PR DESCRIPTION
# Why

It was not possible to dispatch events from SwiftUI views. This PR adds this functionality.

# How

Similarly to how we define `EventDispatcher` in UIKit views, in SwiftUI we'll define it in the props object, like below:

```swift
class MyProps: ExpoSwiftUI.ViewProps {
  var onEvent = EventDispatcher()
}

struct MyView: ExpoSwiftUI.View {
  @EnvironmentObject
  var props: MyProps

  var body: some View {
    EmptyView().onAppear {
      props.onEvent(["foo": "bar"])
    }
  }
}
```

# Test Plan

Tested in the `ContactAccessButton` as part of #33861 