### PR TITLE
Update expo-cli-android.diff

### DIFF
--- a/docs/public/static/diffs/expo-cli-android.diff
+++ b/docs/public/static/diffs/expo-cli-android.diff
@@ -8,7 +8,7 @@ index 01841f5..e1740a6 100644
 
 +    // Bundle with Expo CLI
 +    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", rootDir.getAbsoluteFile().getParentFile().getAbsolutePath(), "android", "absolute"].execute(null, rootDir).text.trim())
-+    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
++    cliFile = new File(["node", "--print", "require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim())
 +    bundleCommand = "export:embed"
 +
      /* Autolinking */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While following [this guide](https://docs.expo.dev/bare/installing-expo-modules/#configure-android-project-to-bundle-with-expo), I ran into an issue that Expo's `cliFile` couldn't be located.

# How
Updated expo-cli-android.diff (following how cliFile path is defined in the [template build.gradle](https://github.com/expo/expo/blob/b3aeeeac3fc5d19bd716b6fe94d16984383c2c09/templates/expo-template-bare-minimum/android/app/build.gradle#L19))

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
