### PR TITLE
[packages][ios]Fix ScreenOrientation.addOrientationChangeListener() Freezes iOS Devices 

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+https://github.com/expo/expo/pull/33867
+- [iOS] Fixed ScreenOrientation.addOrientationChangeListener() Freezes iOS Devices in Expo SDK 52, issue 33853 ([#33867](https://github.com/expo/expo/pull/33867) by [@pjdemers](https://github.com/pjdemers)
+
 ### 💡 Others
 
 ## 8.0.2 - 2024-12-19

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### 🐛 Bug fixes
 
-https://github.com/expo/expo/pull/33867
 - [iOS] Fixed ScreenOrientation.addOrientationChangeListener() Freezes iOS Devices in Expo SDK 52, issue 33853 ([#33867](https://github.com/expo/expo/pull/33867) by [@pjdemers](https://github.com/pjdemers)
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -206,7 +206,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   func screenOrientationDidChange(_ newScreenOrientation: UIInterfaceOrientation) {
     queue.sync(flags: .barrier) {
       // Write with the barrier:
-      if (self.currentScreenOrientation != newScreenOrientation) {
+      if self.currentScreenOrientation != newScreenOrientation {
         // Only change if necessary, to prevent listeners from re-calling this method.
         self.currentScreenOrientation = newScreenOrientation
       }

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -204,9 +204,15 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
    Called at the end of the screen orientation change. Notifies the controllers about the orientation change.
    */
   func screenOrientationDidChange(_ newScreenOrientation: UIInterfaceOrientation) {
-    queue.async(flags: .barrier) {
-      self.currentScreenOrientation = newScreenOrientation
-
+    queue.sync(flags: .barrier) {
+      // Write with the barrier:
+      if (self.currentScreenOrientation != newScreenOrientation) {
+        // Only change if necessary, to prevent listeners from re-calling this method.
+        self.currentScreenOrientation = newScreenOrientation
+      }
+    }
+    queue.async() {
+      // Read without the barrier:
       for controller in self.orientationControllers {
         controller.screenOrientationDidChange(newScreenOrientation)
       }

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -211,7 +211,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
         self.currentScreenOrientation = newScreenOrientation
       }
     }
-    queue.async() {
+    queue.async {
       // Read without the barrier:
       for controller in self.orientationControllers {
         controller.screenOrientationDidChange(newScreenOrientation)


### PR DESCRIPTION
# Why

Fix  Issue #33853 

# How

Fix deadlocking native code.

See [Example README](https://github.com/pjdemers/expo-screen-orientation-deadlock-example/blob/main/README.md) for details

# Test Plan

Tested in iOS simulator, using the bare-expo test driver.

Tested in an iOS simulator, using the bug reporter's [expo-screen-orientation-issue-demo project](https://github.com/costa-rica/expo-screen-orientation-issue-demo).

Tested on a real iOS device, and in simulator, using my own app, and my sample application, [https://github.com/pjdemers/expo-screen-orientation-deadlock-example](https://github.com/pjdemers/expo-screen-orientation-deadlock-example)

# Checklist

- [ X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
