### PR TITLE
[docs] APISection: render type/props method params and their comments

### DIFF
--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -3,7 +3,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { APITypeOrSignatureType } from '~/components/plugins/api/components/APITypeOrSignatureType';
-import { CODE, H2, H3, H4, LI, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, MONOSPACE, UL } from '~/ui/components/Text';
 
 import {
   DefaultPropsDefinitionData,
@@ -20,7 +20,7 @@ import {
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
+import { ELEMENT_SPACING, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -136,6 +136,22 @@ export const renderProp = (
         )}
       </div>
       <APICommentTextBlock comment={extractedComment} includePlatforms={false} inlineHeaders />
+      {extractedSignatures?.length &&
+        extractedSignatures[0].parameters?.map(param => (
+          <div
+            className={mergeClasses(
+              STYLES_SECONDARY,
+              VERTICAL_SPACING,
+              ELEMENT_SPACING,
+              'flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5 font-normal'
+            )}
+            key={param.name}>
+            <MONOSPACE>
+              {param.name}: {resolveTypeName(param.type, sdkVersion)}
+            </MONOSPACE>
+            <APICommentTextBlock comment={param.comment} emptyCommentFallback="No description" />
+          </div>
+        ))}
     </div>
   );
 };

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -149,7 +149,7 @@ export const renderProp = (
             <MONOSPACE>
               {param.name}: {resolveTypeName(param.type, sdkVersion)}
             </MONOSPACE>
-            <APICommentTextBlock comment={param.comment} emptyCommentFallback="No description" />
+            <APICommentTextBlock comment={param.comment} />
           </div>
         ))}
     </div>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -109,16 +109,21 @@ const renderTypeMethodEntry = (
   return null;
 };
 
-const renderTypePropertyRow = (
-  { name, flags, type, comment, defaultValue, signatures, kind }: PropData,
-  sdkVersion: string
-): JSX.Element => {
+const renderTypePropertyRow = (x: PropData, sdkVersion: string): JSX.Element => {
+  const { name, flags, type, comment, defaultValue, signatures, kind } = x;
   const defaultTag = getTagData('default', comment);
   const initValue = parseCommentContent(
     defaultValue ?? (defaultTag ? getCommentContent(defaultTag.content) : undefined)
   );
-  const commentData = getCommentOrSignatureComment(comment, signatures);
+  const commentData = getCommentOrSignatureComment(
+    comment,
+    type?.declaration?.signatures ?? signatures
+  );
   const hasDeprecationNote = Boolean(getTagData('deprecated', comment));
+  const params = type?.declaration?.signatures?.length
+    ? type.declaration.signatures[0].parameters
+    : undefined;
+
   return (
     <Row key={name}>
       <Cell>
@@ -142,6 +147,16 @@ const renderTypePropertyRow = (
           afterContent={renderDefaultValue(initValue)}
           emptyCommentFallback={hasDeprecationNote ? undefined : '-'}
         />
+        {params?.map(param => (
+          <div
+            className="mt-2 flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5"
+            key={param.name}>
+            <MONOSPACE>
+              {param.name}: {resolveTypeName(param.type, sdkVersion)}
+            </MONOSPACE>
+            <APICommentTextBlock comment={param.comment} />
+          </div>
+        ))}
       </Cell>
     </Row>
   );


### PR DESCRIPTION
# Why

Recently spotted that we miss this information in rendered reference docs.

# How

Add param list and description (if available) to the types and props which use method in the definition.

Having table in table does not look that great, so I have experimented with a bit more streamlined appearance.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-01-12 at 20 25 15](https://github.com/user-attachments/assets/85327afe-36b4-41e0-adcf-8c22105d7a03)

![Screenshot 2025-01-12 at 20 25 37](https://github.com/user-attachments/assets/e3eab1d1-4319-44c2-b53e-c6a029ec70d8)

