### PR TITLE
Expand git-submodules instructions

### DIFF
--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -15,11 +15,20 @@ To initialize a submodule on EAS Build builder:
 
 <Step label="1">
 
-Create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories.
+Encode the ssh key you want to use as base64
+```bash
+openssl enc -base64 -in my.key -out my.key.base64
+```
 
 </Step>
 
 <Step label="2">
+
+Create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories.
+
+</Step>
+
+<Step label="3">
 
 Add an [`eas-build-pre-install` npm hook](/build-reference/npm-hooks/) to check out those submodules, for example:
 
@@ -35,7 +44,13 @@ mkdir -p ~/.ssh
 # git remote set-url origin git@github.com:example/repo.git
 
 # restore private key from env variable and generate public key
-echo "$SSH_KEY_BASE64" | base64 -d > ~/.ssh/id_rsa
+# On android build servers, the -i flag is necessary to parse newlines
+# On macOS, this flag means "input file", so it has to be omitted
+if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+  echo "$SSH_KEY_BASE64" | base64 -di > ~/.ssh/id_rsa
+elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
+  echo "$SSH_KEY_BASE64" | base64 -d > ~/.ssh/id_rsa
+fi
 chmod 0600 ~/.ssh/id_rsa
 ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
 


### PR DESCRIPTION
Add instructions on how to generate a base64 encoded ssh key, and changed the load-ssh-keys script to work for both android and iOS builds

# Why

When trying to build our app for both iOS and android, using this script to load an ssh key for private packages, I noticed the android build failed while installing packages. After inspecting the pre-install hook log, i noticed that the base64 command, as listed in this document, gave a 'Invalid format' error. After some troubleshooting, i found out that the `base64` package on macOS is different from that on linux. the `-i` flag in the linux package is for 'ignore garbage', and is required for parsing line separators (see [this](https://stackoverflow.com/questions/15490728/decode-base64-invalid-input) stackoverflow post). 

# How

I found a working solution from the aforementioned stackoverflow post. I tested this solution for my own app.

# Test Plan

I tested the modified script by running both an android and an iOS build

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
