### PR TITLE
[docs] APISection: display single line / non-block examples inline

### DIFF
--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -56,24 +56,39 @@ export const APICommentTextBlock = ({
   );
 
   const examples = getAllTagData('example', comment);
-  const exampleText = examples?.map((example, index) => (
-    <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:!mb-0')}>
-      {inlineHeaders ? (
-        <CALLOUT className="my-1.5 flex flex-row items-center gap-1.5 font-medium text-tertiary">
-          <CodeSquare01Icon className="icon-sm -mt-px text-icon-tertiary" />
-          Example
-        </CALLOUT>
-      ) : (
-        <APIBoxSectionHeader text="Example" className="-mx-4 mb-3 mt-1" Icon={CodeSquare01Icon} />
-      )}
-      <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
-        {getCommentContent(example.content ?? example.name)}
-      </ReactMarkdown>
-    </div>
-  ));
+  const exampleContent = examples?.map((example, index) => {
+    const exampleText = getCommentContent(example.content ?? example.name);
+    const isMultiline = /[\n\r]/.test(exampleText);
+
+    return (
+      <div
+        key={'example-' + index}
+        className={mergeClasses(
+          ELEMENT_SPACING,
+          !isMultiline && 'flex items-center gap-1.5',
+          'last:[&>*]:!mb-0'
+        )}>
+        {inlineHeaders ? (
+          <CALLOUT
+            className={mergeClasses(
+              'my-1.5 flex flex-row items-center gap-1.5 font-medium text-tertiary',
+              !isMultiline && 'my-0'
+            )}>
+            <CodeSquare01Icon className="icon-sm -mt-px text-icon-tertiary" />
+            Example
+          </CALLOUT>
+        ) : (
+          <APIBoxSectionHeader text="Example" className="-mx-4 mb-3 mt-1" Icon={CodeSquare01Icon} />
+        )}
+        <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
+          {exampleText}
+        </ReactMarkdown>
+      </div>
+    );
+  });
 
   const see = getTagData('see', comment);
-  const seeText = see && (
+  const seeContent = see && (
     <InlineHelp
       className={mergeClasses('shadow-none', `!${ELEMENT_SPACING}`)}
       size="sm"
@@ -105,9 +120,9 @@ export const APICommentTextBlock = ({
       {beforeContent}
       {parsedContent}
       {afterContent}
-      {afterContent && !exampleText && <br />}
-      {seeText}
-      {exampleText}
+      {afterContent && !exampleContent && <br />}
+      {seeContent}
+      {exampleContent}
     </div>
   );
 };


### PR DESCRIPTION
# Why

We can save a bit of horizontal space in types/props/object tables by displaying single line / non-block examples inline.

# How

Add simple check if example content contains multiple lines. If it is not a case, alter the container layout to display example value inline with label.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and test are passing.

# Preview
### Single line
![Screenshot 2024-12-31 at 14 22 37](https://github.com/user-attachments/assets/5f6be769-7ef8-4afe-b5c5-a8e48cc3d0e6)

### Single line block
![Screenshot 2024-12-31 at 14 28 11](https://github.com/user-attachments/assets/a00274f4-e25a-4773-9e44-f51e93d6c1d9)
