### PR TITLE
[docs] Add info about expo-dev-client in EAS Build setup guide

### DIFF
--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -72,6 +72,12 @@ To configure an Android or an iOS project for EAS Build, run the following comma
 
 To learn more about what happens behind the scenes, see [build configuration process reference](/build-reference/build-configuration).
 
+For development, we recommend creating a [development build](/develop/development-builds/introduction/) which is a debug build of your app and contains [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. It helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. To install the library, run the following command:
+
+<Terminal cmd={['$ npx expo install expo-dev-client']} />
+
+> **Note:** If you have created your project with `npx react-native`, your project requires further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+
 Additional configuration may be required for some scenarios:
 
 - Does your app code depend on environment variables? [Add them to your build configuration](/build-reference/variables).
@@ -86,7 +92,7 @@ Additional configuration may be required for some scenarios:
 
 ### Build for Android Emulator/device or iOS Simulator
 
-The easiest way to try out EAS Build is to create a build that you can run on your Android device/emulator or iOS Simulator. It's quicker than uploading it to a store, and you don't need store developer membership accounts. If you'd like to try this, read about [creating an installable APK for Android](/build-reference/apk) and [creating a simulator build for iOS](/build-reference/simulators).
+The easiest way to try out EAS Build is to create a build that you can run on your Android device/emulator or iOS Simulator. It's quicker than uploading it to a store, and you don't need store developer membership accounts. If you'd like to try this, read about [creating an installable APK for Android](/tutorial/eas/android-development-build/) and [creating a simulator build for iOS](/tutorial/eas/ios-development-build-for-simulators/).
 
 ### Build for app stores
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -72,7 +72,7 @@ To configure an Android or an iOS project for EAS Build, run the following comma
 
 To learn more about what happens behind the scenes, see [build configuration process reference](/build-reference/build-configuration).
 
-For development, we recommend creating a [development build](/develop/development-builds/introduction/) which is a debug build of your app and contains [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. It helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. To install the library, run the following command:
+For development, we recommend creating a [development build](/develop/development-builds/introduction/), which is a debug build of your app and contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. It helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. To install the library, run the following command:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -76,7 +76,6 @@ For development, we recommend creating a [development build](/develop/developmen
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-
 Additional configuration may be required for some scenarios:
 
 - Does your app code depend on environment variables? [Add them to your build configuration](/build-reference/variables).

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -76,7 +76,6 @@ For development, we recommend creating a [development build](/develop/developmen
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-> **Note:** If you have created your project with `npx react-native`, your project requires further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 Additional configuration may be required for some scenarios:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-10055

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the EAS Build setup guide by
- In Step 3, added recommendation to install `expo-dev-client` within the Configuration step (step 3). This way, any new Expo projects created can leverage the benefits of development clients. We already do this in [Create a development build guide](https://docs.expo.dev/develop/development-builds/create-a-build/) and EAS tutorial.
  - Also, added the note about installing `expo-dev-client` in an Existing React Native section guide so that developers who have created their project with `npx react-native` do not miss out on configuration steps (such as installing `expo` and running `npx pod-install`)
- In Step 4, updated links to create a build for Android device/emulator and iOS Simulator to point to the EAS tutorial relventat chapters by the same name. This way, developers can create their first build as a development build.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: 
- /build/setup/#configure-the-project
- /build/setup/#build-for-android-emulatordevice-or-ios-simulator

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)