### PR TITLE
Fix incorrect folder placement in create-pages.mdx

### DIFF
--- a/docs/pages/router/create-pages.mdx
+++ b/docs/pages/router/create-pages.mdx
@@ -138,9 +138,9 @@ Expo Router recommends sorting components and hooks by "feature" and routes by "
     'app/sign-out',
     'app/profile',
     'app/tasks',
+    'app/profile/[user]',
     'components/authentication',
     'components/tasks/overview',
-    'components/profile/[user]',
   ]}
 />
 


### PR DESCRIPTION
Corrected a minor error in the #Recommended structure section where the route "/profile/[user]" was incorrectly placed inside the components folder instead of the app folder. The route has been moved to the app folder for accuracy and alignment with the Expo Router conventions.

# Why

The previous documentation inaccurately placed the dynamic route "/profile/[user]" inside the components folder, which could lead to confusion since Expo Router requires dynamic routes to be placed inside the app directory for proper functioning. This PR corrects the folder placement to ensure clarity and consistency with Expo Router’s conventions.

# How

The error was corrected by moving the "/profile/[user]" route example from the components folder to the app folder in the #Recommended structure section of the create-pages.mdx file.

# Test Plan

Since this change affects documentation only, no functional code changes were made. The documentation update was visually reviewed to ensure clarity and correctness. To verify, readers can cross-check the recommended structure by creating a dynamic route in a test Expo Router project.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
