### PR TITLE
[android][audio] Guard againist permission errors when recording

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- On `Android`, add checks to methods that will throw without permissions being granted. ([#33986](https://github.com/expo/expo/pull/33986) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Add checks to methods that will throw without permissions being granted. ([#33986](https://github.com/expo/expo/pull/33986) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.3.1 - 2024-12-16
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- On `Android`, add checks to methods that will throw without permissions being granted.
+- On `Android`, add checks to methods that will throw without permissions being granted. ([#33986](https://github.com/expo/expo/pull/33986) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.3.1 - 2024-12-16
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- On `Android`, add checks to methods that will throw without permissions being granted.
+
 ## 0.3.1 - 2024-12-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.net.Uri
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.C.CONTENT_TYPE_DASH
@@ -26,6 +27,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
@@ -326,6 +328,7 @@ class AudioModule : Module() {
       }
 
       AsyncFunction("prepareToRecordAsync") { ref: AudioRecorder, options: RecordingOptions? ->
+        checkRecordingPermission()
         ref.prepareRecording(options)
       }
 
@@ -345,7 +348,6 @@ class AudioModule : Module() {
       }
 
       Function("getStatus") { ref: AudioRecorder ->
-        checkRecordingPermission()
         ref.getAudioRecorderStatus()
       }
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.net.Uri
-import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.C.CONTENT_TYPE_DASH
@@ -27,7 +26,6 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -1,6 +1,8 @@
 package expo.modules.audio
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.media.MediaRecorder
@@ -11,6 +13,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
+import androidx.core.content.ContextCompat
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
 import java.io.File
@@ -33,7 +36,7 @@ class AudioRecorder(
   private var isPrepared = false
   private var shouldCreateRecorder = false
 
-  var recorder = createRecorder(options)
+  private var recorder = createRecorder(options)
   val id = UUID.randomUUID().toString()
   var uri: String? = null
   var uptime = 0L
@@ -106,8 +109,11 @@ class AudioRecorder(
     }
 
   private fun setRecordingOptions(recorder: MediaRecorder, options: RecordingOptions) {
+    if (!hasRecordingPermissions()) {
+      return
+    }
     with(recorder) {
-      setAudioSource(MediaRecorder.AudioSource.DEFAULT)
+      setAudioSource(MediaRecorder.AudioSource.MIC)
       if (options.outputFormat != null) {
         setOutputFormat(options.outputFormat.toMediaOutputFormat())
       } else {
@@ -153,15 +159,25 @@ class AudioRecorder(
     recorder.release()
   }
 
-  fun getAudioRecorderStatus() = Bundle().apply {
-    putBoolean("canRecord", isPrepared)
-    putBoolean("isRecording", isRecording)
-    putLong("durationMillis", getAudioRecorderDurationMillis())
-    if (meteringEnabled) {
-      putInt("metering", getAudioRecorderLevels())
+  fun getAudioRecorderStatus() = if (hasRecordingPermissions()) {
+    Bundle().apply {
+      putBoolean("canRecord", isPrepared)
+      putBoolean("isRecording", isRecording)
+      putLong("durationMillis", getAudioRecorderDurationMillis())
+      if (meteringEnabled) {
+        putInt("metering", getAudioRecorderLevels())
+      }
+      putString("url", uri)
     }
-    putString("url", uri)
+  } else {
+    Bundle().apply {
+      putBoolean("canRecord", false)
+      putBoolean("isRecording", false)
+      putLong("durationMillis", 0)
+      putString("url", null)
+    }
   }
+
 
   private fun getAudioRecorderDurationMillis(): Long {
     var duration = durationAlreadyRecorded
@@ -245,6 +261,9 @@ class AudioRecorder(
 
     return getMapFromDeviceInfo(deviceInfo)
   }
+
+  private fun hasRecordingPermissions() =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
 
   fun getAvailableInputs(audioManager: AudioManager) =
     audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).mapNotNull { deviceInfo ->

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -178,7 +178,6 @@ class AudioRecorder(
     }
   }
 
-
   private fun getAudioRecorderDurationMillis(): Long {
     var duration = durationAlreadyRecorded
     if (isRecording && uptime > 0) {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
@@ -6,7 +6,7 @@ import java.io.File
 import java.io.IOException
 
 fun ensureDirExists(dir: File): File {
-  if (!(dir.isDirectory() || dir.mkdirs())) {
+  if (!(dir.isDirectory || dir.mkdirs())) {
     throw IOException("Couldn't create directory '$dir'")
   }
   return dir
@@ -22,7 +22,7 @@ fun getMapFromDeviceInfo(deviceInfo: AudioDeviceInfo): Bundle {
     AudioDeviceInfo.TYPE_WIRED_HEADSET -> "MicrophoneWired"
     else -> "Unknown device type"
   }
-  map.putString("name", deviceInfo.getProductName().toString())
+  map.putString("name", deviceInfo.productName.toString())
   map.putString("type", type)
   map.putString("uid", deviceInfo.id.toString())
   return map


### PR DESCRIPTION
# Why
Adds more permission checks when attempting to record on Android. Most functions on the `AudioManager` will throw if you interact with them without permission.

# How
Add extra checks when checking the status and creating the recorder object

# Test Plan
bare-expo.

