### PR TITLE
docs: tweak the tabs on create-expo to unify format

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -23,19 +23,19 @@ To create a new project, run the following command:
 
 <Tab label="yarn">
 
-<Terminal cmd={['$ yarn create expo-app@latest']} />
+<Terminal cmd={['$ yarn create expo-app']} />
 
 </Tab>
 
 <Tab label="pnpm">
 
-<Terminal cmd={['$ pnpm create expo-app@latest']} />
+<Terminal cmd={['$ pnpm create expo-app']} />
 
 </Tab>
 
 <Tab label="bun">
 
-<Terminal cmd={['$ bun create expo-app@latest']} />
+<Terminal cmd={['$ bun create expo-app']} />
 
 </Tab>
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -21,21 +21,21 @@ To create a new project, run the following command:
 
 </Tab>
 
-<Tab label="Yarn">
+<Tab label="yarn">
 
-<Terminal cmd={['$ yarn create expo-app']} />
+<Terminal cmd={['$ yarn create expo-app@latest']} />
 
 </Tab>
 
 <Tab label="pnpm">
 
-<Terminal cmd={['$ pnpm create expo-app']} />
+<Terminal cmd={['$ pnpm create expo-app@latest']} />
 
 </Tab>
 
 <Tab label="bun">
 
-<Terminal cmd={['$ bun create expo']} />
+<Terminal cmd={['$ bun create expo-app@latest']} />
 
 </Tab>
 


### PR DESCRIPTION
# Why

I spotted that we use `npm`, `Yarn` (capital), `pnpm`, and `bun`. Thought we should unify that a bit more. I also tweaked the command itself to add `@latest` to all of them.

# How

Docs change

# Test Plan

Docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
