### PR TITLE
[docs] Add SEO updates to Migrate Expo CLI guide

### DIFF
--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -1,6 +1,7 @@
 ---
-title: Migrate to Expo CLI
-description: Learn how to migrate to use Expo CLI instead of @react-native-community/cli in any React Native project.
+title: Migrate from React Native CLI to Expo CLI
+sidebar_title: Migrate to Expo CLI
+description: Learn how to migrate from React Native CLI (@react-native-community/cli) to Expo CLI for any React Native project.
 ---
 
 import { DocsLogo, RouterLogo } from '@expo/styleguide';
@@ -11,7 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { DEMI } from '~/ui/components/Text';
 
-To migrate from `npx @react-native-community/cli@latest init` to Expo CLI, you'll need to install the `expo` package, which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
+To migrate from React Native CLI (`npx @react-native-community/cli@latest init`) to Expo CLI, you'll need to install the `expo` package, which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
 
 It is strongly recommended to use Expo CLI when using other Expo tools. It is required for many tools, such as EAS Update, Expo Router, and expo-dev-client, and other features may not work as well without it.
 
@@ -23,7 +24,7 @@ In most cases, executing the following command in a project directory to install
 
 For a detailed installation guide, see [Install Expo modules](/bare/installing-expo-modules).
 
-## Why Expo CLI instead of `npx react-native`
+## Why Expo CLI instead of React Native CLI
 
 Expo CLI commands provide several benefits over the similar commands in `@react-native-community/cli`, which includes:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

@dankelly2040 mentioned in the last SEO sync that the current Migrate to Expo CLI guide is missing the keyword "React Native CLI" which can add context to the guide itself and benefit SEO.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the page title, description, introduction, and second section heading to include the keyword "React Native CLI". Add a sidebar title to keep the original title in the navigation menu.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview of changes

![CleanShot 2025-01-13 at 22 25 27@2x](https://github.com/user-attachments/assets/0493bf8f-66f7-4b53-8c86-05b06ad20acd)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
