### PR TITLE
[docs] APISection: Namespace children will inherit parent platforms

### DIFF
--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -4,7 +4,12 @@ import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRi
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { H2 } from '~/ui/components/Text';
 
-import { AccessorDefinitionData, MethodDefinitionData, PropData } from './APIDataTypes';
+import {
+  AccessorDefinitionData,
+  CommentTagData,
+  MethodDefinitionData,
+  PropData,
+} from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import {
   getMethodName,
@@ -32,6 +37,7 @@ export type RenderMethodOptions = {
   nested?: boolean;
   exposeInSidebar?: boolean;
   baseNestingLevel?: number;
+  parentPlatforms?: CommentTagData[];
 };
 
 function getMethodRootSignatures(method: MethodDefinitionData | AccessorDefinitionData | PropData) {
@@ -57,13 +63,21 @@ function getMethodRootSignatures(method: MethodDefinitionData | AccessorDefiniti
 
 export const renderMethod = (
   method: MethodDefinitionData | AccessorDefinitionData | PropData,
-  { apiName, exposeInSidebar = true, nested = false, sdkVersion, ...options }: RenderMethodOptions
+  {
+    apiName,
+    exposeInSidebar = true,
+    nested = false,
+    sdkVersion,
+    parentPlatforms,
+    ...options
+  }: RenderMethodOptions
 ) => {
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
 
   return signatures.map(({ name, parameters, comment, type, typeParameter }) => {
     const returnComment = getTagData('returns', comment);
+    const platforms = getAllTagData('platform', comment);
     return (
       <div
         key={`method-signature-${method.name || name}-${parameters?.length ?? 0}`}
@@ -81,7 +95,7 @@ export const renderMethod = (
             parameters,
             typeParameter
           )}
-          comment={comment}
+          platforms={platforms.length > 0 ? platforms : parentPlatforms}
           baseNestingLevel={baseNestingLevel}
         />
         {parameters && parameters.length > 0 && (

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -1,13 +1,13 @@
 import ReactMarkdown from 'react-markdown';
 
-import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
-import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { H2 } from '~/ui/components/Text';
 
 import { ClassDefinitionData, GeneratedData, PropData, TypeDocKind } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
 import { renderMethod } from './APISectionMethods';
-import { getTagData, mdComponents, getCommentContent } from './APISectionUtils';
+import { getTagData, mdComponents, getCommentContent, getAllTagData } from './APISectionUtils';
+import { APIBoxHeader } from './components/APIBoxHeader';
+import { APIBoxSectionHeader } from './components/APIBoxSectionHeader';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { STYLES_APIBOX } from './styles';
 
@@ -34,6 +34,7 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
 
   const methods = getValidMethods(children);
   const returnComment = getTagData('returns', comment);
+  const namespacePlatforms = getAllTagData('platform', comment);
 
   return (
     <div key={`class-definition-${name}`} className={STYLES_APIBOX}>
@@ -48,12 +49,19 @@ const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JS
           </ReactMarkdown>
         </>
       )}
-      {methods?.length ? (
+      {methods?.length > 0 && (
         <>
           <APIBoxSectionHeader text={`${name} Methods`} exposeInSidebar={false} />
-          {methods.map(method => renderMethod(method, { sdkVersion, baseNestingLevel: 4 }))}
+          {methods.map(method =>
+            renderMethod(method, {
+              sdkVersion,
+              nested: true,
+              parentPlatforms: namespacePlatforms,
+              baseNestingLevel: 4,
+            })
+          )}
         </>
-      ) : undefined}
+      )}
     </div>
   );
 };

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -2,7 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { MONOSPACE, RawH3 } from '~/ui/components/Text';
 
-import { CommentData } from '../APIDataTypes';
+import { CommentData, CommentTagData } from '../APIDataTypes';
 import { getCodeHeadingWithBaseNestingLevel, getTagNamesList } from '../APISectionUtils';
 import { APISectionPlatformTags } from './APISectionPlatformTags';
 
@@ -11,9 +11,16 @@ type Props = {
   comment?: CommentData;
   baseNestingLevel?: number;
   deprecated?: boolean;
+  platforms?: CommentTagData[];
 };
 
-export function APIBoxHeader({ name, comment, baseNestingLevel = 3, deprecated = false }: Props) {
+export function APIBoxHeader({
+  name,
+  comment,
+  platforms,
+  baseNestingLevel = 3,
+  deprecated = false,
+}: Props) {
   const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
   return (
     <div
@@ -32,7 +39,7 @@ export function APIBoxHeader({ name, comment, baseNestingLevel = 3, deprecated =
           {name}
         </MONOSPACE>
       </HeaderComponent>
-      <APISectionPlatformTags comment={comment} className="mb-0" />
+      <APISectionPlatformTags comment={comment} platforms={platforms} className="mb-0" />
     </div>
   );
 }


### PR DESCRIPTION
# Why

Supersedes: 
* #33298

# How

When rendering namespaces children should inherit parents platforms (if specified) unless given entry has its own `@platform` tags.

Also added missing `nested` prop to improved the method boxes appearance.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-01-09 at 16 26 39](https://github.com/user-attachments/assets/86a84ea6-1d0b-48c9-976f-9314cfba60b9)
