### PR TITLE
[ios][camera] Fix setting `videoQuality` prop

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix `zoom` on Android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix setting `videoQuality` prop.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix `zoom` on Android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix setting `videoQuality` prop.
+- [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
@@ -1,6 +1,5 @@
 package expo.modules.camera
 
-import expo.modules.camera.records.VideoQuality
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 
@@ -19,5 +18,5 @@ data class PictureOptions(
 
 data class RecordingOptions(
   @Field val maxDuration: Int = 0,
-  @Field val maxFileSize: Int = 0,
+  @Field val maxFileSize: Int = 0
 ) : Record

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
@@ -20,5 +20,4 @@ data class PictureOptions(
 data class RecordingOptions(
   @Field val maxDuration: Int = 0,
   @Field val maxFileSize: Int = 0,
-  @Field val quality: VideoQuality?
 ) : Record

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -134,9 +134,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
 
       Prop("videoQuality") { (view, quality: VideoQuality?) in
-        if let quality, view.videoQuality != quality {
-          view.videoQuality = quality
-        }
+        view.videoQuality = quality ?? .video1080p
       }
 
       Prop("autoFocus") { (view, focusMode: FocusMode?) in

--- a/packages/expo-camera/ios/Current/CameraRecordingOptions.swift
+++ b/packages/expo-camera/ios/Current/CameraRecordingOptions.swift
@@ -3,7 +3,6 @@ import ExpoModulesCore
 struct CameraRecordingOptions: Record {
   @Field var maxDuration: Double?
   @Field var maxFileSize: Double?
-  @Field var quality: VideoQuality?
   @Field var mirror: Bool = false
   @Field var codec: VideoCodec?
 }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -39,10 +39,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var videoQuality: VideoQuality = .video1080p {
     didSet {
-      if session.sessionPreset != videoQuality.toPreset() {
-        Task {
-          await updateSessionPreset(preset: videoQuality.toPreset())
-        }
+      Task {
+        await updateSessionPreset(preset: videoQuality.toPreset())
       }
     }
   }
@@ -544,11 +542,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   func record(options: CameraRecordingOptions, promise: Promise) async {
-    let preset = options.quality?.toPreset()
-    if let preset {
-      await updateSessionPreset(preset: preset)
-    }
-
     if let videoFileOutput, !videoFileOutput.isRecording && videoRecordedPromise == nil {
       if let connection = videoFileOutput.connection(with: .video) {
         let orientation = responsiveWhenOrientationLocked ? physicalOrientation : UIDevice.current.orientation


### PR DESCRIPTION
# Why
Closes #34060
There were too many checks when setting `videoQuality`, leading to it being set inconsistently. Also, it should be set as a prop and not accepted as an argument to `recordAsync`. This was expressed in the TS types but not in native.

# How
Removed some of the checks before setting `videoQuality`. We now only check it at the point we are about to update the session. Removed the `quality` property from `recordAsync`s argument.

# Test Plan
Bare-expo. Videos use the expected `videoQuality`

