### PR TITLE
[cli][doctor] exclude `@expo-google-fonts/*` packages from new arch check

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Add e2e tests for browser history and hash param ([#33524](https://github.com/expo/expo/pull/33524) by [@stephentuso](https://github.com/stephentuso))
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
 - Added `--bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
-- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check.
+- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check. ([#34127](https://github.com/expo/expo/pull/34127) by [@Simek](https://github.com/Simek))
 
 ## 0.22.7 - 2024-12-19
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Add e2e tests for browser history and hash param ([#33524](https://github.com/expo/expo/pull/33524) by [@stephentuso](https://github.com/stephentuso))
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
 - Added `--bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
+- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check.
 
 ## 0.22.7 - 2024-12-19
 

--- a/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
+++ b/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
@@ -52,16 +52,24 @@ describe(checkPackagesCompatibility, () => {
         'expo-image-picker': { newArchitecture: undefined },
       });
 
-    await checkPackagesCompatibility(['expo-image']);
+    await checkPackagesCompatibility(['expo-image', '@expo-google-fonts/inter']);
 
     expect(Log.warn).toHaveBeenCalledTimes(0);
   });
 
-  it(`does not fail for non-listed package`, async () => {
-    nock('https://reactnative.directory').post('/api/libraries/check').reply(200, {});
+  it(`does not fetch or warn when installing @expo-google-fonts/* packages`, async () => {
+    let wasCalled = false;
 
-    await checkPackagesCompatibility(['package-which-do-not-exist']);
+    nock('https://reactnative.directory')
+      .post('/api/libraries/check')
+      .reply(200, () => {
+        wasCalled = true;
+        return {};
+      });
 
+    await checkPackagesCompatibility(['@expo-google-fonts/inter']);
+
+    expect(wasCalled).toBe(false);
     expect(Log.warn).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
+++ b/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
@@ -15,12 +15,20 @@ const ERROR_MESSAGE =
 
 export async function checkPackagesCompatibility(packages: string[]) {
   try {
+    const packagesToCheck = packages.filter(
+      (packageName) => !packageName.startsWith('@expo-google-fonts/')
+    );
+
+    if (!packagesToCheck.length) {
+      return;
+    }
+
     const response = await fetch('https://reactnative.directory/api/libraries/check', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ packages }),
+      body: JSON.stringify({ packages: packagesToCheck }),
     });
 
     if (!response.ok) {
@@ -32,7 +40,7 @@ export async function checkPackagesCompatibility(packages: string[]) {
       ReactNativeDirectoryCheckResult
     >;
 
-    const incompatiblePackages = packages.filter(
+    const incompatiblePackages = packagesToCheck.filter(
       (packageName) => packageMetadata[packageName]?.newArchitecture === 'unsupported'
     );
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Removed cmd.exe warning. ([#33357](https://github.com/expo/expo/pull/33357) by [@keith-kurak](https://github.com/keith-kurak))
+- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check.
 
 ## 1.12.4 — 2024-11-14
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Removed cmd.exe warning. ([#33357](https://github.com/expo/expo/pull/33357) by [@keith-kurak](https://github.com/keith-kurak))
-- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check.
+- Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check. ([#34127](https://github.com/expo/expo/pull/34127) by [@Simek](https://github.com/Simek))
 
 ## 1.12.4 — 2024-11-14
 

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -8,12 +8,13 @@ import {
 
 // Filter out common packages that don't make sense for us to validate on the directory.
 const DEFAULT_PACKAGES_TO_IGNORE = [
-  'react-native',
+  'jest',
   'react',
   'react-dom',
+  'react-native',
   'react-native-web',
-  'jest',
   /^babel-.*$/,
+  /^@expo-google-fonts\/.*$/,
   /^@types\/.*$/,
 ];
 


### PR DESCRIPTION
# Why

Fixes https://github.com/react-native-community/directory/issues/1469:
* https://github.com/react-native-community/directory/issues/1469

# How

Since `@expo-google-fonts/*` packages are basically the font file wrappers, it's safe to skip the new arch check for them.

Performed the related changes in CLI to allow excludes, update Doctor existing exclude list. 

# Test Plan

CLI: Run the updated CLI locally. Add test case for exclusion, make sure that no request is made if list is empty.
Doctor: Run the updated CLI locally on project with `@expo-google-fonts` package
