### PR TITLE
[android][template] Correctly support dark mode

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/res/values/styles.xml
@@ -1,13 +1,6 @@
 <resources>
-  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:textColor">@android:color/black</item>
-    <item name="android:editTextStyle">@style/ResetEditText</item>
+  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-  </style>
-  <style name="ResetEditText" parent="@android:style/Widget.EditText">
-    <item name="android:padding">0dp</item>
-    <item name="android:textColorHint">#c8c8c8</item>
-    <item name="android:textColor">@android:color/black</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="AppTheme">
     <item name="android:windowBackground">@drawable/splashscreen_logo</item>


### PR DESCRIPTION
# Why
Currently, our default template uses a light theme. RN switched to `Theme.AppCompat.DayNight.NoActionBar` in 0.64 so we should do the same. 
cc @zoontek 

# How
Change the base theme to `Theme.AppCompat.DayNight.NoActionBar`. I've also dropped the `textColor` and edit text changes. These cause problems because we would need to provide color variants for each and I believe this is unnecessary. We should not change the default behaviour of RN. This is unexpected for users migrating to expo. RN apps should look identical with or without expo.

# Test Plan

https://github.com/user-attachments/assets/137a5e44-f08a-409d-8111-fe7f4d8f2d2e



