### PR TITLE
[docs] Fix `expo-dev-launcher` plugin name and app variant usage with `addGeneratedScheme`

### DIFF
--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -98,9 +98,9 @@ You can customize other aspects of your app on a per-variant basis. You can swap
 ```js app.config.js
 plugins: [
   [
-    'expo-dev-client',
+    'expo-dev-launcher',
     {
-      addGeneratedScheme: !IS_DEV,
+      addGeneratedScheme: false,
     },
   ],
 ],

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -93,14 +93,14 @@ You can customize other aspects of your app on a per-variant basis. You can swap
 **Examples:**
 
 - If you are using a library that requires you to register your application identifier with an external service to use its SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
-- If you're using [development builds](/develop/development-builds/introduction/), you can configure the [`expo-dev-launcher`](/versions/latest/sdk/dev-client/#configurable-properties) plugin from `expo-dev-client` library to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
+- If you're using [development builds](/develop/development-builds/introduction/), you can configure the `expo-dev-client` plugin to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
 
 ```js app.config.js
 plugins: [
   [
-    'expo-dev-launcher',
+    'expo-dev-client',
     {
-      addGeneratedScheme: false,
+      addGeneratedScheme: !!IS_DEV,
     },
   ],
 ],

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -93,7 +93,7 @@ You can customize other aspects of your app on a per-variant basis. You can swap
 **Examples:**
 
 - If you are using a library that requires you to register your application identifier with an external service to use its SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`.
-- If you're using [development builds](/develop/development-builds/introduction/), you can configure the `expo-dev-client` plugin to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
+- If you're using [development builds](/develop/development-builds/introduction/), you can configure the [`expo-dev-launcher`](/versions/latest/sdk/dev-client/#configurable-properties) plugin from `expo-dev-client` library to disable the app scheme used by Expo CLI and EAS Update QR codes in non-development builds. This ensures that those URLs will always launch the development build, regardless of your device's defaults:
 
 ```js app.config.js
 plugins: [

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -36,7 +36,7 @@ You can configure development client launcher using its built-in [config plugin]
   "expo": {
     "plugins": [
       [
-        "expo-dev-launcher",
+        "expo-dev-client",
         {
           "launchMode": "most-recent"
         }

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -36,7 +36,7 @@ You can configure development client launcher using its built-in [config plugin]
   "expo": {
     "plugins": [
       [
-        "expo-dev-launcher",
+        "expo-dev-client",
         {
           "launchMode": "most-recent"
         }

--- a/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
@@ -36,7 +36,7 @@ You can configure development client launcher using its built-in [config plugin]
   "expo": {
     "plugins": [
       [
-        "expo-dev-launcher",
+        "expo-dev-client",
         {
           "launchMode": "most-recent"
         }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #31881

# How

<!--
How did you build this feature or fix this bug and why?
-->

`expo-dev-client` is the plugin name for the library that contains all the config plugin properties. The option to disable dev-client was added in #31147, but the config plugin usage in DevClient API reference wasn't updated.

This PR:
- Updates the config plugin name to `expo-dev-client` in DevClient API reference
- Adds a `!!` in the App Variants guide's code example. This will help avoid issues when opening a development build, as mentioned in the issue referenced above. I have tested this solution by creating a development and a preview build and installing and running the development build by scanning the QR code from the terminal. It opens the correct variant.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview of changes

Adding `!!` to avoid type coercion in App variants guide code example:

![CleanShot 2025-01-09 at 19 20 52@2x](https://github.com/user-attachments/assets/0c0b36c7-847b-4a4b-9e8f-9f1fef2f7a0c)

Updated config plugin name in Expo DevClient API reference:

![CleanShot 2025-01-09 at 19 22 23@2x](https://github.com/user-attachments/assets/8bfbaa99-a93a-4223-b103-50f8714fa6a8)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
