### PR TITLE
[docs] Add missing light sensor in the Sensors description

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, magnetometer, and pedometer.
+description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, light, magnetometer, and pedometer.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v50.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sensors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, magnetometer, and pedometer.
+description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, light, magnetometer, and pedometer.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-50/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v51.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sensors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, magnetometer, and pedometer.
+description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, light, magnetometer, and pedometer.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v52.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sensors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, magnetometer, and pedometer.
+description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, light, magnetometer, and pedometer.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the Sensors API reference lists all the available sensors in its page description but is missing light sensor reference.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `description` of Sensors API reference for all available SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
