### PR TITLE
[docs][3/n] More versioned link fixes

### DIFF
--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -627,7 +627,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -27,7 +27,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](./sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
 
 ## All Expo SDK packages work in any React Native app
 

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -51,7 +51,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         '* Media: `.mp4`, `.mp3`, `.lottie`',
         '* SQLite database files: `.db`',
         '',
-        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
+        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](./sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/unversioned/sdk/audio-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio-av.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](/versions/latest/sdk/audio/).
+> **warning** The `Audio` component from `expo-av` documented on this page will be replaced by an improved version in `expo-audio` in an upcoming release when the new library is stable. [Learn about `expo-audio`](./audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -92,7 +92,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 ## Using with `expo-file-system`
 
-When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+When using `expo-document-picker` with [`expo-file-system`](./filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 
 To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
-- Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
+- Low Power Mode is enabled. This can be detected with [`expo-battery`](./battery/).
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (to prevent destabilization).
 - iOS dictation is active (to not disturb the microphone input).

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -78,7 +78,7 @@ urlScheme:
     : Linking.createURL(''),
 ```
 
-[`Linking.createURL()`](/versions/latest/sdk/linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
+[`Linking.createURL()`](./linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
 
 #### PaymentSheet localization on iOS
 

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -695,7 +695,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v50.0.0/index.mdx
+++ b/docs/pages/versions/v50.0.0/index.mdx
@@ -25,7 +25,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](./sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
 
 ## All Expo SDK packages work in any React Native app
 

--- a/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/document-picker.mdx
@@ -94,7 +94,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 ## Using with `expo-file-system`
 
-When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+When using `expo-document-picker` with [`expo-file-system`](./filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 
 To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 

--- a/docs/pages/versions/v50.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/haptics.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
-- Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
+- Low Power Mode is enabled. This can be detected with [`expo-battery`](./battery/).
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (to prevent destabilization).
 

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -111,7 +111,7 @@ To use Background Location methods, the following requirements apply:
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 - <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be
   specified in **Info.plist** file. See [background tasks configuration
-  guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
+  guide](./task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/v50.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/stripe.mdx
@@ -74,7 +74,7 @@ urlScheme:
     : Linking.createURL(''),
 ```
 
-[`Linking.createURL()`](/versions/latest/sdk/linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
+[`Linking.createURL()`](.linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
 
 ## Limitations
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -563,7 +563,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v51.0.0/index.mdx
+++ b/docs/pages/versions/v51.0.0/index.mdx
@@ -27,7 +27,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](./sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
 
 ## All Expo SDK packages work in any React Native app
 

--- a/docs/pages/versions/v51.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/asset.mdx
@@ -51,7 +51,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         '* Media: `.mp4`, `.mp3`, `.lottie`',
         '* SQLite database files: `.db`',
         '',
-        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
+        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](./sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/document-picker.mdx
@@ -92,7 +92,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 ## Using with `expo-file-system`
 
-When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+When using `expo-document-picker` with [`expo-file-system`](./filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 
 To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 

--- a/docs/pages/versions/v51.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/haptics.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
-- Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
+- Low Power Mode is enabled. This can be detected with [`expo-battery`](./battery/).
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (to prevent destabilization).
 

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -109,7 +109,7 @@ To use Background Location methods, the following requirements apply:
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 - <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be
   specified in **Info.plist** file. See [background tasks configuration
-  guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
+  guide](./task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/v51.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/stripe.mdx
@@ -72,7 +72,7 @@ urlScheme:
     : Linking.createURL(''),
 ```
 
-[`Linking.createURL()`](/versions/latest/sdk/linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
+[`Linking.createURL()`](./linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
 
 ## Limitations
 

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -625,7 +625,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -27,7 +27,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
+This allows you to write [`Contacts.getContactsAsync()`](./sdk/contacts#contactsgetcontactsasynccontactquery) and read the contacts from the device, read the gyroscope sensor to detect device movement, or start the phone's camera and take photos.
 
 ## All Expo SDK packages work in any React Native app
 

--- a/docs/pages/versions/v52.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/asset.mdx
@@ -51,7 +51,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         '* Media: `.mp4`, `.mp3`, `.lottie`',
         '* SQLite database files: `.db`',
         '',
-        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
+        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](./sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts).',
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
@@ -92,7 +92,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 ## Using with `expo-file-system`
 
-When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+When using `expo-document-picker` with [`expo-file-system`](./filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 
 To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 

--- a/docs/pages/versions/v52.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/haptics.mdx
@@ -18,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
-- Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
+- Low Power Mode is enabled. This can be detected with [`expo-battery`](./battery/).
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (to prevent destabilization).
 - iOS dictation is active (to not disturb the microphone input).

--- a/docs/pages/versions/v52.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/stripe.mdx
@@ -78,7 +78,7 @@ urlScheme:
     : Linking.createURL(''),
 ```
 
-[`Linking.createURL()`](/versions/latest/sdk/linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
+[`Linking.createURL()`](./linking/#createurloptions) will ensure you're using the proper scheme, whether you're running in Expo Go or your production app. `'/--/'` is necessary in Expo Go because it indicates that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.
 
 #### PaymentSheet localization on iOS
 


### PR DESCRIPTION
# Why

Final replacement piece of continuing the pattern of https://app.graphite.dev/github/pr/expo/expo/34037/docs-Fix-versioned-links-to-app-config, this PR replaces incorrect versioned links with relative version links.

# How

This one was more manual than the others in this stack since the location href depends on whether the document was more top-level or an SDK page.

# Test Plan

Manually test all changed links.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
