### PR TITLE
docs(fingerprint): correct typo in fingerprint cli

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- docs(fingerprint): correct typo in fingerprint cli ([#33887](https://github.com/expo/expo/pull/33887) by [@leopic](https://github.com/leopic))
+
 ## 0.11.6 - 2024-12-24
 
 ### 🐛 Bug fixes

--- a/packages/@expo/fingerprint/cli/build/cli.js
+++ b/packages/@expo/fingerprint/cli/build/cli.js
@@ -67,7 +67,7 @@ const commandArgs = args._.slice(1);
 if ((args['--help'] && !command) || !command) {
     Log.exit((0, chalk_1.default) `
 {bold Usage}
-  {dim $} npx @expo/fingeprint <command>
+  {dim $} npx @expo/fingerprint <command>
 
 {bold Commands}
   ${Object.keys(commands).sort().join(', ')}

--- a/packages/@expo/fingerprint/cli/src/cli.ts
+++ b/packages/@expo/fingerprint/cli/src/cli.ts
@@ -54,7 +54,7 @@ if ((args['--help'] && !command) || !command) {
   Log.exit(
     chalk`
 {bold Usage}
-  {dim $} npx @expo/fingeprint <command>
+  {dim $} npx @expo/fingerprint <command>
 
 {bold Commands}
   ${Object.keys(commands).sort().join(', ')}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There is a typo in the name of the fingerprint command in CLI.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Looked for the string to be replaced.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the following command in a terminal:
```bash
npx @expo/fingerprint@latest
```

Ensure the output is:
```bash
Usage
  $ npx @expo/fingerprint <command>
```

And not:
```bash
Usage
  $ npx @expo/fingeprint <command>
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
