### PR TITLE
[4/n] upgrade to react-native 0.77 - fix podfile.lock

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,7 +66,7 @@ jobs:
         working-directory: apps/bare-expo/ios
       - name: 🥥 Install pods in apps/bare-expo/ios
         if: steps.expo-caches.outputs.ios-pods-hit != 'true'
-        run: pod update hermes-engine --no-repo-update && pod install
+        run: pod install
         working-directory: apps/bare-expo/ios
       - name: 🏗️ Build iOS project
         run: ./scripts/start-ios-e2e-test.ts --build

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -619,9 +619,9 @@ PODS:
   - GoogleMaps/Maps (7.4.0):
     - GoogleMaps/Base
   - GooglePlaces (7.3.0)
-  - hermes-engine (0.77.0-rc.5):
-    - hermes-engine/Pre-built (= 0.77.0-rc.5)
-  - hermes-engine/Pre-built (0.77.0-rc.5)
+  - hermes-engine (0.77.0-rc.6):
+    - hermes-engine/Pre-built (= 0.77.0-rc.6)
+  - hermes-engine/Pre-built (0.77.0-rc.6)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -3352,7 +3352,7 @@ SPEC CHECKSUMS:
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GooglePlaces: 0609463845250bbadafa1739938181e54dece439
-  hermes-engine: 5cff8ed7702d512540a236f707a2bb86b474f20a
+  hermes-engine: e929405329190e9df3ef45cea87293072747f2ef
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
@@ -3447,4 +3447,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 567bb58fe91a07874d34e36dc2ed989b409d33cd
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -260,6 +260,7 @@ PODS:
     - React-RCTFabric
     - React-rendererdebug
     - React-utils
+    - ReactAppDependencyProvider
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
@@ -2127,7 +2128,7 @@ SPEC CHECKSUMS:
   ExpoImage: 89f672e47b391a749b56fecb3e2a8d6d68b9b379
   ExpoKeepAwake: 783e68647b969b210a786047c3daa7b753dcac1f
   ExpoLinearGradient: 7ca3b1d1625a1ab85c129abce4a3cdc78a9500a3
-  ExpoModulesCore: f6fcee9041ee48a8edcc7b9cde055cb313297e4c
+  ExpoModulesCore: 0752390621dd30477420a8a3e8711d2852fc430c
   ExpoSplashScreen: 43692d041bf848883410ed9d8836871ca5cf4d6a
   ExpoVideo: 85750319df61d76237b5952fca5a9f39504c6b9b
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
@@ -2208,4 +2209,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 69838eb56567a89dd6f23695b5e8145f838df60d
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2


### PR DESCRIPTION
# Why

Update Hermes engine from 0.77.0-rc.5 to 0.77.0-rc.6 in bare-expo and fabric tester because somehow it was pinned to a wrong version

# How

- update Podfile.lock, update pod install command

# Test Plan

CI green

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)