### PR TITLE
[docs][2/n] More fixing of versioned links in versioned docs

### DIFF
--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](../config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -487,7 +487,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](../config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](../config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](/versions/latest/config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](../config/babel/) and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {


### PR DESCRIPTION
# Why

Continuing the pattern of https://app.graphite.dev/github/pr/expo/expo/34037/docs-Fix-versioned-links-to-app-config, this PR replaces incorrect versioned links with relative version links.

# How

Find: `/versions/latest/config`
Replace: `../config`
In: `docs/pages/versions/**`

# Test Plan

Spot check the links locally.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
