### PR TITLE
[expo-contacts][android][fix] flush contact metadata before adding them again during updateContactAsync

### DIFF
--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -206,6 +206,47 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
       });
     });
 
+    it('Contacts.updateContactAsync() with multiple urls / remove url', async () => {
+      const contactId = await Contacts.addContactAsync({
+        [Contacts.Fields.FirstName]: 'Ken',
+        [Contacts.Fields.UrlAddresses]: [
+          { url: 'https://react-dev.com' },
+          { url: 'https://expo.com' },
+        ],
+      });
+      expect(typeof contactId).toBe('string');
+      const contact = await Contacts.getContactByIdAsync(contactId);
+      expect(contact.urlAddresses.length).toBe(2);
+
+      const modifiedId = await Contacts.updateContactAsync({
+        ...contact,
+        [Contacts.Fields.UrlAddresses]: [],
+      });
+      expect(typeof modifiedId).toBe('string');
+      const contactModified = await Contacts.getContactByIdAsync(modifiedId);
+      expect(contactModified.urlAddresses).toBe(undefined);
+    });
+
+    it('Contacts.updateContactAsync() with multiple urls / add url', async () => {
+      const contactId = await Contacts.addContactAsync({
+        [Contacts.Fields.FirstName]: 'Kenny',
+        [Contacts.Fields.UrlAddresses]: [{ url: 'https://react-dev.com', label: 'home' }],
+      });
+      expect(typeof contactId).toBe('string');
+      const contact = await Contacts.getContactByIdAsync(contactId);
+      expect(contact.urlAddresses.length).toBe(1);
+      const modifiedId = await Contacts.updateContactAsync({
+        ...contact,
+        [Contacts.Fields.UrlAddresses]: [
+          { url: 'https://react-dev.com', label: 'work' },
+          { url: 'https://expo.com', label: 'home' },
+        ],
+      });
+      expect(typeof modifiedId).toBe('string');
+      const contactModified = await Contacts.getContactByIdAsync(modifiedId);
+      expect(contactModified.urlAddresses.length).toBe(2);
+    });
+
     it('Contacts.writeContactToFileAsync() returns uri', async () => {
       createdContacts.map(async ({ id }) => {
         const localUri = await Contacts.writeContactToFileAsync({ id });

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `the native view manager required by name (ExpoContactAccessButton) from NativeViewManagerAdapter isn't exported` warning. ([#33993](https://github.com/expo/expo/pull/33993) by [@lukmccall](https://github.com/lukmccall))
+- Fixed corrupted contact after `updateContactAsync`. ([#34186](https://github.com/expo/expo/pull/34186) by [@freeboub](https://github.com/34186))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -285,13 +285,29 @@ class Contact(var contactId: String) {
           .build()
       )
     }
+
+    // Flush all data from linked db
+    ops.add(getFlushOperation(CommonDataKinds.Event.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Email.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Im.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Phone.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Relation.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Website.CONTENT_ITEM_TYPE, rawContactId!!))
+    ops.add(getFlushOperation(CommonDataKinds.Nickname.CONTENT_ITEM_TYPE, rawContactId!!))
+    // add updated data
     for (map in baseModels) {
       for (item in map) {
-        ops.add(item.getDeleteOperation(rawContactId!!))
         ops.add(item.getInsertOperation(rawContactId))
       }
     }
     return ops
+  }
+
+  private fun getFlushOperation(contentType: String, rawId: String): ContentProviderOperation? {
+      return ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+        .withSelection(String.format("%s=? AND %s=?", ContactsContract.Data.MIMETYPE, ContactsContract.Data.RAW_CONTACT_ID), arrayOf(contentType, rawId))
+        .build()
   }
 
   private val baseModels: Array<List<BaseModel>>


### PR DESCRIPTION
# Why

updateContactAsync corrupts contact:
- update contact without website (to remove it) => the website field is not deleted
- update contact with two website => only one website field is returns

# How

The modified loop was not good. on each field it add 1 delete request and 1 add request.
--> if user wants to remove a field, the delete is not added => field remains in database
--> if user wants to add multiple a field, the delete is not added on each loop => first loop add delete and Add, second loop add delete and add then the second delete will remove data added by by the first add.

Solution:
flush all fields before creating the new add requests

# Test Plan

2 new tests were added to the test suite

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
