### PR TITLE
[docs] small typo fix in custom tab layouts guide

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -82,7 +82,7 @@ A `TabTrigger` can link to a deeply nested route. `<TabTrigger name="route" href
 
 ## Rendering routes
 
-The `TabSlot` component renders the current route. `TabSlot` be can be nested inside other components within `Tabs` but cannot be within the `TabList`.
+The `TabSlot` component renders the current route. `TabSlot` can be nested inside other components within `Tabs` but cannot be within the `TabList`.
 
 ```tsx app/_layout.tsx
 <Tabs>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
