### PR TITLE
[docs] apply ESLint custom rules also to `*.js` files, scripts tweaks

### DIFF
--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -3,6 +3,54 @@ const TAILWIND_DEFAULTS = {
   classRegex: '^(confirmation|container|icon)?(c|C)lass(Name)?$',
 };
 
+const CORE_RULES = {
+  'prettier/prettier': 'error',
+  'no-void': ['warn', { allowAsStatement: true }],
+  'no-return-await': 'off',
+  'import/order': [
+    'warn',
+    {
+      groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
+      'newlines-between': 'always',
+      alphabetize: {
+        order: 'asc',
+      },
+      pathGroups: [
+        {
+          pattern: '~/**',
+          group: 'internal',
+        },
+      ],
+    },
+  ],
+  curly: 'warn',
+  eqeqeq: ['error', 'always', { null: 'ignore' }],
+  'import/no-cycle': ['error', { maxDepth: '∞' }],
+  'lodash/import-scope': [2, 'method'],
+  'unicorn/new-for-builtins': 'warn',
+  'unicorn/no-useless-spread': 'warn',
+  'unicorn/prefer-array-some': 'warn',
+  'unicorn/prefer-at': 'warn',
+  'unicorn/prefer-includes': 'warn',
+  'unicorn/prefer-regexp-test': 'warn',
+  'unicorn/throw-new-error': 'warn',
+  'unicorn/prefer-node-protocol': 'warn',
+  'unicorn/prefer-date-now': 'warn',
+  'unicorn/better-regex': 'warn',
+  'unicorn/prevent-abbreviations': [
+    'warn',
+    {
+      extendDefaultReplacements: false,
+      replacements: {
+        e: {
+          error: true,
+          event: true,
+        },
+      },
+    },
+  ],
+};
+
 module.exports = {
   root: true,
   extends: [
@@ -26,7 +74,7 @@ module.exports = {
       },
       extends: ['plugin:@next/next/recommended', 'plugin:tailwindcss/recommended'],
       rules: {
-        'prettier/prettier': 'error',
+        ...CORE_RULES,
         'no-console': ['warn', { allow: ['warn', 'error'] }],
         '@typescript-eslint/explicit-function-return-type': [
           'off',
@@ -78,8 +126,6 @@ module.exports = {
           },
         ],
         '@typescript-eslint/no-floating-promises': 'error',
-        'no-void': ['warn', { allowAsStatement: true }],
-        'no-return-await': 'off',
         '@typescript-eslint/return-await': ['error', 'always'],
         '@typescript-eslint/no-confusing-non-null-assertion': 'warn',
         '@typescript-eslint/no-extra-non-null-assertion': 'warn',
@@ -106,30 +152,18 @@ module.exports = {
             },
           },
         ],
-        'import/order': [
-          'warn',
-          {
-            groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
-            'newlines-between': 'always',
-            alphabetize: {
-              order: 'asc',
-            },
-            pathGroups: [
-              {
-                pattern: '~/**',
-                group: 'internal',
-              },
-            ],
-          },
-        ],
-        curly: 'warn',
-        eqeqeq: ['error', 'always', { null: 'ignore' }],
-        'import/no-cycle': ['error', { maxDepth: '∞' }],
-        'lodash/import-scope': [2, 'method'],
         'react/no-this-in-sfc': 'off',
         'react/no-unknown-property': ['error', { ignore: ['css', 'mask-type'] }],
-        '@next/next/no-img-element': 'off',
         'react/no-unescaped-entities': 'off',
+        'react/jsx-key': [
+          'error',
+          {
+            checkFragmentShorthand: true,
+            checkKeyMustBeforeSpread: true,
+            warnOnDuplicates: true,
+          },
+        ],
+        '@next/next/no-img-element': 'off',
         'tailwindcss/classnames-order': 'off',
         'tailwindcss/enforces-negative-arbitrary-values': 'error',
         'tailwindcss/enforces-shorthand': 'error',
@@ -151,14 +185,6 @@ module.exports = {
           },
         ],
         'tailwindcss/no-unnecessary-arbitrary-value': ['error', TAILWIND_DEFAULTS],
-        'react/jsx-key': [
-          'error',
-          {
-            checkFragmentShorthand: true,
-            checkKeyMustBeforeSpread: true,
-            warnOnDuplicates: true,
-          },
-        ],
         'no-restricted-properties': [
           'warn',
           {
@@ -177,33 +203,12 @@ module.exports = {
             message: 'describe.only should not be committed to main.',
           },
         ],
-        'unicorn/new-for-builtins': 'warn',
-        'unicorn/no-useless-spread': 'warn',
-        'unicorn/prefer-array-some': 'warn',
-        'unicorn/prefer-at': 'warn',
-        'unicorn/prefer-includes': 'warn',
-        'unicorn/prefer-regexp-test': 'warn',
-        'unicorn/throw-new-error': 'warn',
-        'unicorn/prefer-node-protocol': 'warn',
-        'unicorn/prefer-date-now': 'warn',
-        'unicorn/better-regex': 'warn',
-        'unicorn/prevent-abbreviations': [
-          'warn',
-          {
-            extendDefaultReplacements: false,
-            replacements: {
-              e: {
-                error: true,
-                event: true,
-              },
-            },
-          },
-        ],
       },
     },
     {
       files: ['*.js', '*.cjs', '*.ts'],
       extends: ['universe/node'],
+      rules: CORE_RULES,
     },
     {
       files: ['*.md', '*.mdx'],

--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -165,7 +165,9 @@ export function parseValue(value: string) {
 }
 
 export function findNodeByPropInChildren<T>(element: ReactElement, propToFind: string): T | null {
-  if (!element || typeof element !== 'object') return null;
+  if (!element || typeof element !== 'object') {
+    return null;
+  }
 
   if (element.props?.[propToFind]) {
     return element.props;
@@ -177,7 +179,9 @@ export function findNodeByPropInChildren<T>(element: ReactElement, propToFind: s
     if (Array.isArray(children)) {
       for (const child of Children.toArray(children)) {
         const allProps = findNodeByPropInChildren<T>(child as ReactElement, propToFind);
-        if (allProps) return allProps;
+        if (allProps) {
+          return allProps;
+        }
       }
     } else {
       return findNodeByPropInChildren<T>(children as ReactElement, propToFind);

--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -79,7 +79,9 @@ export const pathStartsWith = (name: string, path: string) => {
 
 export const chunkArray = (array: any[], chunkSize: number) => {
   return array.reduce((acc, _, i) => {
-    if (i % chunkSize === 0) acc.push(array.slice(i, i + chunkSize));
+    if (i % chunkSize === 0) {
+      acc.push(array.slice(i, i + chunkSize));
+    }
     return acc;
   }, []);
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -1,8 +1,8 @@
 import frontmatter from 'front-matter';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
+import { URL, fileURLToPath } from 'node:url';
 import { u as make } from 'unist-builder';
-import { URL, fileURLToPath } from 'url';
 
 import { VERSIONS } from './versions.js';
 
@@ -685,7 +685,7 @@ export default {
 // --- MDX methods ---
 
 function makeSection(name, children = [], props = {}) {
-  return make('section', { name, ...{ expanded: false, ...props } }, children);
+  return make('section', { name, expanded: false, ...props }, children);
 }
 
 function makeGroup(name, children = [], props = {}) {

--- a/docs/constants/versions.js
+++ b/docs/constants/versions.js
@@ -38,11 +38,23 @@ export const VERSIONS = versionDirectories
     return true;
   })
   .sort((a, b) => {
-    if (a === 'unversioned') return -1;
-    if (b === 'unversioned') return 1;
-    if (a === BETA_VERSION) return -1;
-    if (b === BETA_VERSION) return 1;
-    if (a === 'latest') return -1;
-    if (b === 'latest') return 1;
+    if (a === 'unversioned') {
+      return -1;
+    }
+    if (b === 'unversioned') {
+      return 1;
+    }
+    if (a === BETA_VERSION) {
+      return -1;
+    }
+    if (b === BETA_VERSION) {
+      return 1;
+    }
+    if (a === 'latest') {
+      return -1;
+    }
+    if (b === 'latest') {
+      return 1;
+    }
     return semver.major(b) - semver.major(a);
   });

--- a/docs/mdx-plugins/remark-link-rewrite.js
+++ b/docs/mdx-plugins/remark-link-rewrite.js
@@ -1,6 +1,6 @@
-import path from 'path';
+import path from 'node:path';
+import { URL } from 'node:url';
 import { visit } from 'unist-util-visit';
-import { URL } from 'url';
 
 /**
  * @typedef {import('@types/mdast').Root} Root - https://github.com/syntax-tree/mdast#root

--- a/docs/mdx-plugins/remark-link-rewrite.test.js
+++ b/docs/mdx-plugins/remark-link-rewrite.test.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import linkRewrite from './remark-link-rewrite.js';
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -9,6 +9,8 @@ import remarkMdxDisableExplicitJsx from 'remark-mdx-disable-explicit-jsx';
 import remarkMDXFrontmatter from 'remark-mdx-frontmatter';
 import semver from 'semver';
 
+import packageJson from '~/package.json';
+
 import remarkCodeTitle from './mdx-plugins/remark-code-title.js';
 import remarkCreateStaticProps from './mdx-plugins/remark-create-static-props.js';
 import remarkExportHeadings from './mdx-plugins/remark-export-headings.js';
@@ -16,8 +18,6 @@ import remarkLinkRewrite from './mdx-plugins/remark-link-rewrite.js';
 import navigation from './public/static/constants/navigation.json';
 import { VERSIONS } from './public/static/constants/versions.json';
 import createSitemap from './scripts/create-sitemap.js';
-
-import packageJson from '~/package.json';
 
 const newestVersion =
   'betaVersion' in packageJson ? (packageJson?.betaVersion as string) : packageJson.version;

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "yarn generate-static-resources && next dev -p 3002",
-    "build": "yarn copy-latest && next build",
+    "build": "yarn copy-latest && yarn generate-llms && next build",
     "export": "yarn generate-static-resources production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
     "export-preview": "yarn generate-static-resources preview && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
@@ -18,9 +18,10 @@
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.cjs",
     "permissions-sync-android": "npx scrape-permissions-json@latest components/plugins/permissions/data --android",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
-    "generate-static-resources": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js && node ./scripts/generate-llms-txt.js",
+    "generate-static-resources": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",
     "copy-latest": "node ./scripts/copy-latest.js",
+    "generate-llms": "node ./scripts/generate-llms-txt.js",
     "postinstall": "yarn copy-latest && yarn generate-static-resources"
   },
   "packageManager": "yarn@4.6.0",

--- a/docs/scripts/append-dates.js
+++ b/docs/scripts/append-dates.js
@@ -30,6 +30,7 @@ async function appendModificationDate(dir = './pages') {
       }
     }
 
+    console.log(` \x1b[1m\x1b[32m✓\x1b[0m Apended modification dates to doc files`);
     process.exit();
   } catch (error) {
     console.error(error);

--- a/docs/scripts/copy-latest.js
+++ b/docs/scripts/copy-latest.js
@@ -1,6 +1,6 @@
 // Prepare the latest version by copying the actual exact latest version
 import fsExtra from 'fs-extra';
-import { join } from 'path';
+import { join } from 'node:path';
 
 const { copySync, removeSync, readJsonSync } = fsExtra;
 const { version } = readJsonSync('./package.json');

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { SitemapStream } from 'sitemap';
 
 const IGNORED_PAGES = [
@@ -12,9 +12,15 @@ const IGNORED_PAGES = [
  * This allows crawlers to index _all_ pages, without a full page-link-chain.
  */
 export default function createSitemap({ pathMap, domain, output, pathsPriority, pathsHidden }) {
-  if (!pathMap) throw new Error(`⚠️ Couldn't generate sitemap, no 'pathMap' provided`);
-  if (!domain) throw new Error(`⚠️ Couldn't generate sitemap, no 'domain' provided`);
-  if (!output) throw new Error(`⚠️ Couldn't generate sitemap, no 'output' provided`);
+  if (!pathMap) {
+    throw new Error(`⚠️ Couldn't generate sitemap, no 'pathMap' provided`);
+  }
+  if (!domain) {
+    throw new Error(`⚠️ Couldn't generate sitemap, no 'domain' provided`);
+  }
+  if (!output) {
+    throw new Error(`⚠️ Couldn't generate sitemap, no 'output' provided`);
+  }
 
   // Make sure both hidden and prioritized paths are prefixed with slash
   pathsPriority = pathsPriority.map(pathWithStartingSlash);
@@ -23,7 +29,7 @@ export default function createSitemap({ pathMap, domain, output, pathsPriority, 
   // Get a list of URLs from the pathMap that we can use in the sitemap
   const urls = Object.keys(pathMap)
     .filter(
-      url => !IGNORED_PAGES.includes(url) && !pathsHidden.find(hidden => url.startsWith(hidden))
+      url => !IGNORED_PAGES.includes(url) && !pathsHidden.some(hidden => url.startsWith(hidden))
     )
     .map(pathWithTrailingSlash)
     .sort((a, b) => pathSortedByPriority(a, b, pathsPriority));
@@ -61,8 +67,12 @@ function pathWithStartingSlash(url) {
  *   - Matches the order of prioritized paths using "startsWith" check
  */
 function pathSortedByPriority(a, b, priorities = []) {
-  if (a === '/') return -1;
-  if (b === '/') return 1;
+  if (a === '/') {
+    return -1;
+  }
+  if (b === '/') {
+    return 1;
+  }
 
   const aPriority = priorities.findIndex(prio => a.startsWith(prio));
   const bPriority = priorities.findIndex(prio => b.startsWith(prio));

--- a/docs/scripts/generate-llms-txt.js
+++ b/docs/scripts/generate-llms-txt.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import startCase from 'lodash/startCase.js';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const DOCS_DIR = 'pages';
 const OUTPUT_FILENAME = 'llms.txt';
@@ -39,10 +39,12 @@ const SECTIONS = {
 };
 
 function extractFrontmatter(content) {
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---/;
+  const frontmatterRegex = /^---\s*\n([\S\s]*?)\n---/;
   const match = content.match(frontmatterRegex);
 
-  if (!match) return {};
+  if (!match) {
+    return {};
+  }
 
   const frontmatter = match[1];
   const metadata = {};
@@ -62,8 +64,8 @@ function readMDXFile(filePath) {
     const content = fs.readFileSync(filePath, 'utf8');
     const metadata = extractFrontmatter(content);
     return {
-      title: metadata.title || '',
-      description: metadata.description || '',
+      title: metadata.title ?? '',
+      description: metadata.description ?? '',
     };
   } catch (error) {
     console.error(`Error reading MDX file ${filePath}:`, error);
@@ -76,9 +78,15 @@ function getSectionForPath(filePath) {
   const pathParts = relativePath.split(path.sep);
 
   const baseFilename = path.basename(filePath, '.mdx');
-  if (baseFilename === 'core-concepts') return 'core-concepts';
-  if (baseFilename === 'faq') return 'faq';
-  if (pathParts[0] === 'get-started') return 'get-started';
+  if (baseFilename === 'core-concepts') {
+    return 'core-concepts';
+  }
+  if (baseFilename === 'faq') {
+    return 'faq';
+  }
+  if (pathParts[0] === 'get-started') {
+    return 'get-started';
+  }
 
   for (const [section, patterns] of Object.entries(SECTIONS)) {
     for (const pattern of patterns) {
@@ -102,8 +110,9 @@ function shouldIncludePath(filePath) {
   if (relativePath.includes('latest')) {
     return true;
   }
+
   if (
-    relativePath.match(/versions\/v\d+\.\d+\.\d+/) ||
+    /versions\/v\d+\.\d+\.\d+/.test(relativePath) ||
     relativePath.includes('versions/unversioned')
   ) {
     return false;
@@ -178,7 +187,9 @@ function generateMarkdownContent({ title, description, sections, urlsBySection }
 
       urlsBySection[section]
         .sort((a, b) => {
-          if (a.depth !== b.depth) return a.depth - b.depth;
+          if (a.depth !== b.depth) {
+            return a.depth - b.depth;
+          }
           return a.title.localeCompare(b.title);
         })
         .forEach(({ title, url, description, depth }, index, array) => {
@@ -215,7 +226,7 @@ async function generateLlmsTxt() {
 
     const outputPath = path.join(process.cwd(), 'public', OUTPUT_FILENAME);
     await fs.promises.writeFile(outputPath, markdownContent);
-    console.log(`Successfully generated ${OUTPUT_FILENAME}`);
+    console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME}`);
     process.exit(0);
   } catch (error) {
     console.error('Error generating llms.txt:', error);

--- a/docs/scripts/remove-version.js
+++ b/docs/scripts/remove-version.js
@@ -34,8 +34,8 @@ const run = () => {
     if (fs.pathExistsSync(pagesPath)) {
       fs.rmSync(pagesPath, { recursive: true });
     }
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
   }
 
   console.log(`🎉 SDK ${version} files have been removed successfully!`);

--- a/docs/scripts/schema-sync.cjs
+++ b/docs/scripts/schema-sync.cjs
@@ -8,7 +8,7 @@ yarn run schema-sync unversioned -> updates the schema that versions/unversioned
 const parser = require('@apidevtools/json-schema-ref-parser');
 const axios = require('axios');
 const fs = require('fs-extra');
-const path = require('path');
+const path = require('node:path');
 
 const version = process.argv[2];
 

--- a/docs/ui/components/Layout/useAutoScrollTo.ts
+++ b/docs/ui/components/Layout/useAutoScrollTo.ts
@@ -13,7 +13,9 @@ export function useAutoScrollTo<T extends HTMLElement = HTMLDivElement>(selector
 
   useEffect(
     function onMaybeScroll() {
-      if (!selector || !ref.current) return;
+      if (!selector || !ref.current) {
+        return;
+      }
       const target = ref.current.querySelector<HTMLElement>(selector);
       if (target) {
         const bounds = ref.current.getBoundingClientRect();

--- a/docs/ui/components/Snippet/prism-bash.js
+++ b/docs/ui/components/Snippet/prism-bash.js
@@ -1,4 +1,5 @@
 // Base code has been copied over from `prismjs/components/prism-bash`
+/* eslint-disable unicorn/better-regex */
 
 import { Prism } from 'prism-react-renderer';
 
@@ -20,7 +21,7 @@ import { Prism } from 'prism-react-renderer';
   const insideString = {
     bash: commandAfterHeredoc,
     environment: {
-      pattern: RegExp('\\$' + envVars),
+      pattern: new RegExp('\\$' + envVars),
       alias: 'constant',
     },
     variable: [
@@ -60,7 +61,7 @@ import { Prism } from 'prism-react-renderer';
           operator: /:[-=?+]?|[!/]|##?|%%?|\^\^?|,,?/,
           punctuation: /[[\]]/,
           environment: {
-            pattern: RegExp('(\\{)' + envVars),
+            pattern: new RegExp('(\\{)' + envVars),
             lookbehind: true,
             alias: 'constant',
           },
@@ -110,7 +111,7 @@ import { Prism } from 'prism-react-renderer';
       pattern: /(^|[\s;|&]|[<>]\()\w+(?:\.\w+)*(?=\+?=)/,
       inside: {
         environment: {
-          pattern: RegExp('(^|[\\s;|&]|[<>]\\()' + envVars),
+          pattern: new RegExp('(^|[\\s;|&]|[<>]\\()' + envVars),
           lookbehind: true,
           alias: 'constant',
         },
@@ -166,7 +167,7 @@ import { Prism } from 'prism-react-renderer';
       },
     ],
     environment: {
-      pattern: RegExp('\\$?' + envVars),
+      pattern: new RegExp('\\$?' + envVars),
       alias: 'constant',
     },
     variable: insideString.variable,

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -2,11 +2,21 @@ import { capitalize } from '~/components/plugins/api/APISectionUtils';
 import { PlatformName } from '~/types/common';
 
 export function getPlatformName(text: string): PlatformName {
-  if (text.toLowerCase().includes('ios')) return 'ios';
-  if (text.toLowerCase().includes('android')) return 'android';
-  if (text.toLowerCase().includes('web')) return 'web';
-  if (text.toLowerCase().includes('macos')) return 'macos';
-  if (text.toLowerCase().includes('tvos')) return 'tvos';
+  if (text.toLowerCase().includes('ios')) {
+    return 'ios';
+  }
+  if (text.toLowerCase().includes('android')) {
+    return 'android';
+  }
+  if (text.toLowerCase().includes('web')) {
+    return 'web';
+  }
+  if (text.toLowerCase().includes('macos')) {
+    return 'macos';
+  }
+  if (text.toLowerCase().includes('tvos')) {
+    return 'tvos';
+  }
   return '';
 }
 


### PR DESCRIPTION
# Why

While reviewing recent PR I have spotted that we don't apply our custom rule set to the `*.c/js` files, so mostly scripts we use.

# How

Extract non-TS dependent rules from T(J)SX files to the core set, apply rules for the `*.c/js` and `*.ts` files, fix all new warning.

Additionally, I have also move out the LLMs generation to the separate script and moved it to the `build` command, so we do not regenerate the file locally that often.

# Test Plan

There are no lint warning after the changes, LLS file is generated correctly during the build.

# Preview

![Screenshot 2025-01-15 at 14 02 12](https://github.com/user-attachments/assets/e3036a3b-33dd-4a3a-ac9d-f88ae4a3e5b3)

