### PR TITLE
fix(cli): Recurse server action exports to collect all references.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Recurse server action exports to collect all references.
+- Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Recurse server action exports to collect all references.
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
@@ -137,8 +137,11 @@ export function createServerComponentsMiddleware(
     // TODO: Support multiple entry points in a single split server bundle...
     const manifest: Record<string, [string, string]> = {};
     const nestedClientBoundaries: string[] = [];
+    const nestedServerBoundaries: string[] = [];
+    const processedEntryPoints = new Set<string>();
+    async function processEntryPoint(entryPoint: string) {
+      processedEntryPoints.add(entryPoint);
 
-    for (const entryPoint of uniqueEntryPoints) {
       const contents = await ssrLoadModuleArtifacts(entryPoint, {
         environment: 'react-server',
         platform,
@@ -156,6 +159,13 @@ export function createServerComponentsMiddleware(
 
       if (reactClientReferences) {
         nestedClientBoundaries.push(...reactClientReferences!);
+      }
+      const reactServerReferences = contents.artifacts
+        .filter((a) => a.type === 'js')[0]
+        .metadata.reactServerReferences?.map((ref) => fileURLToFilePath(ref));
+
+      if (reactServerReferences) {
+        nestedServerBoundaries.push(...reactServerReferences!);
       }
 
       // Naive check to ensure the module runtime is not included in the server action bundle.
@@ -182,6 +192,30 @@ export function createServerComponentsMiddleware(
       // Import relative to `dist/server/_expo/rsc/web/router.js`
       manifest[entryPoint] = [String(relativeName), outputName];
     }
+
+    async function processEntryPoints(entryPoints: string[], recursions = 0) {
+      // Arbitrary recursion limit to prevent infinite loops.
+      if (recursions > 10) {
+        throw new Error('Recursion limit exceeded while processing server boundaries');
+      }
+
+      for (const entryPoint of entryPoints) {
+        await processEntryPoint(entryPoint);
+      }
+
+      // When a server action has other server actions inside of it, we need to process those as well to ensure all entry points are in the manifest and accounted for.
+      let uniqueNestedServerBoundaries = [...new Set(nestedServerBoundaries)];
+      // Filter out values that have already been processed.
+      uniqueNestedServerBoundaries = uniqueNestedServerBoundaries.filter(
+        (value) => !processedEntryPoints.has(value)
+      );
+      if (uniqueNestedServerBoundaries.length) {
+        debug('bundling nested server action boundaries', uniqueNestedServerBoundaries);
+        return processEntryPoints(uniqueNestedServerBoundaries, recursions + 1);
+      }
+    }
+
+    await processEntryPoints(uniqueEntryPoints);
 
     // Save the SSR manifest so we can perform more replacements in the server renderer and with server actions.
     files.set(`_expo/rsc/${platform}/action-manifest.js`, {


### PR DESCRIPTION
# Why

- Some server actions can import others, these will need a recursive bundling process to collect.
