### PR TITLE
[expo-updates][android] Use more robust mechanism for determining empty multipart bodies

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
+- [android] Use more robust mechanism for determining empty multipart bodies ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

There is an issue when MultipartReader throws an error but consumes all (or some) of the body before the error is thrown. This would cause the catch clause to execute and the body to try to be re-read, thus throwing an error since the body may only be consumed once.

Closes #33974.

# How

The fix is to use a different mechanism for determining if the body is empty, and like iOS not even attempting the multipart parse when it is empty.

# Test Plan

Run the same test we have for this, ensure it still passes. That being said, it'd be helpful to have a body that the reported issue repros for to ensure this fixes the issue.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
