### PR TITLE
[docs][1/n] Fix versioned links to app config

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -26,7 +26,7 @@ The plugin allows you to configure various properties that cannot be set at runt
 
 ### Setup iOS project
 
-To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](../config/app/#usesapplesignin) property to `true` in your project's app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -186,7 +186,7 @@ import { Audio, Video } from 'expo-av';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['RECORD_AUDIO']} />
 

--- a/docs/pages/versions/unversioned/sdk/brightness.mdx
+++ b/docs/pages/versions/unversioned/sdk/brightness.mdx
@@ -101,7 +101,7 @@ An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['WRITE_SETTINGS']} />
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -154,7 +154,7 @@ import * as Calendar from 'expo-calendar';
 
 If you only intend to use the [system-provided calendar UI](#launching-system-provided-calendar-dialogs), you don't need to request any permissions.
 
-Otherwise, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+Otherwise, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -184,7 +184,7 @@ import { CameraView } from 'expo-camera';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/unversioned/sdk/cellular.mdx
+++ b/docs/pages/versions/unversioned/sdk/cellular.mdx
@@ -44,7 +44,7 @@ import * as Cellular from 'expo-cellular';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_PHONE_STATE']} />
 

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -30,7 +30,7 @@ You can configure `expo-document-picker` using its built-in [config plugin](/con
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](../config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -102,7 +102,7 @@ Additionally, any data protected with the `requireAuthentication` option set to 
 
 Apple App Store Connect prompts you to select the type of encryption algorithm your app implements. This is known as **Export Compliance Information**. It is asked when publishing the app or submitting for TestFlight.
 
-When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](/versions/latest/config/app/#usesnonexemptencryption) property to `false` in the app config:
+When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](../config/app/#usesnonexemptencryption) property to `false` in the app config:
 
 {/* prettier-ignore */}
 ```json app.json

--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -82,7 +82,7 @@ import {
 
 Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -84,7 +84,7 @@ urlScheme:
 
 On Android, the translation of `PaymentSheet` is automatically detected based on a device's language settings.
 
-On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
+On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](../config/app/#infoplist) in the app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
+A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](../config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
 For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 

--- a/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
@@ -28,7 +28,7 @@ The plugin allows you to configure various properties that cannot be set at runt
 
 ### Setup iOS project
 
-To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](../config/app/#usesapplesignin) property to `true` in your project's app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -186,7 +186,7 @@ import { Audio, Video } from 'expo-av';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/brightness.mdx
@@ -103,7 +103,7 @@ An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['WRITE_SETTINGS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/calendar.mdx
@@ -146,7 +146,7 @@ import * as Calendar from 'expo-calendar';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -183,7 +183,7 @@ import { CameraView } from 'expo-camera/next';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera.mdx
@@ -184,7 +184,7 @@ import { Camera } from 'expo-camera';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/cellular.mdx
@@ -46,7 +46,7 @@ import * as Cellular from 'expo-cellular';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_PHONE_STATE']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -124,7 +124,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
@@ -32,7 +32,7 @@ You can configure `expo-document-picker` using its built-in [config plugin](/con
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](../config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 

--- a/docs/pages/versions/v50.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/notifications.mdx
@@ -432,7 +432,7 @@ In the table above, whenever `NotificationResponseReceivedListener` is triggered
 
 A background notification (iOS) or a data-only notification (Android) is a remote notification that does not display an alert, play a sound, or add a badge to your app's icon. The purpose of a background notification is to provide a way to wake up your app to trigger an app data refresh in the background.
 
-To handle notifications while the app is in the background on iOS, add `remote-notification` as a value to the array under `ios.infoPlist.UIBackgroundModes` key in your [app config](/versions/latest/config/app/), and add `"content-available": 1` to your push notification payload. Under normal circumstances, the "content-available" flag should launch your app if it isn't running
+To handle notifications while the app is in the background on iOS, add `remote-notification` as a value to the array under `ios.infoPlist.UIBackgroundModes` key in your [app config](../config/app/), and add `"content-available": 1` to your push notification payload. Under normal circumstances, the "content-available" flag should launch your app if it isn't running
 and wasn't killed by the user. However, this is ultimately decided by the OS, so it might not always happen.
 
 On Android, data-only notifications are sent using the `data` key of the push notification request payload.

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -91,7 +91,7 @@ On iOS, values are stored using the [keychain services](https://developer.apple.
 
 Apple App Store Connect prompts you to select the type of encryption algorithm your app implements. This is known as **Export Compliance Information**. It is asked when publishing the app or submitting for TestFlight.
 
-When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](/versions/latest/config/app/#usesnonexemptencryption) property to `false` in the app config:
+When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](../config/app/#usesnonexemptencryption) property to `false` in the app config:
 
 {/* prettier-ignore */}
 ```json app.json

--- a/docs/pages/versions/v50.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sensors.mdx
@@ -45,7 +45,7 @@ import {
 
 Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
+A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](../config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
 For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 

--- a/docs/pages/versions/v51.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/apple-authentication.mdx
@@ -26,7 +26,7 @@ The plugin allows you to configure various properties that cannot be set at runt
 
 ### Setup iOS project
 
-To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](../config/app/#usesapplesignin) property to `true` in your project's app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/v51.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/av.mdx
@@ -185,7 +185,7 @@ import { Audio, Video } from 'expo-av';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/brightness.mdx
@@ -101,7 +101,7 @@ An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['WRITE_SETTINGS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/calendar.mdx
@@ -144,7 +144,7 @@ import * as Calendar from 'expo-calendar';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera-legacy.mdx
@@ -184,7 +184,7 @@ import { Camera } from 'expo-camera/legacy';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera.mdx
@@ -184,7 +184,7 @@ import { CameraView } from 'expo-camera';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/cellular.mdx
@@ -44,7 +44,7 @@ import * as Cellular from 'expo-cellular';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_PHONE_STATE']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
@@ -30,7 +30,7 @@ You can configure `expo-document-picker` using its built-in [config plugin](/con
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](../config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 

--- a/docs/pages/versions/v51.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/securestore.mdx
@@ -89,7 +89,7 @@ On iOS, values are stored using the [keychain services](https://developer.apple.
 
 Apple App Store Connect prompts you to select the type of encryption algorithm your app implements. This is known as **Export Compliance Information**. It is asked when publishing the app or submitting for TestFlight.
 
-When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](/versions/latest/config/app/#usesnonexemptencryption) property to `false` in the app config:
+When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](../config/app/#usesnonexemptencryption) property to `false` in the app config:
 
 {/* prettier-ignore */}
 ```json app.json

--- a/docs/pages/versions/v51.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sensors.mdx
@@ -43,7 +43,7 @@ import {
 
 Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
+A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](../config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
 For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 

--- a/docs/pages/versions/v52.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/apple-authentication.mdx
@@ -26,7 +26,7 @@ The plugin allows you to configure various properties that cannot be set at runt
 
 ### Setup iOS project
 
-To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](../config/app/#usesapplesignin) property to `true` in your project's app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/v52.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/av.mdx
@@ -186,7 +186,7 @@ import { Audio, Video } from 'expo-av';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/brightness.mdx
@@ -101,7 +101,7 @@ An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['WRITE_SETTINGS']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/calendar.mdx
@@ -154,7 +154,7 @@ import * as Calendar from 'expo-calendar';
 
 If you only intend to use the [system-provided calendar UI](#launching-system-provided-calendar-dialogs), you don't need to request any permissions.
 
-Otherwise, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+Otherwise, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/camera.mdx
@@ -184,7 +184,7 @@ import { CameraView } from 'expo-camera';
 
 ### Android
 
-This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/cellular.mdx
@@ -44,7 +44,7 @@ import * as Cellular from 'expo-cellular';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_PHONE_STATE']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
@@ -30,7 +30,7 @@ You can configure `expo-document-picker` using its built-in [config plugin](/con
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [app config](/workflow/configuration/) file as specified [configuration properties](../config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 

--- a/docs/pages/versions/v52.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/securestore.mdx
@@ -102,7 +102,7 @@ Additionally, any data protected with the `requireAuthentication` option set to 
 
 Apple App Store Connect prompts you to select the type of encryption algorithm your app implements. This is known as **Export Compliance Information**. It is asked when publishing the app or submitting for TestFlight.
 
-When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](/versions/latest/config/app/#usesnonexemptencryption) property to `false` in the app config:
+When using `expo-secure-store`, you can set the [`ios.config.usesNonExemptEncryption`](../config/app/#usesnonexemptencryption) property to `false` in the app config:
 
 {/* prettier-ignore */}
 ```json app.json

--- a/docs/pages/versions/v52.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sensors.mdx
@@ -82,7 +82,7 @@ import {
 
 Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/stripe.mdx
@@ -84,7 +84,7 @@ urlScheme:
 
 On Android, the translation of `PaymentSheet` is automatically detected based on a device's language settings.
 
-On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](/versions/latest/config/app/#infoplist) in the app config:
+On iOS, you must enable `CFBundleAllowMixedLocalizations` and add the preferred language using `CFBundleLocalizations` under [`ios.infoPlist`](../config/app/#infoplist) in the app config:
 
 ```json app.json
 {

--- a/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
+A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](../config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
 For more information on Apple's new App Tracking Transparency framework, see their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
 


### PR DESCRIPTION
# Why

Noticed while doing https://app.graphite.dev/github/pr/expo/expo/34036/docs-Link-updates-config-options-to-config-page that the problem of versioned docs pages linking to latest config was more widespread.

This fixes all instances in `docs/pages/versions/**`.

# How

Find: `/versions/latest/config/app`
Replace: `../config/app`
In: `docs/pages/versions/**`

# Test Plan

Spot check a few locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
