### PR TITLE
[types]: Remove transformOrigin type override

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Remove `transformOrigin` type override.
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- Remove `transformOrigin` type override.
+- Remove `transformOrigin` type override. ([#34183](https://github.com/expo/expo/pull/34183) by [@marklawlor](https://github.com/marklawlor))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo/types/react-native-web.d.ts
+++ b/packages/expo/types/react-native-web.d.ts
@@ -99,8 +99,6 @@ declare module 'react-native' {
     /** @platform web */
     touchAction?: string;
     /** @platform web */
-    transformOrigin?: string;
-    /** @platform web */
     transitionDelay?: string;
     /** @platform web */
     transitionDuration?: string;
@@ -219,8 +217,6 @@ declare module 'react-native' {
     perspectiveOrigin?: string;
     /** @platform web */
     touchAction?: string;
-    /** @platform web */
-    transformOrigin?: string;
     /** @platform web */
     transitionDelay?: string;
     /** @platform web */


### PR DESCRIPTION
# Why

Expo added the `transformOrigin` type for compatibility with React Native Web. Since then, `transformOrigin` has been added to core React Native - but using a different syntax than React Native Web (`string | undefined` vs `string | (string | number)[] | undefined`). Since we override the type, users will get a type error when trying to use the new syntax

Reported internally via @Kudo 

# How

Remove our type override.