### PR TITLE
[template] Fix template caption for developer tools shortcut on iOS

### DIFF
--- a/templates/expo-template-default/app/(tabs)/index.tsx
+++ b/templates/expo-template-default/app/(tabs)/index.tsx
@@ -26,7 +26,7 @@ export default function HomeScreen() {
           Press{' '}
           <ThemedText type="defaultSemiBold">
             {Platform.select({
-              ios: 'cmd + d',
+              ios: '\u2303 + d',
               android: 'cmd + m',
               web: 'F12'
             })}


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/issues/34191

The default app template has a text caption which shows the incorrect keyboard shortcut to open the developer tools. This PR corrects the shortcut to **^ + d**

# How

Simple update to the text string.

# Test Plan

Build and run. Correct caption shows.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
