### PR TITLE
[haptics][web] Add web support using Web Vibration API

### DIFF
--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Haptics
-description: A library that provides access to the system's vibration effects on Android, the haptics engine on iOS, and the Web Vibration API on web platforms.
+description: A library that provides access to the system's vibration effects on Android, the haptics engine on iOS, and the Web Vibration API on web.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-haptics'
 packageName: 'expo-haptics'
 iconUrl: '/static/images/packages/expo-haptics.png'

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -24,7 +24,7 @@ On iOS, the Taptic engine will do nothing if any of the following conditions are
 - iOS Camera is active (to prevent destabilization).
 - iOS dictation is active (to not disturb the microphone input).
 
-On web platforms, the library uses the Web Vibration API. Note the following:
+On web, the library uses the Web Vibration API. Note the following:
 
 - The API must be supported by the browser (check [browser compatibility](https://caniuse.com/vibration))
 - The device must have vibration hardware

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -1,10 +1,10 @@
 ---
 title: Haptics
-description: A library that provides access to the system's vibration effects on Android and the haptics engine on iOS.
+description: A library that provides access to the system's vibration effects on Android, the haptics engine on iOS, and the Web Vibration API on web platforms.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-haptics'
 packageName: 'expo-haptics'
 iconUrl: '/static/images/packages/expo-haptics.png'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -15,6 +15,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 - Android devices using Vibrator system service.
 - iOS 10+ devices using the Taptic Engine.
+- Web platforms using the Web Vibration API.
 
 On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
@@ -22,6 +23,13 @@ On iOS, the Taptic engine will do nothing if any of the following conditions are
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (to prevent destabilization).
 - iOS dictation is active (to not disturb the microphone input).
+
+On web platforms, the library uses the Web Vibration API. Note the following:
+
+- The API must be supported by the browser (check [browser compatibility](https://caniuse.com/vibration))
+- The device must have vibration hardware
+- The user must grant permission to use vibration (usually automatic)
+- Some browsers may ignore vibration in certain contexts (for example background tabs)
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -29,7 +29,7 @@ On web platforms, the library uses the Web Vibration API. Note the following:
 - The API must be supported by the browser (check [browser compatibility](https://caniuse.com/vibration))
 - The device must have vibration hardware
 - The user must grant permission to use vibration (usually automatic)
-- Some browsers may ignore vibration in certain contexts (for example background tabs)
+- Some browsers may ignore vibration in certain contexts (for example, background tabs)
 
 ## Installation
 

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Added new method `performAndroidHapticsAsync()`. The `Vibrator` api is no longer recommended. This method avoids it. ([#34077](https://github.com/expo/expo/pull/34077) by [@alanjhughes](https://github.com/alanjhughes))
+- [Web] Add web support using Web Vibration API. ([#34131](https://github.com/expo/expo/pull/34131) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-Provides access to the system's haptics engine on iOS and vibration effects on Android.
+Provides access to the system's haptics engine on iOS, vibration effects on Android, and Web Vibration API on web platforms.
 
 # API documentation
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-Provides access to the system's haptics engine on iOS, vibration effects on Android, and Web Vibration API on web platforms.
+Provides access to the system's haptics engine on iOS, vibration effects on Android, and Web Vibration API on web.
 
 # API documentation
 

--- a/packages/expo-haptics/build/ExpoHaptics.web.d.ts
+++ b/packages/expo-haptics/build/ExpoHaptics.web.d.ts
@@ -1,0 +1,8 @@
+import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
+declare const _default: {
+    notificationAsync(type: NotificationFeedbackType): Promise<void>;
+    impactAsync(style: ImpactFeedbackStyle): Promise<void>;
+    selectionAsync(): Promise<void>;
+};
+export default _default;
+//# sourceMappingURL=ExpoHaptics.web.d.ts.map

--- a/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
+++ b/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoHaptics.web.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.web.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,mBAAmB,EAAE,MAAM,iBAAiB,CAAC;;4BAsBhD,wBAAwB,GAAG,QAAQ,IAAI,CAAC;uBAM7C,mBAAmB,GAAG,QAAQ,IAAI,CAAC;sBAMpC,QAAQ,IAAI,CAAC;;AAbvC,wBAmBE"}
+{"version":3,"file":"ExpoHaptics.web.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.web.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,mBAAmB,EAAE,MAAM,iBAAiB,CAAC;;4BA4BhD,wBAAwB,GAAG,QAAQ,IAAI,CAAC;uBAM7C,mBAAmB,GAAG,QAAQ,IAAI,CAAC;sBAMpC,QAAQ,IAAI,CAAC;;AAbvC,wBAmBE"}

--- a/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
+++ b/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ExpoHaptics.web.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.web.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,mBAAmB,EAAE,MAAM,iBAAiB,CAAC;;4BAsBhD,wBAAwB,GAAG,QAAQ,IAAI,CAAC;uBAM7C,mBAAmB,GAAG,QAAQ,IAAI,CAAC;sBAMpC,QAAQ,IAAI,CAAC;;AAbvC,wBAmBE"}

--- a/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
+++ b/packages/expo-haptics/build/ExpoHaptics.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoHaptics.web.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.web.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,mBAAmB,EAAE,MAAM,iBAAiB,CAAC;;4BA4BhD,wBAAwB,GAAG,QAAQ,IAAI,CAAC;uBAM7C,mBAAmB,GAAG,QAAQ,IAAI,CAAC;sBAMpC,QAAQ,IAAI,CAAC;;AAbvC,wBAmBE"}
+{"version":3,"file":"ExpoHaptics.web.d.ts","sourceRoot":"","sources":["../src/ExpoHaptics.web.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,mBAAmB,EAAE,MAAM,iBAAiB,CAAC;;4BA2BhD,wBAAwB,GAAG,QAAQ,IAAI,CAAC;uBAM7C,mBAAmB,GAAG,QAAQ,IAAI,CAAC;sBAMpC,QAAQ,IAAI,CAAC;;AAbvC,wBAmBE"}

--- a/packages/expo-haptics/package.json
+++ b/packages/expo-haptics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-haptics",
   "version": "14.0.0",
-  "description": "Provides access to the system's haptics engine on iOS and vibration effects on Android.",
+  "description": "Provides access to the system's haptics engine on iOS, vibration effects on Android, and Web Vibration API on web.",
   "main": "src/Haptics.ts",
   "types": "build/Haptics.d.ts",
   "sideEffects": false,

--- a/packages/expo-haptics/src/ExpoHaptics.web.ts
+++ b/packages/expo-haptics/src/ExpoHaptics.web.ts
@@ -4,7 +4,6 @@ import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
  * The vibrate pattern holds an array of values describes alternating periods in which the device is
  * vibrating and not vibrating. Each value in the array is converted to an integer, then interpreted
  * alternately as the duration of milliseconds the device should and should not vibrate.
- * milliseconds it should not be vibrating.
  */
 const vibrationPatterns: Record<
   NotificationFeedbackType | ImpactFeedbackStyle | 'selection',

--- a/packages/expo-haptics/src/ExpoHaptics.web.ts
+++ b/packages/expo-haptics/src/ExpoHaptics.web.ts
@@ -3,7 +3,7 @@ import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
 /**
  * The vibrate pattern holds an array of values describes alternating periods in which the device is
  * vibrating and not vibrating. Each value in the array is converted to an integer, then interpreted
- * alternately as the number of milliseconds the device should vibrate and the number of
+ * alternately as the duration of milliseconds the device should and should not vibrate.
  * milliseconds it should not be vibrating.
  */
 const vibrationPatterns: Record<

--- a/packages/expo-haptics/src/ExpoHaptics.web.ts
+++ b/packages/expo-haptics/src/ExpoHaptics.web.ts
@@ -1,18 +1,24 @@
 import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
 
+/**
+ * The vibrate pattern holds an array of values describes alternating periods in which the device is
+ * vibrating and not vibrating. Each value in the array is converted to an integer, then interpreted
+ * alternately as the number of milliseconds the device should vibrate and the number of
+ * milliseconds it should not be vibrating.
+ */
 const vibrationPatterns: Record<
   NotificationFeedbackType | ImpactFeedbackStyle | 'selection',
   VibratePattern
 > = {
-  [NotificationFeedbackType.Success]: [50],
-  [NotificationFeedbackType.Warning]: [50, 50, 50],
-  [NotificationFeedbackType.Error]: [200, 100, 200],
-  [ImpactFeedbackStyle.Light]: [30],
+  [NotificationFeedbackType.Success]: [40, 100, 40],
+  [NotificationFeedbackType.Warning]: [50, 100, 50],
+  [NotificationFeedbackType.Error]: [60, 100, 60, 100, 60],
+  [ImpactFeedbackStyle.Light]: [40],
   [ImpactFeedbackStyle.Medium]: [50],
-  [ImpactFeedbackStyle.Heavy]: [80],
-  [ImpactFeedbackStyle.Soft]: [20],
-  [ImpactFeedbackStyle.Rigid]: [100],
-  selection: [30],
+  [ImpactFeedbackStyle.Heavy]: [60],
+  [ImpactFeedbackStyle.Soft]: [35],
+  [ImpactFeedbackStyle.Rigid]: [45],
+  selection: [50],
 };
 
 function isVibrationAvailable(): boolean {

--- a/packages/expo-haptics/src/ExpoHaptics.web.ts
+++ b/packages/expo-haptics/src/ExpoHaptics.web.ts
@@ -1,0 +1,41 @@
+import { NotificationFeedbackType, ImpactFeedbackStyle } from './Haptics.types';
+
+const vibrationPatterns: Record<
+  NotificationFeedbackType | ImpactFeedbackStyle | 'selection',
+  VibratePattern
+> = {
+  [NotificationFeedbackType.Success]: [50],
+  [NotificationFeedbackType.Warning]: [50, 50, 50],
+  [NotificationFeedbackType.Error]: [200, 100, 200],
+  [ImpactFeedbackStyle.Light]: [30],
+  [ImpactFeedbackStyle.Medium]: [50],
+  [ImpactFeedbackStyle.Heavy]: [80],
+  [ImpactFeedbackStyle.Soft]: [20],
+  [ImpactFeedbackStyle.Rigid]: [100],
+  selection: [30],
+};
+
+function isVibrationAvailable(): boolean {
+  return typeof window !== 'undefined' && 'navigator' in window && 'vibrate' in navigator;
+}
+
+export default {
+  async notificationAsync(type: NotificationFeedbackType): Promise<void> {
+    if (!isVibrationAvailable()) {
+      return;
+    }
+    navigator.vibrate(vibrationPatterns[type]);
+  },
+  async impactAsync(style: ImpactFeedbackStyle): Promise<void> {
+    if (!isVibrationAvailable()) {
+      return;
+    }
+    navigator.vibrate(vibrationPatterns[style]);
+  },
+  async selectionAsync(): Promise<void> {
+    if (!isVibrationAvailable()) {
+      return;
+    }
+    navigator.vibrate(vibrationPatterns.selection);
+  },
+};


### PR DESCRIPTION
# Why

This PR adds web platform support to `expo-haptics` using the Web Vibration API.

While many devices (like usually desktop devices and iOS web browsers) don't support the Web Vibration API, having a web implementation is still valuable because:

1. It prevents runtime errors when the package is used in universal apps
2. It provides haptic feedback on supported devices/browsers (mainly Android devices)
3. It follows the principle of progressive enhancement - the functionality is available when possible but gracefully falls back when not supported

This implementation ensures that `expo-haptics` can be used in universal Expo applications without requiring platform-specific code branches or error handling.

# How

- Added web implementation using navigator.vibrate()
- Updated package description, README and docs to include web support
- Added appropriate vibration patterns for different haptic feedback types

The implementation provides a graceful fallback when vibration is not supported or permission is not granted.

# Test Plan

Tested with a Fairphone 3+ and a Samsung Galaxy Note 10

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
