### PR TITLE
[docs] APISection: allow displaying override entities in classes

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -156,7 +156,7 @@ export type InterfaceDefinitionData = {
 
 export type ClassDefinitionData = InterfaceDefinitionData & {
   type?: TypeDefinitionData;
-  isSensor: boolean;
+  allowOverwrites: boolean;
 };
 
 // Methods section

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -29,6 +29,7 @@ const CLASS_NAMES_MAP: Record<string, string> = {
   DeviceMotionSensor: 'DeviceMotion',
   GyroscopeSensor: 'Gyroscope',
   MagnetometerSensor: 'Magnetometer',
+  LightSensor: 'LightSensor',
 } as const;
 
 const CLASSES_TO_IGNORE_INHERITED_PROPS = [
@@ -61,10 +62,10 @@ const isInheritedFromCommonClass = (child: PropData) =>
   );
 
 const remapClass = (clx: ClassDefinitionData) => {
-  clx.isSensor = !!CLASS_NAMES_MAP[clx.name] || Object.values(CLASS_NAMES_MAP).includes(clx.name);
+  clx.allowOverwrites = true;
   clx.name = CLASS_NAMES_MAP[clx.name] ?? clx.name;
 
-  if (clx.isSensor && clx.extendedTypes) {
+  if (clx.allowOverwrites && clx.extendedTypes) {
     clx.extendedTypes = clx.extendedTypes.map(type => ({
       ...type,
       name: type.name === 'default' ? 'DeviceSensor' : type.name,
@@ -75,12 +76,20 @@ const remapClass = (clx: ClassDefinitionData) => {
 };
 
 const renderClass = (
-  { name, comment, type, extendedTypes, children, implementedTypes, isSensor }: ClassDefinitionData,
+  {
+    name,
+    comment,
+    type,
+    extendedTypes,
+    children,
+    implementedTypes,
+    allowOverwrites,
+  }: ClassDefinitionData,
   sdkVersion: string
 ): JSX.Element => {
   const properties = children?.filter(isProp);
   const methods = children
-    ?.filter(child => isMethod(child, isSensor) && !isInheritedFromCommonClass(child))
+    ?.filter(child => isMethod(child, allowOverwrites) && !isInheritedFromCommonClass(child))
     .sort((a: PropData, b: PropData) => a.name.localeCompare(b.name));
   const returnComment = getTagData('returns', comment);
 


### PR DESCRIPTION
# Why

Fixes missing `Directory.list()` and two other methods in `LightSensor` API reference docs.

# How

Allow showing class entities which override base class ones. We do it previously for sensors, but looks like it can be enabled globally without side effects.

In the process I have rename one of the object fields to better represent what the flag means. 

Found out during testing that The changes also added two missing me

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-01-08 at 21 11 31](https://github.com/user-attachments/assets/9a798223-cac5-4f54-8db2-e4cdef64319d)
![Screenshot 2025-01-08 at 21 11 16](https://github.com/user-attachments/assets/8d406413-8575-4430-926b-735fbf80194d)

