### PR TITLE
fix(cli): env vars for serve command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Ensure we hydrate env vars in the project when running `npx expo serve`.
+- Ensure we hydrate env vars in the project when running `npx expo serve`. ([#34064](https://github.com/expo/expo/pull/34064) by [@EvanBacon](https://github.com/EvanBacon))
 - Add e2e testing to server function errors ([#33971](https://github.com/expo/expo/pull/33971) by [@EvanBacon](https://github.com/EvanBacon))
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Ensure we hydrate env vars in the project when running `npx expo serve`.
 - Add e2e testing to server function errors ([#33971](https://github.com/expo/expo/pull/33971) by [@EvanBacon](https://github.com/EvanBacon))
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))
 - Add minor fixes to nested server actions. ([#32925](https://github.com/expo/expo/pull/32925) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -8,6 +8,7 @@ import send from 'send';
 import * as Log from '../log';
 import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
+import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv } from '../utils/nodeEnv';
 import { resolvePortAsync } from '../utils/port';
 
@@ -19,7 +20,9 @@ type Options = {
 const debug = require('debug')('expo:serve') as typeof console.log;
 
 // Start a basic http server
-export async function serveAsync(projectRoot: string, options: Options) {
+export async function serveAsync(inputDir: string, options: Options) {
+  const projectRoot = findUpProjectRootOrAssert(inputDir);
+
   setNodeEnv('production');
   require('@expo/env').load(projectRoot);
 
@@ -33,7 +36,7 @@ export async function serveAsync(projectRoot: string, options: Options) {
   }
   options.port = port;
 
-  const serverDist = options.isDefaultDirectory ? path.join(projectRoot, 'dist') : projectRoot;
+  const serverDist = options.isDefaultDirectory ? path.join(inputDir, 'dist') : inputDir;
   //  TODO: `.expo/server/ios`, `.expo/server/android`, etc.
 
   if (!(await directoryExistsAsync(serverDist))) {


### PR DESCRIPTION
# Why

When running `npx expo serve .expo/server/ios` the env vars don't get picked up.
