### PR TITLE
[docs] change fingerprintExperimental reference to fingerprint

### DIFF
--- a/docs/pages/eas-update/deployment-patterns.mdx
+++ b/docs/pages/eas-update/deployment-patterns.mdx
@@ -136,7 +136,7 @@ This flow is for projects that need to build and update their Android and iOS ap
 
 This flow is an example of a flow for managing versioned releases.
 
-> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, `"nativeVersion"` and `"fingerprintExperimental"`). You will need to [manually specify](/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
+> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, `"nativeVersion"` and `"fingerprint"`). You will need to [manually specify](/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
 
 Here are the parts of the deployment process above that make up this flow:
 


### PR DESCRIPTION
# Why

`fingerprintExperimental` was changed to `fingerprint` in the SDK 51 release (https://github.com/expo/expo/pull/28220)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
