### PR TITLE
[dev-launcher] shorter timeout for launchLastOpenedBundle mode

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed black stuck screen when loading an unreachable server from last opened url. ([#34067](https://github.com/expo/expo/pull/34067) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
@@ -12,7 +12,8 @@ typedef void (^OnManifestError)(NSError *error);
 
 - (instancetype)initWithURL:(NSURL *)url
              installationID:(NSString *)installationID
-                    session:(NSURLSession *)session;
+                    session:(NSURLSession *)session
+             requestTimeout:(NSTimeInterval)requestTimeout;
 
 - (void)isManifestURLWithCompletion:(IsManifestURL)completion
                             onError:(OnManifestError)onError;

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -16,9 +16,10 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 
 @interface EXDevLauncherManifestParser ()
 
-@property (weak, nonatomic) NSURLSession *session;
 @property (strong, nonatomic) NSURL *url;
 @property (nonatomic, strong) NSString *installationID;
+@property (weak, nonatomic) NSURLSession *session;
+@property (nonatomic, assign) NSTimeInterval requestTimeout;
 
 @end
 
@@ -28,11 +29,13 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 - (instancetype)initWithURL:(NSURL *)url
              installationID:(NSString *)installationID
                     session:(NSURLSession *)session
+             requestTimeout:(NSTimeInterval)requestTimeout
 {
   if (self = [super init]) {
-    self.session = session;
     self.url = url;
     self.installationID = installationID;
+    self.session = session;
+    self.requestTimeout = requestTimeout;
   }
   return self;
 }
@@ -100,6 +103,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   [request setHTTPMethod:method];
   [request setValue:@"ios" forHTTPHeaderField:@"expo-platform"];
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"accept"];
+  [request setTimeoutInterval:self.requestTimeout];
   if (self.installationID) {
     [request setValue:self.installationID forHTTPHeaderField:@"Expo-Dev-Client-ID"];
   }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -115,7 +115,11 @@
 - (void)_testIsManifestURLString:(NSString *)urlString expected:(BOOL)expectedIsManifestUrl description:(NSString *)description
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:description];
 
@@ -139,7 +143,11 @@
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
   }];
 
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/platform"] installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/platform"]
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"request should include expo-platform header"];
 
@@ -164,7 +172,11 @@
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
   }];
 
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/installation-id"] installationID:installationID session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/installation-id"]
+                                         installationID:installationID
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"request should include expo-dev-client-id header"];
 
@@ -189,7 +201,11 @@
   }];
 
   NSURL *url = [NSURL URLWithString:@"http://ohhttpstubs"];
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"should parse manifest successfully"];
 
@@ -222,7 +238,11 @@
   }];
 
   NSURL *url = [NSURL URLWithString:@"http://ohhttpstubs"];
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"should parse manifest successfully"];
 
@@ -249,7 +269,11 @@
   }];
 
   NSURL *url = [NSURL URLWithString:@"http://ohhttpstubs"];
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"should parse manifest successfully"];
 
@@ -275,7 +299,11 @@
   }];
 
   NSURL *url = [NSURL URLWithString:@"http://ohhttpstubs"];
-  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:url installationID:nil session:NSURLSession.sharedSession];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"should fail to parse manifest"];
 


### PR DESCRIPTION
# Why

close ENG-14231

# How

having a shorter timeout for loading last opened url. originally ios has 60s timeout, which would be too long and stucks in black screen. android okhttp by default is 10s. this pr tries to align the ios timeout value as android.

# Test Plan

test launch for a last opened url with an unreachable server

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
