### PR TITLE
[router-ui][docs] Add tvos as platform and fix package name

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-ui.mdx
@@ -2,7 +2,7 @@
 title: Router UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
-packageName: 'expo-router-ui'
+packageName: 'expo-router'
 platforms: ['android', 'ios', 'web']
 isNew: true
 ---

--- a/docs/pages/versions/unversioned/sdk/router-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-ui.mdx
@@ -3,7 +3,7 @@ title: Router UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
-platforms: ['android', 'ios', 'web']
+platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 

--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -3,7 +3,7 @@ title: Router
 description: A file-based routing library for React Native and web applications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 

--- a/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
@@ -2,7 +2,7 @@
 title: Router UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
-packageName: 'expo-router-ui'
+packageName: 'expo-router'
 platforms: ['android', 'ios', 'web']
 isNew: true
 ---

--- a/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
@@ -3,7 +3,7 @@ title: Router UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
-platforms: ['android', 'ios', 'web']
+platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 

--- a/docs/pages/versions/v52.0.0/sdk/router.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router.mdx
@@ -3,7 +3,7 @@ title: Router
 description: A file-based routing library for React Native and web applications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-router'
 packageName: 'expo-router'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Expo Router UI reference page is missing tvos platform and has the wrong `packageName` in the API page's metadata. 
The former came from a question so used a quick example to see if the `expo-router/ui` package is working on tvos: https://github.com/expo/expo/pull/33631#issuecomment-2571708241.
The latter leads to a 404 npm page.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `tvos` to platform in Router UI reference
- Update package name to `expo-router` since the `expo-router/ui` is its submodule in Router UI reference
- Fix platform order in the Router reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-01-06 at 00 46 47@2x](https://github.com/user-attachments/assets/cd156984-abfd-46a2-a231-73cb3c557b22)

![CleanShot 2025-01-06 at 00 46 55@2x](https://github.com/user-attachments/assets/ba951077-43fa-4adc-a291-c1302ebd5672)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
