### PR TITLE
[ci] Only run codemention on primary repo (not forks)

### DIFF
--- a/.github/workflows/codemention.yaml
+++ b/.github/workflows/codemention.yaml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 jobs:
   codemention:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
# Why

Noticing that codemention is running on forks and mentioning us. This PR disables that, at least in forks that pass this point in repo history.

# How

Add if conditional.

# Test Plan

Inspect. See codemention still runs on this PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
