### PR TITLE
[docs] Fix external broken links and other minor fixes

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -21,7 +21,7 @@ const homeDirectories = [
   'review',
 ];
 /** Manual list of directories to categorize as "Learn" */
-const learnDirectories = ['tutorial', 'ui-programming', 'additional-resources'];
+const learnDirectories = ['tutorial', 'additional-resources'];
 /** Manual list of directories to categorize as "Archive" */
 const archiveDirectories = ['archive'];
 /** Manual list of directories to categorize as "Reference" */

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -52,7 +52,7 @@ Once installation is complete, apply the changes from the following diffs to con
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />
 
-Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L28-L55).
+Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/sdk-52/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L28-L55).
 
 Save all of your changes and update your iOS Deployment Target in Xcode to `iOS 15.1`:
 

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -52,7 +52,7 @@ Once installation is complete, apply the changes from the following diffs to con
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />
 
-Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/sdk-52/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L28-L55).
+Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/sdk-52/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L33-L60).
 
 Save all of your changes and update your iOS Deployment Target in Xcode to `iOS 15.1`:
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -30,7 +30,7 @@ There's so much more to explore, and the links below will help you to explore th
 
 Below are four suggested phases of incremental adoption. These phases generally progress from quick changes to improve developer experience, to more significant workflow and codebase optimizations.
 
-Only the first phase &mdhash; prerequisites &mdhash; is required by other phases. After following its instructions, you can skip to the tools and services that are most relevant to your goals in adopting Expo.
+Only the first phase &mdash; prerequisites &mdash; is required by other phases. After following its instructions, you can skip to the tools and services that are most relevant to your goals in adopting Expo.
 
 ### Prerequisites
 

--- a/docs/pages/eas/hosting/workflows.mdx
+++ b/docs/pages/eas/hosting/workflows.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_title: Workflows
 title: Deploy with Workflows
-description: Leanr how to automate EAS Hosting deployments with Workflows.
+description: Learn how to automate EAS Hosting deployments with Workflows.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/eas/webhooks.mdx
+++ b/docs/pages/eas/webhooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Webhooks
-description: Learn how to configure webhooks to get alerts on EAS Build and EAS submit completion.
+description: Learn how to configure webhooks to get alerts on EAS Build and Submit completion.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -51,7 +51,7 @@ We used Flexbox to layout our components. Check out the following recommendation
 To learn more about implementing different types of gestures and animations, we recommend the following documentation:
 
 - [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/)
-- [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs)
+- [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started)
 
 ## Join the community
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -197,7 +197,7 @@ Let's take a look at our app on Android, iOS and the web:
 
 <ContentSpotlight file="tutorial/tap-gesture.mp4" />
 
-> For a complete reference of the tap gesture API, see the [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/api/gestures/tap-gesture) documentation.
+> For a complete reference of the tap gesture API, see the [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture) documentation.
 
 </Step>
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -140,7 +140,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
 - It's supported only on Android and iOS, it doesn't work on Web.
 
-Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets) to learn more.
+Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 
 ## Remote debugging and GLView
 

--- a/docs/pages/versions/v50.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gl-view.mdx
@@ -142,7 +142,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
 - It's supported only on Android and iOS, it doesn't work on Web.
 
-Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets) to learn more.
+Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 
 ## Remote debugging and GLView
 

--- a/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
@@ -140,7 +140,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
 - It's supported only on Android and iOS, it doesn't work on Web.
 
-Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets) to learn more.
+Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 
 ## Remote debugging and GLView
 

--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -1,7 +1,7 @@
 ---
 title: FileSystem (next)
 description: A library that provides access to the local file system on the device.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-file-system/next'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-file-system/src/next'
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos']

--- a/docs/pages/versions/v52.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/gl-view.mdx
@@ -140,7 +140,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
 - It's supported only on Android and iOS, it doesn't work on Web.
 
-Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets) to learn more.
+Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 
 ## Remote debugging and GLView
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While reviewing the docs, I found multiple minor/outdated information, typos, and broken external links.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Fixes typo when referencing in `&mdash;` in Existing React Native overview
- Fixes multiple broken external inks
- Removes `ui-programming` from the list of directories inside `navigation.js`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
