### PR TITLE
feature(cli): add `--dev` to `npx expo install` to simplify saving development dependencies

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Estimate Xcode binary path in minimal builds. ([#33415](https://github.com/expo/expo/pull/33415) by [@EvanBacon](https://github.com/EvanBacon))
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
 - Add support for Bun's text-based lock file format `bun.lock` ([#33825](https://github.com/expo/expo/pull/33825) by [@tharakadesilva](https://github.com/tharakadesilva))
-- Add `--dev` to `npx expo install` to avoid complexity around `npx expo install -- --(save-)dev`.
+- Add `--dev` to `npx expo install` to avoid complexity around `npx expo install -- --(save-)dev`. ([#34029](https://github.com/expo/expo/pull/34029) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Estimate Xcode binary path in minimal builds. ([#33415](https://github.com/expo/expo/pull/33415) by [@EvanBacon](https://github.com/EvanBacon))
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
 - Add support for Bun's text-based lock file format `bun.lock` ([#33825](https://github.com/expo/expo/pull/33825) by [@tharakadesilva](https://github.com/tharakadesilva))
+- Add `--dev` to `npx expo install` to avoid complexity around `npx expo install -- --(save-)dev`.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -44,6 +44,7 @@ it('runs `npx expo install --help`', async () => {
 
       Options
         --check     Check which installed packages need to be updated
+        --dev       Save the dependencies as devDependencies
         --fix       Automatically update any invalid package versions
         --npm       Use npm to install dependencies. Default when package-lock.json exists
         --yarn      Use Yarn to install dependencies. Default when yarn.lock exists

--- a/packages/@expo/cli/src/install/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/resolveOptions-test.ts
@@ -33,6 +33,7 @@ describe(resolveArgsAsync, () => {
         pnpm: false,
         bun: false,
         fix: false,
+        dev: false,
       },
       extras: ['--npm', '-g', 'not-a-plugin'],
     });
@@ -48,6 +49,7 @@ describe(resolveArgsAsync, () => {
         pnpm: false,
         bun: false,
         fix: false,
+        dev: false,
       },
       extras: [],
     });

--- a/packages/@expo/cli/src/install/index.ts
+++ b/packages/@expo/cli/src/install/index.ts
@@ -25,6 +25,7 @@ export const expoInstall: Command = async (argv) => {
       `npx expo install`,
       [
         `--check     Check which installed packages need to be updated`,
+        '--dev       Save the dependencies as devDependencies',
         `--fix       Automatically update any invalid package versions`,
         chalk`--npm       Use npm to install dependencies. {dim Default when package-lock.json exists}`,
         chalk`--yarn      Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -9,6 +9,7 @@ import { Options } from './resolveOptions';
 import * as Log from '../log';
 import { checkPackagesCompatibility } from './utils/checkPackagesCompatibility';
 import { getVersionedPackagesAsync } from '../start/doctor/dependencies/getVersionedPackages';
+import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { learnMore } from '../utils/link';
@@ -67,7 +68,7 @@ export async function installAsync(
   }
 
   // note(simek): check out the packages compatibility with New Architecture against RND API
-  if (!process.env.EXPO_NO_NEW_ARCH_COMPAT_CHECK) {
+  if (!env.EXPO_NO_NEW_ARCH_COMPAT_CHECK) {
     await checkPackagesCompatibility(otherPackages);
   }
 

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -3,6 +3,7 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 
 import * as Log from '../log';
+import type { Options } from './resolveOptions';
 import { getRunningProcess } from '../utils/getRunningProcess';
 
 /**
@@ -16,7 +17,8 @@ export async function installExpoPackageAsync(
     packageManagerArguments,
     expoPackageToInstall,
     followUpCommandArgs,
-  }: {
+    dev,
+  }: Pick<Options, 'dev'> & {
     /** Package manager to use when installing the versioned packages. */
     packageManager: PackageManager.NodePackageManager;
     /**
@@ -40,7 +42,11 @@ export async function installExpoPackageAsync(
 
   // Safe to use current process to upgrade Expo package- doesn't affect current process
   try {
-    await packageManager.addAsync([...packageManagerArguments, expoPackageToInstall]);
+    if (dev) {
+      await packageManager.addDevAsync([...packageManagerArguments, expoPackageToInstall]);
+    } else {
+      await packageManager.addAsync([...packageManagerArguments, expoPackageToInstall]);
+    }
   } catch (error) {
     Log.error(
       chalk`Cannot install the latest Expo package. Install {bold expo@latest} with ${packageManager.name} and then run {bold npx expo install} again.`

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -56,7 +56,9 @@ export async function installExpoPackageAsync(
 
   // Spawn a new process to install the rest of the packages if there are any, as only then will the latest Expo package be used
   if (followUpCommandArgs.length) {
-    let commandSegments = ['expo', 'install', ...followUpCommandArgs];
+    let commandSegments = ['expo', 'install', dev ? '--dev' : '', ...followUpCommandArgs].filter(
+      Boolean
+    );
     if (packageManagerArguments.length) {
       commandSegments = [...commandSegments, '--', ...packageManagerArguments];
     }

--- a/packages/@expo/cli/src/install/resolveOptions.ts
+++ b/packages/@expo/cli/src/install/resolveOptions.ts
@@ -32,7 +32,7 @@ export async function resolveArgsAsync(
   const { variadic, extras, flags } = parseVariadicArguments(argv);
 
   assertUnexpectedVariadicFlags(
-    ['--check', '--fix', '--npm', '--pnpm', '--yarn', '--bun'],
+    ['--check', '--dev', '--fix', '--npm', '--pnpm', '--yarn', '--bun'],
     { variadic, extras, flags },
     'npx expo install'
   );
@@ -42,6 +42,7 @@ export async function resolveArgsAsync(
     variadic,
     options: resolveOptions({
       fix: !!flags['--fix'],
+      dev: !!flags['--dev'],
       check: !!flags['--check'],
       yarn: !!flags['--yarn'],
       npm: !!flags['--npm'],

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -234,6 +234,11 @@ class Env {
   get EXPO_UNSTABLE_DEPLOY_SERVER(): boolean {
     return boolish('EXPO_UNSTABLE_DEPLOY_SERVER', false);
   }
+
+  /** Disable the React Native Directory compatibility check for new architecture when installing packages */
+  get EXPO_NO_NEW_ARCH_COMPAT_CHECK(): boolean {
+    return boolish('EXPO_NO_NEW_ARCH_COMPAT_CHECK', false);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

This is a follow-up from #33998, mostly to reduce the complexity around Windows vs Linux/macOS and all different package managers. While it's possible already to save as `devDependencies` using `npx expo install .. -- --save-dev` (for npm / pnpm -- `--dev` for yarn / bun), it's not easy to write or document it. Just adding `--dev` makes things way easier.

# How

- Added `--dev` flag to `npx expo install`

# Test Plan

- `npx expo install --dev prettier eslint-config-prettier eslint-plugin-prettier`
- `npx expo install --dev expo` (mostly useful for monorepos, to update / add a devdep to Expo - when using peer dependencies)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
