### PR TITLE
[docs] streamline code blocks content handling

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -1,6 +1,6 @@
 import partition from 'lodash/partition';
 import { Language, Prism } from 'prism-react-renderer';
-import { Children, ReactElement, ReactNode, isValidElement } from 'react';
+import { Children, ReactElement, ReactNode, PropsWithChildren } from 'react';
 
 // Read more: https://github.com/FormidableLabs/prism-react-renderer#custom-language-support
 async function initPrismAsync() {
@@ -33,6 +33,7 @@ export function cleanCopyValue(value: string) {
     .replace(/\/\*\s?@(tutinfo[^*]+|end|hide[^*]+).?\*\//g, '')
     .replace(/#\s?@(tutinfo[^#]+|end|hide[^#]+).?#/g, '')
     .replace(/<!--\s?@(tutinfo[^<>]+|end|hide[^<>]+).?-->/g, '')
+    .replace(/%%placeholder-start%%.*%%placeholder-end%%/g, '')
     .replace(/^ +\r?\n|\n +\r?$/gm, '');
 }
 
@@ -163,30 +164,11 @@ export function parseValue(value: string) {
   };
 }
 
-export function getRootCodeBlockProps(children: ReactNode, className?: string) {
-  if (className?.startsWith('language')) {
-    return { className, children };
-  }
-
-  const firstChild = Children.toArray(children)[0];
-  if (isValidElement(firstChild) && firstChild.props.className) {
-    if (firstChild.props.className.startsWith('language')) {
-      return {
-        className: firstChild.props.className,
-        children: firstChild.props.children,
-        isNested: true,
-      };
-    }
-  }
-
-  return {};
-}
-
-export function findPropInChildren(element: ReactElement, propToFind: string): string | null {
+export function findNodeByPropInChildren<T>(element: ReactElement, propToFind: string): T | null {
   if (!element || typeof element !== 'object') return null;
 
   if (element.props?.[propToFind]) {
-    return element.props[propToFind];
+    return element.props;
   }
 
   if (element.props?.children) {
@@ -194,15 +176,32 @@ export function findPropInChildren(element: ReactElement, propToFind: string): s
 
     if (Array.isArray(children)) {
       for (const child of Children.toArray(children)) {
-        const wantedProp: string | null = findPropInChildren(child as ReactElement, propToFind);
-        if (wantedProp) return wantedProp;
+        const allProps = findNodeByPropInChildren<T>(child as ReactElement, propToFind);
+        if (allProps) return allProps;
       }
     } else {
-      return findPropInChildren(children as ReactElement, propToFind);
+      return findNodeByPropInChildren<T>(children as ReactElement, propToFind);
     }
   }
 
   return null;
+}
+
+export function getCodeBlockDataFromChildren(children?: ReactNode, className?: string) {
+  if (typeof children === 'string') {
+    return {
+      ...parseValue(children),
+      language: className ? className.split('-')[1] : 'jsx',
+    };
+  }
+  const codeNode = findNodeByPropInChildren<PropsWithChildren<{ className: string }>>(
+    children as ReactElement,
+    'className'
+  );
+  const code = parseValue(codeNode?.children?.toString() ?? '');
+  const codeLanguage = codeNode?.className ? codeNode.className.split('-')[1] : 'jsx';
+
+  return { ...code, language: codeLanguage };
 }
 
 export function getCollapseHeight(params?: Record<string, string>) {

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -7,10 +7,9 @@ import tippy, { roundArrow } from 'tippy.js';
 
 import {
   cleanCopyValue,
-  getRootCodeBlockProps,
   getCodeData,
-  parseValue,
   getCollapseHeight,
+  getCodeBlockDataFromChildren,
 } from '~/common/code-utilities';
 import { useCodeBlockSettingsContext } from '~/providers/CodeBlockSettingsProvider';
 import { Snippet } from '~/ui/components/Snippet/Snippet';
@@ -38,17 +37,21 @@ export function Code({ className, children, title }: CodeProps) {
   const contentRef = useRef<HTMLPreElement>(null);
   const { preferredTheme, wordWrap } = useCodeBlockSettingsContext();
 
-  const rootProps = getRootCodeBlockProps(children, className);
-  const codeBlockData = parseValue(rootProps?.children?.toString() ?? '');
-  const codeBlockTitle = codeBlockData?.title ?? title;
+  const {
+    language,
+    value,
+    params,
+    title: blockTitle,
+  } = getCodeBlockDataFromChildren(children, className);
+  const codeBlockTitle = blockTitle ?? title;
 
   const [isExpanded, setExpanded] = useState(false);
   const [collapseBound, setCollapseBound] = useState<number | undefined>(undefined);
   const [blockHeight, setBlockHeight] = useState<number | undefined>(undefined);
 
-  const collapseHeight = getCollapseHeight(codeBlockData.params);
+  const collapseHeight = getCollapseHeight(params);
   const showExpand = !isExpanded && blockHeight && collapseBound && blockHeight > collapseBound;
-  const highlightedHtml = getCodeData(codeBlockData.value, rootProps.className);
+  const highlightedHtml = getCodeData(value, language);
 
   useEffect(() => {
     const tippyFunc = testTippy || tippy;
@@ -93,7 +96,7 @@ export function Code({ className, children, title }: CodeProps) {
   return codeBlockTitle ? (
     <Snippet>
       <SnippetHeader title={codeBlockTitle} Icon={getIconForFile(codeBlockTitle)}>
-        <CopyAction text={cleanCopyValue(codeBlockData.value)} />
+        <CopyAction text={cleanCopyValue(value)} />
         <SettingsAction />
       </SnippetHeader>
       <SnippetContent className="p-0">

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -159,8 +159,8 @@ const APISectionProps = ({
       ) : (
         <div>
           {baseProp && <APISectionDeprecationNote comment={baseProp.comment} />}
-          <APIBoxSectionHeader text={header} exposeInSidebar baseNestingLevel={99} />
           {baseProp?.comment && <APICommentTextBlock comment={baseProp.comment} />}
+          <APIBoxSectionHeader text={header} exposeInSidebar baseNestingLevel={99} />
         </div>
       )}
       {data.map((propsDefinition: PropsDefinitionData) =>

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -9,6 +9,7 @@ type CopyActionProps = SnippetActionProps & {
 
 export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
   const [copyDone, setCopyDone] = useState(false);
+
   const onCopyClick = () => {
     void navigator.clipboard?.writeText(text);
     setCopyDone(true);

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -1,8 +1,8 @@
 import { mergeClasses, SnackLogo } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
-import { useEffect, useRef, useState, PropsWithChildren, ReactElement } from 'react';
+import { useEffect, useRef, useState, PropsWithChildren } from 'react';
 
-import { cleanCopyValue, findPropInChildren } from '~/common/code-utilities';
+import { cleanCopyValue, getCodeBlockDataFromChildren } from '~/common/code-utilities';
 import { SNACK_URL, getSnackFiles } from '~/common/snack';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
@@ -69,13 +69,7 @@ export const SnackInline = ({
     return `${document.location.origin}/static/examples/${getSelectedDocsVersion()}`;
   };
 
-  const getCode = () => {
-    const code = contentRef.current ? (contentRef.current.textContent ?? '') : '';
-    return code.replace(/%%placeholder-start%%.*%%placeholder-end%%/g, '');
-  };
-
-  const prismBlockClassName = findPropInChildren(children as ReactElement, 'className');
-  const codeLanguage = prismBlockClassName ? prismBlockClassName.split('-')[1] : 'jsx';
+  const { language, value } = getCodeBlockDataFromChildren(children);
 
   return (
     <Snippet className="mb-3 flex flex-col prose-pre:!m-0 prose-pre:!border-0">
@@ -95,15 +89,15 @@ export const SnackInline = ({
               value={JSON.stringify(
                 getSnackFiles({
                   templateId,
-                  code: getCode(),
+                  code: value,
                   files,
                   baseURL: getExamplesPath(),
-                  codeLanguage,
+                  codeLanguage: language,
                 })
               )}
             />
           )}
-          <CopyAction text={cleanCopyValue(getCode())} />
+          <CopyAction text={cleanCopyValue(value)} />
           <SnippetAction
             disabled={!isReady}
             rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/34055

# How

Streamline code blocks content extraction and handling. Fix "Show More" label appearing in `InlineSnack` components.

# Test Plan

The changes have been reviewed by running docs app locally.

I have tested multiple code block variants in MDX files, as well as API Section usages, but would be nice to cross check that anyway.