### PR TITLE
[expo-blur][android] Bump Dimezis/BlurView to latest patch version

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Bump the Dimezis/BlurView dependency to the latest patch version.
+- [Android] Bump the Dimezis/BlurView dependency to the latest patch version. ([#34012](https://github.com/expo/expo/pull/34012) by [@jakobsen](https://github.com/jakobsen))
 
 ### 💡 Others
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Bump the Dimezis/BlurView dependency to the latest patch version.
+
 ### 💡 Others
 
 ## 14.0.1 — 2024-10-22

--- a/packages/expo-blur/android/build.gradle
+++ b/packages/expo-blur/android/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-  implementation 'com.github.Dimezis:BlurView:version-2.0.3'
+  implementation 'com.github.Dimezis:BlurView:version-2.0.6'
 }


### PR DESCRIPTION
# What

When attempting to run a brand new expo project on the Android emulator I got the following error:

```
> Configure project :react-native-reanimated
Android gradle plugin: 8.6.0
Gradle: 8.10.2

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task
':app:processDebugResources'.
> Could not resolve all dependencies for configuration
':app:debugRuntimeClasspath'.
   > Could not find com.github.Dimezis:BlurView:version-2.0.3.
     Searched in the following locations:
       -
https://oss.sonatype.org/content/repositories/snapshots/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
       -
https://repo.maven.apache.org/maven2/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
       -
https://dl.google.com/dl/android/maven2/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
       -
https://www.jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
       -
file:/Users/erik/dreng/app/node_modules/react-native/android/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
       -
file:/Users/erik/dreng/app/node_modules/jsc-android/dist/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
     Required by:
         project :app > project :expo > project :expo-blur
```

Upon further investigation, I discovered that BlurView 2.0.3 is unavailable from jitpack, see https://www.jitpack.io/#Dimezis/BlurView.

In https://github.com/jitpack/jitpack.io/issues/6766, the library author recommends using the latest version:

> Just use the latest version folks.
> There is some problem with the Jitpack - it tried rebuilding some of
the lib versions but failed because one dependency was no longer available.
This ended up breaking previously existing artifacts



# How

Bump the dependency version in `packages/expo-blur/android/build.gradle`.

# Test Plan

All android tests for `expo-blur` pass.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/bd4e7763-2ea4-459a-a2d7-5b291833dd99" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
