### PR TITLE
[modules-core][iOS] Use REACT_NATIVE_PATH to determine react-native version

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -21,7 +21,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk52-0.76.3",
+          "key": "sdk52-0.76.3-hermes",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "macos-sonoma-14.6-xcode-16.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -414,17 +414,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.76.3):
-    - hermes-engine/cdp (= 0.76.3)
-    - hermes-engine/Hermes (= 0.76.3)
-    - hermes-engine/inspector (= 0.76.3)
-    - hermes-engine/inspector_chrome (= 0.76.3)
-    - hermes-engine/Public (= 0.76.3)
-  - hermes-engine/cdp (0.76.3)
-  - hermes-engine/Hermes (0.76.3)
-  - hermes-engine/inspector (0.76.3)
-  - hermes-engine/inspector_chrome (0.76.3)
-  - hermes-engine/Public (0.76.3)
+  - hermes-engine (0.77.0-rc.6):
+    - hermes-engine/cdp (= 0.77.0-rc.6)
+    - hermes-engine/Hermes (= 0.77.0-rc.6)
+    - hermes-engine/inspector (= 0.77.0-rc.6)
+    - hermes-engine/inspector_chrome (= 0.77.0-rc.6)
+    - hermes-engine/Public (= 0.77.0-rc.6)
+  - hermes-engine/cdp (0.77.0-rc.6)
+  - hermes-engine/Hermes (0.77.0-rc.6)
+  - hermes-engine/inspector (0.77.0-rc.6)
+  - hermes-engine/inspector_chrome (0.77.0-rc.6)
+  - hermes-engine/Public (0.77.0-rc.6)
   - JKBigInteger (0.0.6)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
@@ -3181,7 +3181,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 699c9e93f5af5892ce55dabed81ca70680bb356d
+  hermes-engine: 8df0e6a8ad0f9483895d22062cb42f4abdc0e0d2
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3267,7 +3267,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 6008d74df8122d6af6d9d08096bff19a8c6ba647
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: fc5ce5bf284640d3af6431c3a5c3bc121e98d045
-  RNReanimated: 95e2f00605658327d2563d097495c0f4a347f337
+  RNReanimated: 73f82f396b041e5a9f2fe00695e94dc9c5ec788b
   RNScreens: d022507f2b6d76c73335e9e35aedcf7bb2f791b0
   RNSVG: 536cd3c866c878faf72beaba166c8b02fe2b762b
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
@@ -3285,7 +3285,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: c24f990b03a68a7f6fe704b15dd487e7bb6b603e
   StripeUICore: f2d514e900c37436dc5427fdf2c29d68ab1c2935
   UMAppLoader: bda51f73f8599e336a778b23e0956130d1e244d5
-  Yoga: 3deb2471faa9916c8a82dda2a22d3fba2620ad37
+  Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 8c7220860d6fd530eca70da461198f5a2007bf70

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
 - Show `UnimplementedExpoView` in place of SwiftUI views when the New Architecture is not enabled. ([#33901](https://github.com/expo/expo/pull/33901) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Use REACT_NATIVE_PATH to determine react-native version ([#34042](https://github.com/expo/expo/pull/34042) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -1,14 +1,16 @@
 require 'json'
 
-absolute_react_native_path = 'react-native'
+absolute_react_native_path = ''
 if !ENV['REACT_NATIVE_PATH'].nil?
   absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+else
+  absolute_react_native_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
 end
 
 unless defined?(install_modules_dependencies)
   # `install_modules_dependencies` and `add_dependency` are defined in react_native_pods.rb.
   # When running with `pod ipc spec`, these methods are not defined and we have to require manually.
-  require File.join(File.dirname(`node --print "require.resolve('#{absolute_react_native_path}/package.json')"`), "scripts/react_native_pods")
+  require File.join(absolute_react_native_path, "scripts/react_native_pods")
 end
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -1,16 +1,21 @@
 require 'json'
 
+absolute_react_native_path = 'react-native'
+if !ENV['REACT_NATIVE_PATH'].nil?
+  absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+end
+
 unless defined?(install_modules_dependencies)
   # `install_modules_dependencies` and `add_dependency` are defined in react_native_pods.rb.
   # When running with `pod ipc spec`, these methods are not defined and we have to require manually.
-  require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
+  require File.join(File.dirname(`node --print "require.resolve('#{absolute_react_native_path}/package.json')"`), "scripts/react_native_pods")
 end
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 reactNativeVersion = '0.0.0'
 begin
-  reactNativeVersion = `node --print "require('react-native/package.json').version"`
+  reactNativeVersion = `node --print "require('#{absolute_react_native_path}/package.json').version"`
 rescue
   reactNativeVersion = '0.0.0'
 end


### PR DESCRIPTION
# Why

Pod installation on Expo Go is falling because `modules-core` is not resolving the react native version correctly 

# How

Given that expo-go uses a custom react native path and not the traditional node_modules path we need to read the react_native path from the `REACT_NATIVE_PATH` env var

# Test Plan

Run `pod install` on expo-go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
