### PR TITLE
[updates] Fix fingerprint test

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -74,6 +74,8 @@ runs:
         EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: host.exp.exponent
         MAX_RETRIES: ${{ inputs.retries }}
         RETRY_DELAY: 30
+        EXPO_DEBUG: ${{ runner.debug && '1' || '0' }}
+
 
     - name: Wait for build to finish
       shell: bash

--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for testing Apple TV build
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - name: 🚀 Build with EAS for tvOS
@@ -95,14 +95,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: 'updates_testing_debug'
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On tvOS compile workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: updates_testing_debug

--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -67,7 +67,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E disabled tests
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
@@ -76,14 +76,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: ${{ matrix.variant }}
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On ${{ matrix.platform }} workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: ${{ matrix.variant }}

--- a/.github/workflows/updates-e2e-error-recovery.yml
+++ b/.github/workflows/updates-e2e-error-recovery.yml
@@ -67,7 +67,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E error recovery tests
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
@@ -76,14 +76,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: ${{ matrix.variant }}
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On ${{ matrix.platform }} workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: ${{ matrix.variant }}

--- a/.github/workflows/updates-e2e-fingerprint.yml
+++ b/.github/workflows/updates-e2e-fingerprint.yml
@@ -27,7 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  if: false # disable here instead of workflow UI so that a PR can re-enable
   build:
     strategy:
       fail-fast: false
@@ -70,7 +69,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E fingerprint tests
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
@@ -79,14 +78,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: ${{ matrix.variant }}
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On ${{ matrix.platform }} workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: ${{ matrix.variant }}

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -67,7 +67,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E startup tests
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
@@ -76,14 +76,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: ${{ matrix.variant }}
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On ${{ matrix.platform }} workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: ${{ matrix.variant }}

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -93,7 +93,7 @@ jobs:
       - name: 📦 Get commit message
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
-        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E tests
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
@@ -102,14 +102,14 @@ jobs:
         with:
           platform: ${{ env.EAS_PLATFORM }}
           profile: ${{ matrix.variant }}
-          projectRoot: './updates-e2e'
+          projectRoot: '${{ runner.temp }}/updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On ${{ matrix.platform }} workflow canceled
         if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
         run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
-        working-directory: './updates-e2e'
+        working-directory: '${{ runner.temp }}/updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: ${{ matrix.variant }}

--- a/packages/expo-updates/e2e/fixtures/Updates-fingerprint.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-fingerprint.e2e.ts
@@ -70,42 +70,4 @@ describe('Basic tests', () => {
 
     await device.terminateApp();
   });
-
-  it('does not download new update when it takes longer than timeout', async () => {
-    const bundleFilename = 'bundle1.js';
-    const newNotifyString = 'test-update-1';
-    const hash = await Update.copyBundleToStaticFolder(
-      projectRoot,
-      bundleFilename,
-      newNotifyString,
-      platform
-    );
-    const manifest =
-      await Update.getUpdateManifestForBundleFilenameWithFingerprintRuntimeVersionAsync(
-        new Date(),
-        hash,
-        'test-update-1-key',
-        bundleFilename,
-        [],
-        projectRoot,
-        platform
-      );
-
-    Server.start(Update.serverPort, protocolVersion, 7000);
-    await Server.serveSignedManifest(manifest, projectRoot);
-    await device.installApp();
-    await device.launchApp({
-      newInstance: true,
-    });
-    await waitForAppToBecomeVisible();
-    const message = await testElementValueAsync('updateString');
-
-    if (message !== 'test') {
-      console.log(debugInstructions);
-    }
-
-    jestExpect(message).toBe('test');
-
-    await device.terminateApp();
-  });
 });

--- a/packages/expo-updates/e2e/fixtures/project_files/.fingerprintignore
+++ b/packages/expo-updates/e2e/fixtures/project_files/.fingerprintignore
@@ -1,1 +1,3 @@
-**/ios/Gymfile
+**/android/**/*
+**/ios/**/*
+node_modules/ansi-styles/index.js


### PR DESCRIPTION
# Why

The fingerprint test was broken since the project is a bare project, and we don't install pods on the CI runner ahead of dispatching the `eas build` call, which causes the fingerprint there to differ from the fingerprint on the builder, thus causing the EAS Build to fail.

Closes ENG-14055.

# How

The remedy is to treat this project like a managed project, ignoring the native directories for the fingerprint. This doesn't dilute the test coverage since the test is purely testing that the full runtime version embedding mechanism of the library works, and taking just a fingerprint of the JS or something is sufficient.

This also does a few more things:
- Use `${{ runner.temp }}` for base to ensure repo packages don't show up in the project. This is so that the config getter doesn't add web to the config platforms just because react-dom is installed in the projects parent (the repo). Behavior was added by https://github.com/expo/expo/pull/32149 and may cause unstable fingerprints sometimes if it's only present in CI.
- Enable EXPO_DEBUG when GHA runner is debug enabled.
- no idea why `node_modules/ansi-styles/index.js` needed to be added to fingerprintignore but it was causing a fingerprint mismatch.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
