### PR TITLE
[templates] Fix `@react-native/gradle-plugin` resolution in `settings.gradle` for isolated dependencies

### DIFF
--- a/templates/expo-template-bare-minimum/android/settings.gradle
+++ b/templates/expo-template-bare-minimum/android/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+    includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().toString())
 }
 plugins { id("com.facebook.react.settings") }
 


### PR DESCRIPTION
# Why

With isolated modules, we can only require direct project or package dependencies. Meaning that for `@react-native/gradle-plugin` resolution fails in a pnpm project or monorepo and fails an Android build.

Like the resolution just below it for `expo-modules-autolinking` or at the bottom of the file, `@react-native/gradle-plugin` is not a direct dependency of the user's project. Instead it's a dependency of `react-native`, so it should be resolved via `react-native` to prevent isolated dependency issues.

# How

- Replace raw `@react-native/gradle-plugin` resolution with `paths` addition of `react-native`

# Test Plan

- First regressed in #30034
- Line later changed in #31814

In theory this reproduces as such:
- Clone https://github.com/kitten/expo-pnpm-monorepo-reproduction
  - _Note:_ The reproduction is a regular pnpm workspace with an Expo template app added to it as a workspace package. **Note that there's no `.npmrc` containing a hoisted dependency setting.** This triggers the related bug due to isolated dependencies.
- Run `pnpm install`
- Go to `apps/native-app/`
- Run `pnpm run android`

However, in practice, even when deleting `~/.gradle`, I cannot get this line to cause problems anymore. It's pretty clearly not what we'd like it to be though 😅 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
