### PR TITLE
[docs] Update babel config references

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -118,7 +118,7 @@ Using a Babel plugin to transform your environment variable references in your c
 + const apiUrl = process.env.EXPO_PUBLIC_API_URL;
 ```
 
-Then you can remove the plugin from your Babel config:
+Then you can remove the plugin from your [Babel config](/versions/latest/config/babel/):
 
 ```diff babel.config.js
 module.exports = function (api) {

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -91,7 +91,7 @@ You can incrementally adopt the React Compiler in your app using a few strategie
 
 Configure the Babel plugin to only run on specific files or components. To do this:
 
-1. If your project doesn't have [`babel.config.js`](/versions/latest/config/babel/), create one by running `npx expo customize babel.config.js`.
+1. If your project doesn't have [**babel.config.js**](/versions/latest/config/babel/), create one by running `npx expo customize babel.config.js`.
 2. Add the following to your project's Babel configuration.
 
 ```js babel.config.js

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -54,7 +54,7 @@ Install the React compiler runtime module:
 
 ### Enabling the linter
 
-> In the future, all of these steps below will be automated by Expo CLI.
+> In the future, all of the following steps below will be automated by Expo CLI.
 
 Additionally, you should use the ESLint plugin to continuously enforce the rules of React in your project.
 
@@ -89,7 +89,10 @@ You can incrementally adopt the React Compiler in your app using a few strategie
 
 <Step label="1">
 
-Configure the Babel plugin to only run on specific files or components. To do this, add the following to your project's Babel configuration:
+Configure the Babel plugin to only run on specific files or components. To do this:
+
+1. If your project doesn't have [`babel.config.js`](/versions/latest/config/babel/), create one by running `npx expo customize babel.config.js`.
+2. Add the following to your project's Babel configuration.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -92,7 +92,7 @@ You can incrementally adopt the React Compiler in your app using a few strategie
 Configure the Babel plugin to only run on specific files or components. To do this:
 
 1. If your project doesn't have [**babel.config.js**](/versions/latest/config/babel/), create one by running `npx expo customize babel.config.js`.
-2. Add the following to your project's Babel configuration.
+2. Add the following configuration to **babel.config.js**:
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -394,7 +394,7 @@ You can mark if your module has side-effects in the **package.json**:
 
 Side-effects will prevent the removal of unused modules and disable module inlining to ensure JS code runs in the expected order. Side-effects will be removed if they're empty or contain only comments and directives (`"use strict"`, `"use client"`, and so on).
 
-When Expo tree shaking is enabled, you can safely enable `inlineRequires` in your `metro.config.js` for production bundles. This will lazily load modules when they're evaluated, leading to faster startup time. Avoid using this feature without Expo tree shaking as it will move modules around in ways that can change the execution order of side-effects.
+When Expo tree shaking is enabled, you can safely enable `inlineRequires` in your **metro.config.js** for production bundles. This will lazily load modules when they're evaluated, leading to faster startup time. Avoid using this feature without Expo tree shaking as it will move modules around in ways that can change the execution order of side-effects.
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -39,7 +39,7 @@ Configure Next.js to transform language features:
 
 <Collapsible summary={<>Next.js with swc. (Recommended)</>}>
 
-Using Next.js with SWC is recommended. You can configure the **babel.config.js** to only account for native:
+Using Next.js with SWC is recommended. You can configure the [**babel.config.js**](/versions/latest/config/babel/) to only account for native:
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -48,7 +48,7 @@ The default [Prebuild template](#prebuild-template) includes support for [Expo A
 
 Transpiler used for removing language features that aren't available in the runtime's [JavaScript engine](#javascript-engine). [Metro](#metro-bundler) uses Babel internally.
 
-Projects can configure how Babel is used by modifying the **babel.config.js** file in the project directory. This file is optional when using [Expo CLI](#expo-cli). Expo projects should extend the default Babel preset [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo).
+Projects can configure how Babel is used by modifying the [**babel.config.js**](/versions/latest/config/babel/) file in the project directory. This file is optional when using [Expo CLI](#expo-cli). Expo projects should extend the default Babel preset [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo).
 
 ### Bare workflow
 

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -76,7 +76,7 @@ In Expo Router, use the `npx expo export --platform web` command to export to th
 
 ## Babel configuration
 
-Like before, the root **babel.config.js** file is used for both web and native. You can change the preset by using the `platform` property in the API caller:
+Like before, the root [**babel.config.js**](/versions/latest/config/babel/) file is used for both web and native. You can change the preset by using the `platform` property in the API caller:
 
 ```js babel.config.js
 module.exports = api => {

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the `babel.config.js` and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -487,7 +487,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -487,7 +487,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the `babel.config.js` and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the `babel.config.js` and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the `babel.config.js` and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [`babel.config.js`](/versions/latest/config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Update multiple docs to add a link to the Babel config reference page.
- In the React compiler guide, add instructions to create a `babel.config.js` file since the file isn't included in SDK 52 and above default projects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

All links and updated info has been verified by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
