### PR TITLE
[video][ios] Fix `AVPlayer` not deallocating when the player is unmounted regression

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `AVPlayer` not deallocating when the player is unmounted. ([#33922](https://github.com/expo/expo/pull/33922) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 - Fixed `generateThumbnailsAsync` not being available on Android in the types. ([#33491](https://github.com/expo/expo/pull/33491) by [@hirbod](https://github.com/hirbod))

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -143,8 +143,8 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       let videoSource = videoSource,
       let url = videoSource.uri
     else {
-      DispatchQueue.main.async { [weak self] in
-        self?.pointer.replaceCurrentItem(with: nil)
+      DispatchQueue.main.async { [pointer] in
+        pointer.replaceCurrentItem(with: nil)
       }
       return
     }


### PR DESCRIPTION
# Why

Fixes a regression accidentaly introduced in this PR https://github.com/expo/expo/pull/33123
Fixes https://github.com/expo/expo/issues/33804

# How

When replacing with `nil` use a strong capture to the `pointer` to be sure that the `AVPlayer` receives the message to replace the current item even when `replaceCurrentItem` is called from the `deinit` block.

# Test Plan

Tested in BareExpo in iOS simulator
