### PR TITLE
docs: minor grammar fix

### DIFF
--- a/docs/pages/distribution/app-size.mdx
+++ b/docs/pages/distribution/app-size.mdx
@@ -55,7 +55,7 @@ The following table shows that while the APK size increased, which may slightly 
 | 49  | 66 MB               | 27.6 MB               | 28.2 MB | 11.7 MB     |
 | 50  | 168.1 MB            | 62.1 MB               | 27.4 MB | 11.7 MB     |
 
-If you would like to revert back to the previous behavior, you can set `useLegacyPackaging` to `true` in your **gradle.properties** or by using [`expo-build-properties`](/versions/latest/sdk/build-properties/).
+If you would like to revert to the previous behavior, you can set `useLegacyPackaging` to `true` in your **gradle.properties** or by using [`expo-build-properties`](/versions/latest/sdk/build-properties/).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

Minor grammar fix to remove redundancy.

