### PR TITLE
[build-properties] Add `android.useDayNightTheme`

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `android.useDayNightTheme` to enable overriding the templates use of a light theme.
+- Add `android.useDayNightTheme` to enable overriding the templates use of a light theme. ([#33989](https://github.com/expo/expo/pull/33989) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `android.useDayNightTheme` to enable overriding the templates use of a light theme.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-build-properties/build/android.d.ts
+++ b/packages/expo-build-properties/build/android.d.ts
@@ -20,3 +20,4 @@ export declare const withAndroidPurgeProguardRulesOnce: ConfigPlugin;
 export declare function updateAndroidProguardRules(contents: string, newProguardRules: string | null, updateMode: 'append' | 'overwrite'): string;
 export declare const withAndroidCleartextTraffic: ConfigPlugin<PluginConfigType>;
 export declare const withAndroidQueries: ConfigPlugin<PluginConfigType>;
+export declare const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType>;

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.updateAndroidProguardRules = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
+exports.withAndroidDayNightTheme = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.updateAndroidProguardRules = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
@@ -87,6 +87,10 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
             });
             return JSON.stringify(extraMavenRepos);
         },
+    },
+    {
+        propName: 'android.useDayNightTheme',
+        propValueGetter: (config) => (config.android?.useDayNightTheme ?? false).toString(),
     },
 ], 'withAndroidBuildProperties');
 /**
@@ -212,3 +216,28 @@ const withAndroidQueries = (config, props) => {
     });
 };
 exports.withAndroidQueries = withAndroidQueries;
+const withAndroidDayNightTheme = (config, props) => {
+    return (0, config_plugins_1.withAndroidStyles)(config, (config) => {
+        if (!props.android?.useDayNightTheme) {
+            return config;
+        }
+        const { style = [] } = config.modResults.resources;
+        if (!style.length) {
+            return config;
+        }
+        // Remove the hardcoded colors.
+        const toRemove = ['android:textColor', 'android:editTextStyle'];
+        // We only want to return the AppTheme here. We can drop the `ResetEditText` style.
+        config.modResults.resources.style = [
+            {
+                $: {
+                    name: 'AppTheme',
+                    parent: 'Theme.AppCompat.DayNight.NoActionBar',
+                },
+                item: [...style[0].item.filter(({ $ }) => !toRemove.includes($.name))],
+            },
+        ];
+        return config;
+    });
+};
+exports.withAndroidDayNightTheme = withAndroidDayNightTheme;

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -225,17 +225,19 @@ const withAndroidDayNightTheme = (config, props) => {
         if (!style.length) {
             return config;
         }
+        // Replace `AppTheme` and remove `ResetEditText`
+        const excludedStyles = ['AppTheme', 'ResetEditText'];
         // Remove the hardcoded colors.
-        const toRemove = ['android:textColor', 'android:editTextStyle'];
-        // We only want to return the AppTheme here. We can drop the `ResetEditText` style.
+        const excludedAttributes = ['android:textColor', 'android:editTextStyle'];
         config.modResults.resources.style = [
             {
                 $: {
                     name: 'AppTheme',
                     parent: 'Theme.AppCompat.DayNight.NoActionBar',
                 },
-                item: [...style[0].item.filter(({ $ }) => !toRemove.includes($.name))],
+                item: [...style[0].item.filter(({ $ }) => !excludedAttributes.includes($.name))],
             },
+            ...style.filter(({ $ }) => !excludedStyles.includes($.name)),
         ];
         return config;
     });

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -133,6 +133,12 @@ export interface PluginConfigTypeAndroid {
      *  @see [Android documentation](https://developer.android.com/guide/topics/manifest/queries-element)
      */
     manifestQueries?: PluginConfigTypeAndroidQueries;
+    /**
+     * Changes the apps theme to a DayNight variant to correctly support dark mode.
+     *
+     * @see [Android documentation](https://developer.android.com/develop/ui/views/theming/darktheme)
+     */
+    useDayNightTheme?: boolean;
 }
 /**
  * @platform android

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -107,6 +107,7 @@ const schema = {
                 },
                 usesCleartextTraffic: { type: 'boolean', nullable: true },
                 useLegacyPackaging: { type: 'boolean', nullable: true },
+                useDayNightTheme: { type: 'boolean', nullable: true },
                 manifestQueries: {
                     type: 'object',
                     properties: {

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -22,6 +22,7 @@ const withBuildProperties = (config, props) => {
     //
     // plugins order matter: the later one would run first
     config = (0, android_1.withAndroidPurgeProguardRulesOnce)(config);
+    config = (0, android_1.withAndroidDayNightTheme)(config, pluginConfig);
     config = (0, ios_1.withIosBuildProperties)(config, pluginConfig);
     config = (0, ios_1.withIosDeploymentTarget)(config, pluginConfig);
     return config;

--- a/packages/expo-build-properties/src/__tests__/android-queries-test.ts
+++ b/packages/expo-build-properties/src/__tests__/android-queries-test.ts
@@ -26,7 +26,7 @@ const defaultQueries = [
 ];
 
 describe(withAndroidQueries, () => {
-  test('it does not change the manifest default if no queries are provided', async () => {
+  it('does not change the manifest default if no queries are provided', async () => {
     const { modResults: androidModResults } = await compileMockModWithResultsAsync<
       AndroidConfig.Manifest.AndroidManifest,
       PluginConfigType
@@ -53,7 +53,7 @@ describe(withAndroidQueries, () => {
     expect(androidModResults.manifest.queries[0].intent).toHaveLength(1);
   });
 
-  test('it adds the provider if defined', async () => {
+  it('adds the provider if defined', async () => {
     const pluginConfig: PluginConfigType = {
       android: {
         manifestQueries: {
@@ -85,7 +85,7 @@ describe(withAndroidQueries, () => {
     expect(result.provider?.[0].$['android:authorities']).toBe('com.expo.provider');
   });
 
-  test('it does not add the provider if undefined', async () => {
+  it('does not add the provider if undefined', async () => {
     const pluginConfig: PluginConfigType = {
       android: {
         manifestQueries: {
@@ -148,7 +148,7 @@ describe(withAndroidQueries, () => {
     expect(result.package?.some((p) => p.$['android:name'] === 'com.expo.test')).toBe(true);
   });
 
-  test('it correctly adds a single intent', async () => {
+  it('correctly adds a single intent', async () => {
     const pluginConfig: PluginConfigType = {
       android: {
         manifestQueries: {
@@ -185,7 +185,7 @@ describe(withAndroidQueries, () => {
     expect(result?.intent).toHaveLength(2);
   });
 
-  test('it correctly adds two intents', async () => {
+  it('correctly adds two intents', async () => {
     const pluginConfig: PluginConfigType = {
       android: {
         manifestQueries: {
@@ -227,7 +227,7 @@ describe(withAndroidQueries, () => {
     expect(result.intent).toHaveLength(3);
   });
 
-  test('it correctly adds three intents', async () => {
+  it('correctly adds three intents', async () => {
     const pluginConfig: PluginConfigType = {
       android: {
         manifestQueries: {

--- a/packages/expo-build-properties/src/__tests__/withBuildPropertiesDayNight-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildPropertiesDayNight-test.ts
@@ -1,0 +1,166 @@
+import { withAndroidStyles } from 'expo/config-plugins';
+
+import { compileMockModWithResultsAsync } from './mockMods';
+import { withBuildProperties } from '../withBuildProperties';
+
+jest.mock('@expo/config-plugins/build/plugins/android-plugins', () => {
+  const plugins = jest.requireActual('@expo/config-plugins/build/plugins/android-plugins');
+  return {
+    ...plugins,
+    withAndroidStyles: jest.fn().mockImplementation((config) => config),
+  };
+});
+
+const defaultStyles = [
+  {
+    $: {
+      name: 'AppTheme',
+      parent: 'Theme.AppCompat.Light.NoActionBar',
+    },
+    item: [
+      {
+        _: '@android:color/black',
+        $: {
+          name: 'android:textColor',
+        },
+      },
+      {
+        _: '@style/ResetEditText',
+        $: {
+          name: 'android:editTextStyle',
+        },
+      },
+      {
+        _: '@drawable/rn_edit_text_material',
+        $: {
+          name: 'android:editTextBackground',
+        },
+      },
+      {
+        $: {
+          name: 'colorPrimary',
+        },
+        _: '@color/colorPrimary',
+      },
+      {
+        $: {
+          name: 'android:statusBarColor',
+        },
+        _: '#ffffff',
+      },
+    ],
+  },
+  {
+    $: {
+      name: 'ResetEditText',
+      parent: '@android:style/Widget.EditText',
+    },
+    item: [
+      {
+        _: '0dp',
+        $: {
+          name: 'android:padding',
+        },
+      },
+      {
+        _: '#c8c8c8',
+        $: {
+          name: 'android:textColorHint',
+        },
+      },
+      {
+        _: '@android:color/black',
+        $: {
+          name: 'android:textColor',
+        },
+      },
+    ],
+  },
+  {
+    $: {
+      name: 'Theme.App.SplashScreen',
+      parent: 'AppTheme',
+    },
+    item: [
+      {
+        _: '@drawable/splashscreen_logo',
+        $: {
+          name: 'android:windowBackground',
+        },
+      },
+    ],
+  },
+];
+
+const userDefined = [
+  ...defaultStyles,
+  {
+    $: {
+      name: 'MyTheme',
+      parent: 'Theme.MyTheme',
+    },
+    item: [
+      {
+        _: '@android:color/red',
+        $: {
+          name: 'android:textColor',
+        },
+      },
+    ],
+  },
+];
+
+describe(withBuildProperties, () => {
+  it('correctly modifies the theme for dark mode support', async () => {
+    const { modResults } = await createModResult(true, defaultStyles);
+    const { style } = modResults.resources;
+    const appTheme = style.find(({ $ }) => $.name === 'AppTheme');
+    expect(appTheme.$.parent).toBe('Theme.AppCompat.DayNight.NoActionBar');
+  });
+
+  it('removes the `ResetEditText` style', async () => {
+    const { modResults } = await createModResult(true, defaultStyles);
+    const { style } = modResults.resources;
+    const resetEditText = style.find(({ $ }) => $.name === 'ResetEditText');
+    expect(resetEditText).toBeUndefined();
+  });
+
+  it('correctly removes the hardcoded colors from the `AppTheme`', async () => {
+    const { modResults } = await createModResult(true, defaultStyles);
+    const { style } = modResults.resources;
+
+    const excludedAttributes = ['android:textColor', 'android:editTextStyle'];
+
+    const appTheme = style.find(({ $ }) => $.name === 'AppTheme');
+    const items = appTheme.item.filter(({ $ }) => excludedAttributes.includes($.name));
+    expect(items).toHaveLength(0);
+  });
+
+  it('does not modify the styles if `useDayNightTheme` is false', async () => {
+    const { modResults } = await createModResult(false, defaultStyles);
+    expect(modResults.resources.style).toEqual(defaultStyles);
+  });
+
+  it('does not override user defined styles', async () => {
+    const { modResults } = await createModResult(true, userDefined);
+
+    const userStyle = modResults.resources.style.find(({ $ }) => $.name === 'MyTheme');
+    expect(userStyle).toBeDefined();
+  });
+});
+
+async function createModResult(useDayNightTheme: boolean, style: any[]) {
+  return compileMockModWithResultsAsync(
+    {},
+    {
+      plugin: withBuildProperties,
+      pluginProps: { android: { useDayNightTheme } },
+      mod: withAndroidStyles,
+      modResults: {
+        resources: {
+          style,
+        },
+      },
+    }
+  );
+}

--- a/packages/expo-build-properties/src/__tests__/withBuildPropertiesDayNight-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildPropertiesDayNight-test.ts
@@ -112,21 +112,21 @@ const userDefined = [
 
 describe(withBuildProperties, () => {
   it('correctly modifies the theme for dark mode support', async () => {
-    const { modResults } = await createModResult(true, defaultStyles);
+    const { modResults } = await createModResult(true);
     const { style } = modResults.resources;
     const appTheme = style.find(({ $ }) => $.name === 'AppTheme');
     expect(appTheme.$.parent).toBe('Theme.AppCompat.DayNight.NoActionBar');
   });
 
   it('removes the `ResetEditText` style', async () => {
-    const { modResults } = await createModResult(true, defaultStyles);
+    const { modResults } = await createModResult(true);
     const { style } = modResults.resources;
     const resetEditText = style.find(({ $ }) => $.name === 'ResetEditText');
     expect(resetEditText).toBeUndefined();
   });
 
   it('correctly removes the hardcoded colors from the `AppTheme`', async () => {
-    const { modResults } = await createModResult(true, defaultStyles);
+    const { modResults } = await createModResult(true);
     const { style } = modResults.resources;
 
     const excludedAttributes = ['android:textColor', 'android:editTextStyle'];
@@ -137,7 +137,7 @@ describe(withBuildProperties, () => {
   });
 
   it('does not modify the styles if `useDayNightTheme` is false', async () => {
-    const { modResults } = await createModResult(false, defaultStyles);
+    const { modResults } = await createModResult(false);
     expect(modResults.resources.style).toEqual(defaultStyles);
   });
 
@@ -149,7 +149,7 @@ describe(withBuildProperties, () => {
   });
 });
 
-async function createModResult(useDayNightTheme: boolean, style: any[]) {
+async function createModResult(useDayNightTheme: boolean, style: any[] = defaultStyles) {
   return compileMockModWithResultsAsync(
     {},
     {

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -278,18 +278,20 @@ export const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType> = (config,
       return config;
     }
 
+    // Replace `AppTheme` and remove `ResetEditText`
+    const excludedStyles = ['AppTheme', 'ResetEditText'];
     // Remove the hardcoded colors.
-    const toRemove = ['android:textColor', 'android:editTextStyle'];
+    const excludedAttributes = ['android:textColor', 'android:editTextStyle'];
 
-    // We only want to return the AppTheme here. We can drop the `ResetEditText` style.
     config.modResults.resources.style = [
       {
         $: {
           name: 'AppTheme',
           parent: 'Theme.AppCompat.DayNight.NoActionBar',
         },
-        item: [...style[0].item.filter(({ $ }) => !toRemove.includes($.name))],
+        item: [...style[0].item.filter(({ $ }) => !excludedAttributes.includes($.name))],
       },
+      ...style.filter(({ $ }) => !excludedStyles.includes($.name)),
     ];
 
     return config;

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -4,6 +4,7 @@ import {
   History,
   WarningAggregator,
   withAndroidManifest,
+  withAndroidStyles,
   withDangerousMod,
 } from 'expo/config-plugins';
 import fs from 'fs';
@@ -98,6 +99,10 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
         });
         return JSON.stringify(extraMavenRepos);
       },
+    },
+    {
+      propName: 'android.useDayNightTheme',
+      propValueGetter: (config) => (config.android?.useDayNightTheme ?? false).toString(),
     },
   ],
   'withAndroidBuildProperties'
@@ -258,6 +263,35 @@ export const withAndroidQueries: ConfigPlugin<PluginConfigType> = (config, props
     };
 
     config.modResults.manifest.queries = [newQueries];
+    return config;
+  });
+};
+
+export const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withAndroidStyles(config, (config) => {
+    if (!props.android?.useDayNightTheme) {
+      return config;
+    }
+
+    const { style = [] } = config.modResults.resources;
+    if (!style.length) {
+      return config;
+    }
+
+    // Remove the hardcoded colors.
+    const toRemove = ['android:textColor', 'android:editTextStyle'];
+
+    // We only want to return the AppTheme here. We can drop the `ResetEditText` style.
+    config.modResults.resources.style = [
+      {
+        $: {
+          name: 'AppTheme',
+          parent: 'Theme.AppCompat.DayNight.NoActionBar',
+        },
+        item: [...style[0].item.filter(({ $ }) => !toRemove.includes($.name))],
+      },
+    ];
+
     return config;
   });
 };

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -157,6 +157,12 @@ export interface PluginConfigTypeAndroid {
    *  @see [Android documentation](https://developer.android.com/guide/topics/manifest/queries-element)
    */
   manifestQueries?: PluginConfigTypeAndroidQueries;
+  /**
+   * Changes the apps theme to a DayNight variant to correctly support dark mode.
+   *
+   * @see [Android documentation](https://developer.android.com/develop/ui/views/theming/darktheme)
+   */
+  useDayNightTheme?: boolean;
 }
 
 // @docsMissing
@@ -564,6 +570,8 @@ const schema: JSONSchemaType<PluginConfigType> = {
         usesCleartextTraffic: { type: 'boolean', nullable: true },
 
         useLegacyPackaging: { type: 'boolean', nullable: true },
+
+        useDayNightTheme: { type: 'boolean', nullable: true },
 
         manifestQueries: {
           type: 'object',

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -6,6 +6,7 @@ import {
   withAndroidPurgeProguardRulesOnce,
   withAndroidCleartextTraffic,
   withAndroidQueries,
+  withAndroidDayNightTheme,
 } from './android';
 import { withIosBuildProperties, withIosDeploymentTarget } from './ios';
 import { PluginConfigType, validateConfig } from './pluginConfig';
@@ -30,6 +31,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
   //
   // plugins order matter: the later one would run first
   config = withAndroidPurgeProguardRulesOnce(config);
+  config = withAndroidDayNightTheme(config, pluginConfig);
 
   config = withIosBuildProperties(config, pluginConfig);
   config = withIosDeploymentTarget(config, pluginConfig);


### PR DESCRIPTION
# Why
#33957 will be a breaking change because of how it affects text color on Android. We will hold off on this until SDK 53. In the meantime, users who want to enable this change now can use this property `android.useDayNightTheme`.

# How
Added a new android property, `useDayNightTheme`

# Test Plan
Sandbox. Tested with true, false and when the property is not present. All work correctly.
Added unit tests
