### PR TITLE
[docs] Update references of `--save-dev` command in multiple pages

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -12,8 +12,10 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
+
+<TabsGroup>
 
 [Jest](https://jestjs.io) is the most widely used unit and snapshot JavaScript testing framework. In this guide, you will learn how to set up Jest in your project, write a unit test, write a snapshot test, and best practices for structuring your tests when using Jest with React Native.
 
@@ -31,15 +33,57 @@ If you have created your project using [different template](/more/create-expo/#-
 
 Install `jest-expo` and other required dev dependencies in your project. Run the following command from your project's root directory:
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# For all other package managers',
-    '$ npx expo install -- --save-dev jest-expo jest @types/jest',
+    '# For macOS and Linux',
+    '$ npx expo install jest-expo jest @types/jest -- --save-dev',
     '',
-    '# For yarn',
-    '$ yarn add -D jest-expo jest @types/jest',
+    '# For Windows with Powershell',
+    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev jest-expo jest @types/jest']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install jest-expo jest @types/jest -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install jest-expo jest @types/jest -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install jest-expo jest @types/jest "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 > **Note:** If your project is not using TypeScript, you can skip installing `@types/jest`.
 
@@ -113,15 +157,57 @@ The [React Native Testing Library (`@testing-library/react-native`)](https://cal
 
 To install it, run the following command:
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# For all other package managers',
-    '$ npx expo install -- --save-dev @testing-library/react-native',
+    '# For macOS and Linux',
+    '$ npx expo install @testing-library/react-native -- --save-dev',
     '',
-    '# For yarn',
-    '$ yarn add -D @testing-library/react-native',
+    '# For Windows with Powershell',
+    '$ npx expo install @testing-library/react-native "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev @testing-library/react-native']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install @testing-library/react-native -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install @testing-library/react-native "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install @testing-library/react-native -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install @testing-library/react-native "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 > **warning** **Deprecated:** If you are using the default Expo template, after installing this library, you can uninstall the `react-test-renderer` and `@types/react-test-renderer` from your project's dev dependencies. The `react-test-renderer` has been deprecated and will no longer be maintained in the future. See [React's documentation for more information](https://react.dev/warnings/react-test-renderer).
 
@@ -313,3 +399,5 @@ For more information, see [CLI Options](https://jestjs.io/docs/en/cli) in Jest d
   href="/build-reference/e2e-tests/"
   Icon={Cube01Icon}
 />
+
+</TabsGroup>

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -41,7 +41,7 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
   cmd={[
     '$ npx expo install jest-expo jest @types/jest -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install jest-expo jest @types/jest -- --dev',
   ]}
 />
@@ -143,7 +143,7 @@ To install it, run the following command:
   cmd={[
     '$ npx expo install @testing-library/react-native -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install @testing-library/react-native -- --dev',
   ]}
 />
@@ -156,7 +156,7 @@ To install it, run the following command:
   cmd={[
     '$ npx expo install @testing-library/react-native "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install @testing-library/react-native "--" --dev',
   ]}
 />

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -35,48 +35,26 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install jest-expo jest @types/jest -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev jest-expo jest @types/jest']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install jest-expo jest @types/jest -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install jest-expo jest @types/jest -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install jest-expo jest @types/jest "--" --dev',
   ]}
 />
@@ -159,48 +137,26 @@ To install it, run the following command:
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install @testing-library/react-native -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install @testing-library/react-native "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev @testing-library/react-native']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install @testing-library/react-native -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install @testing-library/react-native "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install @testing-library/react-native -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install @testing-library/react-native "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install @testing-library/react-native "--" --dev',
   ]}
 />

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -6,8 +6,10 @@ description: An in-depth guide on configuring an Expo project with TypeScript.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tab, Tabs } from '~/ui/components/Tabs';
+import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
+
+<TabsGroup>
 
 Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). The JavaScript interface of Expo SDK is written in TypeScript.
 
@@ -17,7 +19,33 @@ This guide provides a quick way to get started for a new project and also steps 
 
 To create a new project, use the default template which includes base TypeScript configuration, example code, and basic navigation structure:
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal cmd={['$ npx create-expo-app@latest']} />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn create expo-app']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal cmd={['$ pnpm create expo-app']} />
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal cmd={['$ bun create expo']} />
+
+</Tab>
+
+</Tabs>
 
 After you create a new project using the command above, make sure to follow instructions from:
 
@@ -49,8 +77,6 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
 <Tabs>
 
 <Tab label="npx">
-
-<Terminal cmd={['$ npx expo install typescript @types/react -- --save-dev']} />
 
 <Terminal
   cmd={[
@@ -220,15 +246,57 @@ Some Expo libraries provide both static types and type generation capabilities. 
 
 Additional setup is required to use TypeScript for configuration files such as **metro.config.js** or **app.config.js**. You need to utilize [`ts-node` require hook](https://github.com/TypeStrong/ts-node#programmatic) to import TypeScript files within your JS config file. This hook allows TypeScript imports while keeping the root file as JavaScript.
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# For all other package managers',
-    '$ npx expo install -- --save-dev ts-node',
+    '# For macOS and Linux',
+    '$ npx expo install ts-node -- --save-dev',
     '',
-    '# For yarn',
-    '$ yarn add -D ts-node',
+    '# For Windows with Powershell',
+    '$ npx expo install ts-node "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev ts-node']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install ts-node -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install ts-node "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install ts-node -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install ts-node "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 ### metro.config.js
 
@@ -296,3 +364,5 @@ Some language features may require additional configuration. For example, if you
 A good place to start learning TypeScript is the official [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html).
 
 **For TypeScript and React components,** we recommend referring to the [React TypeScript CheatSheet](https://github.com/typescript-cheatsheets/react) to learn how to type your React components in a variety of common situations.
+
+</TabsGroup>

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -19,33 +19,7 @@ This guide provides a quick way to get started for a new project and also steps 
 
 To create a new project, use the default template which includes base TypeScript configuration, example code, and basic navigation structure:
 
-<Tabs>
-
-<Tab label="npx">
-
 <Terminal cmd={['$ npx create-expo-app@latest']} />
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn create expo-app']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal cmd={['$ pnpm create expo-app']} />
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal cmd={['$ bun create expo']} />
-
-</Tab>
-
-</Tabs>
 
 After you create a new project using the command above, make sure to follow instructions from:
 
@@ -76,48 +50,26 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install typescript @types/react -- --save-dev',
+    '$ npx expo install typescript @types/react  -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install typescript @types/react "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev typescript @types/react']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install typescript @types/react -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install typescript @types/react "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install typescript @types/react -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install typescript @types/react "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install typescript @types/react "--" --dev',
   ]}
 />
@@ -248,48 +200,26 @@ Additional setup is required to use TypeScript for configuration files such as *
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install ts-node -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install ts-node "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev ts-node']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install ts-node -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install ts-node "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install ts-node -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install ts-node "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install ts-node "--" --dev',
   ]}
 />

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -206,7 +206,7 @@ Additional setup is required to use TypeScript for configuration files such as *
   cmd={[
     '$ npx expo install ts-node -- --save-dev',
     '',
-   '# For Bun and Yarn',
+    '# For Bun and Yarn',
     '$ npx expo install ts-node -- --dev',
   ]}
 />

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -46,16 +46,6 @@ Rename files to convert them to TypeScript. For example, start with the root com
 
 To install required `devDependencies` such as `typescript` and `@types/react` in **package.json**:
 
-<Terminal
-  cmd={[
-    '# For all other package managers',
-    '$ npx expo install -- --save-dev typescript @types/react',
-    '',
-    '# For yarn',
-    '$ yarn add -D typescript @types/react',
-  ]}
-/>
-
 <Tabs>
 
 <Tab label="npx">

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -56,7 +56,7 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
   cmd={[
     '$ npx expo install typescript @types/react  -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install typescript @types/react -- --dev',
   ]}
 />
@@ -69,7 +69,7 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
   cmd={[
     '$ npx expo install typescript @types/react "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install typescript @types/react "--" --dev',
   ]}
 />
@@ -206,7 +206,7 @@ Additional setup is required to use TypeScript for configuration files such as *
   cmd={[
     '$ npx expo install ts-node -- --save-dev',
     '',
-    '# For bun and yarn',
+   '# For Bun and Yarn',
     '$ npx expo install ts-node -- --dev',
   ]}
 />
@@ -219,7 +219,7 @@ Additional setup is required to use TypeScript for configuration files such as *
   cmd={[
     '$ npx expo install ts-node "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install ts-node "--" --dev',
   ]}
 />

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -6,6 +6,7 @@ description: An in-depth guide on configuring an Expo project with TypeScript.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
 Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). The JavaScript interface of Expo SDK is written in TypeScript.
@@ -54,6 +55,60 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
     '$ yarn add -D typescript @types/react',
   ]}
 />
+
+<Tabs>
+
+<Tab label="npx">
+
+<Terminal cmd={['$ npx expo install typescript @types/react -- --save-dev']} />
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install typescript @types/react -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install typescript @types/react "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev typescript @types/react']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install typescript @types/react -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install typescript @types/react "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install typescript @types/react -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install typescript @types/react "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 > **info** Alternatively, run `npx expo start` command to install `typescript` and `@types/react` dev dependencies.
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -7,7 +7,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
+
+<TabsGroup>
 
 [ESLint](https://eslint.org/) is a JavaScript linter that helps you find and fix errors in your code. It's a great tool to help you write better code and catch mistakes before they make it to production. In conjunction, you can use [Prettier](https://prettier.io/docs/en/), a code formatter that ensures all the code files follow a consistent styling.
 
@@ -372,3 +374,5 @@ To use `npx expo lint` command to lint your code, update the `lint` script in yo
 Now you can run `npx expo lint` to lint your code.
 
 </Step>
+
+</TabsGroup>

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -27,17 +27,57 @@ To set up ESLint in your Expo project, you can use the Expo CLI to install the n
 
 Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo) in your project.
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# Install required ESLint configuration manually',
+    '# For macOS and Linux',
+    '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
     '',
-    '# For other package managers',
-    '$ npx expo install -- --save-dev eslint@8 eslint-config-expo',
-    '',
-    '# For yarn only',
-    '$ yarn add -D eslint eslint-config-expo',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev eslint@8 eslint-config-expo']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install eslint@8 eslint-config-expo -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint@8 eslint-config-expo "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 </Step>
 
@@ -127,7 +167,7 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(
-  /* @info This will no longer assert linting errors */ __dirname /* @end */
+  /* @info This will no longer assert linting errors. */ __dirname /* @end */
 );
 
 module.exports = config;
@@ -139,15 +179,57 @@ module.exports = config;
 
 To install Prettier in your project:
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# For other package managers',
-    '$ npx expo install -- --save-dev prettier eslint-config-prettier eslint-plugin-prettier',
+    '# For macOS and Linux',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
     '',
-    '# For yarn only',
-    '$ yarn add -D prettier eslint-config-prettier eslint-plugin-prettier',
+    '# For Windows with Powershell',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev prettier eslint-config-prettier eslint-plugin-prettier']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 ### Setup
 
@@ -200,15 +282,57 @@ If you're migrating from an older version of Expo SDK that has `eslint-config-un
 
 Remove the `eslint-config-universe` library and install the `eslint-config-expo` manually:
 
+<Tabs>
+
+<Tab label="npx">
+
 <Terminal
   cmd={[
-    '# For other package managers',
-    '$ npx expo install -- --save-dev eslint-config-expo',
+    '# For macOS and Linux',
+    '$ npx expo install eslint-config-expo -- --save-dev',
     '',
-    '# For yarn only',
-    '$ yarn add -D eslint-config-expo',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint-config-expo "--" --save-dev',
   ]}
 />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add --dev eslint-config-expo']} />
+
+</Tab>
+
+<Tab label="pnpm">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install eslint-config-expo -- --save-dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint-config-expo "--" --save-dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="bun">
+
+<Terminal
+  cmd={[
+    '# For macOS and Linux',
+    '$ npx expo install eslint-config-expo -- --dev',
+    '',
+    '# For Windows with Powershell',
+    '$ npx expo install eslint-config-expo "--" --dev',
+  ]}
+/>
+
+</Tab>
+
+</Tabs>
 
 </Step>
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -31,48 +31,26 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev eslint@8 eslint-config-expo']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install eslint@8 eslint-config-expo -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install eslint@8 eslint-config-expo "--" --dev',
   ]}
 />
@@ -183,48 +161,26 @@ To install Prettier in your project:
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev prettier eslint-config-prettier eslint-plugin-prettier']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --dev',
   ]}
 />
@@ -286,48 +242,26 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
 
 <Tabs>
 
-<Tab label="npx">
+<Tab label="macOS/Linux">
 
 <Terminal
   cmd={[
-    '# For macOS and Linux',
     '$ npx expo install eslint-config-expo -- --save-dev',
     '',
-    '# For Windows with Powershell',
-    '$ npx expo install eslint-config-expo "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal cmd={['$ yarn add --dev eslint-config-expo']} />
-
-</Tab>
-
-<Tab label="pnpm">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
-    '$ npx expo install eslint-config-expo -- --save-dev',
-    '',
-    '# For Windows with Powershell',
-    '$ npx expo install eslint-config-expo "--" --save-dev',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="bun">
-
-<Terminal
-  cmd={[
-    '# For macOS and Linux',
+    '# For bun and yarn',
     '$ npx expo install eslint-config-expo -- --dev',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal
+  cmd={[
+    '$ npx expo install eslint-config-expo "--" --save-dev',
     '',
-    '# For Windows with Powershell',
+    '# For bun and yarn',
     '$ npx expo install eslint-config-expo "--" --dev',
   ]}
 />

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -37,7 +37,7 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
   cmd={[
     '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install eslint@8 eslint-config-expo -- --dev',
   ]}
 />
@@ -50,7 +50,7 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
   cmd={[
     '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install eslint@8 eslint-config-expo "--" --dev',
   ]}
 />
@@ -167,7 +167,7 @@ To install Prettier in your project:
   cmd={[
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --dev',
   ]}
 />
@@ -180,7 +180,7 @@ To install Prettier in your project:
   cmd={[
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --dev',
   ]}
 />
@@ -248,7 +248,7 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
   cmd={[
     '$ npx expo install eslint-config-expo -- --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install eslint-config-expo -- --dev',
   ]}
 />
@@ -261,7 +261,7 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
   cmd={[
     '$ npx expo install eslint-config-expo "--" --save-dev',
     '',
-    '# For bun and yarn',
+    '# For Bun and Yarn',
     '$ npx expo install eslint-config-expo "--" --dev',
   ]}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update references of the `--save-dev` command to install dev dependency in an Expo project for different desktop operating systems and different variant of the same option for bun and yarn package managers.

Fixes #33998

Context [Slack thread](https://exponent-internal.slack.com/archives/C5ERY0TAR/p1736298684450699?thread_ts=1736295415.501569&cid=C5ERY0TAR)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- In the Unit testing, Using ESLint, and Using TypeScript guides, update the references to the `--save-dev` command as per the discussion in the Slack link and the GitHub issue linked above for macOS/Linux and Windows platforms.
- When using bun and yarn v1, the `--dev` option is used to install dev dependencies, so `--save-dev` doesn't work with `npx expo`. For reference, see https://bun.sh/guides/install/add-dev.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview Example

![CleanShot 2025-01-08 at 20 34 14](https://github.com/user-attachments/assets/575173cf-79aa-4313-88e1-dcba4fec05ff)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
