### PR TITLE
fix(cli): Fix compiler usage with RSC HMR.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix compiler usage with RSC HMR.
+- Fix compiler usage with RSC HMR. ([#34128](https://github.com/expo/expo/pull/34128) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we hydrate env vars in the project when running `npx expo serve`. ([#34064](https://github.com/expo/expo/pull/34064) by [@EvanBacon](https://github.com/EvanBacon))
 - Add e2e testing to server function errors ([#33971](https://github.com/expo/expo/pull/33971) by [@EvanBacon](https://github.com/EvanBacon))
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix compiler usage with RSC HMR.
 - Ensure we hydrate env vars in the project when running `npx expo serve`. ([#34064](https://github.com/expo/expo/pull/34064) by [@EvanBacon](https://github.com/EvanBacon))
 - Add e2e testing to server function errors ([#33971](https://github.com/expo/expo/pull/33971) by [@EvanBacon](https://github.com/EvanBacon))
 - Recurse server action exports to collect all references. ([#33934](https://github.com/expo/expo/pull/33934) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -201,7 +201,7 @@ export function getMetroDirectBundleOptions(
     baseUrl: baseUrl || undefined,
     routerRoot,
     bytecode: bytecode ? '1' : undefined,
-    reactCompiler: reactCompiler || undefined,
+    reactCompiler: reactCompiler ? String(reactCompiler) : undefined,
     dom: domRoot,
   };
 


### PR DESCRIPTION
# Why

- Use a string for the boolean to match query params value when performing SSR HMR with React Compiler.
