### PR TITLE
[docs] Fix typos in multiple docs

### DIFF
--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -302,7 +302,7 @@ Modify the **app/(tabs)/index.tsx** file:
 ```tsx app/(tabs)/index.tsx
 import { View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-/* @tutinfo Import <CODE>useState</CODE> hook from React.*/
+/* @tutinfo Import <CODE>useState</CODE> hook from <CODE>react<CODE>.*/
 import { useState } from 'react';
 /* @end */
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** This page documents an upcoming version of the Audio library. **Expo audio is currently in alpha and subject to breaking changes.**
+> **warning** This page documents an upcoming version of the Audio library. **Expo Audio is currently in alpha and subject to breaking changes.**
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 

--- a/docs/pages/versions/v52.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio.mdx
@@ -14,7 +14,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** This page documents an upcoming version of the Audio library. **Expo audio is currently in alpha and subject to breaking changes.**
+> **warning** This page documents an upcoming version of the Audio library. **Expo Audio is currently in alpha and subject to breaking changes.**
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through multiple doc, found a couple of typos which are fixed in this PR.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
