### PR TITLE
Update TSConfig Base JSX Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Switched JSX options in `tsconfig.base.json` from legacy `"react-native"` to the new and better optimized `"react-jsx"`
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🛠 Breaking changes
 
-- [typescript] Updated default TSConfig to use `"jsx": "react-jsx"` instead of the deprecated `"jsx": "react-native"` option ([#34051](https://github.com/expo/expo/pull/34051)) @asleepace
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Switched JSX options in `tsconfig.base.json` from legacy `"react-native"` to the new and better optimized `"react-jsx"`
-
 ### 🛠 Breaking changes
+
+- [typescript] Updated default TSConfig to use `"jsx": "react-jsx"` instead of the deprecated `"jsx": "react-native"` option ([#34051](https://github.com/expo/expo/pull/34051)) @asleepace
 
 ### 🎉 New features
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [typescript] Updated default TSConfig to use `"jsx": "react-jsx"` instead of the deprecated `"jsx": "react-native"` option ([#34051](https://github.com/expo/expo/pull/34051)) @asleepace
+
 ### 🎉 New features
 
 - support react-native 0.77 ([#33946](https://github.com/expo/expo/pull/33946) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,
-    "jsx": "react-native",
+    "jsx": "react-jsx",
     "lib": ["DOM", "ESNext"],
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
# Why

This fixes an issue which was causing a Catch-22 type situation with React Fragments, basically using the shorthand notation leads to a warning, but using the explicit syntax also causes a warning.

| Shorthand Warning | Explicit Warning |
|-------------------|------------------|
| <img width="893" alt="FragmentShorthandWarning" src="https://github.com/user-attachments/assets/3d14b185-143e-4f14-84e2-9873d85587d8" /> | <img width="765" alt="FragmentExplicitWarning" src="https://github.com/user-attachments/assets/a2d74932-79de-4266-bf05-fd550012ccef" /> |

Related issue: https://github.com/facebook/create-react-app/issues/9877

# How

- Use `"react-jsx"` instead of legacy `"react-native"` option

# Test Plan

0. Run `npx tsc` and make note of existing warnings and errors
1. Switch config to use `"react-jsx"`
2. Run `npx tsc` and check there are new warnings or errors
3. Apply the same process in a monorepo 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
