### PR TITLE
[fingerprint] Finish adding args to fingerprint CLI

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - docs(fingerprint): correct typo in fingerprint cli ([#33887](https://github.com/expo/expo/pull/33887) by [@leopic](https://github.com/leopic))
+- Finish adding args to fingerprint CLI. ([#34045](https://github.com/expo/expo/pull/34045) by [@wschurman](https://github.com/wschurman))
 
 ## 0.11.6 - 2024-12-24
 

--- a/packages/@expo/fingerprint/build/Fingerprint.types.d.ts
+++ b/packages/@expo/fingerprint/build/Fingerprint.types.d.ts
@@ -58,31 +58,31 @@ export type FingerprintDiffItem = {
 export type Platform = 'android' | 'ios';
 export interface Options {
     /**
-     * Only get native files from the given platforms. Default is `['android', 'ios']`.
+     * Limit native files to those for specified platforms. Default is `['android', 'ios']`.
      */
     platforms?: Platform[];
     /**
-     * I/O concurrent limit. Default is the number of CPU core.
+     * I/O concurrency limit. Default is the number of CPU cores.
      */
     concurrentIoLimit?: number;
     /**
-     * The algorithm passing to `crypto.createHash()`. Default is `'sha1'`.
+     * The algorithm to use for `crypto.createHash()`. Default is `'sha1'`.
      */
     hashAlgorithm?: string;
     /**
-     * Excludes directories from hashing. This supported pattern is as `glob()`.
+     * Exclude specified directories from hashing. The supported pattern is the same as `glob()`.
      * Default is `['android/build', 'android/app/build', 'android/app/.cxx', 'ios/Pods']`.
      * @deprecated Use `ignorePaths` instead.
      */
     dirExcludes?: string[];
     /**
-     * Ignore files and directories from hashing. This supported pattern is as `glob()`.
+     * Ignore files and directories from hashing. The supported pattern is the same as `glob()`.
      *
-     * Please note that the pattern matching is slightly different from gitignore. For example, we don't support partial matching where `build` does not match `android/build`. You should use `'**' + '/build'` instead.
-     * @see [minimatch implementations](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations) for more reference.
+     * Please note that the pattern matching is slightly different from gitignore. Partial matching is unsupported. For example, `build` does not match `android/build`; instead, use `'**' + '/build'`.
+     * @see [minimatch implementations](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations) for further reference.
      *
-     * Besides this `ignorePaths`, fingerprint comes with implicit default ignorePaths defined in `Options.DEFAULT_IGNORE_PATHS`.
-     * If you want to override the default ignorePaths, use `!` prefix.
+     * Fingerprint comes with implicit default ignorePaths defined in `Options.DEFAULT_IGNORE_PATHS`.
+     * If you want to override the default ignorePaths, use `!` prefix in `ignorePaths`.
      */
     ignorePaths?: string[];
     /**
@@ -90,7 +90,7 @@ export interface Options {
      */
     extraSources?: HashSource[];
     /**
-     * Skips some sources from fingerprint.
+     * Skips some sources from fingerprint. Value is the result of bitwise-OR'ing desired values of SourceSkips.
      * @default DEFAULT_SOURCE_SKIPS
      */
     sourceSkips?: SourceSkips;

--- a/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
+++ b/packages/@expo/fingerprint/cli/src/commands/generateFingerprint.ts
@@ -13,7 +13,11 @@ export const generateFingerprintAsync: Command = async (argv) => {
     {
       // Types
       '--help': Boolean,
-      '--platform': String,
+      '--platform': [String],
+      '--concurrent-io-limit': Number,
+      '--hash-algorithm': String,
+      '--ignore-path': [String],
+      '--source-skips': Number,
       '--debug': Boolean,
       // Aliases
       '-h': '--help',
@@ -31,7 +35,11 @@ Generate fingerprint for a project
   {dim $} npx @expo/fingerprint fingerprint:generate
 
   Options
-  --platform <string>                  Platform to generate a fingerprint for
+  --platform <string[]>                Limit native files to those for specified platforms. Default is ['android', 'ios'].
+  --concurrent-io-limit <number>       I/O concurrent limit. Default is the number of CPU cores.
+  --hash-algorithm <string>            The algorithm to use for crypto.createHash(). Default is 'sha1'.
+  --ignore-path <string[]>             Ignore files and directories from hashing. The supported pattern is the same as glob().
+  --source-skips <number>              Skips some sources from fingerprint. Value is the result of bitwise-OR'ing desired values of SourceSkips. Default is DEFAULT_SOURCE_SKIPS.
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `,
@@ -39,18 +47,56 @@ Generate fingerprint for a project
     );
   }
 
-  const platform = args['--platform'];
-  if (platform && !['ios', 'android'].includes(platform)) {
-    throw new CommandError(`Invalid platform argument: ${platform}`);
+  const platforms = args['--platform'];
+  if (platforms) {
+    if (!Array.isArray(platforms)) {
+      throw new CommandError(`Invalid value for --platform`);
+    }
+
+    if (!(platforms as any[]).every((elem) => ['ios', 'android'].includes(elem))) {
+      throw new CommandError(`Invalid value for --platform: ${platforms}`);
+    }
+  }
+
+  const concurrentIoLimit = args['--concurrent-io-limit'];
+  if (concurrentIoLimit && !Number.isInteger(concurrentIoLimit)) {
+    throw new CommandError(
+      `Invalid value for --concurrent-io-limit argument: ${concurrentIoLimit}`
+    );
+  }
+
+  const hashAlgorithm = args['--hash-algorithm'];
+  if (hashAlgorithm && typeof hashAlgorithm !== 'string') {
+    throw new CommandError(`Invalid value for --hash-algorithm: ${hashAlgorithm}`);
+  }
+
+  const ignorePaths = args['--ignore-path'];
+  if (ignorePaths) {
+    if (!Array.isArray(ignorePaths)) {
+      throw new CommandError(`Invalid value for --ignore-path`);
+    }
+
+    if (!(ignorePaths as any[]).every((elem) => typeof elem === 'string')) {
+      throw new CommandError(`Invalid value for --ignore-path: ${ignorePaths}`);
+    }
+  }
+
+  const sourceSkips = args['--source-skips'];
+  if (sourceSkips && !Number.isInteger(sourceSkips)) {
+    throw new CommandError(`Invalid value for --source-skips argument: ${sourceSkips}`);
   }
 
   const options: Options = {
     debug: !!process.env.DEBUG || args['--debug'],
+    silent: true,
     useRNCoreAutolinkingFromExpo: process.env['USE_RNCORE_AUTOLINKING_FROM_EXPO']
       ? boolish('USE_RNCORE_AUTOLINKING_FROM_EXPO')
       : undefined,
-    ...(platform ? { platforms: [platform] } : null),
-    silent: true,
+    ...(platforms ? { platforms } : null),
+    ...(concurrentIoLimit ? { concurrentIoLimit } : null),
+    ...(hashAlgorithm ? { hashAlgorithm } : null),
+    ...(ignorePaths ? { ignorePaths } : null),
+    ...(sourceSkips ? { sourceSkips } : null),
   };
 
   const projectRoot = getProjectRoot(args);

--- a/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import rimraf from 'rimraf';
 
+import getFingerprintHashFromCLIAsync from './utils/CLIUtils';
 import { createProjectHashAsync } from '../../src/Fingerprint';
 
 jest.mock('../../src/sourcer/ExpoConfigLoader', () => ({
@@ -39,26 +40,41 @@ describe('bare project test', () => {
 
   it('should have same hash after adding js only library', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
+
     await spawnAsync('npx', ['expo', 'install', '@react-navigation/core'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).toBe(hash2);
   });
 
   it('should have different hash after adding native library', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
+
     await spawnAsync('npx', ['expo', 'install', 'react-native-reanimated'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 
   it('should have different hash after changing podfile', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
+
     const filePath = path.join(projectRoot, 'ios', 'Podfile');
     const contents = await fs.readFile(filePath, 'utf8');
     await fs.writeFile(
@@ -66,11 +82,17 @@ describe('bare project test', () => {
       modifyPodfileContents(contents, /(:path)\s*=>.*,$/gm, `$1 => ../node_modules/react-native,`)
     );
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 
   it('should have same hash for specifing android platform after changing podfile', async () => {
     const hash = await createProjectHashAsync(projectRoot, { platforms: ['android'] });
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot, ['--platform', 'android']);
+    expect(hash).toEqual(hashCLI);
+
     const filePath = path.join(projectRoot, 'ios', 'Podfile');
     const contents = await fs.readFile(filePath, 'utf8');
     await fs.writeFile(
@@ -79,6 +101,9 @@ describe('bare project test', () => {
     );
     await fs.writeFile(filePath, contents);
     const hash2 = await createProjectHashAsync(projectRoot, { platforms: ['android'] });
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot, ['--platform', 'android']);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).toBe(hash2);
   });
 });

--- a/packages/@expo/fingerprint/e2e/__tests__/managed-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/managed-test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import rimraf from 'rimraf';
 
+import getFingerprintHashFromCLIAsync from './utils/CLIUtils';
 import {
   createFingerprintAsync,
   createProjectHashAsync,
@@ -56,27 +57,40 @@ describe('managed project test', () => {
 
   it('should have same hash after updating js code', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
 
     const jsPath = path.join(projectRoot, 'App.js');
     const js = await fs.readFile(jsPath, 'utf8');
     await fs.writeFile(jsPath, `${js}\n// adding comments`);
 
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).toBe(hash2);
   });
 
   it('should have different hash after adding native library', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
+
     await spawnAsync('npx', ['expo', 'install', 'expo-updates'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 
   it('should have different hash after updating `jsEngine`', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
 
     const configPath = path.join(projectRoot, 'app.json');
     const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
@@ -84,26 +98,40 @@ describe('managed project test', () => {
     await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 
   it('should have different hash after updating icon file', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
 
     const iconPath = path.join(projectRoot, 'assets', 'icon.png');
     await fs.writeFile(iconPath, '');
 
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 
   it('should have different hash after adding js only config-plugin', async () => {
     const hash = await createProjectHashAsync(projectRoot);
+    const hashCLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash).toEqual(hashCLI);
+
     await spawnAsync('npx', ['expo', 'install', 'expo-build-properties'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });
     const hash2 = await createProjectHashAsync(projectRoot);
+    const hash2CLI = await getFingerprintHashFromCLIAsync(projectRoot);
+    expect(hash2).toEqual(hash2CLI);
+
     expect(hash).not.toBe(hash2);
   });
 

--- a/packages/@expo/fingerprint/e2e/__tests__/updates-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/updates-test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import rimraf from 'rimraf';
 
+import getFingerprintHashFromCLIAsync from './utils/CLIUtils';
 import { createProjectHashAsync } from '../../src/Fingerprint';
 
 jest.mock('../../src/sourcer/ExpoConfigLoader', () => ({
@@ -56,6 +57,14 @@ describe('updates managed support', () => {
       ignorePaths: ['android/**/*', 'ios/**/*'],
     });
 
+    const fingerprintHash1FromCLI = await getFingerprintHashFromCLIAsync(projectRoot, [
+      '--ignore-path',
+      'android/**/*',
+      '--ignore-path',
+      'ios/**/*',
+    ]);
+    expect(fingerprintHash1).toEqual(fingerprintHash1FromCLI);
+
     // Reset modules to prevent cached `require(projectRoot/package.json)`
     jest.resetModules();
 
@@ -67,5 +76,13 @@ describe('updates managed support', () => {
       ignorePaths: ['android/**/*', 'ios/**/*'],
     });
     expect(fingerprintHash1).toEqual(fingerprintHash2);
+
+    const fingerprintHash2FromCLI = await getFingerprintHashFromCLIAsync(projectRoot, [
+      '--ignore-path',
+      'android/**/*',
+      '--ignore-path',
+      'ios/**/*',
+    ]);
+    expect(fingerprintHash2).toEqual(fingerprintHash2FromCLI);
   });
 });

--- a/packages/@expo/fingerprint/e2e/__tests__/utils/CLIUtils.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/utils/CLIUtils.ts
@@ -1,0 +1,24 @@
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+
+const cliPath = path.resolve(__dirname, '..', '..', '..', 'bin', 'cli.js');
+
+export default async function getFingerprintHashFromCLIAsync(
+  projectRoot: string,
+  args: string[] = []
+) {
+  try {
+    const { stdout: fingerprintJSONFromCLI } = await spawnAsync(
+      cliPath,
+      ['fingerprint:generate', ...args],
+      {
+        stdio: 'pipe',
+        cwd: projectRoot,
+      }
+    );
+    return JSON.parse(fingerprintJSONFromCLI).hash;
+  } catch (e) {
+    console.error(JSON.stringify(e));
+    throw e;
+  }
+}

--- a/packages/@expo/fingerprint/src/Fingerprint.types.ts
+++ b/packages/@expo/fingerprint/src/Fingerprint.types.ts
@@ -67,35 +67,35 @@ export type Platform = 'android' | 'ios';
 
 export interface Options {
   /**
-   * Only get native files from the given platforms. Default is `['android', 'ios']`.
+   * Limit native files to those for specified platforms. Default is `['android', 'ios']`.
    */
   platforms?: Platform[];
 
   /**
-   * I/O concurrent limit. Default is the number of CPU core.
+   * I/O concurrency limit. Default is the number of CPU cores.
    */
   concurrentIoLimit?: number;
 
   /**
-   * The algorithm passing to `crypto.createHash()`. Default is `'sha1'`.
+   * The algorithm to use for `crypto.createHash()`. Default is `'sha1'`.
    */
   hashAlgorithm?: string;
 
   /**
-   * Excludes directories from hashing. This supported pattern is as `glob()`.
+   * Exclude specified directories from hashing. The supported pattern is the same as `glob()`.
    * Default is `['android/build', 'android/app/build', 'android/app/.cxx', 'ios/Pods']`.
    * @deprecated Use `ignorePaths` instead.
    */
   dirExcludes?: string[];
 
   /**
-   * Ignore files and directories from hashing. This supported pattern is as `glob()`.
+   * Ignore files and directories from hashing. The supported pattern is the same as `glob()`.
    *
-   * Please note that the pattern matching is slightly different from gitignore. For example, we don't support partial matching where `build` does not match `android/build`. You should use `'**' + '/build'` instead.
-   * @see [minimatch implementations](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations) for more reference.
+   * Please note that the pattern matching is slightly different from gitignore. Partial matching is unsupported. For example, `build` does not match `android/build`; instead, use `'**' + '/build'`.
+   * @see [minimatch implementations](https://github.com/isaacs/minimatch#comparisons-to-other-fnmatchglob-implementations) for further reference.
    *
-   * Besides this `ignorePaths`, fingerprint comes with implicit default ignorePaths defined in `Options.DEFAULT_IGNORE_PATHS`.
-   * If you want to override the default ignorePaths, use `!` prefix.
+   * Fingerprint comes with implicit default ignorePaths defined in `Options.DEFAULT_IGNORE_PATHS`.
+   * If you want to override the default ignorePaths, use `!` prefix in `ignorePaths`.
    */
   ignorePaths?: string[];
 
@@ -105,7 +105,7 @@ export interface Options {
   extraSources?: HashSource[];
 
   /**
-   * Skips some sources from fingerprint.
+   * Skips some sources from fingerprint. Value is the result of bitwise-OR'ing desired values of SourceSkips.
    * @default DEFAULT_SOURCE_SKIPS
    */
   sourceSkips?: SourceSkips;


### PR DESCRIPTION
# Why

This adds the missing options to the CLI.

Closes ENG-14091.

# How

Add missing options. Also add e2e tests for the CLI.

# Test Plan

Run e2e tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
