### PR TITLE
[expo-updates] Add simple CLI E2E test

### DIFF
--- a/.github/workflows/updates-e2e-cli.yml
+++ b/.github/workflows/updates-e2e-cli.yml
@@ -1,0 +1,54 @@
+name: Updates CLI e2e
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e-cli.yml
+      - packages/expo-updates/cli/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e-cli.yml
+      - packages/expo-updates/cli/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: E2E Test expo-updates CLI
+        run: yarn test:e2e-cli --ci --runInBand
+        working-directory: packages/expo-updates
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates CLI E2E

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
@@ -15,6 +15,7 @@ const path_1 = __importDefault(require("path"));
 async function syncConfigurationToNativeAsync(options) {
     if (options.workflow !== 'generic') {
         // not applicable to managed workflow
+        return;
     }
     switch (options.platform) {
         case 'android':

--- a/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
@@ -20,6 +20,7 @@ export async function syncConfigurationToNativeAsync(
 ): Promise<void> {
   if (options.workflow !== 'generic') {
     // not applicable to managed workflow
+    return;
   }
 
   switch (options.platform) {

--- a/packages/expo-updates/e2e-cli/__tests__/cli-test.ts
+++ b/packages/expo-updates/e2e-cli/__tests__/cli-test.ts
@@ -1,0 +1,78 @@
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+import rimraf from 'rimraf';
+
+import runCLIAsync from './utils/CLIUtils';
+
+describe('CLI', () => {
+  jest.setTimeout(600000);
+  const tmpDir = require('temp-dir');
+  const projectName = 'update-e2e-cli-project';
+  const projectRoot = path.join(tmpDir, projectName);
+
+  beforeAll(async () => {
+    rimraf.sync(projectRoot);
+    await spawnAsync('yarn', ['create', 'expo-app', '-t', 'bare-minimum', projectName], {
+      stdio: 'inherit',
+      cwd: tmpDir,
+      env: {
+        ...process.env,
+        // Do not inherit the package manager from this repository
+        npm_config_user_agent: undefined,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    rimraf.sync(projectRoot);
+  });
+
+  test('fingerprint:generate basic case', async () => {
+    await expect(
+      runCLIAsync(projectRoot, 'fingerprint:generate', ['--platform', 'ios'])
+    ).resolves.not.toThrow();
+  });
+
+  test('runtimeversion:resolve basic case', async () => {
+    await expect(
+      runCLIAsync(projectRoot, 'runtimeversion:resolve', ['--platform', 'ios'])
+    ).resolves.not.toThrow();
+  });
+
+  test('codesigning:generate basic case', async () => {
+    await expect(
+      runCLIAsync(projectRoot, 'codesigning:generate', [
+        '--key-output-directory',
+        'keys',
+        '--certificate-output-directory',
+        'certs',
+        '--certificate-validity-duration-years',
+        '10',
+        '--certificate-common-name',
+        'testname',
+      ])
+    ).resolves.not.toThrow();
+  });
+
+  test('codesigning:configure basic case', async () => {
+    await expect(
+      runCLIAsync(projectRoot, 'codesigning:configure', [
+        '--key-input-directory',
+        'keys',
+        '--certificate-input-directory',
+        'certs',
+      ])
+    ).resolves.not.toThrow();
+  });
+
+  test('configuration:syncnative basic case', async () => {
+    await expect(
+      runCLIAsync(projectRoot, 'configuration:syncnative', [
+        '--platform',
+        'ios',
+        '--workflow',
+        'generic',
+      ])
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/expo-updates/e2e-cli/__tests__/utils/CLIUtils.ts
+++ b/packages/expo-updates/e2e-cli/__tests__/utils/CLIUtils.ts
@@ -1,0 +1,21 @@
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+
+const cliPath = path.resolve(__dirname, '..', '..', '..', 'bin', 'cli.js');
+
+export default async function runCLIAsync(
+  projectRoot: string,
+  command: string,
+  args: string[] = []
+) {
+  try {
+    const { stdout } = await spawnAsync(cliPath, [command, ...args], {
+      stdio: 'pipe',
+      cwd: projectRoot,
+    });
+    return stdout;
+  } catch (e) {
+    console.error(JSON.stringify(e));
+    throw e;
+  }
+}

--- a/packages/expo-updates/e2e-cli/jest.config.js
+++ b/packages/expo-updates/e2e-cli/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  ...require('expo-module-scripts/jest-preset-cli'),
+  preset: 'ts-jest',
+  displayName: require('../package').name,
+  rootDir: __dirname,
+  roots: ['.'],
+};

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -15,7 +15,8 @@
     "test": "expo-module test",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
-    "expo-module": "expo-module"
+    "expo-module": "expo-module",
+    "test:e2e-cli": "yarn run prepare && expo-module test --config e2e-cli/jest.config.js"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
# Why

These need a simple sanity check test since quite a few places use them (EAS CLI, in particular). More tests may be added in follow-up PRs.

Closes ENG-11507.

# How

Add test, add workflow that runs the test.

# Test Plan

Run test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
