### PR TITLE
feat: enable having EXPO_API_MIRROR to use custom api servers

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add support for Bun's text-based lock file format `bun.lock` ([#33825](https://github.com/expo/expo/pull/33825) by [@tharakadesilva](https://github.com/tharakadesilva))
 - Add `--dev` to `npx expo install` to avoid complexity around `npx expo install -- --(save-)dev`. ([#34029](https://github.com/expo/expo/pull/34029) by [@byCedric](https://github.com/byCedric))
 - Add `EXPO_NO_DEPENDENCY_VALIDATION` flag to disable dependency validation for `npx expo install` and `npx expo start`. ([#34122](https://github.com/expo/expo/pull/34122) by [@byCedric](https://github.com/byCedric))
+- Add `CUSTOM_API_URL` env variable to support custom API urls for mirroring API requests. ([#34207](https://github.com/expo/expo/pull/34207) by [@sayjeyhi](https://github.com/sayjeyhi))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Add support for Bun's text-based lock file format `bun.lock` ([#33825](https://github.com/expo/expo/pull/33825) by [@tharakadesilva](https://github.com/tharakadesilva))
 - Add `--dev` to `npx expo install` to avoid complexity around `npx expo install -- --(save-)dev`. ([#34029](https://github.com/expo/expo/pull/34029) by [@byCedric](https://github.com/byCedric))
 - Add `EXPO_NO_DEPENDENCY_VALIDATION` flag to disable dependency validation for `npx expo install` and `npx expo start`. ([#34122](https://github.com/expo/expo/pull/34122) by [@byCedric](https://github.com/byCedric))
-- Add `CUSTOM_API_URL` env variable to support custom API urls for mirroring API requests. ([#34207](https://github.com/expo/expo/pull/34207) by [@sayjeyhi](https://github.com/sayjeyhi))
+- Add `EXPO_API_MIRROR` env variable to support custom API urls for mirroring API requests. ([#34207](https://github.com/expo/expo/pull/34207) by [@sayjeyhi](https://github.com/sayjeyhi))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -2,7 +2,9 @@ import { env } from '../utils/env';
 
 /** Get the URL for the expo.dev API. */
 export function getExpoApiBaseUrl(): string {
-  if (env.EXPO_STAGING) {
+  if (env.CUSTOM_API_URL) {
+    return `${env.CUSTOM_API_URL}`;
+  } else if (env.EXPO_STAGING) {
     return `https://staging-api.expo.dev`;
   } else if (env.EXPO_LOCAL) {
     return `http://127.0.0.1:3000`;

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -2,8 +2,8 @@ import { env } from '../utils/env';
 
 /** Get the URL for the expo.dev API. */
 export function getExpoApiBaseUrl(): string {
-  if (env.CUSTOM_API_URL) {
-    return `${env.CUSTOM_API_URL}`;
+  if (env.EXPO_API_MIRROR) {
+    return env.EXPO_API_MIRROR;
   } else if (env.EXPO_STAGING) {
     return `https://staging-api.expo.dev`;
   } else if (env.EXPO_LOCAL) {

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -36,8 +36,8 @@ class Env {
   }
 
   /** Enable having custom API server */
-  get CUSTOM_API_URL() {
-    return string('CUSTOM_API_URL', '');
+  get EXPO_API_MIRROR() {
+    return string('EXPO_API_MIRROR', '');
   }
 
   /** Is running in non-interactive CI mode */

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -35,6 +35,11 @@ class Env {
     return boolish('EXPO_LOCAL', false);
   }
 
+  /** Enable having custom API server */
+  get CUSTOM_API_URL() {
+    return string('CUSTOM_API_URL', '');
+  }
+
   /** Is running in non-interactive CI mode */
   get CI() {
     return boolish('CI', false);


### PR DESCRIPTION
# Why

We are working on a system to run the expo internally on our servers and there is a problem with running `npm run web` which tries to load `native-modules` from the expo servers. Due to the requirement for the proxy server, we can't call the expo server directly, and also due to some limitations `undici` feature for `http_proxy` env variable doesn't help at all.

So this small change can help users like us also other people who might want to mirror API calls from there custom API URL.

# How

explained above.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
