### PR TITLE
[android][bare-expo] Use DayNight theme

### DIFF
--- a/apps/bare-expo/android/app/src/main/res/values/styles.xml
+++ b/apps/bare-expo/android/app/src/main/res/values/styles.xml
@@ -1,15 +1,6 @@
 <resources>
-  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:textColor">@android:color/black</item>
-    <item name="android:editTextStyle">@style/ResetEditText</item>
+  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-    <item name="colorPrimary">@color/colorPrimary</item>
-    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-  </style>
-  <style name="ResetEditText" parent="@android:style/Widget.EditText">
-    <item name="android:padding">0dp</item>
-    <item name="android:textColorHint">#c8c8c8</item>
-    <item name="android:textColor">@android:color/black</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">@color/splashscreen_background</item>


### PR DESCRIPTION
# Why
Looks like we had been using the correct theme but it was reverted in #27195 after running prebuild and the template had set the light theme
 
# How
Change the styles. Not sure if we can just run a full prebuild.

# Test Plan
bare-expo. Themes working correctly
