### PR TITLE
[docs] Apply APIBox formatting to package.json reference

### DIFF
--- a/docs/pages/versions/unversioned/config/package-json.mdx
+++ b/docs/pages/versions/unversioned/config/package-json.mdx
@@ -4,11 +4,13 @@ description: A reference for Expo-specific properties that can be used in the pa
 isNew: true
 ---
 
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
+
 **package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
 
-## `install`
+<PaddedAPIBox>
 
-### `exclude`
+## `install.exclude`
 
 The following commands perform a version check for the libraries installed in a project and give a warning when a library's version is different from the version recommended by Expo:
 
@@ -19,7 +21,6 @@ By specifying the library under the `install.exclude` array in the **package.jso
 
 ```json package.json
 {
-  /* @hide Other package.json properties... */ /* @end */
   "expo": {
     "install": {
       "exclude": ["expo-updates", "expo-splash-screen"]
@@ -28,15 +29,25 @@ By specifying the library under the `install.exclude` array in the **package.jso
 }
 ```
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ## `doctor`
 
 Allows configuring the behavior of the [`npx expo-doctor`](/develop/tools/#expo-doctor) command.
+
+<PaddedAPIBox>
 
 ### `reactNativeDirectoryCheck`
 
@@ -66,13 +77,17 @@ You can customize this check by adding the following configuration in your proje
 
 By default, the check is enabled and unknown packages are listed.
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ### `appConfigFieldsNotSyncedCheck`
 
 Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 
-You can disable/enable this check by adding the following configuration to your project's **package.json** file:
+You can disable or enable this check by adding the following configuration to your project's **package.json** file:
 
 ```json package.json
 {
@@ -85,3 +100,7 @@ You can disable/enable this check by adding the following configuration to your 
   }
 }
 ```
+
+</PaddedAPIBox>
+
+</PaddedAPIBox>

--- a/docs/pages/versions/v52.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v52.0.0/config/package-json.mdx
@@ -4,11 +4,13 @@ description: A reference for Expo-specific properties that can be used in the pa
 isNew: true
 ---
 
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
+
 **package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
 
-## `install`
+<PaddedAPIBox>
 
-### `exclude`
+## `install.exclude`
 
 The following commands perform a version check for the libraries installed in a project and give a warning when a library's version is different from the version recommended by Expo:
 
@@ -19,7 +21,6 @@ By specifying the library under the `install.exclude` array in the **package.jso
 
 ```json package.json
 {
-  /* @hide Other package.json properties... */ /* @end */
   "expo": {
     "install": {
       "exclude": ["expo-updates", "expo-splash-screen"]
@@ -28,15 +29,25 @@ By specifying the library under the `install.exclude` array in the **package.jso
 }
 ```
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ## `doctor`
 
 Allows configuring the behavior of the [`npx expo-doctor`](/develop/tools/#expo-doctor) command.
+
+<PaddedAPIBox>
 
 ### `reactNativeDirectoryCheck`
 
@@ -66,13 +77,17 @@ You can customize this check by adding the following configuration in your proje
 
 By default, the check is enabled and unknown packages are listed.
 
+</PaddedAPIBox>
+
+<PaddedAPIBox>
+
 ### `appConfigFieldsNotSyncedCheck`
 
 Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 
-You can disable/enable this check by adding the following configuration to your project's **package.json** file:
+You can disable or enable this check by adding the following configuration to your project's **package.json** file:
 
 ```json package.json
 {
@@ -85,3 +100,7 @@ You can disable/enable this check by adding the following configuration to your 
   }
 }
 ```
+
+</PaddedAPIBox>
+
+</PaddedAPIBox>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @Simek.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `PaddedAPIBox` component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2024-12-31 at 22 07 30@2x](https://github.com/user-attachments/assets/caf5d6fb-1e13-41c7-befc-7e1695a6104b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
