### PR TITLE
Fix ambiguous return type error in Swift closure

### DIFF
--- a/packages/expo-splash-screen/ios/SplashScreenModule.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenModule.swift
@@ -24,7 +24,7 @@ public class SplashScreenModule: Module {
       }
     }
 
-    AsyncFunction("preventAutoHideAsync") {
+    AsyncFunction("preventAutoHideAsync") { () -> Bool in
       // The user has manually invoked prevent autohide, this is used to allow libraries
       // such as expo-router to know whether it's safe to hide or if they should wait for
       // the user to do it.


### PR DESCRIPTION
# Why

When trying to run a freshly created expo sdk 52 app (expo 52.0.24) with npx expo run:ios the process runs into this error:

❌  (node_modules/expo-splash-screen/ios/SplashScreenModule.swift:27:50)

  25 |     }
  26 | 
> 27 |    AsyncFunction("preventAutoHideAsync") { () -> Promise<Void> in
     |                                                  ^ cannot specialize non-generic type 'Promise'
  28 |       // The user has manually invoked prevent autohide, this is used to allow libraries
  29 |       // such as expo-router to know whether it's safe to hide or if they should wait for
  30 |       // the user to do it.


# How

By running npx expo run:ios  in a fresh expo sdk 52 project

# Test Plan

By running npx expo run:ios  in a fresh expo sdk 52 project. Now the project runs successfully on ios.

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
