### PR TITLE
[updates] Disable fingerprint workflow in workflow file

### DIFF
--- a/.github/workflows/updates-e2e-fingerprint.yml
+++ b/.github/workflows/updates-e2e-fingerprint.yml
@@ -27,6 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  if: false # disable here instead of workflow UI so that a PR can re-enable
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Why

Currently this workflow is disabled via the workflows UI. This is preventing us from testing fixes to it in new PRs (draft or otherwise).

# How

Before we re-enable it in the workflows UI, we need to disable it in the workflow file itself. That will allow follow-up PRs to test re-enabling it in the PR.

# Test Plan

N/A (this is a no-op).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
