### PR TITLE
[expo-updates][ios] Inject logger from controllers down to dependent objects

### DIFF
--- a/apps/expo-go/ios/Client/HomeAppLoader.swift
+++ b/apps/expo-go/ios/Client/HomeAppLoader.swift
@@ -28,7 +28,7 @@ final class HomeAppLoader: AppLoader {
     completionQueue: DispatchQueue
   ) {
     self.manifestAndAssetRequestHeaders = manifestAndAssetRequestHeaders
-    self.downloader = FileDownloader(config: config)
+    self.downloader = FileDownloader(config: config, logger: logger)
     self.completionQueue = completionQueue
     super.init(config: config, logger: logger, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
   }

--- a/apps/expo-go/ios/Client/HomeAppLoaderTask.swift
+++ b/apps/expo-go/ios/Client/HomeAppLoaderTask.swift
@@ -87,7 +87,8 @@ public final class HomeAppLoaderTask: NSObject {
         database: database,
         directory: directory,
         selectionPolicy: selectionPolicy,
-        launchedUpdate: launchedUpdate
+        launchedUpdate: launchedUpdate,
+        logger: self.logger
       )
     }
   }
@@ -118,7 +119,8 @@ public final class HomeAppLoaderTask: NSObject {
         config: self.config,
         database: self.database,
         directory: self.directory,
-        completionQueue: self.loaderTaskQueue
+        completionQueue: self.loaderTaskQueue,
+        logger: self.logger
       )
       launcher.launchUpdate(withSelectionPolicy: self.selectionPolicy) { error, success in
         if success {

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) dispatch_queue_t appLoaderQueue;
 
 @property (nonatomic, nullable) EXUpdatesConfig *config;
+@property (nonatomic, nonnull) EXUpdatesLogger *logger;
 @property (nonatomic, nullable) EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, nullable) id<EXUpdatesAppLauncher> appLauncher;
 
@@ -77,6 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @synthesize remoteUpdateStatus = _remoteUpdateStatus;
 @synthesize shouldShowRemoteUpdateStatus = _shouldShowRemoteUpdateStatus;
 @synthesize config = _config;
+@synthesize logger = _logger;
 @synthesize selectionPolicy = _selectionPolicy;
 @synthesize appLauncher = _appLauncher;
 @synthesize isUpToDate = _isUpToDate;
@@ -84,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithManifestUrl:(NSURL *)url
 {
   if (self = [super init]) {
+    _logger = [[EXUpdatesLogger alloc] init];
     _manifestUrl = url;
     _httpManifestUrl = [EXAppLoaderExpoUpdates _httpUrlFromManifestUrl:_manifestUrl];
     _appLoaderQueue = dispatch_queue_create("host.exp.exponent.LoaderQueue", DISPATCH_QUEUE_SERIAL);
@@ -419,7 +422,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                                              database:updatesDatabaseManager.database
                                                                             directory:updatesDatabaseManager.updatesDirectory
                                                                       selectionPolicy:_selectionPolicy
-                                                                        delegateQueue:_appLoaderQueue];
+                                                                        delegateQueue:_appLoaderQueue
+                                                                               logger:_logger];
   loaderTask.delegate = self;
   [loaderTask start];
 }
@@ -432,7 +436,8 @@ NS_ASSUME_NONNULL_BEGIN
                                         database:updatesDatabaseManager.database
                                        directory:updatesDatabaseManager.updatesDirectory
                                  selectionPolicy:_selectionPolicy
-                                  launchedUpdate:_appLauncher.launchedUpdate];
+                                  launchedUpdate:_appLauncher.launchedUpdate
+                                          logger:_logger];
   }
 }
 

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXUpdatesDatabaseManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXUpdatesDatabaseManager.m
@@ -47,7 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
   __block BOOL success = NO;
   __block NSError *dbError;
   dispatch_sync(self.database.databaseQueue, ^{
-    success = [self.database openDatabaseInDirectory:self.updatesDirectory error:&dbError];
+    EXUpdatesLogger *logger = [[EXUpdatesLogger alloc] init];
+    success = [self.database openDatabaseInDirectory:self.updatesDirectory logger:logger error:&dbError];
   });
 
   if (dbError) {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- [iOS] Inject logger from controllers down to dependent objects. ([#34035](https://github.com/expo/expo/pull/34035) by [@wschurman](https://github.com/wschurman))
+
 ## 0.26.10 - 2024-12-05
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -267,7 +267,7 @@ public class AppController: NSObject {
       let updatesDatabase = UpdatesDatabase()
       do {
         let directory = try initializeUpdatesDirectory()
-        try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: directory)
+        try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: directory, logger: logger)
         _sharedInstance = EnabledAppController(config: config, database: updatesDatabase, updatesDirectory: directory)
       } catch {
         let cause = UpdatesError.appControllerInitializationError(cause: error)
@@ -307,12 +307,14 @@ public class AppController: NSObject {
       config = try? UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: nil)
     }
 
+    let logger = UpdatesLogger()
+
     var updatesDirectory: URL?
     let updatesDatabase = UpdatesDatabase()
     var directoryDatabaseException: Error?
     do {
       updatesDirectory = try initializeUpdatesDirectory()
-      try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: updatesDirectory!)
+      try initializeUpdatesDatabase(updatesDatabase: updatesDatabase, inUpdatesDirectory: updatesDirectory!, logger: logger)
     } catch {
       directoryDatabaseException = error
     }
@@ -331,12 +333,12 @@ public class AppController: NSObject {
     return try UpdatesUtils.initializeUpdatesDirectory()
   }
 
-  private static func initializeUpdatesDatabase(updatesDatabase: UpdatesDatabase, inUpdatesDirectory updatesDirectory: URL) throws {
+  private static func initializeUpdatesDatabase(updatesDatabase: UpdatesDatabase, inUpdatesDirectory updatesDirectory: URL, logger: UpdatesLogger) throws {
     var dbError: Error?
     let semaphore = DispatchSemaphore(value: 0)
     updatesDatabase.databaseQueue.async {
       do {
-        try updatesDatabase.openDatabase(inDirectory: updatesDirectory)
+        try updatesDatabase.openDatabase(inDirectory: updatesDirectory, logger: logger)
       } catch {
         dbError = error
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -43,14 +43,14 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
 
   private var launchAssetError: UpdatesError?
 
-  public required init(config: UpdatesConfig, database: UpdatesDatabase, directory: URL, completionQueue: DispatchQueue) {
+  public required init(config: UpdatesConfig, database: UpdatesDatabase, directory: URL, completionQueue: DispatchQueue, logger: UpdatesLogger) {
     self.launcherQueue = DispatchQueue(label: "expo.launcher.LauncherQueue")
     self.completedAssets = 0
     self.config = config
     self.database = database
     self.directory = directory
     self.completionQueue = completionQueue
-    self.logger = UpdatesLogger()
+    self.logger = logger
   }
 
   public func isUsingEmbeddedAssets() -> Bool {
@@ -360,7 +360,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
   }
 
   private lazy var downloader: FileDownloader = {
-    FileDownloader(config: config)
+    FileDownloader(config: config, logger: self.logger)
   }()
 }
 // swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -132,7 +132,8 @@ public final class AppLoaderTask: NSObject {
     database: UpdatesDatabase,
     directory: URL,
     selectionPolicy: SelectionPolicy,
-    delegateQueue: DispatchQueue
+    delegateQueue: DispatchQueue,
+    logger: UpdatesLogger
   ) {
     self.config = config
     self.database = database
@@ -145,7 +146,7 @@ public final class AppLoaderTask: NSObject {
     self.isUpToDate = false
     self.delegateQueue = delegateQueue
     self.loaderTaskQueue = DispatchQueue(label: "expo.loader.LoaderTaskQueue")
-    self.logger = UpdatesLogger()
+    self.logger = logger
   }
 
   public func start() {
@@ -260,7 +261,8 @@ public final class AppLoaderTask: NSObject {
         database: database,
         directory: directory,
         selectionPolicy: selectionPolicy,
-        launchedUpdate: launchedUpdate
+        launchedUpdate: launchedUpdate,
+        logger: self.logger
       )
     }
   }
@@ -323,7 +325,7 @@ public final class AppLoaderTask: NSObject {
   }
 
   private func launch(withCompletion completion: @escaping (_ error: UpdatesError?, _ success: Bool) -> Void) {
-    let launcher = AppLauncherWithDatabase(config: config, database: database, directory: directory, completionQueue: loaderTaskQueue)
+    let launcher = AppLauncherWithDatabase(config: config, database: database, directory: directory, completionQueue: loaderTaskQueue, logger: self.logger)
     candidateLauncher = launcher
     launcher.launchUpdate(withSelectionPolicy: selectionPolicy, completion: completion)
   }
@@ -476,7 +478,8 @@ public final class AppLoaderTask: NSObject {
           config: self.config,
           database: self.database,
           directory: self.directory,
-          completionQueue: self.loaderTaskQueue
+          completionQueue: self.loaderTaskQueue,
+          logger: self.logger
         )
         newLauncher.launchUpdate(withSelectionPolicy: self.selectionPolicy) { error, success in
           if success {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -69,14 +69,14 @@ public final class FileDownloader {
   private var config: UpdatesConfig!
   private var logger: UpdatesLogger!
 
-  public convenience init(config: UpdatesConfig) {
-    self.init(config: config, urlSessionConfiguration: URLSessionConfiguration.default)
+  public convenience init(config: UpdatesConfig, logger: UpdatesLogger) {
+    self.init(config: config, urlSessionConfiguration: URLSessionConfiguration.default, logger: logger)
   }
 
-  required init(config: UpdatesConfig, urlSessionConfiguration: URLSessionConfiguration) {
+  required init(config: UpdatesConfig, urlSessionConfiguration: URLSessionConfiguration, logger: UpdatesLogger) {
     self.sessionConfiguration = urlSessionConfiguration
     self.config = config
-    self.logger = UpdatesLogger()
+    self.logger = logger
     self.session = URLSession(configuration: sessionConfiguration)
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -20,7 +20,7 @@ public final class RemoteAppLoader: AppLoader {
     launchedUpdate: Update?,
     completionQueue: DispatchQueue
   ) {
-    self.downloader = FileDownloader(config: config)
+    self.downloader = FileDownloader(config: config, logger: logger)
     self.completionQueue = completionQueue
     super.init(config: config, logger: logger, database: database, directory: directory, launchedUpdate: launchedUpdate, completionQueue: completionQueue)
   }

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -89,9 +89,9 @@ public final class UpdatesDatabase: NSObject {
     closeDatabase()
   }
 
-  public func openDatabase(inDirectory directory: URL) throws {
+  public func openDatabase(inDirectory directory: URL, logger: UpdatesLogger) throws {
     dispatchPrecondition(condition: .onQueue(databaseQueue))
-    db = try UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: directory)
+    db = try UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: directory, logger: logger)
   }
 
   public func closeDatabase() {

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 // swiftlint:disable identifier_name
+// swiftlint:disable function_parameter_count
 
 // sqlite db opening OpaquePointer doesn't work well with nullability
 // swiftlint:disable force_unwrapping
@@ -92,20 +93,26 @@ internal final class UpdatesDatabaseInitialization {
     CREATE INDEX "index_json_data_scope_key" ON "json_data" ("scope_key");
   """
 
-  static func initializeDatabaseWithLatestSchema(inDirectory directory: URL) throws -> OpaquePointer {
+  static func initializeDatabaseWithLatestSchema(inDirectory directory: URL, logger: UpdatesLogger) throws -> OpaquePointer {
     return try initializeDatabaseWithLatestSchema(
       inDirectory: directory,
-      migrations: UpdatesDatabaseMigrationRegistry.migrations()
+      migrations: UpdatesDatabaseMigrationRegistry.migrations(),
+      logger: logger
     )
   }
 
-  static func initializeDatabaseWithLatestSchema(inDirectory directory: URL, migrations: [UpdatesDatabaseMigration]) throws -> OpaquePointer {
+  static func initializeDatabaseWithLatestSchema(
+    inDirectory directory: URL,
+    migrations: [UpdatesDatabaseMigration],
+    logger: UpdatesLogger
+  ) throws -> OpaquePointer {
     return try initializeDatabase(
       withSchema: LatestSchema,
       filename: LatestFilename,
       inDirectory: directory,
       shouldMigrate: true,
-      migrations: migrations
+      migrations: migrations,
+      logger: logger
     )
   }
 
@@ -114,9 +121,9 @@ internal final class UpdatesDatabaseInitialization {
     filename: String,
     inDirectory directory: URL,
     shouldMigrate: Bool,
-    migrations: [UpdatesDatabaseMigration]
+    migrations: [UpdatesDatabaseMigration],
+    logger: UpdatesLogger
   ) throws -> OpaquePointer {
-    let logger = UpdatesLogger()
     let dbUrl = directory.appendingPathComponent(filename)
     var shouldInitializeDatabaseSchema = !FileManager.default.fileExists(atPath: dbUrl.path)
 
@@ -248,4 +255,5 @@ internal final class UpdatesDatabaseInitialization {
 }
 
 // swiftlint:enable force_unwrapping
+// swiftlint:enable function_parameter_count
 // swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 // swiftlint:disable closure_body_length
+// swiftlint:disable function_parameter_count
 
 import Foundation
 
@@ -17,10 +18,9 @@ public final class UpdatesReaper: NSObject {
     database: UpdatesDatabase,
     directory: URL,
     selectionPolicy: SelectionPolicy,
-    launchedUpdate: Update
+    launchedUpdate: Update,
+    logger: UpdatesLogger
   ) {
-    let logger = UpdatesLogger()
-
     database.databaseQueue.async {
       let beginDeleteFromDatabase = Date()
 
@@ -105,4 +105,5 @@ public final class UpdatesReaper: NSObject {
   }
 }
 
+// swiftlint:enable function_parameter_count
 // swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -276,7 +276,8 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
       config: configuration,
       database: self.database,
       directory: self.updatesDirectory!,
-      completionQueue: self.controllerQueue
+      completionQueue: self.controllerQueue,
+      logger: self.logger
     )
     launcher.launchUpdate(withSelectionPolicy: self.selectionPolicy()) { error, success in
       if !success {
@@ -301,7 +302,8 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
         database: database,
         directory: updatesDirectory,
         selectionPolicy: selectionPolicy(),
-        launchedUpdate: launchedUpdate
+        launchedUpdate: launchedUpdate,
+        logger: self.logger
       )
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -40,7 +40,11 @@ public class DisabledAppController: InternalAppControllerInterface {
   required init(error: UpdatesError?) {
     self.initializationError = error
     self.eventManager = QueueUpdatesEventManager(logger: self.logger)
-    self.stateMachine = UpdatesStateMachine(eventManager: self.eventManager, validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting])
+    self.stateMachine = UpdatesStateMachine(
+      logger: self.logger,
+      eventManager: self.eventManager,
+      validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting]
+    )
   }
 
   public func start() {

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -1,7 +1,5 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable force_unwrapping
-
 import SwiftUI
 import ExpoModulesCore
 
@@ -56,7 +54,7 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     )
     self.logger.info(message: "AppController sharedInstance created")
     self.eventManager = QueueUpdatesEventManager(logger: logger)
-    self.stateMachine = UpdatesStateMachine(eventManager: self.eventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+    self.stateMachine = UpdatesStateMachine(logger: self.logger, eventManager: self.eventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
   }
 
   public func start() {
@@ -250,5 +248,3 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     return EmbeddedAppLoader.embeddedManifest(withConfig: self.config, database: self.database)
   }
 }
-
-// swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
+++ b/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
@@ -93,14 +93,16 @@ public final class ErrorRecovery: NSObject {
 
   private let logger: UpdatesLogger
 
-  public convenience override init() {
+  public convenience init(logger: UpdatesLogger) {
     self.init(
+      logger: logger,
       errorRecoveryQueue: DispatchQueue(label: "expo.controller.errorRecoveryQueue"),
       remoteLoadTimeout: ErrorRecovery.RemoteLoadTimeoutMs
     )
   }
 
   public required init(
+    logger: UpdatesLogger,
     errorRecoveryQueue: DispatchQueue,
     remoteLoadTimeout: Int
   ) {
@@ -117,7 +119,7 @@ public final class ErrorRecovery: NSObject {
     self.errorRecoveryQueue = errorRecoveryQueue
     self.remoteLoadTimeout = remoteLoadTimeout
     self.encounteredErrors = []
-    self.logger = UpdatesLogger()
+    self.logger = logger
   }
 
   public func startMonitoring() {

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
@@ -10,10 +10,12 @@ import ExpoModulesCore
 /**
  Class that implements logging for expo-updates in its own os.log category
  */
-public final class UpdatesLogger {
+@objc(EXUpdatesLogger)
+@objcMembers
+public final class UpdatesLogger: NSObject {
   static let EXPO_UPDATES_LOG_CATEGORY = "expo-updates"
 
-  public init() {}
+  public override init() {}
 
   private let logger = Logger(logHandlers: [
     createOSLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),

--- a/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
@@ -32,7 +32,7 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
     self.successBlock = successBlock
     self.errorBlock = errorBlock
 
-    self.fileDownloader = FileDownloader(config: self.config)
+    self.fileDownloader = FileDownloader(config: self.config, logger: self.logger)
   }
 
   func getLoggerTimerLabel() -> String {

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -53,7 +53,8 @@ final class RelaunchProcedure: StateMachineProcedure {
       config: config,
       database: database,
       directory: updatesDirectory,
-      completionQueue: controllerQueue
+      completionQueue: controllerQueue,
+      logger: self.logger
     )
   }
 
@@ -100,7 +101,8 @@ final class RelaunchProcedure: StateMachineProcedure {
         database: database,
         directory: updatesDirectory,
         selectionPolicy: selectionPolicy,
-        launchedUpdate: launchedUpdate
+        launchedUpdate: launchedUpdate,
+        logger: self.logger
       )
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -27,7 +27,7 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
     self.controllerQueue = controllerQueue
     self.updatesDirectory = updatesDirectory
     self.logger = logger
-
+    self.errorRecovery = ErrorRecovery(logger: logger)
     self.errorRecovery.delegate = self
   }
 
@@ -48,7 +48,7 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
     self.launcher = launcher
   }
 
-  private let errorRecovery = ErrorRecovery()
+  private let errorRecovery: ErrorRecovery
   private var errorRecoveryRemoteAppLoader: RemoteAppLoader?
   internal func requestStartErrorMonitoring() {
     errorRecovery.startMonitoring()
@@ -87,7 +87,8 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
       database: database,
       directory: updatesDirectory,
       selectionPolicy: selectionPolicy,
-      delegateQueue: controllerQueue
+      delegateQueue: controllerQueue,
+      logger: self.logger
     )
     loaderTask!.delegate = self
     loaderTask!.swiftDelegate = self

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -236,15 +236,15 @@ public extension UpdatesStateContext {
  in a production app, instantiated as a property of AppController.
  */
 internal class UpdatesStateMachine {
+  private let logger: UpdatesLogger
   private let eventManager: UpdatesEventManager
   private let validUpdatesStateValues: Set<UpdatesStateValue>
 
-  required init(eventManager: UpdatesEventManager, validUpdatesStateValues: Set<UpdatesStateValue>) {
+  required init(logger: UpdatesLogger, eventManager: UpdatesEventManager, validUpdatesStateValues: Set<UpdatesStateValue>) {
+    self.logger = logger
     self.eventManager = eventManager
     self.validUpdatesStateValues = validUpdatesStateValues
   }
-
-  private let logger = UpdatesLogger()
 
   private lazy var serialExecutorQueue: StateMachineSerialExecutorQueue = {
     return StateMachineSerialExecutorQueue(


### PR DESCRIPTION
# Why

Roughly the iOS equivalent to https://github.com/expo/expo/pull/31951. Namely this blurb:

> Also refactor so that the controllers each are the owners of the logger and that the logger is explicitly injected. While this isn't strictly necessary, it helps to identify which classes only needed context in order to instantiate their own logger instance.

Closes ENG-13825.

# How

Grep for UpdatesLogger(), inject via constructor instead, compile, fix, repeat.

# Test Plan

Compile Expo Go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
