### PR TITLE
[iOS][core][autolinking] Get access to `coreFeatures`

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -1,5 +1,6 @@
 require_relative 'constants'
 require_relative 'package'
+require_relative 'packages_config'
 
 # Require extensions to CocoaPods' classes
 require_relative 'cocoapods/sandbox'
@@ -18,6 +19,8 @@ module Expo
 
       validate_target_definition()
       resolve_result = resolve()
+
+      Expo::PackagesConfig.instance.coreFeatures = resolve_result['coreFeatures']
 
       @packages = resolve_result['modules'].map { |json_package| Package.new(json_package) }
       @extraPods = resolve_result['extraDependencies']

--- a/packages/expo-modules-autolinking/scripts/ios/packages_config.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/packages_config.rb
@@ -1,0 +1,15 @@
+require 'singleton'
+
+module Expo
+  # This class is used to store the configuration of the packages that are being used in the project.
+  # It is a singleton class, so it can be accessed from anywhere in the project.
+  class PackagesConfig
+    include Singleton
+    
+    attr_accessor :coreFeatures
+    
+    def initialize
+      @coreFeatures = []
+    end
+  end
+end

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -36,6 +36,12 @@ if new_arch_enabled
   compiler_flags << ' ' << new_arch_compiler_flags
 end
 
+# List of features that are required by linked modules
+coreFeatures = []
+if defined?(Expo::PackagesConfig)
+  coreFeatures = Expo::PackagesConfig.instance.coreFeatures
+end
+
 Pod::Spec.new do |s|
   s.name           = 'ExpoModulesCore'
   s.version        = package['version']


### PR DESCRIPTION
# Why

iOS part of the https://github.com/expo/expo/pull/34081

# How

This PR introduces a method for accessing `coreFeatures` directly from the podspec. 

In addition to this change, I also considered alternative ways to inject configuration into the package podspec. I explored the following options:

- **Using Environment Variables**: This approach would allow us to pass data, but it is limited to strings, which may pose restrictions in the long run.
- **Overriding [_eval_pod](https://github.com/CocoaPods/Core/blob/a53e235aa4d1eec8a21042e022ba7bcaca14ae56/lib/cocoapods-core/specification.rb#L843) and injecting custom bindings**: This could provide a more user-friendly syntax, allowing users to reference the `coreFeatures` variable directly within the podspec. However, this method has its challenges. It would be difficult to limit the injection of this variable to just one package, as it would likely be declared globally. Furthermore, there is no direct connection between the current pod and this function, making it unclear which package is being parsed. While we could use the spec path to determine this, it seems overly complicated.

After taking everything into account, I decided to create a singleton to share the configuration. Seems to be the easiest solution to maintain. 

# Test Plan

- bare-expo ✅ 