### PR TITLE
[cli] support --bytecode in export:embed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))
 - Add e2e tests for browser history and hash param ([#33524](https://github.com/expo/expo/pull/33524) by [@stephentuso](https://github.com/stephentuso))
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
+- Added `--bundle-bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
 
 ## 0.22.7 - 2024-12-19
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))
 - Add e2e tests for browser history and hash param ([#33524](https://github.com/expo/expo/pull/33524) by [@stephentuso](https://github.com/stephentuso))
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
-- Added `--bundle-bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
+- Added `--bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
 
 ## 0.22.7 - 2024-12-19
 

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -331,7 +331,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
   ]);
 });
 
-it('runs `npx expo export:embed --bundle-bytecode`', async () => {
+it('runs `npx expo export:embed --bytecode`', async () => {
   const projectRoot = ensureTesterReady('static-rendering');
   const output = 'dist-export-embed';
   await fs.promises.rm(path.join(projectRoot, output), { force: true, recursive: true });
@@ -352,7 +352,7 @@ it('runs `npx expo export:embed --bundle-bytecode`', async () => {
       'ios',
       '--dev',
       'false',
-      '--bundle-bytecode',
+      '--bytecode',
       'true',
     ],
     {

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { projectRoot, getLoadedModulesAsync, findProjectFiles } from './utils';
+import { isHermesBytecodeBundleAsync } from '../../src/export/exportHermes';
 import { executeExpoAsync } from '../utils/expo';
 
 const originalForceColor = process.env.FORCE_COLOR;
@@ -63,6 +64,7 @@ it('runs `npx expo export:embed --help`', async () => {
         --unstable-transform-profile <string>  Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default
         --reset-cache                          Removes cached files
         --eager                                Eagerly export the bundle with default options
+        --bundle-bytecode                      Export the bundle as Hermes bytecode bundle
         -v, --verbose                          Enables debug logging
         --config <string>                      Path to the CLI configuration file
         --read-global-cache                    Try to fetch transformed JS code from the global cache, if configured.
@@ -327,4 +329,46 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
     'output.js.map',
     'raw/__e2e___staticrendering_sweet.ttf',
   ]);
+});
+
+it('runs `npx expo export:embed --bundle-bytecode`', async () => {
+  const projectRoot = ensureTesterReady('static-rendering');
+  const output = 'dist-export-embed';
+  await fs.promises.rm(path.join(projectRoot, output), { force: true, recursive: true });
+  await fs.promises.mkdir(path.join(projectRoot, output));
+
+  // `npx expo export:embed`
+  await executeExpoAsync(
+    projectRoot,
+    [
+      'export:embed',
+      '--entry-file',
+      resolveRelativeEntryPoint(projectRoot, { platform: 'ios' }),
+      '--bundle-output',
+      `./${output}/output.js`,
+      '--assets-dest',
+      output,
+      '--platform',
+      'ios',
+      '--dev',
+      'false',
+      '--bundle-bytecode',
+      'true',
+    ],
+    {
+      env: {
+        NODE_ENV: 'production',
+        EXPO_USE_STATIC: 'static',
+        E2E_ROUTER_JS_ENGINE: 'hermes',
+        E2E_ROUTER_SRC: 'static-rendering',
+        E2E_ROUTER_ASYNC: 'development',
+        EXPO_USE_FAST_RESOLVER: 'true',
+      },
+    }
+  );
+
+  const outputDir = path.join(projectRoot, 'dist-export-embed');
+
+  // Ensure output.js is a Hermes bytecode bundle
+  expect(await isHermesBytecodeBundleAsync(path.join(outputDir, 'output.js'))).toBe(true);
 });

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -64,7 +64,7 @@ it('runs `npx expo export:embed --help`', async () => {
         --unstable-transform-profile <string>  Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default
         --reset-cache                          Removes cached files
         --eager                                Eagerly export the bundle with default options
-        --bundle-bytecode                      Export the bundle as Hermes bytecode bundle
+        --bytecode                             Export the bundle as Hermes bytecode bundle
         -v, --verbose                          Enables debug logging
         --config <string>                      Path to the CLI configuration file
         --read-global-cache                    Try to fetch transformed JS code from the global cache, if configured.

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -210,7 +210,7 @@ export async function exportEmbedBundleAndAssetsAsync(
         mode: options.dev ? 'development' : 'production',
         engine: isHermes ? 'hermes' : undefined,
         serializerIncludeMaps: !!sourceMapUrl,
-        bytecode: options.bundleBytecode ?? false,
+        bytecode: options.bytecode ?? false,
         // source map inline
         reactCompiler: !!exp.experiments?.reactCompiler,
       },

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -39,6 +39,15 @@ import { resolveRealEntryFilePath } from '../../utils/filePath';
 
 const debug = require('debug')('expo:export:embed');
 
+/**
+ * Extended type for the Metro server build result to support the `code` property as a `Buffer`.
+ */
+type ExtendedMetroServerBuildResult =
+  | Awaited<ReturnType<Server['build']>>
+  | {
+      code: string | Buffer;
+    };
+
 function guessCopiedAppleBundlePath(bundleOutput: string) {
   // Ensure the path is familiar before guessing.
   if (!bundleOutput.match(/\/Xcode\/DerivedData\/.*\/Build\/Products\//)) {
@@ -134,6 +143,7 @@ export async function exportEmbedInternalAsync(projectRoot: string, options: Opt
 
   // Persist bundle and source maps.
   await Promise.all([
+    // @ts-expect-error: The `save()` method from metro is typed to support `code: string` only but it also supports `Buffer` actually.
     output.save(bundle, options, Log.log),
 
     // Write dom components proxy files.
@@ -162,7 +172,7 @@ export async function exportEmbedBundleAndAssetsAsync(
   projectRoot: string,
   options: Options
 ): Promise<{
-  bundle: Awaited<ReturnType<Server['build']>>;
+  bundle: ExtendedMetroServerBuildResult;
   assets: readonly BundleAssetWithFileHashes[];
   files: ExportAssetMap;
 }> {
@@ -200,8 +210,7 @@ export async function exportEmbedBundleAndAssetsAsync(
         mode: options.dev ? 'development' : 'production',
         engine: isHermes ? 'hermes' : undefined,
         serializerIncludeMaps: !!sourceMapUrl,
-        // Never output bytecode in the exported bundle since that is hardcoded in the native run script.
-        bytecode: false,
+        bytecode: options.bundleBytecode ?? false,
         // source map inline
         reactCompiler: !!exp.experiments?.reactCompiler,
       },
@@ -271,7 +280,7 @@ export async function exportEmbedBundleAndAssetsAsync(
     return {
       files,
       bundle: {
-        code: bundles.artifacts.filter((a: any) => a.type === 'js')[0].source.toString(),
+        code: bundles.artifacts.filter((a: any) => a.type === 'js')[0].source,
         // Can be optional when source maps aren't enabled.
         map: bundles.artifacts.filter((a: any) => a.type === 'map')[0]?.source.toString(),
       },

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -29,6 +29,8 @@ export const expoExportEmbed: Command = async (argv) => {
 
     // New flag to guess the other flags based on the environment.
     '--eager': Boolean,
+    // Export the bundle as Hermes bytecode bundle
+    '--bundle-bytecode': Boolean,
 
     // This is here for compatibility with the `npx react-native bundle` command.
     // devs should use `DEBUG=expo:*` instead.
@@ -65,6 +67,7 @@ export const expoExportEmbed: Command = async (argv) => {
         `--unstable-transform-profile <string>  Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default`,
         `--reset-cache                          Removes cached files`,
         `--eager                                Eagerly export the bundle with default options`,
+        `--bundle-bytecode                      Export the bundle as Hermes bytecode bundle`,
         `-v, --verbose                          Enables debug logging`,
 
         `--config <string>                      Path to the CLI configuration file`,
@@ -91,6 +94,7 @@ export const expoExportEmbed: Command = async (argv) => {
   return (async () => {
     const parsed = await resolveCustomBooleanArgsAsync(argv ?? [], rawArgsMap, {
       '--eager': Boolean,
+      '--bundle-bytecode': Boolean,
       '--dev': Boolean,
       '--minify': Boolean,
       '--sourcemap-use-absolute-path': Boolean,

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -30,7 +30,7 @@ export const expoExportEmbed: Command = async (argv) => {
     // New flag to guess the other flags based on the environment.
     '--eager': Boolean,
     // Export the bundle as Hermes bytecode bundle
-    '--bundle-bytecode': Boolean,
+    '--bytecode': Boolean,
 
     // This is here for compatibility with the `npx react-native bundle` command.
     // devs should use `DEBUG=expo:*` instead.
@@ -67,7 +67,7 @@ export const expoExportEmbed: Command = async (argv) => {
         `--unstable-transform-profile <string>  Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default`,
         `--reset-cache                          Removes cached files`,
         `--eager                                Eagerly export the bundle with default options`,
-        `--bundle-bytecode                      Export the bundle as Hermes bytecode bundle`,
+        `--bytecode                             Export the bundle as Hermes bytecode bundle`,
         `-v, --verbose                          Enables debug logging`,
 
         `--config <string>                      Path to the CLI configuration file`,
@@ -94,7 +94,7 @@ export const expoExportEmbed: Command = async (argv) => {
   return (async () => {
     const parsed = await resolveCustomBooleanArgsAsync(argv ?? [], rawArgsMap, {
       '--eager': Boolean,
-      '--bundle-bytecode': Boolean,
+      '--bytecode': Boolean,
       '--dev': Boolean,
       '--minify': Boolean,
       '--sourcemap-use-absolute-path': Boolean,

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -29,6 +29,7 @@ export interface Options {
   verbose: boolean;
   unstableTransformProfile?: string;
   eager?: boolean;
+  bundleBytecode?: boolean;
 }
 
 function assertIsBoolean(val: any): asserts val is boolean {
@@ -79,6 +80,7 @@ export function resolveOptions(
     dev,
     minify: parsed.args['--minify'] as boolean | undefined,
     eager: !!parsed.args['--eager'],
+    bundleBytecode: parsed.args['--bundle-bytecode'] as boolean | undefined,
   };
 
   if (commonOptions.eager) {

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -29,7 +29,7 @@ export interface Options {
   verbose: boolean;
   unstableTransformProfile?: string;
   eager?: boolean;
-  bundleBytecode?: boolean;
+  bytecode?: boolean;
 }
 
 function assertIsBoolean(val: any): asserts val is boolean {
@@ -80,7 +80,7 @@ export function resolveOptions(
     dev,
     minify: parsed.args['--minify'] as boolean | undefined,
     eager: !!parsed.args['--eager'],
-    bundleBytecode: parsed.args['--bundle-bytecode'] as boolean | undefined,
+    bytecode: parsed.args['--bytecode'] as boolean | undefined,
   };
 
   if (commonOptions.eager) {


### PR DESCRIPTION
# Why

add `--bytecode` option to export:embed, so that it can output hermes bytecode bundle directly for repack

# How

- add `--bytecode` support. we use metro's [`save`](https://github.com/facebook/metro/blob/dd3e56c63b4a7076ba5433fef357edc143f0fcaf/packages/metro/src/shared/output/bundle.flow.js#L45-L89) method to save bundle. though it is typed to support string only, but the writeFile does not specify encoding and can support Buffer actually. i would use correct type from our side and `@ts-expect-error` for metro call.

# Test Plan

- ci passed
- add an e2e test case for `--bytecode`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
