### PR TITLE
[docs] Create a custom APIBox component to apply padding styles for manual usage

### DIFF
--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -11,7 +11,7 @@ import {
 import { PlatformName } from '~/types/common';
 import { MONOSPACE, RawH3 } from '~/ui/components/Text';
 
-type APIBoxProps = PropsWithChildren<{
+export type APIBoxProps = PropsWithChildren<{
   header?: string;
   platforms?: PlatformName[];
   className?: string;

--- a/docs/components/plugins/PaddedAPIBox.tsx
+++ b/docs/components/plugins/PaddedAPIBox.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+
+import { APIBox } from '~/components/plugins/APIBox';
+
+type PaddedAPIBoxProps = PropsWithChildren<unknown>;
+
+export function PaddedAPIBox({ children, ...props }: PaddedAPIBoxProps) {
+  return (
+    <APIBox className="px-4 py-3" {...props}>
+      {children}
+    </APIBox>
+  );
+}

--- a/docs/components/plugins/PaddedAPIBox.tsx
+++ b/docs/components/plugins/PaddedAPIBox.tsx
@@ -1,12 +1,10 @@
-import { PropsWithChildren } from 'react';
+import { mergeClasses } from '@expo/styleguide';
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { APIBox, APIBoxProps } from '~/components/plugins/APIBox';
 
-type PaddedAPIBoxProps = PropsWithChildren<unknown>;
-
-export function PaddedAPIBox({ children, ...props }: PaddedAPIBoxProps) {
+export function PaddedAPIBox({ children, className, ...props }: APIBoxProps) {
   return (
-    <APIBox className="px-4 py-3" {...props}>
+    <APIBox className={mergeClasses('px-4 py-3', className)} {...props}>
       {children}
     </APIBox>
   );

--- a/docs/pages/debugging/create-devtools-plugins.mdx
+++ b/docs/pages/debugging/create-devtools-plugins.mdx
@@ -3,7 +3,7 @@ title: Create a dev tools plugin
 description: Learn how to create a dev tools plugin to enhance your development experience.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -45,7 +45,7 @@ The template includes a simple example of sending and receiving messages between
 
 The client object returned by `useDevToolsPluginClient` includes:
 
-<APIBox header="addMessageListener">
+<PaddedAPIBox header="addMessageListener" className="px-4 pt-3">
 
 Listens for a message matching the typed string and invokes the callback with the message data.
 
@@ -56,9 +56,9 @@ client.addMessageListener('ping', data => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="sendMessage">
+<PaddedAPIBox header="sendMessage" className="px-4 pt-3">
 
 Listens for a message matching the typed string and invokes the callback with the message data.
 
@@ -67,7 +67,7 @@ const client = useDevToolsPluginClient('my-devtools-plugin');
 client?.sendMessage('ping', { from: 'web' });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
 Edit the Expo app inside the **webui** folder to customize the user interface that displays diagnostic information from your app or triggers test scenarios:
 

--- a/docs/pages/debugging/create-devtools-plugins.mdx
+++ b/docs/pages/debugging/create-devtools-plugins.mdx
@@ -45,7 +45,7 @@ The template includes a simple example of sending and receiving messages between
 
 The client object returned by `useDevToolsPluginClient` includes:
 
-<PaddedAPIBox header="addMessageListener" className="px-4 pt-3">
+<PaddedAPIBox header="addMessageListener">
 
 Listens for a message matching the typed string and invokes the callback with the message data.
 
@@ -58,7 +58,7 @@ client.addMessageListener('ping', data => {
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="sendMessage" className="px-4 pt-3">
+<PaddedAPIBox header="sendMessage">
 
 Listens for a message matching the typed string and invokes the callback with the message data.
 

--- a/docs/pages/guides/configuring-statusbar.mdx
+++ b/docs/pages/guides/configuring-statusbar.mdx
@@ -27,7 +27,7 @@ Configuring the status bar while the splash screen is visible on Android is avai
 
 <Collapsible summary="See the full list of options available to configure the status bar statically on Android">
 
-<PaddedAPIBox header="androidStatusBar.barStyle" platforms={["android"]} className="px-4 pt-3">
+<PaddedAPIBox header="androidStatusBar.barStyle" platforms={["android"]}>
 
 This option can be used to configure whether the status bar content (icons and text in the status bar) is light, or dark. Usually, a status bar with a light background has dark content, and a status bar with a dark background has light content.
 
@@ -41,7 +41,7 @@ The valid values are:
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="androidStatusBar.backgroundColor" platforms={["android"]} className="px-4 pt-3">
+<PaddedAPIBox header="androidStatusBar.backgroundColor" platforms={["android"]}>
 
 This option can be used to specify the background color of the status bar. Defaults to `#00000000` (transparent) for the `dark-content` bar style and `#00000088` (semi-transparent black) for the `light-content` bar style.
 
@@ -49,7 +49,7 @@ The valid value is a 6-character long hexadecimal solid color string with the fo
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="androidStatusBar.translucent" platforms={["android"]} className="px-4 pt-3">
+<PaddedAPIBox header="androidStatusBar.translucent" platforms={["android"]}>
 
 Value type - `boolean`.
 
@@ -62,7 +62,7 @@ Defaults to `true` to match the iOS status bar behavior (which can only float ab
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="androidStatusBar.hidden" platforms={["android"]} className="px-4 pt-3">
+<PaddedAPIBox header="androidStatusBar.hidden" platforms={["android"]}>
 
 Value type - `boolean`.
 

--- a/docs/pages/guides/configuring-statusbar.mdx
+++ b/docs/pages/guides/configuring-statusbar.mdx
@@ -3,7 +3,7 @@ title: Configuring the status bar
 description: Learn how to configure the status bar using expo-status-bar library.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { CODE } from '~/ui/components/Text';
@@ -27,7 +27,7 @@ Configuring the status bar while the splash screen is visible on Android is avai
 
 <Collapsible summary="See the full list of options available to configure the status bar statically on Android">
 
-<APIBox header="androidStatusBar.barStyle" platforms={["android"]}>
+<PaddedAPIBox header="androidStatusBar.barStyle" platforms={["android"]} className="px-4 pt-3">
 
 This option can be used to configure whether the status bar content (icons and text in the status bar) is light, or dark. Usually, a status bar with a light background has dark content, and a status bar with a dark background has light content.
 
@@ -39,17 +39,17 @@ The valid values are:
 > If you choose `light-content` and have either a very light image set as the `SplashScreen` or `backgroundColor` set to a light color, the status bar icons may blend in and not be visible.
 > Similarly, for the `dark content` when you have a very dark image set as the `SplashScreen` or `backgroundColor` set to a dark color.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="androidStatusBar.backgroundColor" platforms={["android"]}>
+<PaddedAPIBox header="androidStatusBar.backgroundColor" platforms={["android"]} className="px-4 pt-3">
 
 This option can be used to specify the background color of the status bar. Defaults to `#00000000` (transparent) for the `dark-content` bar style and `#00000088` (semi-transparent black) for the `light-content` bar style.
 
 The valid value is a 6-character long hexadecimal solid color string with the format `#RRGGBB` (for example, `#C2185B`) or an 8-character long hexadecimal color string with transparency with the format `#RRGGBBAA` (for example, `#23C1B255`).
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="androidStatusBar.translucent" platforms={["android"]}>
+<PaddedAPIBox header="androidStatusBar.translucent" platforms={["android"]} className="px-4 pt-3">
 
 Value type - `boolean`.
 
@@ -60,9 +60,9 @@ Defaults to `true` to match the iOS status bar behavior (which can only float ab
 > A translucent status bar makes sense when the `backgroundColor` is using a transparent color (`#RRGGBBAA`).
 > When you use a translucent status bar and a solid `backgroundColor` (`#RRGGBB`) then the upper part of your app will be partially covered by the non-transparent status bar and thus some of your app's content might not be visible to the user.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="androidStatusBar.hidden" platforms={["android"]}>
+<PaddedAPIBox header="androidStatusBar.hidden" platforms={["android"]} className="px-4 pt-3">
 
 Value type - `boolean`.
 
@@ -70,7 +70,7 @@ This option instructs the system whether the status bar should be visible or not
 
 When the status bar is not visible it can be presented via the `swipe down` gesture. When set to `true`, the status bar will not respect the `backgroundColor` or `barStyle` settings.
 
-</APIBox>
+</PaddedAPIBox>
 
 </Collapsible>
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -158,7 +158,7 @@ module.exports = {
 ```
 
 </PaddedAPIBox>
-<PaddedAPIBox platforms={['ios']} className="px-4 pt-3">
+<PaddedAPIBox platforms={['ios']}>
 
 ### `flags`
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -3,8 +3,8 @@ title: Autolinking
 description: Learn how to use Expo Autolinking to automatically link native dependencies in your Expo project.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { Terminal } from '~/ui/components/Snippet';
 
 Usually, when you're developing a native mobile app and want to install a third-party library, you're asked to add the dependency to the manifest files of your package managers (**build.gradle** on Android, **Podfile** for CocoaPods on iOS, **Package.swift** for SwiftPM on iOS).
@@ -20,7 +20,7 @@ The core implementation can be found in the [`expo-modules-autolinking`](https:/
 
 ## CLI commands
 
-<APIBox>
+<PaddedAPIBox>
 
 ### `search`
 
@@ -47,8 +47,8 @@ The above command returns an object in JSON format with modules that have been f
 }
 ```
 
-</APIBox>
-<APIBox>
+</PaddedAPIBox>
+<PaddedAPIBox>
 
 ### `resolve`
 
@@ -81,8 +81,8 @@ For example, with the `--platform apple` option it returns an object in JSON for
 }
 ```
 
-</APIBox>
-<APIBox>
+</PaddedAPIBox>
+<PaddedAPIBox>
 
 ### `verify`
 
@@ -90,7 +90,7 @@ Verifies the search results by checking whether there are no duplicate packages,
 
 <Terminal cmd={['$ npx expo-modules-autolinking verify']} />
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Configuration
 
@@ -100,7 +100,7 @@ The behavior of the module resolution can be customized using some configuration
 - per platform overrides with `expo.autolinking.ios` and `expo.autolinking.android` objects
 - options provided to the CLI command, the `use_expo_modules!` method in the **Podfile** or `useExpoModules` function in the **settings.gradle**
 
-<APIBox>
+<PaddedAPIBox>
 
 ### `searchPaths`
 
@@ -122,8 +122,8 @@ When used with the CLI, you can pass the search paths as command arguments like 
 
 <Terminal cmd={['$ npx expo-modules-autolinking search ../../packages']} />
 
-</APIBox>
-<APIBox>
+</PaddedAPIBox>
+<PaddedAPIBox>
 
 ### `exclude`
 
@@ -157,8 +157,8 @@ module.exports = {
 };
 ```
 
-</APIBox>
-<APIBox platforms={['ios']}>
+</PaddedAPIBox>
+<PaddedAPIBox platforms={['ios']} className="px-4 pt-3">
 
 ### `flags`
 
@@ -191,7 +191,7 @@ use_expo_modules!({
 
 </CodeBlocksTable>
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Common questions
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -4,8 +4,8 @@ description: An API reference of Expo modules API.
 sidebar_title: Module API
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIMethod } from '~/components/plugins/api/APIMethod';
 import { FileTree } from '~/ui/components/FileTree';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
@@ -19,7 +19,7 @@ The native modules API is an abstraction layer on top of [JSI](https://reactnati
 As you might have noticed in the snippets on the [Get Started](/modules/get-started) page, each module class must implement the `definition` function.
 The module definition consists of the DSL components that describe the module's functionality and behavior.
 
-<APIBox header="Name">
+<PaddedAPIBox header="Name">
 
 Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument. This can be inferred from the module's class name, but it's recommended to set it explicitly for clarity.
 
@@ -27,8 +27,8 @@ Sets the name of the module that JavaScript code will use to refer to the module
 Name("MyModuleName")
 ```
 
-</APIBox>
-<APIBox header="Constants">
+</PaddedAPIBox>
+<PaddedAPIBox header="Constants">
 
 Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
 
@@ -63,8 +63,8 @@ Constants {
 ```
 
 </CodeBlocksTable>
-</APIBox>
-<APIBox header="Function">
+</PaddedAPIBox>
+<PaddedAPIBox header="Function">
 
 Defines a native synchronous function that will be exported to JavaScript. Synchronous means that when the function is executed in JavaScript, its native code is run on the same thread and blocks further execution of the script until the native function returns.
 
@@ -104,8 +104,8 @@ function getMessage() {
 }
 ```
 
-</APIBox>
-<APIBox header="AsyncFunction">
+</PaddedAPIBox>
+<PaddedAPIBox header="AsyncFunction">
 
 Defines a JavaScript function that always returns a `Promise` and whose native code is by default dispatched on a different thread than the JavaScript runtime runs on.
 
@@ -206,8 +206,8 @@ AsyncFunction("suspendFunction") Coroutine { message: String ->
 }
 ```
 
-</APIBox>
-<APIBox header="Events">
+</PaddedAPIBox>
+<PaddedAPIBox header="Events">
 
 Defines event names that the module can send to JavaScript.
 
@@ -227,8 +227,8 @@ Events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
 
 See [Sending events](#sending-events) to learn how to send events from the native code to JavaScript/TypeScript.
 
-</APIBox>
-<APIBox header="Property">
+</PaddedAPIBox>
+<PaddedAPIBox header="Property">
 
 Defines a new property directly on the JavaScript object that represents a native module. It is the same as calling [`Object.defineProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) on the module object.
 
@@ -292,8 +292,8 @@ MyModule.foo;
 MyModule.foo = 'foobar';
 ```
 
-</APIBox>
-<APIBox header="View">
+</PaddedAPIBox>
+<PaddedAPIBox header="View">
 
 Enables the module to be used as a native view. Definition components that are accepted as part of the view definition: [`Prop`](#prop), [`Events`](#events), [`GroupView`](#groupview) and [`AsyncFunction`](#asyncfunction).
 
@@ -331,8 +331,8 @@ View(TextView::class) {
 
 > **Info** Support for rendering SwiftUI views is planned. For now, you can use [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) and add its content view to your UIKit view.
 
-</APIBox>
-<APIBox header="Prop">
+</PaddedAPIBox>
+<PaddedAPIBox header="Prop">
 
 Defines a setter for the view prop of given name.
 
@@ -361,76 +361,76 @@ Prop("background") { view: View, @ColorInt color: Int ->
 
 > **Note** Props of function type (callbacks) are not supported yet.
 
-</APIBox>
-<APIBox header="OnCreate">
+</PaddedAPIBox>
+<PaddedAPIBox header="OnCreate">
 
 Defines module's lifecycle listener that is called right after module initialization. If you need to set up something when the module gets initialized, use this instead of module's class initializer.
 
-</APIBox>
-<APIBox header="OnDestroy">
+</PaddedAPIBox>
+<PaddedAPIBox header="OnDestroy">
 
 Defines module's lifecycle listener that is called when the module is about to be deallocated. Use it instead of module's class destructor.
 
-</APIBox>
-<APIBox header="OnStartObserving">
+</PaddedAPIBox>
+<PaddedAPIBox header="OnStartObserving">
 
 Defines the function that is invoked when the first event listener is added.
 
-</APIBox>
-<APIBox header="OnStopObserving">
+</PaddedAPIBox>
+<PaddedAPIBox header="OnStopObserving">
 
 Defines the function that is invoked when all event listeners are removed.
 
-</APIBox>
-<APIBox header="OnAppContextDestroys">
+</PaddedAPIBox>
+<PaddedAPIBox header="OnAppContextDestroys">
 
 Defines module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
 
-</APIBox>
-<APIBox header="OnAppEntersForeground" platforms={["ios"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnAppEntersForeground" platforms={["ios"]}>
 
 Defines the listener that is called when the app is about to enter the foreground mode.
 
 > **Note** This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
 
-</APIBox>
-<APIBox header="OnAppEntersBackground" platforms={["ios"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnAppEntersBackground" platforms={["ios"]}>
 
 Defines the listener that is called when the app enters the background mode.
 
 > **Note** This function is not available on Android — you may want to use [`OnActivityEntersBackground`](#onactivityentersbackground) instead.
 
-</APIBox>
-<APIBox header="OnAppBecomesActive" platforms={["ios"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnAppBecomesActive" platforms={["ios"]}>
 
 Defines the listener that is called when the app becomes active again (after `OnAppEntersForeground`).
 
 > **Note** This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
 
-</APIBox>
-<APIBox header="OnActivityEntersForeground" platforms={["android"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnActivityEntersForeground" platforms={["android"]}>
 
 Defines the activity lifecycle listener that is called right after the activity is resumed.
 
 > **Note** This function is not available on iOS — you may want to use [`OnAppEntersForeground`](#onappentersforeground) instead.
 
-</APIBox>
-<APIBox header="OnActivityEntersBackground" platforms={["android"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnActivityEntersBackground" platforms={["android"]}>
 
 Defines the activity lifecycle listener that is called right after the activity is paused.
 
 > **Note** This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
 
-</APIBox>
-<APIBox header="OnActivityDestroys" platforms={["android"]}>
+</PaddedAPIBox>
+<PaddedAPIBox header="OnActivityDestroys" platforms={["android"]}>
 
 Defines the activity lifecycle listener that is called when the activity owning the JavaScript context is about to be destroyed.
 
 > **Note** This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="GroupView" platforms={["android"]}>
+<PaddedAPIBox header="GroupView" platforms={["android"]}>
 
 Enables the view to be used as a view group. Definition components that are accepted as part of the group view definition: [`AddChildView`](#addchildview), [`GetChildCount`](#getchildcount), [`GetChildViewAt`](#getchildviewat), [`RemoveChildView`](#removechildview), [`RemoveChildViewAt`](#removechildviewat).
 
@@ -447,9 +447,9 @@ GroupView<ViewGroup> {
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="AddChildView" platforms={["android"]}>
+<PaddedAPIBox header="AddChildView" platforms={["android"]}>
 
 Defines action that adds a child view to the view group.
 
@@ -465,9 +465,9 @@ AddChildView { parent, child: View, index ->
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="GetChildCount" platforms={["android"]}>
+<PaddedAPIBox header="GetChildCount" platforms={["android"]}>
 
 Defines action the retrieves the number of child views in the view group.
 
@@ -483,9 +483,9 @@ GetChildCount { parent ->
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="GetChildViewAt" platforms={["android"]}>
+<PaddedAPIBox header="GetChildViewAt" platforms={["android"]}>
 
 Defines action that retrieves a child view at a specific index from the view group.
 
@@ -501,9 +501,9 @@ GetChildViewAt { parent, index ->
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="RemoveChildView" platforms={["android"]}>
+<PaddedAPIBox header="RemoveChildView" platforms={["android"]}>
 
 Defines action that removes a specific child view from the view group.
 
@@ -519,9 +519,9 @@ RemoveChildView { parent, child: View ->
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="RemoveChildViewAt" platforms={["android"]}>
+<PaddedAPIBox header="RemoveChildViewAt" platforms={["android"]}>
 
 Defines action that removes a child view at a specific index from the view group.
 
@@ -537,13 +537,13 @@ RemoveChildViewAt { parent, index ->
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Argument types
 
 Fundamentally, only primitive and serializable data can be passed back and forth between the runtimes. However, usually native modules need to receive custom data structures — more sophisticated than just the dictionary/map where the values are of unknown (`Any`) type and so each value has to be validated and cast on its own. The Expo Modules API provides protocols to make it more convenient to work with data objects, to provide automatic validation, and finally, to ensure native type-safety on each object member.
 
-<APIBox header="Primitives">
+<PaddedAPIBox header="Primitives">
 
 All functions and view prop setters accept all common primitive types in Swift and Kotlin as the arguments. This includes arrays, dictionaries/maps and optionals of these primitive types.
 
@@ -552,8 +552,8 @@ All functions and view prop setters accept all common primitive types in Swift a
 | Swift    | `Bool`, `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Float32`, `Double`, `String` |
 | Kotlin   | `Boolean`, `Int`, `Long`, `Float`, `Double`, `String`, `Pair`                                                                  |
 
-</APIBox>
-<APIBox header="Convertibles">
+</PaddedAPIBox>
+<PaddedAPIBox header="Convertibles">
 
 _Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. For example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers `(x, y)` or a JavaScript object with numeric `x` and `y` properties.
 
@@ -586,8 +586,8 @@ Similarly, some common Android types from packages like `java.io`, `java.net`, o
 | `kotlin.ByteArray`                                                            | `Uint8Array` <StatusTag note="SDK 50+" />                                                                                                                                         |
 | `kotlin.time.Duration`                                                        | `number` represents a duration in seconds <StatusTag note="SDK 52+" />                                                                                                            |
 
-</APIBox>
-<APIBox header="Records">
+</PaddedAPIBox>
+<PaddedAPIBox header="Records">
 
 _Record_ is a convertible type and an equivalent of the dictionary (Swift) or map (Kotlin), but represented as a struct where each field can have its type and provide a default value.
 It is a better way to represent a JavaScript object with the native type safety.
@@ -631,8 +631,8 @@ Function("readFile") { path: String, options: FileReadOptions ->
 ```
 
 </CodeBlocksTable>
-</APIBox>
-<APIBox header="Enums">
+</PaddedAPIBox>
+<PaddedAPIBox header="Enums">
 
 With enums, we can go even further with the above example (with `FileReadOptions` record) and limit supported encodings to `"utf8"` and `"base64"`. To use an enum as an argument or record field, it must represent a primitive value (for example, `String`, `Int`) and conform to `Enumerable`.
 
@@ -666,8 +666,8 @@ class FileReadOptions : Record {
 ```
 
 </CodeBlocksTable>
-</APIBox>
-<APIBox header="Eithers">
+</PaddedAPIBox>
+<PaddedAPIBox header="Eithers">
 
 There are some use cases where you want to pass various types for a single function argument. This is where Either types might come in handy.
 They act as a container for a value of one of a couple of types.
@@ -704,8 +704,8 @@ The implementation for three Either types is currently provided out of the box, 
 - `EitherOfThree<FirstType, SecondType, ThirdType>` — A container for one of three types.
 - `EitherOfFour<FirstType, SecondType, ThirdType, FourthType>` — A container for one of four types.
 
-</APIBox>
-<APIBox header="JavaScript values">
+</PaddedAPIBox>
+<PaddedAPIBox header="JavaScript values">
 
 It's also possible to use a `JavaScriptValue` type which is a holder for any value that can be represented in JavaScript.
 This type is useful when you want to mutate the given argument or when you want to omit type validations and conversions.
@@ -748,11 +748,11 @@ Function("mutateMe") { jsObject: JavaScriptObject ->
 
 </CodeBlocksTable>
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Native classes
 
-<APIBox header="Module">
+<PaddedAPIBox header="Module">
 
 A base class for a native module.
 
@@ -786,9 +786,9 @@ A base class for a native module.
   ]}
 />
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="AppContext">
+<PaddedAPIBox header="AppContext">
 
 The app context is an interface to a single Expo app.
 
@@ -887,9 +887,9 @@ The app context is an interface to a single Expo app.
   platforms={['iOS']}
 />
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="ExpoView">
+<PaddedAPIBox header="ExpoView">
 
 A base class that should be used by all exported views.
 
@@ -940,11 +940,11 @@ class LinearGradientModule : Module() {
 
 </CodeBlocksTable>
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Guides
 
-<APIBox>
+<PaddedAPIBox>
 ### Sending events
 
 While JavaScript/TypeScript to Native communication is mostly covered by native functions, you might also want to let the JavaScript/TypeScript code know about certain system events, for example, when the clipboard content changes.
@@ -1044,9 +1044,9 @@ Clipboard.addListener('onClipboardChanged', (event: ClipboardChangeEvent) => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox>
+<PaddedAPIBox>
 ### View callbacks
 
 Some events are connected to a certain view. For example, the touch event should be sent only to the underlying JavaScript view which was pressed. In that case, you can't use `sendEvent` described in [`Sending events`](#sending-events). The `expo-modules-core` introduces a view callbacks mechanism to handle view-bound events.
@@ -1128,7 +1128,7 @@ export default function MainView() {
 
 Provided payload is available under the `nativeEvent` key.
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Examples
 

--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -10,7 +10,7 @@ import { FileTree } from '~/ui/components/FileTree';
 
 > **warning** **Warning:** `unstable_settings` currently do not work with [async routes](/router/reference/async-routes/) (development-only). This is why the feature is designated _unstable_.
 
-<PaddedAPIBox header="initialRouteName" className="px-4 pt-3">
+<PaddedAPIBox header="initialRouteName">
 
 When deep linking to a route, you may want to provide a user with a "back" button. The `initialRouteName` sets the default screen of the stack and should match a valid filename (without the extension).
 

--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -5,12 +5,12 @@ sidebar_title: Settings
 hideTOC: true
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { FileTree } from '~/ui/components/FileTree';
 
 > **warning** **Warning:** `unstable_settings` currently do not work with [async routes](/router/reference/async-routes/) (development-only). This is why the feature is designated _unstable_.
 
-<APIBox header="initialRouteName">
+<PaddedAPIBox header="initialRouteName" className="px-4 pt-3">
 
 When deep linking to a route, you may want to provide a user with a "back" button. The `initialRouteName` sets the default screen of the stack and should match a valid filename (without the extension).
 
@@ -31,4 +31,4 @@ export default function Layout() {
 
 Now deep linking directly to `/other` or reloading the page will continue to show the back arrow.
 
-</APIBox>
+</PaddedAPIBox>

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -3,7 +3,7 @@ title: Static Rendering
 description: Learn how to render routes to static HTML and CSS files with Expo Router.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -155,7 +155,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 <FileTree files={['dist/blog/alpha.html', 'dist/blog/beta.html']} />
 
-<APIBox header="generateStaticParams">
+<PaddedAPIBox header="generateStaticParams" className="px-4 pt-3">
 
 A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as `localStorage` or `document`. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
 
@@ -195,7 +195,7 @@ export async function generateStaticParams(params: {
 }
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
 ### Read files using `process.cwd()`
 

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -155,7 +155,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 <FileTree files={['dist/blog/alpha.html', 'dist/blog/beta.html']} />
 
-<PaddedAPIBox header="generateStaticParams" className="px-4 pt-3">
+<PaddedAPIBox header="generateStaticParams">
 
 A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as `localStorage` or `document`. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
 

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -24,7 +24,7 @@ Before you proceed, ensure you have set up `jest-expo` according to the [Unit te
 
 `renderRouter` accepts the same [options](https://callstack.github.io/react-native-testing-library/docs/api#render-options) as `render` and introduces an additional option `initialUrl`, which sets an initial route for simulating deep-linking.
 
-<PaddedAPIBox header="Inline file system" className="px-4 pt-3">
+<PaddedAPIBox header="Inline file system">
 
 `renderRouter(mock: Record<string, ReactComponent>, options: RenderOptions)`
 
@@ -53,7 +53,7 @@ it('my-test', async () => {
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="Inline file system with `null` components" className="px-4 pt-3">
+<PaddedAPIBox header="Inline file system with `null` components">
 
 `renderRouter(mock: string[], options: RenderOptions)`
 
@@ -73,7 +73,7 @@ it('my-test', async () => {
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="Path to fixture" className="px-4 pt-3">
+<PaddedAPIBox header="Path to fixture">
 
 `renderRouter(fixturePath: string, options: RenderOptions)`
 
@@ -88,7 +88,7 @@ it('my-test', async () => {
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="Path to the fixture with overrides" className="px-4 pt-3">
+<PaddedAPIBox header="Path to the fixture with overrides">
 
 `renderRouter({ appDir: string, overrides: Record<string, ReactComponent>}, options: RenderOptions)`
 
@@ -112,7 +112,7 @@ it('my-test', async () => {
 
 The following matches have been added to `expect` and can be used to assert values on `screen`.
 
-<PaddedAPIBox header="toHavePathname()" className="px-4 pt-3">
+<PaddedAPIBox header="toHavePathname()">
 
 Assert the current pathname against a given string. The matcher uses the value of the [`usePathname`](/router/reference/hooks/#usepathname) hook on the current `screen`.
 
@@ -122,7 +122,7 @@ expect(screen).toHavePathname('/my-router');
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="toHavePathnameWithParams()" className="px-4 pt-3">
+<PaddedAPIBox header="toHavePathnameWithParams()">
 
 Assert the current pathname, including URL parameters, against a given string. This is useful to assert the appearance of URL in a web browser.
 
@@ -132,7 +132,7 @@ expect(screen).toHavePathnameWithParams('/my-router?hello=world');
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="toHaveSegments()" className="px-4 pt-3">
+<PaddedAPIBox header="toHaveSegments()">
 
 Assert the current segments against an array of strings. The matcher uses the value of the [`useSegments`](/router/reference/hooks/#usesegments) hook on the current `screen`.
 
@@ -141,7 +141,7 @@ expect(screen).toHaveSegments(['[id]']);
 ```
 
 </PaddedAPIBox>
-<PaddedAPIBox header="useLocalSearchParams()" className="px-4 pt-3">
+<PaddedAPIBox header="useLocalSearchParams()">
 
 Assert the current local URL parameters against an object. The matcher uses the value of the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook on the current `screen`.
 
@@ -150,7 +150,7 @@ expect(screen).useLocalSearchParams({ first: 'abc' });
 ```
 
 </PaddedAPIBox>
-<PaddedAPIBox header="useGlobalSearchParams()" className="px-4 pt-3">
+<PaddedAPIBox header="useGlobalSearchParams()">
 
 Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hook.
 
@@ -162,7 +162,7 @@ expect(screen).useGlobalSearchParams({ first: 'abc' });
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="toHaveRouterState()" className="px-4 pt-3">
+<PaddedAPIBox header="toHaveRouterState()">
 
 An advanced matcher that asserts the current router state against an object.
 

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -4,7 +4,7 @@ sidebar_title: Testing
 description: Learn how to create integration tests for your app when using Expo Router.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
 Expo Router relies on your file system, which can present challenges when setting up mocks for integration tests. Expo Router's submodule, `expo-router/testing-library`, is a set of testing utilities built on top of the popular [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/) and allows you to quickly create in-memory Expo Router apps that are pre-configured for testing.
 
@@ -24,7 +24,7 @@ Before you proceed, ensure you have set up `jest-expo` according to the [Unit te
 
 `renderRouter` accepts the same [options](https://callstack.github.io/react-native-testing-library/docs/api#render-options) as `render` and introduces an additional option `initialUrl`, which sets an initial route for simulating deep-linking.
 
-<APIBox header="Inline file system">
+<PaddedAPIBox header="Inline file system" className="px-4 pt-3">
 
 `renderRouter(mock: Record<string, ReactComponent>, options: RenderOptions)`
 
@@ -51,9 +51,9 @@ it('my-test', async () => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="Inline file system with `null` components">
+<PaddedAPIBox header="Inline file system with `null` components" className="px-4 pt-3">
 
 `renderRouter(mock: string[], options: RenderOptions)`
 
@@ -71,9 +71,9 @@ it('my-test', async () => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="Path to fixture">
+<PaddedAPIBox header="Path to fixture" className="px-4 pt-3">
 
 `renderRouter(fixturePath: string, options: RenderOptions)`
 
@@ -86,9 +86,9 @@ it('my-test', async () => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="Path to the fixture with overrides">
+<PaddedAPIBox header="Path to the fixture with overrides" className="px-4 pt-3">
 
 `renderRouter({ appDir: string, overrides: Record<string, ReactComponent>}, options: RenderOptions)`
 
@@ -106,13 +106,13 @@ it('my-test', async () => {
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Jest matchers
 
 The following matches have been added to `expect` and can be used to assert values on `screen`.
 
-<APIBox header="toHavePathname()">
+<PaddedAPIBox header="toHavePathname()" className="px-4 pt-3">
 
 Assert the current pathname against a given string. The matcher uses the value of the [`usePathname`](/router/reference/hooks/#usepathname) hook on the current `screen`.
 
@@ -120,9 +120,9 @@ Assert the current pathname against a given string. The matcher uses the value o
 expect(screen).toHavePathname('/my-router');
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="toHavePathnameWithParams()">
+<PaddedAPIBox header="toHavePathnameWithParams()" className="px-4 pt-3">
 
 Assert the current pathname, including URL parameters, against a given string. This is useful to assert the appearance of URL in a web browser.
 
@@ -130,9 +130,9 @@ Assert the current pathname, including URL parameters, against a given string. T
 expect(screen).toHavePathnameWithParams('/my-router?hello=world');
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="toHaveSegments()">
+<PaddedAPIBox header="toHaveSegments()" className="px-4 pt-3">
 
 Assert the current segments against an array of strings. The matcher uses the value of the [`useSegments`](/router/reference/hooks/#usesegments) hook on the current `screen`.
 
@@ -140,8 +140,8 @@ Assert the current segments against an array of strings. The matcher uses the va
 expect(screen).toHaveSegments(['[id]']);
 ```
 
-</APIBox>
-<APIBox header="useLocalSearchParams()">
+</PaddedAPIBox>
+<PaddedAPIBox header="useLocalSearchParams()" className="px-4 pt-3">
 
 Assert the current local URL parameters against an object. The matcher uses the value of the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook on the current `screen`.
 
@@ -149,8 +149,8 @@ Assert the current local URL parameters against an object. The matcher uses the 
 expect(screen).useLocalSearchParams({ first: 'abc' });
 ```
 
-</APIBox>
-<APIBox header="useGlobalSearchParams()">
+</PaddedAPIBox>
+<PaddedAPIBox header="useGlobalSearchParams()" className="px-4 pt-3">
 
 Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hook.
 
@@ -160,9 +160,9 @@ Assert the current global URL parameters against an object. The matcher uses the
 expect(screen).useGlobalSearchParams({ first: 'abc' });
 ```
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="toHaveRouterState()">
+<PaddedAPIBox header="toHaveRouterState()" className="px-4 pt-3">
 
 An advanced matcher that asserts the current router state against an object.
 
@@ -172,4 +172,4 @@ expect(screen).toHaveRouterState({
 });
 ```
 
-</APIBox>
+</PaddedAPIBox>

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
+<PaddedAPIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 <APIBoxSectionHeader text="SafeAreaView Props" />
 
-<PaddedAPIBox header="edges" headerNestingLevel={4} className="px-4 pt-3">
+<PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
 <CALLOUT theme="tertiary" className="text-2xs">Optional&ensp;•&ensp;Type: [`Edge[]`](#edge)&ensp;•&ensp;Default: `["top", "right", "bottom", "left"]`</CALLOUT>
@@ -67,7 +67,7 @@ Sets the edges to apply the safe area insets to.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4} className="px-4 pt-3">
+<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
 <CALLOUT theme="tertiary" className="text-2xs">
   Optional&ensp;•&ensp;Type: `boolean`&ensp;•&ensp;Default: `true`
@@ -81,7 +81,7 @@ On iOS 10+, emulate the safe area using the status bar height and home indicator
 
 ## Hooks
 
-<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
+<PaddedAPIBox header="useSafeAreaInsets()">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -105,7 +105,7 @@ function HookComponent() {
 
 ## Types
 
-<PaddedAPIBox header="Edge" className="px-4 pt-3">
+<PaddedAPIBox header="Edge">
 
 String union of possible edges.
 
@@ -113,7 +113,7 @@ Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
+<PaddedAPIBox header="EdgeInsets">
 
 Represent the hook result.
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -9,9 +9,9 @@ platforms: ['android', 'ios', 'web', 'tvos']
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
+import { APIBoxSectionHeader } from '~/components/plugins/api/components/PaddedAPIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<APIBox header="SafeAreaView">
+<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 <APIBoxSectionHeader text="SafeAreaView Props" />
 
-<APIBox header="edges" headerNestingLevel={4}>
+<PaddedAPIBox header="edges" headerNestingLevel={4} className="px-4 pt-3">
 
 {/* prettier-ignore */}
 <CALLOUT theme="tertiary" className="text-2xs">Optional&ensp;•&ensp;Type: [`Edge[]`](#edge)&ensp;•&ensp;Default: `["top", "right", "bottom", "left"]`</CALLOUT>
@@ -65,9 +65,9 @@ function SomeComponent() {
 
 Sets the edges to apply the safe area insets to.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="emulateUnlessSupported" headerNestingLevel={4}>
+<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4} className="px-4 pt-3">
 
 <CALLOUT theme="tertiary" className="text-2xs">
   Optional&ensp;•&ensp;Type: `boolean`&ensp;•&ensp;Default: `true`
@@ -76,12 +76,12 @@ Sets the edges to apply the safe area insets to.
 
 On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
 
-</APIBox>
-</APIBox>
+</PaddedAPIBox>
+</PaddedAPIBox>
 
 ## Hooks
 
-<APIBox header="useSafeAreaInsets()">
+<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -101,19 +101,19 @@ function HookComponent() {
 
 <CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Types
 
-<APIBox header="Edge">
+<PaddedAPIBox header="Edge" className="px-4 pt-3">
 
 String union of possible edges.
 
 Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="EdgeInsets">
+<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
 
 Represent the hook result.
 
@@ -126,7 +126,7 @@ Represent the hook result.
 | `right`  | `number` | Value of right inset.  |
 | `top`    | `number` | Value of top inset.    |
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Guides
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -11,7 +11,7 @@ import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRi
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/PaddedAPIBoxSectionHeader';
+import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -37,7 +37,7 @@ import {
 
 ## Components
 
-<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
+<PaddedAPIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -59,7 +59,7 @@ function SomeComponent() {
 
 ## Props
 
-<PaddedAPIBox header="edges" className="px-4 pt-3">
+<PaddedAPIBox header="edges">
 
 <CALLOUT theme="secondary">
   Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
@@ -70,7 +70,7 @@ Sets the edges to apply the safe area insets to.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="emulateUnlessSupported" className="px-4 pt-3">
+<PaddedAPIBox header="emulateUnlessSupported">
 
 <CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
 <br />
@@ -82,7 +82,7 @@ On iOS 10+, emulate the safe area using the status bar height and home indicator
 
 ## Hooks
 
-<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
+<PaddedAPIBox header="useSafeAreaInsets()">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -106,7 +106,7 @@ function HookComponent() {
 
 ## Types
 
-<PaddedAPIBox header="Edge" className="px-4 pt-3">
+<PaddedAPIBox header="Edge">
 
 String union of possible edges.
 
@@ -114,7 +114,7 @@ Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
+<PaddedAPIBox header="EdgeInsets">
 
 Represent the hook result.
 

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -8,8 +8,8 @@ packageName: 'react-native-safe-area-context'
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -8,7 +8,7 @@ packageName: 'react-native-safe-area-context'
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { APIBox } from '~/components/plugins/APIBox';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
@@ -37,7 +37,7 @@ import {
 
 ## Components
 
-<APIBox header="SafeAreaView">
+<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -59,7 +59,7 @@ function SomeComponent() {
 
 ## Props
 
-<APIBox header="edges">
+<PaddedAPIBox header="edges" className="px-4 pt-3">
 
 <CALLOUT theme="secondary">
   Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
@@ -68,21 +68,21 @@ function SomeComponent() {
 
 Sets the edges to apply the safe area insets to.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="emulateUnlessSupported">
+<PaddedAPIBox header="emulateUnlessSupported" className="px-4 pt-3">
 
 <CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
 <br />
 
 On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
 
-</APIBox>
-</APIBox>
+</PaddedAPIBox>
+</PaddedAPIBox>
 
 ## Hooks
 
-<APIBox header="useSafeAreaInsets()">
+<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -102,19 +102,19 @@ function HookComponent() {
 
 <CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Types
 
-<APIBox header="Edge">
+<PaddedAPIBox header="Edge" className="px-4 pt-3">
 
 String union of possible edges.
 
 Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="EdgeInsets">
+<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
 
 Represent the hook result.
 
@@ -127,7 +127,7 @@ Represent the hook result.
 | `right`  | `number` | Value of right inset.  |
 | `top`    | `number` | Value of top inset.    |
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Guides
 

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -9,8 +9,8 @@ platforms: ['android', 'ios', 'web', 'tvos']
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<APIBox header="SafeAreaView">
+<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 ## Props
 
-<APIBox header="edges">
+<PaddedAPIBox header="edges" className="px-4 pt-3">
 
 <CALLOUT theme="secondary">
   Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
@@ -66,21 +66,21 @@ function SomeComponent() {
 
 Sets the edges to apply the safe area insets to.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="emulateUnlessSupported">
+<PaddedAPIBox header="emulateUnlessSupported" className="px-4 pt-3">
 
 <CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
 <br />
 
 On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
 
-</APIBox>
-</APIBox>
+</PaddedAPIBox>
+</PaddedAPIBox>
 
 ## Hooks
 
-<APIBox header="useSafeAreaInsets()">
+<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -100,19 +100,19 @@ function HookComponent() {
 
 <CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Types
 
-<APIBox header="Edge">
+<PaddedAPIBox header="Edge" className="px-4 pt-3">
 
 String union of possible edges.
 
 Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="EdgeInsets">
+<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
 
 Represent the hook result.
 
@@ -125,7 +125,7 @@ Represent the hook result.
 | `right`  | `number` | Value of right inset.  |
 | `top`    | `number` | Value of top inset.    |
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Guides
 

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
+<PaddedAPIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 ## Props
 
-<PaddedAPIBox header="edges" className="px-4 pt-3">
+<PaddedAPIBox header="edges">
 
 <CALLOUT theme="secondary">
   Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
@@ -68,7 +68,7 @@ Sets the edges to apply the safe area insets to.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="emulateUnlessSupported" className="px-4 pt-3">
+<PaddedAPIBox header="emulateUnlessSupported">
 
 <CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
 <br />
@@ -80,7 +80,7 @@ On iOS 10+, emulate the safe area using the status bar height and home indicator
 
 ## Hooks
 
-<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
+<PaddedAPIBox header="useSafeAreaInsets()">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -104,7 +104,7 @@ function HookComponent() {
 
 ## Types
 
-<PaddedAPIBox header="Edge" className="px-4 pt-3">
+<PaddedAPIBox header="Edge">
 
 String union of possible edges.
 
@@ -112,7 +112,7 @@ Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
+<PaddedAPIBox header="EdgeInsets">
 
 Represent the hook result.
 

--- a/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
+<PaddedAPIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 <APIBoxSectionHeader text="SafeAreaView Props" />
 
-<PaddedAPIBox header="edges" headerNestingLevel={4} className="px-4 pt-3">
+<PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
 <CALLOUT theme="tertiary" className="text-2xs">Optional&ensp;•&ensp;Type: [`Edge[]`](#edge)&ensp;•&ensp;Default: `["top", "right", "bottom", "left"]`</CALLOUT>
@@ -67,7 +67,7 @@ Sets the edges to apply the safe area insets to.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4} className="px-4 pt-3">
+<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
 <CALLOUT theme="tertiary" className="text-2xs">
   Optional&ensp;•&ensp;Type: `boolean`&ensp;•&ensp;Default: `true`
@@ -81,7 +81,7 @@ On iOS 10+, emulate the safe area using the status bar height and home indicator
 
 ## Hooks
 
-<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
+<PaddedAPIBox header="useSafeAreaInsets()">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -105,7 +105,7 @@ function HookComponent() {
 
 ## Types
 
-<PaddedAPIBox header="Edge" className="px-4 pt-3">
+<PaddedAPIBox header="Edge">
 
 String union of possible edges.
 
@@ -113,7 +113,7 @@ Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
+<PaddedAPIBox header="EdgeInsets">
 
 Represent the hook result.
 

--- a/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
@@ -9,9 +9,9 @@ platforms: ['android', 'ios', 'web', 'tvos']
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
+import { APIBoxSectionHeader } from '~/components/plugins/api/components/PaddedAPIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
@@ -35,7 +35,7 @@ import {
 
 ## Components
 
-<APIBox header="SafeAreaView">
+<PaddedAPIBox header="SafeAreaView" className="px-4 pt-3">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
@@ -57,7 +57,7 @@ function SomeComponent() {
 
 <APIBoxSectionHeader text="SafeAreaView Props" />
 
-<APIBox header="edges" headerNestingLevel={4}>
+<PaddedAPIBox header="edges" headerNestingLevel={4} className="px-4 pt-3">
 
 {/* prettier-ignore */}
 <CALLOUT theme="tertiary" className="text-2xs">Optional&ensp;•&ensp;Type: [`Edge[]`](#edge)&ensp;•&ensp;Default: `["top", "right", "bottom", "left"]`</CALLOUT>
@@ -65,9 +65,9 @@ function SomeComponent() {
 
 Sets the edges to apply the safe area insets to.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="emulateUnlessSupported" headerNestingLevel={4}>
+<PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4} className="px-4 pt-3">
 
 <CALLOUT theme="tertiary" className="text-2xs">
   Optional&ensp;•&ensp;Type: `boolean`&ensp;•&ensp;Default: `true`
@@ -76,12 +76,12 @@ Sets the edges to apply the safe area insets to.
 
 On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
 
-</APIBox>
-</APIBox>
+</PaddedAPIBox>
+</PaddedAPIBox>
 
 ## Hooks
 
-<APIBox header="useSafeAreaInsets()">
+<PaddedAPIBox header="useSafeAreaInsets()" className="px-4 pt-3">
 
 Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
@@ -101,19 +101,19 @@ function HookComponent() {
 
 <CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" /> [`EdgeInsets`](#edgeinsets)
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Types
 
-<APIBox header="Edge">
+<PaddedAPIBox header="Edge" className="px-4 pt-3">
 
 String union of possible edges.
 
 Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
 
-</APIBox>
+</PaddedAPIBox>
 
-<APIBox header="EdgeInsets">
+<PaddedAPIBox header="EdgeInsets" className="px-4 pt-3">
 
 Represent the hook result.
 
@@ -126,7 +126,7 @@ Represent the hook result.
 | `right`  | `number` | Value of right inset.  |
 | `top`    | `number` | Value of top inset.    |
 
-</APIBox>
+</PaddedAPIBox>
 
 ## Guides
 

--- a/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/safe-area-context.mdx
@@ -11,7 +11,7 @@ import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRi
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/PaddedAPIBoxSectionHeader';
+import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14593

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Create a custom wrapper component around `APIBox` so we can expand this component with more styles, if required, for manual usage.
- Update all `APIBox` component manual usage with the new component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-12-30 at 02 37 02](https://github.com/user-attachments/assets/c69f1e3d-952f-45e4-b948-08ae3d4bdac2)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
