### PR TITLE
[docs] Update continuous deployment documentation

### DIFF
--- a/docs/pages/eas-update/continuous-deployment.mdx
+++ b/docs/pages/eas-update/continuous-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 title: Continuous deployment
-description: Learn how to use the fingerprint runtime version for continuous deployment in production and during development.
+description: Learn how to use the fingerprint runtime version and GitHub actions for continuous deployment.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -23,25 +23,23 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 ## GitHub Action: continuous-deploy-fingerprint
 
-> **info** This is available in beta for SDK 51 and not yet considered stable. Use may result in unexpected system behavior.
+> **info** Available for SDK 52 and above.
 
-Expo provides a GitHub Action called [continuous-deploy-fingerprint](https://github.com/expo/expo-github-action/tree/main/continuous-deploy-fingerprint) to provide CI/CD for a React Native project. It dictates that every JS change (update) is deployed to all compatible builds over-the-air, and new builds are created when the runtime changes.
+Expo provides the [continuous-deploy-fingerprint](https://github.com/expo/expo-github-action/tree/main/continuous-deploy-fingerprint) GitHub Action to continuously deploy React Native projects that use the [`fingerprint` runtime version policy](/versions/latest/sdk/updates/#fingerprint). It deploys every JS change as an EAS Update to all compatible builds over-the-air, and new builds are automatically created using EAS Build when a runtime change is detected.
 
-It is typically accomplished by performing roughly these steps:
+<Collapsible summary="How do I debug the commands that are run in the action?">
 
-1. Run application tests, abort if tests fail (`continuous-deploy-fingerprint` does not currently run tests, you can do configure your workflow to run tests first).
-2. Calculate fingerprint for relevant platforms using the `npx expo-updates fingerprint:generate` command.
-3. Check for EAS builds with a runtime version equal to the fingerprint (`eas build:list --runtimeVersion <fingerprint>`). Create a new build if none exists yet.
-   - (optional) Submit to app stores for full continuous deployment. This has not yet been tested and is not recommended.
-4. Run `eas update` to publish an update for the current commit.
+Running your GitHub workflows in debug mode will automatically add the `--debug` flag to the commands run as part of the action, and the output will be available in the workflow run logs.
+
+</Collapsible>
 
 ### Fingerprint runtime versioning
 
-The [`fingerprint` runtime version policy](/eas-update/runtime-versions/#fingerprint-runtime-version-policy) uses the `@expo/fingerprint` package to generate a hash of your project when making a build or publishing an update, and then uses that hash as the runtime version. The hash is calculated based on dependencies, custom native code, native project files, and configuration, amongst other things.
+The [`fingerprint` runtime version policy](/versions/latest/sdk/updates/#fingerprint) uses the [`@expo/fingerprint`](https://github.com/expo/expo/tree/main/packages/%40expo/fingerprint) package to generate a hash of your project when making a build or publishing an update, and then uses that hash as the runtime version. The hash is calculated based on dependencies, custom native code, native project files, and configuration, amongst other things.
 
 By automatically calculating the runtime version, you don't have to be concerned about native layer compatibility with the JavaScript application when deploying updates to builds.
 
-<Collapsible summary="How do I debug fingerprint inconsistencies between my local machine and CI/CD?">
+<Collapsible summary="How do I debug fingerprint mismatches between my local machine and CI/CD?">
 
 If you notice different fingerprints being generated across different machines or environments, it may mean that unanticipated files are being included in the hash calculation. `@expo/fingerprint` has a predetermined set of files to include/exclude for hash calculation, but often your project setup may require additional excludes. For projects that include native directories (**android** and **ios**) this is more common.
 
@@ -55,12 +53,6 @@ To identify differences in fingerprints on different machines or environments:
   - [JSON Diff](https://www.jsondiff.com/) to compare the output and identify the files causing the discrepancies.
 
 To exclude files causing the differences, add them to the **.fingerprintignore** file as described in the [`@expo/fingerprint` README](https://www.npmjs.com/package/@expo/fingerprint).
-
-</Collapsible>
-
-<Collapsible summary="How do I debug the commands that are run in the workflow?">
-
-Running your GitHub workflows in debug mode will automatically add the `--debug` flag to the commands run as part of the action, and the output will be available in the workflow run logs.
 
 </Collapsible>
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -169,8 +169,6 @@ Also, if you select a different native version between Android and iOS, you'll e
 
 <Collapsible summary="fingerprint">
 
-> **warning** The `fingerprint` runtime policy is still in beta for SDK >= 51 and not yet considered stable. Use may result in unexpected behavior.
-
 The `"fingerprint"` runtime version policy automatically calculates the runtime version for you, including through changes like SDK upgrades or adding custom native code.
 
 ```json

--- a/docs/pages/versions/v51.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/updates.mdx
@@ -166,26 +166,6 @@ Also, if you select a different native version between Android and iOS, you'll e
 
 </Collapsible>
 
-<Collapsible summary="fingerprint">
-
-> **warning** The `fingerprint` runtime policy is still in beta for SDK >= 51 and not yet considered stable. Use may result in unexpected behavior.
-
-The `"fingerprint"` runtime version policy automatically calculates the runtime version for you, including through changes like SDK upgrades or adding custom native code.
-
-```json
-{
-  "expo": {
-    "runtimeVersion": {
-      "policy": "fingerprint"
-    }
-  }
-}
-```
-
-This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
-
-</Collapsible>
-
 </Collapsible>
 
 #### Native configuration and overriding

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -169,8 +169,6 @@ Also, if you select a different native version between Android and iOS, you'll e
 
 <Collapsible summary="fingerprint">
 
-> **warning** The `fingerprint` runtime policy is still in beta for SDK >= 51 and not yet considered stable. Use may result in unexpected behavior.
-
 The `"fingerprint"` runtime version policy automatically calculates the runtime version for you, including through changes like SDK upgrades or adding custom native code.
 
 ```json


### PR DESCRIPTION
# Why

This updates the continuous deployment doc to not duplicate information that was moved to the readme for the github action.

This also removes the disclaimer for using the fingerprint runtime version in SDK >= 52 and removes it from the SDK 51 docs. It has been in use in projects now for a decent while (one year ish) and reported issues have slowed as we've added the ability to customize your fingerprint and diagnose inconsistencies.

Once soft fingerprinting has been added to the website, we can update the debugging section of this doc to indicate that the website can be used as well to diff.

# How

Update docs, remove warnings.

# Test Plan

Navigate to doc locally, check all links, proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
