### PR TITLE
[docs] Upgrade Vale dev dependency, update comment delimiter usage and vale config

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -14,6 +14,8 @@ SkippedScopes = script, style, pre, figure, code, tt, tr, td, span
 # List of styles to load
 BasedOnStyles = expo-docs
 
+CommentDelimiters = {/*, */}
+
 # Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
 BlockIgnores = (?s) <Terminal(\s|\n)[^/>]*?property
 TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch,

--- a/docs/package.json
+++ b/docs/package.json
@@ -84,7 +84,7 @@
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vvago/vale": "^3.9.0",
+    "@vvago/vale": "^3.9.2",
     "acorn": "^8.14.0",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.7",

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -18,7 +18,7 @@ All standard advice around [narrowing down the source of an error](https://expo.
 
 Before you go further, you need to be sure that you have located the error message and read it. How you do this will be different depending on whether you're investigating a build failure or runtime error.
 
-{/* <!-- vale off --> */}
+{/* vale off */}
 
 ### Runtime errors
 
@@ -28,7 +28,7 @@ Refer to the ["Production errors" section of the debugging guide](/debugging/run
 
 If you can't find any useful information through this approach, try [narrowing down the source of the crash step by step](https://expo.fyi/manual-debugging).
 
-{/* <!-- vale on --> */}
+{/* vale on */}
 
 ### Build errors
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -518,7 +518,7 @@ You can localize your App Store presence in [multiple languages](#apple-info-lan
 
 </Collapsible>
 
-{/* <!-- vale off --> */}
+{/* vale off */}
 
 <MetadataTable>
   {[
@@ -696,7 +696,7 @@ You can localize your App Store presence in [multiple languages](#apple-info-lan
     { name: 'Vietnamese', description: 'vi' },
   ]}
 </MetadataTable>
-{/* <!-- vale on --> */}
+{/* vale on*/}
 
 ### Apple release
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -40,7 +40,7 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 
 Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
 
-{/* <!-- vale off --> */}
+{/* vale off */}
 
 <Terminal
   cmd={[
@@ -52,7 +52,7 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
   ]}
 />
 
-{/* <!-- vale on --> */}
+{/* vale on */}
 
 </Step>
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3212,9 +3212,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vvago/vale@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@vvago/vale@npm:3.9.0"
+"@vvago/vale@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@vvago/vale@npm:3.9.2"
   dependencies:
     axios: "npm:^1.4.0"
     rimraf: "npm:^5.0.0"
@@ -3222,7 +3222,7 @@ __metadata:
     unzipper: "npm:^0.10.14"
   bin:
     vale: bin/vale
-  checksum: 10c0/36fb118a071f104c653e8c91c72d0a58fb0570912e900facd560aa2b8f631b42faadc06ba566b2c2ea67378fcb67c072df0d73747aa210ba303458369e4e65ac
+  checksum: 10c0/1252f207c6da7f61468288cd6d0e0ebba649ebfa2c2c1550f079d1ab3c4741fbb8653d880cc239910cc2b0ee885a7a510dfb24aff127145ec33e1790711544d4
   languageName: node
   linkType: hard
 
@@ -5614,7 +5614,7 @@ __metadata:
     "@types/prismjs": "npm:^1.26.5"
     "@types/react": "npm:^18.3.12"
     "@types/react-dom": "npm:^18.3.1"
-    "@vvago/vale": "npm:^3.9.0"
+    "@vvago/vale": "npm:^3.9.2"
     acorn: "npm:^8.14.0"
     autoprefixer: "npm:^10.4.20"
     axios: "npm:^1.7.7"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

With Vale `3.9.2`, using comment delimiter to switch the vale rule in a `.mdx` file now supports MDX comment syntax. More info about syntax usage and comment delimiters in Vale documentation: https://vale.sh/docs/keys/commentdelimiters.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Upgrade Vale dev dependency to use `3.9.2`
- Update vale configuration to add `CommentDelimiters` for mdx file type
- Update comment delimiter usage in multiple mdx files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After applying these changes, run `yarn run lint-prose`, and there will be no warnings or errors from the Vale lint tool.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
