### PR TITLE
[docs][custom-tabs] Typos and API correction

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -240,7 +240,7 @@ All components also have a hook version and allows to you create the same functi
 
 ### Customizing how tab screens are rendered
 
-The `TabSlot` accepts an `options` prop with `renderFn` property. This function can be used to override how your screen is rendered, allowing you to implement advanced functionality such as animations or persisting/unmounting screens. See the [Router UI Reference](/versions/latest/sdk/router-ui/) for more information.
+The `TabSlot` accepts a `renderFn` property. This function can be used to override how your screen is rendered, allowing you to implement advanced functionality such as animations or persisting/unmounting screens. See the [Router UI Reference](/versions/latest/sdk/router-ui/) for more information.
 
 ## Common questions
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -22,7 +22,7 @@ There are four components offered by `expo-router/ui` to create custom tab layou
 | `TabTrigger` | A trigger component to switch to the specified tab. It is used to define the route using `href` prop and a `name` for each tab. |
 | `TabSlot`    | A slot to render the currently selected tab.                                                                                    |
 
-A bare minimum structure of a custom tab layout would consist of a `TabList` (containing `TabTrigger` components for each tab) and a`TabSlot`, all within the `Tabs` component), as shown here:
+A bare minimum structure of a custom tab layout would consist of a `TabList` (containing `TabTrigger` components for each tab) and a`TabSlot`, all within the `Tabs` component, as shown here:
 
 ```tsx app/(tabs)/_layout.tsx|collapseHeight=440
 import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -59,7 +59,7 @@ Dynamic routes are allowed and can be provided with values via the `href`.
 
 <FileTree files={['_layout.tsx', ['[slug].tsx']]} />
 
-The trigger `<Trigger name="dynamic page" href="/hello-world" />` will create a tab for **[slug].tsx** with the params `{ slug: 'hello-world' }`. This setup can be useful for displaying an arbitrary number of tabs in the tab bar, based on end-user data, such as showing a separate tab for each user profile in an app.
+The trigger `<TabTrigger name="dynamic page" href="/hello-world" />` will create a tab for **[slug].tsx** with the params `{ slug: 'hello-world' }`. This setup can be useful for displaying an arbitrary number of tabs in the tab bar, based on end-user data, such as showing a separate tab for each user profile in an app.
 
 ### Ambiguous routes
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I found three minor issues in the guide regarding custom tabs with expo-router/ui 
https://docs.expo.dev/router/advanced/custom-tabs

1. An extra parentheses seems to have snuck in there
![image](https://github.com/user-attachments/assets/59792e1f-9cbd-4bc2-814a-c07793fc4a1a)

2. I assume this is a typo and should be `TabTrigger` instead of `Trigger`
![image](https://github.com/user-attachments/assets/d24c46b1-c127-438b-a0c7-9c0f80527578)

3. The `TabSlot` components does not take an `options` property. It does however take the `renderFn` directly. 
![image](https://github.com/user-attachments/assets/f1564858-aa32-41b6-8c8e-9ac6becd9589)

The `options` propert is not found on the `TabSlot`
![image](https://github.com/user-attachments/assets/757b3279-d99a-4cc9-a1b5-88dd0004048e)

It works well giving it `renderFn` directly
![image](https://github.com/user-attachments/assets/42cd19bc-53b6-4b44-a5ac-94bec39b9bf2)


# How

<!--
How did you build this feature or fix this bug and why?
-->

I made the changes I proposed in:
docs/pages/router/advanced/custom-tabs.mdx

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
