### PR TITLE
[docs] Use complete option name instead of shorthand

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -130,7 +130,7 @@ module.exports = function (api) {
 };
 ```
 
-After updating your Babel config file, be sure to clear your cache with `npx expo start -c`.
+After updating your Babel config file, be sure to clear your cache with `npx expo start --clear`.
 
 ### From direnv
 

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -158,7 +158,7 @@ module.exports = function (api) {
 
 After updating the Babel config file, run the following command to clear the bundler cache:
 
-<Terminal cmd={['$ npx expo start -c']} />
+<Terminal cmd={['$ npx expo start --clear']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Use complete option name instead of shorthand when describing the `--clear` option from Expo CLI. This is our recommended way of describing a command in docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update both instances of where shorthand `-c` option was described.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
