### PR TITLE
[expo-go] Fix reloading when typing in text input

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -89,7 +89,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   BOOL interactionEnabled = !UIApplication.sharedApplication.isIgnoringInteractionEvents;
   BOOL hasFirstResponder = NO;
-  [EXKernelDevKeyCommands handleKeyboardEvent:event];
   
   if (interactionEnabled) {
     UIResponder *firstResponder = nil;
@@ -225,7 +224,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                [weakSelf _handleMenuCommand];
                              }];
   [self registerKeyCommandWithInput:@"r"
-                      modifierFlags:UIKeyModifierCommand
+                      modifierFlags:0
                              action:^(__unused UIKeyCommand *_) {
                                [weakSelf _handleRefreshCommand];
                              }];

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3181,7 +3181,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: b760390372f18b3b2478c5ea999cd4552285e445
+  hermes-engine: 699c9e93f5af5892ce55dabed81ca70680bb356d
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f


### PR DESCRIPTION
# Why
Closes #33905
Fixes regression from #31703

# How
Remove the `handleKeyboardEvent` call from `EX_handleKeyUIEventSwizzle` and drop the modifier from the `r` command.

# Test Plan
Expo go. Typing `r` in a `TextInput` will no longer cause the app to reload. Outside of `TextInput` it works as expected.

https://github.com/user-attachments/assets/1eedd51c-38dd-45bf-91d0-0e3c9bf52cd5

