### PR TITLE
[core][iOS] Add `UnimplementedExpoView` as a stub for SwiftUI on the old architecture

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
+- Show `UnimplementedExpoView` in place of SwiftUI views when the New Architecture is not enabled. ([#33901](https://github.com/expo/expo/pull/33901) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -42,16 +42,18 @@ extension ExpoSwiftUI {
     }
 
     public override func createView(appContext: AppContext) -> UIView? {
+#if RCT_NEW_ARCH_ENABLED
       let props = Props()
       let view = HostingView(viewType: ViewType.self, props: props, appContext: appContext)
 
-#if RCT_NEW_ARCH_ENABLED
       // Set up events to call view's `dispatchEvent` method.
       // This is supported only on the new architecture, `dispatchEvent` exists only there.
       props.setUpEvents(view.dispatchEvent(_:payload:))
-#endif
 
       return view
+#else
+      return UnimplementedExpoView(appContext: appContext, text: "Rendering SwiftUI views is possible only with the New Architecture enabled")
+#endif
     }
 
     public override func getSupportedPropNames() -> [String] {

--- a/packages/expo-modules-core/ios/Core/Views/UnimplementedExpoView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/UnimplementedExpoView.swift
@@ -1,0 +1,35 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+/**
+ Stub for views that are not implemented in certain conditions,
+ e.g. whether the New Architecture is enabled.
+ */
+public class UnimplementedExpoView: ExpoView {
+  private let label: UILabel
+
+  public required init(appContext: AppContext? = nil) {
+    label = UILabel()
+    label.backgroundColor = .red.withAlphaComponent(0.4)
+    label.textColor = .white
+    label.textAlignment = .center
+    label.text = "View is not implemented"
+    label.numberOfLines = 0
+    label.allowsDefaultTighteningForTruncation = true
+    label.adjustsFontSizeToFitWidth = true
+
+    super.init(appContext: appContext)
+
+    addSubview(label)
+  }
+
+  public convenience init(appContext: AppContext, text: String) {
+    self.init(appContext: appContext)
+    label.text = text
+  }
+
+  public override var bounds: CGRect {
+    didSet {
+      label.frame = bounds
+    }
+  }
+}


### PR DESCRIPTION
# Why

Most of the features in SwiftUI are not available in the old architecture, so it would be nice to show a stub view, similarly to how React Native shows an unimplemented view on the New Architecture when the component doesn't support the interop layer.

# How

Added simple `UnimplementedExpoView` class and used it in place of the SwiftUI hosting view when the New Architecture is not enabled.

# Test Plan

Here is how the example for MeshGradient looks without the New Architecture enabled 👇 

![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-31 at 17 44 22](https://github.com/user-attachments/assets/e46eb97a-8bca-4b6f-8967-cd2dbe27ff2e)
