### PR TITLE
[router]: Fix lint errors

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix linting errors
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 💡 Others
 
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix linting errors
+- Fix linting errors ([#34033](https://github.com/expo/expo/pull/34033) by [@marklawlor](https://github.com/marklawlor))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -193,7 +193,7 @@ it('allows for custom elements', () => {
 it('can dynamically add tabs', () => {
   renderRouter(
     {
-      _layout: () => {
+      _layout: function TabLayout() {
         const [showAll, setShowAll] = useState(false);
 
         const tabs = showAll ? (


### PR DESCRIPTION
# Why

Fix `expo-router` lint error after eslint update