### PR TITLE
fix(metro-runtime): parse errors with babel code frame identical on Windows and Mac

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/04-server-error-boundaries.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/04-server-error-boundaries.test.ts
@@ -107,7 +107,7 @@ test.describe(inputDir, () => {
 
     console.time('error-type');
     const text = await page.textContent('[data-testid="logbox_title"]');
-    expect(text).toMatch(/(Syntax Error|Uncaught Error)/);
+    expect(text).toBe('Syntax Error');
     console.timeEnd('error-type');
 
     expect(pageErrors.all.length).toEqual(2);

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Parse errors with Babel code frames as syntax errors on Windows. ([#34017](https://github.com/expo/expo/pull/34017) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 - fix: add e2e testing to server function errors ([#33971](https://github.com/expo/expo/pull/33971) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/metro-runtime/src/error-overlay/Data/parseLogBoxLog.tsx
+++ b/packages/@expo/metro-runtime/src/error-overlay/Data/parseLogBoxLog.tsx
@@ -14,7 +14,7 @@ type ExceptionData = any;
 const BABEL_TRANSFORM_ERROR_FORMAT =
   /^(?:TransformError )?(?:SyntaxError: |ReferenceError: )(.*): (.*) \((\d+):(\d+)\)\n\n([\s\S]+)/;
 const BABEL_CODE_FRAME_ERROR_FORMAT =
-  /^(?:TransformError )?(?:.*):? (?:.*?)(\/.*): ([\s\S]+?)\n([ >]{2}[\d\s]+ \|[\s\S]+|\u{001b}[\s\S]+)/u;
+  /^(?:TransformError )?(?:.*):? (?:.*?)([/|\\].*): ([\s\S]+?)\n([ >]{2}[\d\s]+ \|[\s\S]+|\u{001b}[\s\S]+)/u;
 const METRO_ERROR_FORMAT =
   /^(?:InternalError Metro has encountered an error:) (.*): (.*) \((\d+):(\d+)\)\n\n([\s\S]+)/u;
 


### PR DESCRIPTION
# Why

With the CLI E2E tests now also running on Windows, we noticed a weird anomaly with LogBox and dependency issues in RSC bundles. It results in a different error type on both Windows and Mac for the exact same error.

- Thrown error: `UnableToResolveError` (Metro's built-in error for missing dependencies)
- Windows: `Uncaught Error`
- MacOS: `Syntax Error`

# How

- Fixed `@expo/metro-runtime` babel code frame error matcher

# Test Plan

See CI and E2E tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
