### PR TITLE
[android][expo-blur] Fix :expo-blur:compileDebugKotlin in android devices

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ## 14.0.1 — 2024-10-22
 
-_This version does not introduce any user-facing changes._
+### 🛠 Breaking changes
+
+- Update BlurView dependency to version-2.0.6. ([#34080](https://github.com/expo/expo/pull/34080) by [@bhattaraijay05](https://github.com/bhattaraijay05))
 
 ## 14.0.0 — 2024-10-22
 

--- a/packages/expo-blur/android/build.gradle
+++ b/packages/expo-blur/android/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-  implementation 'com.github.Dimezis:BlurView:version-2.0.3'
+  implementation 'com.github.Dimezis:BlurView:version-2.0.6'
 }


### PR DESCRIPTION
# Why
The BlurView dependency needed to be migrated from JCenter to JitPack due to JCenter's closure. Additionally, the previous version (2.0.3) encountered build issues, specifically failing to resolve the required BlurView-version-2.0.3.aar file.

# How

The dependency was updated to use JitPack as the source and the version was upgraded to 2.0.6. This resolved the build error related to the missing BlurView-version-2.0.3.aar and ensured continued stability and availability of the dependency.


# Test Plan

Tested by building the project with the updated dependency configuration. Verified that the build succeeds without errors. Below is the error encountered with version 2.0.3 for reference
> Task :expo-blur:compileDebugKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':expo-blur:compileDebugKotlin'.
> Could not resolve all files for configuration ':expo-blur:debugCompileClasspath'.
   > Failed to transform BlurView-version-2.0.3.aar (com.github.Dimezis:BlurView:version-2.0.3) to match attributes {artifactType=android-classes-jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-api}.
      > Could not find BlurView-version-2.0.3.aar (com.github.Dimezis:BlurView:version-2.0.3).
        Searched in the following locations:
            https://www.jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.aar


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
