### PR TITLE
[expo-font][ios] Fix crash when writing to fontFamilyAliases

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix crash when writing to fontFamilyAliases ([#34044](https://github.com/expo/expo/pull/34044) by [@techied](https://github.com/techied))
+
 ### 💡 Others
 
 ## 13.0.2 - 2024-12-19

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -34,7 +34,7 @@ internal struct FontFamilyAliasManager {
    */
   internal static func setAlias(_ familyNameAlias: String, forFont font: String) {
     maybeSwizzleUIFont()
-    queue.sync {
+    queue.sync(flags: .barrier) {
       fontFamilyAliases[familyNameAlias] = font
     }
   }


### PR DESCRIPTION
# Why

There is a race condition in FontFamilyAliasManager when writing to the fontFamilyAliases dictionary

A previous fix was merged but is incomplete

https://terros-tech.sentry.io/share/issue/487498d3f5f94727bd724b942369b84a/

https://github.com/expo/expo/pull/33574

# How

A barrier flag is used when writing to the fontFamilyAliases dictionary. This pauses dictionary reads until the write is complete.

# Test Plan

We have patched this internally and released a version of our app with the patched dependency. We have received no further crash reports from expo-font.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
