### PR TITLE
[doctor] add .env support

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added `.env` support. ([#33988](https://github.com/expo/expo/pull/33988) by [@kudo](https://github.com/kudo))
+
 ## 1.12.8 — 2025-03-13
 
 ### 💡 Others

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@expo/config": "~11.0.0",
+    "@expo/env": "~1.0.0",
     "@expo/json-file": "~9.1.0",
     "@expo/schemer": "1.5.3",
     "@expo/spawn-async": "^1.7.2",

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@expo/config';
+import { load as loadEnv } from '@expo/env';
 import chalk from 'chalk';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
@@ -7,6 +8,7 @@ import { env } from './utils/env';
 import { isNetworkError } from './utils/errors';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
+import { setNodeEnv } from './utils/nodeEnv';
 import { logNewSection } from './utils/ora';
 import { endTimer, formatMilliseconds, startTimer } from './utils/timer';
 import { ltSdkVersion } from './utils/versions';
@@ -126,6 +128,9 @@ export async function runChecksAsync(
  */
 export async function actionAsync(projectRoot: string, showVerboseTestResults: boolean) {
   try {
+    setNodeEnv('development');
+    loadEnv(projectRoot);
+
     const projectConfig = getConfig(projectRoot);
 
     // expo-doctor relies on versioned CLI, which is only available for 44+

--- a/packages/expo-doctor/src/utils/nodeEnv.ts
+++ b/packages/expo-doctor/src/utils/nodeEnv.ts
@@ -1,0 +1,11 @@
+/**
+ * Set the environment to production or development
+ * lots of tools use this to determine if they should run in a dev mode.
+ */
+export function setNodeEnv(mode: 'development' | 'production') {
+  process.env.NODE_ENV = process.env.NODE_ENV || mode;
+  process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
+
+  // @ts-expect-error: Add support for external React libraries being loaded in the same process.
+  globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
+}


### PR DESCRIPTION
# Why

fixes #33938

# How

as expo-cli to load `.env` as well as setup default NODE_ENV.
the code is mainly referenced from https://github.com/expo/expo/blob/924bc643aa3410c9df1d11fb44fae58ba041ac31/packages/%40expo/cli/src/config/configAsync.ts#L47-L48

# Test Plan

on a blank project the following setup and test with expo-doctor
`app.config.js`
```js
module.exports = (config) => {
  if (process.env.NODE_ENV === undefined) {
    throw new Error("no NODE_ENV")
  }
  if (process.env.EXPO_PUBLIC_TEST === undefined) {
    throw new Error("no EXPO_PUBLIC_TEST")
  }
  return config;
}
```

`.env`
```
EXPO_PUBLIC_TEST=test
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
