### PR TITLE
fix(cli): add `EAI_AGAIN` DNS service errors to offline detection

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
+- Add `EAI_AGAIN` DNS service errors to offline detection.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
-- Add `EAI_AGAIN` DNS service errors to offline detection.
+- Add `EAI_AGAIN` DNS service errors to offline detection. ([#34014](https://github.com/expo/expo/pull/34014) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -134,6 +134,7 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
  * Determine if the provided error is related to a network issue.
  * When this returns true, offline mode should be enabled.
  *   - `ENOTFOUND` is thrown when the DNS lookup failed
+ *   - `EAI_AGAIN` is thrown when DNS lookup failed due to a server-side error
  *   - `UND_ERR_CONNECT_TIMEOUT` is thrown after DNS is resolved, but server can't be reached
  *
  * @see https://nodejs.org/api/errors.html
@@ -141,7 +142,9 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
  */
 function isNetworkError(error: Error & { code?: string }) {
   return (
-    'code' in error && error.code && ['ENOTFOUND', 'UND_ERR_CONNECT_TIMEOUT'].includes(error.code)
+    'code' in error &&
+    error.code &&
+    ['ENOTFOUND', 'EAI_AGAIN', 'UND_ERR_CONNECT_TIMEOUT'].includes(error.code)
   );
 }
 


### PR DESCRIPTION
# Why

Someone on Bluesky mentioned running into this error. [`EAI_AGAIN`](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html) indicates that the DNS service returned a server-side error. Although it doesn't indicate the user is offline, it does prevent the CLI from accessing the Expo API to fetch the `expo-*` dependency versions to validate against.

# How

- Added `EAI_AGAIN` to fetch errors offline detection

# Test Plan

Unclear how to reproduce the error itself, seems like you'd need to set it up through Docker or a custom DNS service to throw this error.

Edit: https://bsky.app/profile/2p4b.bsky.social/post/3lf7zywzxqk2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
