### PR TITLE
[template] Add cleanup prompt in reset-project script

### DIFF
--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -99,9 +99,9 @@ const moveDirectories = async (userInput) => {
 };
 
 rl.question(
-  "Do you want to move existing files to /app-example instead of deleting them? (Y/N): ",
+  "Do you want to move existing files to /app-example instead of deleting them? (Y/n): ",
   (answer) => {
-    const userInput = answer.trim().toLowerCase();
+    const userInput = answer.trim().toLowerCase() || "y";
     if (userInput === "y" || userInput === "n") {
       moveDirectories(userInput).finally(() => rl.close());
     } else {


### PR DESCRIPTION
# Why

Follow up #29059

After some time using the `reset-project` script, it’s great that it resets the project, but it does leave the `app-example` folder and the script itself behind. Cleaning these up manually works, but it might not be the easiest or most user-friendly experience.

It might be beneficial if the script could prompt the user with a question, asking whether they would like the script to also delete the `app-example` folder and the `reset-project` script command after running. This would streamline the cleanup process and reduce manual steps for users.

# How

This PR updates the project `reset-script` to include a prompt question that asks users if they want to delete the `/app-example` directory and the corresponding `package.json` entry. This ensures users have more control over the cleanup process after resetting the project.

```bash
Do you want to delete the /app-example folder and this script? (Y/N):
```

If the user answers `Y`, the script deletes:
- `/app-example` directory
- The `reset-project` entry in package.json

```bash
📁 /app-example directory created.
➡️ /app moved to /app-example/app.
➡️ /components moved to /app-example/components.
➡️ /hooks moved to /app-example/hooks.
➡️ /constants moved to /app-example/constants.
➡️ /scripts moved to /app-example/scripts.

📁 New /app directory created.
📄 app/index.tsx created.
📄 app/_layout.tsx created.
Do you want to delete the /app-example folder and this script? (Y/N): y
✅ /app-example folder deleted.
✅ Script entry removed from package.json.

✅ Project reset complete. Next steps:
1. Run `npx expo start` to start a development server.
2. Edit app/index.tsx to edit the main screen.
```

If the user answers `N`, no files are deleted, and users are informed of manual cleanup steps.

# Test Plan

Create a new project:
- Run `npx create-expo-app@latest .`
- Copy the `reset-project.js` script from this PR into `/scripts/reset-project.js`
- Execute `npx run reset-project`
- Answer `Y`:
Confirm that `/app-example` and the `reset-project` entry in `package.json` are deleted.
Answer `N`:
Verify that no files are deleted and the correct instructions for manual cleanup are displayed.
- Run `npx expo start` and ensure the project starts successfully

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
