### PR TITLE
[CLI]: Fixed import example in create expo module cli

### DIFF
--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -471,7 +471,7 @@ function printFurtherLocalInstructions(slug: string, name: string) {
   console.log();
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add this line to your App.js or App.tsx file:`);
-  console.log(`${chalk.gray.italic(`import ${name} './modules/${slug}';`)}`);
+  console.log(`${chalk.gray.italic(`import ${name} from './modules/${slug}';`)}`);
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
   console.log(


### PR DESCRIPTION
# Why

The import example provided by the cli is not correct

# How

```
- console.log(`${chalk.gray.italic(`import ${name} './modules/${slug}';`)}`);
+ console.log(`${chalk.gray.italic(`import ${name} from './modules/${slug}';`)}`);
```

# Test Plan

Copy the output to the project