### PR TITLE
[expo-location][Android] Add missing ProGuard rule to fix task consumer failed

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing Proguard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
+
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)
 
 ### 💡 Others

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing Proguard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
+- Add missing ProGuard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
 
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)
 

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -15,6 +15,7 @@ android {
   defaultConfig {
     versionCode 29
     versionName "18.0.2"
+    consumerProguardFiles("proguard-rules.pro")
   }
 }
 

--- a/packages/expo-location/android/proguard-rules.pro
+++ b/packages/expo-location/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+# https://github.com/expo/expo/issues/3918
+
+-keep class expo.modules.location.** { *; }

--- a/packages/expo-location/android/proguard-rules.pro
+++ b/packages/expo-location/android/proguard-rules.pro
@@ -1,3 +1,3 @@
 # https://github.com/expo/expo/issues/3918
 
--keep class expo.modules.location.** { *; }
+-keep class expo.modules.location.taskConsumers.** { *; }


### PR DESCRIPTION
# Why

Fixes `Error: Initializing task consumer 'expo.modules.location.a.b' failed.` in ProGuard-enabled Android builds.

This issue was initially raised in https://github.com/expo/expo/issues/3918

# How

Created a `proguard-rules.pro` file containing a rule to keep all `expo-location` classes as suggested in the issue, and added the file's name inside the `defaultConfig` block of the library's `build.gradle`

# Test Plan

See related issue comment for testing: https://github.com/expo/expo/issues/3918#issue-428658930

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
