### PR TITLE
fix(@expo/metro-runtime): Location class is making AppleTV crashes locally.

### DIFF
--- a/packages/@expo/metro-runtime/src/location/Location.native.ts
+++ b/packages/@expo/metro-runtime/src/location/Location.native.ts
@@ -23,11 +23,18 @@ class Location {
     try {
       url.username = '';
     } catch {
-      throw new Error(
+      console.error(
         'Attempting to use the window.location polyfill before the URL built-in has been polyfilled.'
       );
     }
-    url.password = '';
+
+    try {
+      url.password = '';
+    } catch {
+      console.error(
+        'Attempting to use the window.location polyfill before the URL built-in has been polyfilled.'
+      );
+    }
     Object.defineProperties(this, {
       hash: {
         get() {


### PR DESCRIPTION

# Why

When building an AppleTV TV app, I get a build crash with the following error (screenshot). After wrapping the assignment for `url.username` I got the same error for `url.password`, so it was needed to wrap both in a `try-catch block`.

Also, I'm removing the `throw` statement and replacing it with a `console.error` because the throw is causing the app to crash as well.

Tested those changes in a local patch and worked as expected.

![Screenshot 2025-01-14 at 11 09 52 AM](https://github.com/user-attachments/assets/1ed6ef01-8238-47c6-9446-78240a187b41)
