### PR TITLE
fix(metro-config): ignore static creation for images with a pixel density descriptor for client web

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🐛 Bug fixes
 
 - Make exported sourcemap paths relative on Windows. ([#33503](https://github.com/expo/expo/pull/33503) by [@byCedric](https://github.com/byCedric))
+- Ignore static creation for images with a pixel density descriptor for client web ([#34108](https://github.com/expo/expo/pull/34108) by [@exzos28](https://github.com/exzos28))
 
 ## 0.19.7 - 2024-12-10
 

--- a/packages/@expo/metro-config/src/transform-worker/asset-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/asset-transformer.ts
@@ -98,7 +98,8 @@ export async function transform(
       : options.publicPath
   );
 
-  if (isServerEnv || options.platform === 'web') {
+  const hasMultipleDescriptors = data.scales?.length > 1 && data.files?.length > 1;
+  if (isServerEnv || (options.platform === 'web' && !hasMultipleDescriptors)) {
     const type = !data.type ? '' : `.${data.type}`;
     const assetPath = !isExport
       ? data.httpServerLocation + '/' + data.name + type


### PR DESCRIPTION
# How

Ignore static creation for an image with multiple pixel density descriptors. As a result, they will be added to AssetRegistry and processed in Image (react-native-web) component [here](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/Image/index.js#L122). Thereby “selecting” an image with a pixel density descriptor will be similar to Image from react-native.

# Test Plan

Add images with a pixel density descriptor (@2x, @3x, etc) to the project. Run web, the “correct” image for that pixel density should be rendered.

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
