### PR TITLE
[docs] APISection: display deprecated note inline, add header decoration

### DIFF
--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -1,5 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { getTagData } from '~/components/plugins/api/APISectionUtils';
 import { CALLOUT, H2 } from '~/ui/components/Text';
 
 import { ConstantDefinitionData } from './APIDataTypes';
@@ -22,7 +23,11 @@ const renderConstant = (
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} className={STYLES_APIBOX}>
     <APISectionDeprecationNote comment={comment} sticky />
-    <APIBoxHeader name={`${apiName ? `${apiName}.` : ''}${name}`} comment={comment} />
+    <APIBoxHeader
+      name={`${apiName ? `${apiName}.` : ''}${name}`}
+      comment={comment}
+      deprecated={Boolean(getTagData('deprecated', comment))}
+    />
     {type && (
       <CALLOUT className={mergeClasses(STYLES_SECONDARY, ELEMENT_SPACING, VERTICAL_SPACING)}>
         Type: <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -125,7 +125,7 @@ const renderInterface = (
       <APISectionDeprecationNote comment={comment} sticky />
       <APIBoxHeader name={name} comment={comment} />
       {extendedTypes?.length ? (
-        <CALLOUT className={ELEMENT_SPACING}>
+        <CALLOUT className={mergeClasses(ELEMENT_SPACING, 'px-4')}>
           <span className={STYLES_SECONDARY}>Extends: </span>
           {extendedTypes.map(extendedType => (
             <CODE key={`extend-${extendedType.name}`}>
@@ -135,14 +135,6 @@ const renderInterface = (
         </CALLOUT>
       ) : null}
       <APICommentTextBlock comment={comment} includePlatforms={false} />
-      {interfaceMethods.length > 0 && (
-        <>
-          <APIBoxSectionHeader text={`${name} Methods`} exposeInSidebar baseNestingLevel={99} />
-          {interfaceMethods.map(method =>
-            renderMethod(method, { exposeInSidebar: false, sdkVersion })
-          )}
-        </>
-      )}
       {interfaceFields.length > 0 && (
         <>
           <Table containerClassName="rounded-none border-0 border-t">
@@ -151,6 +143,14 @@ const renderInterface = (
               {interfaceFields.map(field => renderInterfacePropertyRow(field, sdkVersion))}
             </tbody>
           </Table>
+        </>
+      )}
+      {interfaceMethods.length > 0 && (
+        <>
+          <APIBoxSectionHeader text={`${name} Methods`} exposeInSidebar baseNestingLevel={99} />
+          {interfaceMethods.map(method =>
+            renderMethod(method, { exposeInSidebar: false, sdkVersion, nested: true })
+          )}
         </>
       )}
     </div>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -16,6 +16,7 @@ import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import {
   extractDefaultPropValue,
   getCommentOrSignatureComment,
+  getTagData,
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
@@ -112,8 +113,13 @@ export const renderProp = (
     <div
       key={`prop-entry-${name}`}
       className={mergeClasses('border-t border-palette-gray4 first:border-t-0')}>
-      <APISectionDeprecationNote comment={extractedComment} sticky />
-      <APIBoxHeader name={name} comment={extractedComment} baseNestingLevel={baseNestingLevel} />
+      <APISectionDeprecationNote comment={extractedComment} className="mx-4 mb-0 mt-3" />
+      <APIBoxHeader
+        name={name}
+        comment={extractedComment}
+        baseNestingLevel={baseNestingLevel}
+        deprecated={Boolean(getTagData('deprecated', extractedComment))}
+      />
       <div className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -10,9 +10,10 @@ type Props = {
   name: string;
   comment?: CommentData;
   baseNestingLevel?: number;
+  deprecated?: boolean;
 };
 
-export function APIBoxHeader({ name, comment, baseNestingLevel = 3 }: Props) {
+export function APIBoxHeader({ name, comment, baseNestingLevel = 3, deprecated = false }: Props) {
   const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
   return (
     <div
@@ -22,7 +23,12 @@ export function APIBoxHeader({ name, comment, baseNestingLevel = 3 }: Props) {
         '[&_h3]:!mb-0'
       )}>
       <HeaderComponent tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="!wrap-anywhere !text-base !leading-snug">
+        <MONOSPACE
+          weight="medium"
+          className={mergeClasses(
+            '!wrap-anywhere !text-base !leading-snug',
+            deprecated && 'text-secondary line-through decoration-quaternary decoration-[0.5px]'
+          )}>
           {name}
         </MONOSPACE>
       </HeaderComponent>


### PR DESCRIPTION
# Why

Alek has reported a small regression in APISection to me after latest changes:

![image (2)](https://github.com/user-attachments/assets/66969c6c-466c-406f-9ce7-2f40c6523126)

# How

Display deprecated note inline in nested variant, add decoration to the deprecated entity header (similar to one already present in ToC), small tweaks for interfaces rendering in edge-cases.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-01-07 at 13 00 29](https://github.com/user-attachments/assets/5b9852ce-cbe1-46e6-9a43-c53cf5f835e4)
