### PR TITLE
Remove misleading limitation disclaimer in app-versions.mdx

### DIFF
--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -149,5 +149,4 @@ In the case of [existing React Native projects](/bare/overview/), the values in 
 ### Limitations
 
 - With `autoIncrement`, you need to commit your changes on every build if you want the version change to persist. This can be difficult to coordinate when building on CI.
-- `autoIncrement` is not supported if you are using a dynamic config file (such as **app.config.js**).
 - For existing React Native projects with Gradle configuration that supports multiple flavors, EAS CLI is not able to read or modify the version, so `autoIncrement` option is not supported, and versions will not be listed in the build details page on [expo.dev](https://expo.dev).


### PR DESCRIPTION
https://github.com/expo/eas-cli/issues/892 says that this limitation is no longer present, and everyone seems to be in agreement.

I have yet to validate myself, but spent good time reading the docs and doing it the old fashioned way, because I trusted the docs to be up-to-date.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
See above

# How

<!--
How did you build this feature or fix this bug and why?
-->
Just docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Someone in the know can validate that it is true.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
