### PR TITLE
feat: Support EAS Update when RSC is configured.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Support EAS Update when RSC is configured.
 - Add `+html` and `+native-intent` to `expo customize`. ([#33368](https://github.com/expo/expo/pull/33368) by [@EvanBacon](https://github.com/EvanBacon))
 - Estimate Xcode binary path in minimal builds. ([#33415](https://github.com/expo/expo/pull/33415) by [@EvanBacon](https://github.com/EvanBacon))
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support EAS Update when RSC is configured.
+- Support EAS Update when RSC is configured. ([#33975](https://github.com/expo/expo/pull/33975) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `+html` and `+native-intent` to `expo customize`. ([#33368](https://github.com/expo/expo/pull/33368) by [@EvanBacon](https://github.com/EvanBacon))
 - Estimate Xcode binary path in minimal builds. ([#33415](https://github.com/expo/expo/pull/33415) by [@EvanBacon](https://github.com/EvanBacon))
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -274,10 +274,13 @@ export async function exportAppAsync(
         files.set('assetmap.json', { contents: JSON.stringify(createAssetMap({ assets })) });
       }
 
+      const targetDomain = devServer.isReactServerComponentsEnabled ? 'client/' : '';
       const fileNames = Object.fromEntries(
         Object.entries(bundles).map(([platform, bundle]) => [
           platform,
-          bundle.artifacts.filter((asset) => asset.type === 'js').map((asset) => asset.filename),
+          bundle.artifacts
+            .filter((asset) => asset.type === 'js')
+            .map((asset) => targetDomain + asset.filename),
         ])
       );
 


### PR DESCRIPTION
# Why

- Partially support publishing RSC projects to EAS Update and using them in Expo Go. Still requires a bit of configuration but at least RSC won't break EAS Update.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
