### PR TITLE
[docs] Ignore "Show more" inside `cleanCopyValue()` utility

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -33,7 +33,8 @@ export function cleanCopyValue(value: string) {
     .replace(/\/\*\s?@(tutinfo[^*]+|end|hide[^*]+).?\*\//g, '')
     .replace(/#\s?@(tutinfo[^#]+|end|hide[^#]+).?#/g, '')
     .replace(/<!--\s?@(tutinfo[^<>]+|end|hide[^<>]+).?-->/g, '')
-    .replace(/^ +\r?\n|\n +\r?$/gm, '');
+    .replace(/^ +\r?\n|\n +\r?$/gm, '')
+    .replace(/Show\s+[Mm]ore\s*$/, '');
 }
 
 export function escapeHtml(text: string) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #34055

# How

<!--
How did you build this feature or fix this bug and why?
-->
Add "Show More" as a pattern to ignore in the `cleanCodeCopy` utility function so that when copying the code, the SnippetOverlay button value does not get copied.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Verify by opening this URL: http://localhost:3002/versions/latest/sdk/video/?redirected
- Copy and paste code in a `test.tsx` file and the "Show more" button text should not be included in the snippet

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
