### PR TITLE
[docs] Update app config section title for consistency in API reference

### DIFF
--- a/docs/pages/guides/apple-privacy.mdx
+++ b/docs/pages/guides/apple-privacy.mdx
@@ -17,7 +17,7 @@ A privacy manifest is a file named **PrivacyInfo.xcprivacy** that is included in
 
 These APIs currently include accessing UserDefaults, file timestamp, system boot time, disk space, and active keyboard. Apple considers it an open list that can be expanded in the future.
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can include an iOS privacy manifest by using the `privacyManifests` field under `expo.ios` in your app config.
 

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -16,7 +16,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-asset` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -29,7 +29,7 @@ See the [playlist example app](https://github.com/expo/playlist-example) for an 
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-av` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -24,7 +24,7 @@ Additionally, it provides methods to launch the [system-provided calendar UI](#l
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-calendar` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -25,7 +25,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-contacts` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -25,7 +25,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/devicemotion.mdx
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -24,7 +24,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-document-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 The recommended way to add fonts to your app is through `expo-font` built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run: [android|ios]`). The plugin allows you to embed font files at build time which is more efficient than using [`loadAsync`](#loadasyncfontfamilyorfontmap-source). See the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -34,7 +34,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-image-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-local-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -17,7 +17,7 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-localization` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -26,7 +26,7 @@ import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-location` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-media-library` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
@@ -35,7 +35,7 @@ On both Android and iOS platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -28,7 +28,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-secure-store` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -18,7 +18,7 @@ import { Step } from '~/ui/components/Step';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-sqlite` for advanced configurations using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -24,7 +24,7 @@ For more information on Apple's new App Tracking Transparency framework, see the
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -28,7 +28,7 @@ See the [playlist example app](https://github.com/expo/playlist-example) for an 
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-av` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -39,7 +39,7 @@ The `BarCodeScanner` component has difficulty scanning barcodes with black backg
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-barcode-scanner` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/calendar.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-calendar` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -30,7 +30,7 @@ import PrereleaseNotice from '~/ui/components/PrereleaseNotice';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -27,7 +27,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-contacts` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
@@ -27,7 +27,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/devicemotion.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/devicemotion.mdx
@@ -24,7 +24,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
@@ -26,7 +26,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-document-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/v50.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/font.mdx
@@ -24,7 +24,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-font` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
@@ -36,7 +36,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-image-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/local-authentication.mdx
@@ -24,7 +24,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-local-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/localization.mdx
@@ -19,7 +19,7 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-localization` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -27,7 +27,7 @@ import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-location` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/media-library.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-media-library` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/screen-orientation.mdx
@@ -37,7 +37,7 @@ On both Android and iOS platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -30,7 +30,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-secure-store` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 ### Background modes on iOS
 

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -26,7 +26,7 @@ For more information on Apple's new App Tracking Transparency framework, see the
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/asset.mdx
@@ -16,7 +16,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-asset` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/av.mdx
@@ -28,7 +28,7 @@ See the [playlist example app](https://github.com/expo/playlist-example) for an 
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-av` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/bar-code-scanner.mdx
@@ -37,7 +37,7 @@ The `BarCodeScanner` component has difficulty scanning barcodes with black backg
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-barcode-scanner` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/calendar.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-calendar` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera-legacy.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/contacts.mdx
@@ -25,7 +25,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-contacts` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/dev-client.mdx
@@ -25,7 +25,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/devicemotion.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/devicemotion.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
@@ -24,7 +24,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-document-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/v51.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/font.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-font` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
@@ -34,7 +34,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-image-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/local-authentication.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-local-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/localization.mdx
@@ -17,7 +17,7 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-localization` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -25,7 +25,7 @@ import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-location` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/media-library.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-media-library` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screen-orientation.mdx
@@ -35,7 +35,7 @@ On both Android and iOS platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/securestore.mdx
@@ -28,7 +28,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-secure-store` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v51.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/task-manager.mdx
@@ -21,7 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 ### Background modes on iOS
 

--- a/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
@@ -24,7 +24,7 @@ For more information on Apple's new App Tracking Transparency framework, see the
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/asset.mdx
@@ -16,7 +16,7 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-asset` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/av.mdx
@@ -29,7 +29,7 @@ See the [playlist example app](https://github.com/expo/playlist-example) for an 
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-av` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/calendar.mdx
@@ -24,7 +24,7 @@ Additionally, it provides methods to launch the [system-provided calendar UI](#l
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-calendar` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/camera.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-camera` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/contacts.mdx
@@ -25,7 +25,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-contacts` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/dev-client.mdx
@@ -25,7 +25,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 If you are installing this in an [existing React Native app](/bare/overview/), start by installing [`expo`](/bare/installing-expo-modules/) in your project. Then, follow the instructions from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/devicemotion.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/devicemotion.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
@@ -24,7 +24,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-document-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/v52.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/font.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 The recommended way to add fonts to your app is through `expo-font` built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run: [android|ios]`). The plugin allows you to embed font files at build time which is more efficient than using [`loadAsync`](#loadasyncfontfamilyorfontmap-source). See the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
 

--- a/docs/pages/versions/v52.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/imagepicker.mdx
@@ -34,7 +34,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-image-picker` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/local-authentication.mdx
@@ -22,7 +22,7 @@ import {
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-local-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/localization.mdx
@@ -17,7 +17,7 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-localization` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -26,7 +26,7 @@ import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-location` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/media-library.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-media-library` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/screen-orientation.mdx
@@ -35,7 +35,7 @@ On both Android and iOS platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for iOS, your iPad is always in landscape mode unless you open two applications side by side. To be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/securestore.mdx
@@ -28,7 +28,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-secure-store` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sqlite.mdx
@@ -18,7 +18,7 @@ import { Step } from '~/ui/components/Step';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-sqlite` for advanced configurations using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
@@ -24,7 +24,7 @@ For more information on Apple's new App Tracking Transparency framework, see the
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, there are two different section titles in API docs used:
![CleanShot 2025-01-06 at 15 50 02@2x](https://github.com/user-attachments/assets/b5413eb4-d409-404c-845b-54af3cdaa0a7)

![CleanShot 2025-01-06 at 15 48 42@2x](https://github.com/user-attachments/assets/a529d0e6-82ce-44ff-8439-9e199215a604)

Since we have started to use "Configuration in app config" because "app config" itself represents different file extensions, this PR updates the left-over section titles to the updated verbiage for consistency.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit an API doc: http://localhost:3001/versions/latest/sdk/video/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
