### PR TITLE
feat(docs): add eas hosting option

### DIFF
--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -3,13 +3,14 @@ title: Publish websites
 description: Learn how to deploy Expo websites for production.
 ---
 
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 An Expo web app can be served locally for testing the production behavior, and deployed to a hosting service. We recommend deploying to [EAS Hosting](/eas/hosting) for the best feature support. You can also self-host or use a third-party service.
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -8,7 +8,6 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -10,7 +10,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 An Expo web app can be served locally for testing the production behavior, and deployed to a hosting service. We recommend deploying to [EAS Hosting](/eas/hosting) for the best feature support. You can also self-host or use a third-party service.
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -1,6 +1,6 @@
 ---
-title: Publish websites with Metro
-description: Different ways to publish the Expo web app with third-party services.
+title: Publish websites
+description: Learn how to deploy Expo websites for production.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
@@ -8,10 +8,20 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
-> **warning** In SDK 50 and above, `metro` is the default bundler for web apps. The previous [guide for publishing with `webpack` is available here](/archive/publishing-websites-webpack/).
+An Expo web app can be served locally for testing the production behavior, and deployed to a hosting service. We recommend deploying to [EAS Hosting](/eas/hosting) for the best feature support. You can also self-host or use a third-party service.
 
-A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
+<BoxLink
+  title="Deploying instantly with EAS"
+  description="EAS Hosting is the best way to deploy your web app with support for custom domains, SSL, and more."
+  href="/eas/hosting/get-started"
+  Icon={Rocket02Icon}
+/>
+
+For SDK 49 and below, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
 
 ## Output targets
 
@@ -38,9 +48,7 @@ Expo Router supports three output targets for web apps.
 
 ## Create a build
 
-Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you'll need to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
-
-<TabsGroup>
+Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or deploy to a hosting service, you'll need to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
 
 Run the universal export command to compile the project for web:
 
@@ -50,33 +58,22 @@ The resulting project files are located in the **dist** directory. Any files ins
 
 ## Serve locally
 
-Use [Serve CLI](https://www.npmjs.com/package/serve) to quickly test locally how your website will be hosted in production. Run the following command to serve the static bundle:
+Use `npx expo serve` to quickly test locally how your website will be hosted in production. Run the following command to serve the static bundle:
 
-<Tabs>
+<Terminal cmd={['$ npx expo serve']} />
 
-<Tab label="single">
+Open [`http://localhost:8081`](http://localhost:8081) to see your project in action. This is **HTTP only**, so permissions, camera, location, and many other secure features may not work as expected.
 
-<Terminal cmd={['$ npx serve dist --single']} />
+## Hosting with EAS
 
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will not work.
+When you're ready to go to production, you can instantly deploy your website with EAS CLI.
 
-</Tab>
-
-<Tab label="server">
-
-You need to create a custom server to host the websites with API routes. Learn more about [serving locally with Express](/router/reference/api-routes/#express).
-
-</Tab>
-
-<Tab label="static">
-
-<Terminal cmd={['$ npx serve dist']} />
-
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will not work.
-
-</Tab>
-
-</Tabs>
+<BoxLink
+  title="Deploying instantly with EAS"
+  description="EAS Hosting is the best way to deploy your web app with support for custom domains, SSL, and more."
+  href="/eas/hosting/get-started"
+  Icon={Rocket02Icon}
+/>
 
 ## Hosting on third-party services
 
@@ -299,8 +296,6 @@ In case you want to change the header for hosting add the following config for `
 ```
 
 </Step>
-
-</TabsGroup>
 
 ### GitHub Pages
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 An Expo web app can be served locally for testing the production behavior, and deployed to a hosting service. We recommend deploying to [EAS Hosting](/eas/hosting) for the best feature support. You can also self-host or use a third-party service.
 
@@ -17,7 +17,7 @@ An Expo web app can be served locally for testing the production behavior, and d
   title="Deploying instantly with EAS"
   description="EAS Hosting is the best way to deploy your web app with support for custom domains, SSL, and more."
   href="/eas/hosting/get-started"
-  Icon={Rocket02Icon}
+  Icon={Cloud01Icon}
 />
 
 For SDK 49 and below, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
@@ -71,7 +71,7 @@ When you're ready to go to production, you can instantly deploy your website wit
   title="Deploying instantly with EAS"
   description="EAS Hosting is the best way to deploy your web app with support for custom domains, SSL, and more."
   href="/eas/hosting/get-started"
-  Icon={Rocket02Icon}
+  Icon={Cloud01Icon}
 />
 
 ## Hosting on third-party services

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 Expo Router enables you to write server code for all platforms, right in your **app** directory.
 
@@ -208,7 +208,7 @@ You can deploy the server for production using [EAS Hosting](/eas/hosting/get-st
   title="Deploy instantly with EAS"
   description="EAS Hosting is the best way to deploy your Expo API routes and servers."
   href="/eas/hosting/get-started"
-  Icon={Rocket02Icon}
+  Icon={Cloud01Icon}
 />
 
 ## Hosting on third-party services

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -9,6 +9,8 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
 Expo Router enables you to write server code for all platforms, right in your **app** directory.
 
@@ -198,6 +200,19 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 ## Deployment
 
+When you're ready to deploy to production, simply run [`npx expo export`](/more/expo-cli#exporting) to create the server bundle in the `dist` folder. This server can be tested locally with `npx expo serve` (Expo SDK 52), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
+
+You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
+
+<BoxLink
+  title="Deploy instantly with EAS"
+  description="EAS Hosting is the best way to deploy your Expo API routes and servers."
+  href="/eas/hosting/get-started"
+  Icon={Rocket02Icon}
+/>
+
+## Hosting on third-party services
+
 > **warning** This is experimental and subject to breaking changes. We have no continuous tests against this configuration.
 
 Every cloud hosting provider needs a custom adapter to support the Expo server runtime. The following third-party providers have unofficial or experimental support from the Expo team.
@@ -209,10 +224,6 @@ Before deploying to these providers, it may be good to be familiar with the basi
 - The `@expo/server` package is included with `expo` and delegates requests to the server routes.
 - `@expo/server` does **not** inflate environment variables from **.env** files. They are expected to load either by the hosting provider or the user.
 - Metro is not included in the server.
-
-### Testing Locally
-
-You can test the local production server in Expo SDK 52 by running `npx expo serve`. This will start the production server locally and serve the static files and API routes. Visit the URL in a web browser or create a native build with the origin set to the local server URL.
 
 ### Express
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -5,12 +5,13 @@ description: Learn how to create server endpoints with Expo Router.
 
 > **warning** API Routes is an experimental feature. Available from Expo Router v3.
 
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 Expo Router enables you to write server code for all platforms, right in your **app** directory.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -200,8 +200,7 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 ## Deployment
 
-When you're ready to deploy to production, run [`npx expo export`](/more/expo-cli#exporting) to create the server bundle in the `dist` folder. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and higher), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
-
+When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and higher), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
 <BoxLink

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -200,7 +200,7 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 ## Deployment
 
-When you're ready to deploy to production, simply run [`npx expo export`](/more/expo-cli#exporting) to create the server bundle in the `dist` folder. This server can be tested locally with `npx expo serve` (Expo SDK 52), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
+When you're ready to deploy to production, run [`npx expo export`](/more/expo-cli#exporting) to create the server bundle in the `dist` folder. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and higher), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 


### PR DESCRIPTION
# Why

EAS Hosting was just released (technically still in Beta). This PR adds EAS Hosting to the docs as the recommended hosting service for websites and API routes.
