### PR TITLE
[web-browser][ios] Fix crash when using popover presentation on iPad

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad. ([#33996](https://github.com/expo/expo/pull/33996) by [@jblarriviere](https://github.com/jblarriviere))
+
 ### 💡 Others
 
 ## 14.0.1 — 2024-11-14

--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -32,12 +32,11 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
     while currentViewController?.presentedViewController != nil {
       currentViewController = currentViewController?.presentedViewController
     }
-  
     if UIDevice.current.userInterfaceIdiom == .pad {
-     let viewFrame = currentViewController!.view.frame
+     let viewFrame = currentViewController?.view.frame
       viewController.popoverPresentationController?.sourceRect = CGRect(
-        x: viewFrame.midX,
-        y: viewFrame.maxY,
+        x: viewFrame?.midX ?? 0,
+        y: viewFrame?.maxY ?? 0,
         width: 0,
         height: 0
       )

--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -33,7 +33,7 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
       currentViewController = currentViewController?.presentedViewController
     }
     if UIDevice.current.userInterfaceIdiom == .pad {
-     let viewFrame = currentViewController?.view.frame
+      let viewFrame = currentViewController?.view.frame
       viewController.popoverPresentationController?.sourceRect = CGRect(
         x: viewFrame?.midX ?? 0,
         y: viewFrame?.maxY ?? 0,

--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -32,6 +32,18 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
     while currentViewController?.presentedViewController != nil {
       currentViewController = currentViewController?.presentedViewController
     }
+  
+    if UIDevice.current.userInterfaceIdiom == .pad {
+     let viewFrame = currentViewController!.view.frame
+      viewController.popoverPresentationController?.sourceRect = CGRect(
+        x: viewFrame.midX,
+        y: viewFrame.maxY,
+        width: 0,
+        height: 0
+      )
+      viewController.popoverPresentationController?.sourceView = currentViewController?.view
+    }
+
     currentViewController?.present(viewController, animated: true) {
       self.didPresent()
     }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33995

# How

Replicating fix of similar issue (see #29892) : Check we are running on iPad and set the properties

You can see how it looks here. I'm not sure if it's the expected behaviour from iPad users, I'm not using any. I'd be happy to get some feedback about it.
<img width="630" alt="Screenshot 2025-01-07 at 16 02 08" src="https://github.com/user-attachments/assets/b4a66fb8-65d3-4a82-a405-a293a76a704d" />

# Test Plan

Tested in repro project : https://github.com/jblarriviere/web-browser-test (last commit applies similar patch)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
