### PR TITLE
[docs] fix header disappearing on mobile in certain situations

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -55,7 +55,7 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
     return (
       <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
         <div className="max-lg-gutters:sticky">{header}</div>
-        <div className="mx-auto flex h-[calc(100vh-60px)] w-full items-center justify-between">
+        <div className="mx-auto flex h-[calc(100dvh-60px)] w-full items-center justify-between">
           <div
             className={mergeClasses(
               'flex h-full max-w-[280px] shrink-0 flex-col overflow-hidden border-r border-r-default',
@@ -72,7 +72,7 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
           </div>
           <div
             className={mergeClasses(
-              'flex h-[calc(100vh-60px)] w-full overflow-hidden',
+              'flex h-[calc(100dvh-60px)] w-full overflow-hidden',
               'max-lg-gutters:overflow-auto',
               isMobileMenuVisible && 'hidden'
             )}>


### PR DESCRIPTION
# Why

Fixes ENG-14715

# How

Correct viewport height unit used for layout calculation.

# Test Plan

The changes have been reviewed by running docs app locally, and connecting to it via phone on the same network.

# Preview

https://github.com/user-attachments/assets/4f152265-83c7-4fbf-ba4f-3c458a3a518c

