### PR TITLE
[docs] Highlighted a new import in the getting started tutorial

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -72,7 +72,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
-/* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>React</CODE>. */import { useState, useRef } from 'react';/* @end */
+/* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>react</CODE>. */import { useState, useRef } from 'react';/* @end */
 /* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -72,7 +72,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
-/* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>React</CODE>. */import { useState, useRef } from 'react';* @end */
+/* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>React</CODE>. */import { useState, useRef } from 'react';/* @end */
 /* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -72,7 +72,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
-import { useState, useRef } from 'react';
+/* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>React</CODE>. */import { useState, useRef } from 'react';* @end */
 /* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {


### PR DESCRIPTION
The "useRef" hook was added in this section however it wasn't highlighted. 

Highlighted it and added the correct tooltip to align it with the rest of the doc.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Folks who are new to the world to react/react native like me use the highlights to follow along and understand what changes are being made in the tutorial. 

Explaning the import would help others realise the change they are making and hopefully understand it a bit better. 
# How

<!--
How did you build this feature or fix this bug and why?
-->
I came across this while I was following the tutorial to build my first expo app! 

Fixed the issue by adding the a tooltip and highlighting the import (similar to the rest of the docs)
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Here's a screenshot of the proposed fix: 

![image](https://github.com/user-attachments/assets/c14e86c9-5526-4bdb-b951-403ef259bbd2)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
