### PR TITLE
docs: update tutorial

### DIFF
--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -117,7 +117,7 @@ export default function Button({ label, theme, /* @tutinfo Pass this prop to tri
 
   return (
     <View style={styles.buttonContainer}>
-      <Pressable style={styles.button} onPress={() => alert('You pressed a button.')}>
+      <Pressable style={styles.button} onPress={/* @tutinfo */onPress/* @end */}>
         <Text style={styles.buttonLabel}>{label}</Text>
       </Pressable>
     </View>


### PR DESCRIPTION
# Why

In this chapter in the tutorial we add a new option to the button, yet we did not update the whole options we have, this update will make it easier to understand and implement the next chapter.

Related page; https://docs.expo.dev/tutorial/image-picker/

we can either add this code update in the image-picker chapter, or update it in the create modal chapter, I preferred to keep in the image-picker so that the whole onPress change happen in one place

in the create modal chapter this code is written, yet I felt it would make more sense to have it before.  Maybe it would be possible to add an info about that? 

![image](https://github.com/user-attachments/assets/a99dfbf3-89bb-4db3-bd5e-bbc8d0458694)


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
