### PR TITLE
[mail-composer][iOS] Fix MailComposer backdrop dismiss on iPad

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix mail modal callback when dismissing the composer through multitasking controls on iPad. ([#34040](https://github.com/expo/expo/pull/34040) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 14.0.1 — 2024-10-22

--- a/packages/expo-mail-composer/ios/MailComposingSession.swift
+++ b/packages/expo-mail-composer/ios/MailComposingSession.swift
@@ -4,7 +4,7 @@ import MessageUI
 import MobileCoreServices
 import ExpoModulesCore
 
-internal final class MailComposingSession: NSObject, MFMailComposeViewControllerDelegate {
+internal final class MailComposingSession: NSObject, MFMailComposeViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
   typealias ComposingCallback = (Result<[String: String], Exception>) -> ()
 
   let appContext: AppContext
@@ -47,6 +47,9 @@ internal final class MailComposingSession: NSObject, MFMailComposeViewController
       return
     }
     self.callback = callback
+    if let presentationController = composeController.presentationController {
+      presentationController.delegate = self
+    }
     currentViewController.present(composeController, animated: true)
   }
 
@@ -70,6 +73,14 @@ internal final class MailComposingSession: NSObject, MFMailComposeViewController
         callback(.failure(UnknownResultException(result)))
       }
     }
+  }
+
+  // MARK: - UIAdaptivePresentationControllerDelegate
+  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    guard let callback = self.callback else {
+      return
+    }
+    callback(.success(["status": "cancelled"]))
   }
 }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/33824
Closes ENG-14653

When presenting the mail modal on iPad users can dismiss it by touching a small bar on the top.

![Screenshot 2025-01-08 at 18 19 45](https://github.com/user-attachments/assets/c8d569db-a306-4271-b35c-a8848cf17f7a)

 This is due to the multitasking feature on iPads, where the users can drag the Mail Composer view to the middle bar, etc, causing it to be dismissed without triggering the "standard" `mailComposeController(_:didFinishWithResult:error:)` method.


# How

Update `MailComposingSession` to extend `UIAdaptivePresentationControllerDelegate` and return status `cancelled` when  the modal is manually dismissed 

# Test Plan

Run [ExampleApp](https://github.com/gugagobbato/expo-mail-composer-issue) on iPad and iPhone

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
