### PR TITLE
[guides] Add guideline for referencing app config

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -110,7 +110,7 @@ When referencing Expo Go, the supported text should avoid implying: "running an 
 
 ### Referencing app.json/app.config.json/app.config.js/app.config.ts
 
-When referencing the multiple variants of app config file file, such as app.json, app.config.json, app.config.js, or app.config.ts, use "**app config**" or "**app config** file" and link to its [documentation page](https://docs.expo.dev/workflow/configuration/). This helps the reader understand that these files are interchangeable and can be used in the same context.
+When referencing the multiple variants of app config file, such as app.json, app.config.json, app.config.js, or app.config.ts, use "**app config**" or "**app config** file" and link to its [documentation page](https://docs.expo.dev/workflow/configuration/). This helps the reader understand that these files are interchangeable and can be used in the same context.
 
 If there is a need to reference a specific file format, use the appropriate file name.
 

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -108,6 +108,12 @@ In most cases, to refer to multiple platforms (Android, iOS, and Web) in one sen
 
 When referencing Expo Go, the supported text should avoid implying: "running an app", "developing an app", or "previewing an app". One alternative to avoid these constraints is: "testing your project".
 
+### Referencing app.json/app.config.json/app.config.js/app.config.ts
+
+When referencing the multiple variants of app config file file, such as app.json, app.config.json, app.config.js, or app.config.ts, use "**app config**" or "**app config** file" and link to its [documentation page](https://docs.expo.dev/workflow/configuration/). This helps the reader understand that these files are interchangeable and can be used in the same context.
+
+If there is a need to reference a specific file format, use the appropriate file name.
+
 ## Punctuation
 
 ### Use double quotes in prose


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Sometimes, we reference multiple file formats for app config in a single sentence. However, the reference term "app config" can be used when there is no requirement to reference a specific format.

This PR adds a guideline about that to the writing style guide.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
