### PR TITLE
[modules] Remove old config names

### DIFF
--- a/packages/expo-blur/expo-module.config.json
+++ b/packages/expo-blur/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-blur",
-  "platforms": ["ios", "tvos", "android"],
-  "ios": {
+  "platforms": ["apple", "tvos", "android"],
+  "apple": {
     "modules": ["BlurViewModule"]
   },
-  "android":{
-    "modulesClassNames": ["expo.modules.blur.BlurModule"]
+  "android": {
+    "modules": ["expo.modules.blur.BlurModule"]
   }
 }

--- a/packages/expo-blur/expo-module.config.json
+++ b/packages/expo-blur/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blur",
-  "platforms": ["apple", "tvos", "android"],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["BlurViewModule"]
   },

--- a/packages/expo-cellular/expo-module.config.json
+++ b/packages/expo-cellular/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-cellular",
-  "platforms": ["ios", "android", "web"],
-  "ios": {
-    "modulesClassNames": ["CellularModule"]
+  "platforms": ["apple", "android", "web"],
+  "apple": {
+    "modules": ["CellularModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.cellular.CellularModule"]
+    "modules": ["expo.modules.cellular.CellularModule"]
   }
 }

--- a/packages/expo-clipboard/expo-module.config.json
+++ b/packages/expo-clipboard/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-clipboard",
-  "platforms": ["ios", "android", "web"],
-  "ios": {
-    "modulesClassNames": ["ClipboardModule"]
+  "platforms": ["apple", "android", "web"],
+  "apple": {
+    "modules": ["ClipboardModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.clipboard.ClipboardModule"]
+    "modules": ["expo.modules.clipboard.ClipboardModule"]
   }
 }

--- a/packages/expo-image-picker/expo-module.config.json
+++ b/packages/expo-image-picker/expo-module.config.json
@@ -1,9 +1,9 @@
 {
-  "platforms": ["android", "ios"],
-  "ios": {
-    "modulesClassNames": ["ImagePickerModule"]
+  "platforms": ["android", "apple"],
+  "apple": {
+    "modules": ["ImagePickerModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.imagepicker.ImagePickerModule"]
+    "modules": ["expo.modules.imagepicker.ImagePickerModule"]
   }
 }

--- a/packages/expo-image-picker/expo-module.config.json
+++ b/packages/expo-image-picker/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["android", "apple"],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["ImagePickerModule"]
   },

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-linear-gradient",
-  "platforms": ["apple", "tvos", "android"],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["LinearGradientModule"]
   },

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-linear-gradient",
-  "platforms": ["ios", "tvos", "android"],
-  "ios": {
-    "modulesClassNames": ["LinearGradientModule"]
+  "platforms": ["apple", "tvos", "android"],
+  "apple": {
+    "modules": ["LinearGradientModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.lineargradient.LinearGradientModule"]
+    "modules": ["expo.modules.lineargradient.LinearGradientModule"]
   }
 }

--- a/packages/expo-maps/expo-module.config.json
+++ b/packages/expo-maps/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-maps",
-  "platforms": ["ios", "android"],
-  "ios": {
-    "modulesClassNames": ["ExpoGoogleMapsModule", "ExpoAppleMapsModule"]
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["ExpoGoogleMapsModule", "ExpoAppleMapsModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.maps.ExpoGoogleMapsModule"]
+    "modules": ["expo.modules.maps.ExpoGoogleMapsModule"]
   }
 }

--- a/packages/expo-tracking-transparency/expo-module.config.json
+++ b/packages/expo-tracking-transparency/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-tracking-transparency",
   "platforms": ["apple", "android"],
-  "ios": {
-    "modulesClassNames": ["TrackingTransparencyModule"]
+  "apple": {
+    "modules": ["TrackingTransparencyModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.trackingtransparency.TrackingTransparencyModule"]
+    "modules": ["expo.modules.trackingtransparency.TrackingTransparencyModule"]
   }
 }


### PR DESCRIPTION
# Why
Removes the old naming conventions in `expo-module.config.json` across various packages.

# How

# Test Plan

