### PR TITLE
[Android][core][autolinking] Get access to `coreFeatures`

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -4,6 +4,7 @@ import expo.modules.plugin.configuration.ExpoAutolinkingConfig
 import expo.modules.plugin.gradle.afterAndroidApplicationProject
 import expo.modules.plugin.gradle.applyAarProject
 import expo.modules.plugin.gradle.applyPlugin
+import expo.modules.plugin.gradle.beforeProject
 import expo.modules.plugin.gradle.beforeRootProject
 import expo.modules.plugin.gradle.linkAarProject
 import expo.modules.plugin.gradle.linkBuildDependence
@@ -14,6 +15,7 @@ import expo.modules.plugin.text.Colors
 import expo.modules.plugin.text.Emojis
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
+import org.gradle.internal.extensions.core.extra
 
 class SettingsManager(
   val settings: Settings,
@@ -53,6 +55,11 @@ class SettingsManager(
       config.allAarProjects
         .filter { it.name == project.name }
         .forEach(project::applyAarProject)
+    }
+
+    // Defines the required features for the core module
+    settings.gradle.beforeProject("expo-modules-core") { project ->
+      project.extra.set("features", config.coreFeatures)
     }
 
     settings.gradle.beforeRootProject { rootProject: Project ->

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -59,7 +59,7 @@ class SettingsManager(
 
     // Defines the required features for the core module
     settings.gradle.beforeProject("expo-modules-core") { project ->
-      project.extra.set("features", config.coreFeatures)
+      project.extra.set("coreFeatures", config.coreFeatures)
     }
 
     settings.gradle.beforeRootProject { rootProject: Project ->

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/GradleExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/GradleExtension.kt
@@ -16,6 +16,17 @@ internal inline fun Gradle.beforeRootProject(crossinline action: (rootProject: P
 }
 
 /**
+ * Adds an action to be called before the given project is evaluated.
+ */
+internal inline fun Gradle.beforeProject(projectName: String, crossinline action: (project: Project) -> Unit) {
+  beforeProject { project ->
+    if (project.name == projectName) {
+      action(project)
+    }
+  }
+}
+
+/**
  * Adds an action to be called immediately after an Android application project is evaluated.
  */
 internal inline fun Gradle.afterAndroidApplicationProject(crossinline action: (androidApplication: Project) -> Unit) {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.modules.SerializersModule
 @Serializable
 data class ExpoAutolinkingConfig(
   val modules: List<ExpoModule> = emptyList(),
-  val extraDependencies: List<MavenRepo> = emptyList()
+  val extraDependencies: List<MavenRepo> = emptyList(),
+  val coreFeatures: List<String> = emptyList()
 ) {
   /**
    * Returns all gradle projects from all modules.

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -6,7 +6,7 @@ group = 'host.exp.exponent'
 version = '2.0.6'
 
 // List of features that are required by linked modules
-def features = project.findProperty("features") ?: []
+def coreFeatures = project.findProperty("coreFeatures") ?: []
 
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 apply from: expoModulesCorePlugin

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'com.android.library'
 group = 'host.exp.exponent'
 version = '2.0.6'
 
+// List of features that are required by linked modules
+def features = project.findProperty("features") ?: []
+
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 apply from: expoModulesCorePlugin
 applyKotlinExpoModulesCorePlugin()


### PR DESCRIPTION
# Why

Gets access to the `coreFeatures` field defined by the autolinking.

# How

Exposed the `coreFeatures` from autolinking to the `expo-modules-core`. Also, we can use a similar mechanism in other packages to enable some functionality conditionally.  

# Test Plan

- manually using bare-expo ✅ 