### PR TITLE
[CI] fix iOS unit tests

### DIFF
--- a/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
@@ -46,7 +46,7 @@ final class DataUint8ArrayConvertiblesSpec: ExpoSpec {
         .eval(
           "expo.modules.BlobModule.echoAsync(new Uint8Array([0x00, 0xff])).then((result) => { globalThis.result = result; })"
         )
-      expect(try runtime.eval("globalThis.result instanceof Uint8Array").getBool()).toEventually(beTrue())
+      expect(safeBoolEval("globalThis.result instanceof Uint8Array")).toEventually(beTrue())
       let array = try runtime.eval("Array.from(globalThis.result)").asArray()
       expect(array[0]?.getInt()) == 0x00
       expect(array[1]?.getInt()) == 0xff
@@ -57,11 +57,29 @@ final class DataUint8ArrayConvertiblesSpec: ExpoSpec {
         .eval(
           "expo.modules.BlobModule.echoMapAsync({ key: new Uint8Array([0x00, 0xff]) }).then((result) => { globalThis.result = result; })"
         )
-      expect(try runtime.eval("globalThis.result != null && globalThis.result.key instanceof Uint8Array").getBool()).toEventually(beTrue())
+      expect(safeBoolEval("globalThis.result != null && globalThis.result.key instanceof Uint8Array")).toEventually(beTrue())
       let array = try runtime.eval("Array.from(globalThis.result.key)").asArray()
       expect(array[0]?.getInt()) == 0x00
       expect(array[1]?.getInt()) == 0xff
     }
+
+    // For async tests, this is a safe way to repeatedly evaluate JS
+    // and catch both Swift and ObjC exceptions
+    func safeBoolEval(_ js: String) -> Bool {
+      var result = false
+      do {
+        try EXUtilities.catchException {
+          guard let jsResult = try? runtime.eval(js) else {
+            return
+          }
+          result = jsResult.getBool()
+        }
+      } catch {
+        return false
+      }
+      return result
+    }
+
   }
 }
 

--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseSpec.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseSpec.swift
@@ -54,7 +54,7 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
 
       db = UpdatesDatabase()
       db.databaseQueue.sync {
-        try! db.openDatabase(inDirectory: testDatabaseDir)
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
       }
     }
 
@@ -92,7 +92,8 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
           config: config,
           database: db,
           directory: testDatabaseDir,
-          completionQueue: DispatchQueue.global(qos: .default)
+          completionQueue: DispatchQueue.global(qos: .default),
+          logger: UpdatesLogger()
         )
         let successValue = Synchronized<Bool?>(nil)
         launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1")) { error, success in

--- a/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
+++ b/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
@@ -303,7 +303,10 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
 
     describe("database persistence") {
       it("persists") {
-        let db = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: testDatabaseDir)
+        let db = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
+          inDirectory: testDatabaseDir,
+          logger: UpdatesLogger()
+        )
 
         // insert some test data
         let insertSql = """
@@ -314,7 +317,10 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
 
         // mimic the app closing and reopening
         sqlite3_close(db)
-        let newDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: testDatabaseDir)
+        let newDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
+          inDirectory: testDatabaseDir,
+          logger: UpdatesLogger()
+        )
 
         // ensure the data is still there
         let selectSql = "SELECT * FROM `assets` WHERE `url` IS NULL AND `key` = 'bundle-1614137401950' AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0"
@@ -333,7 +339,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v4.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -361,7 +368,10 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         sqlite3_close(db)
 
         // initialize without specifying migrations in order to run them all
-        let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: testDatabaseDir)
+        let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
+          inDirectory: testDatabaseDir,
+          logger: UpdatesLogger()
+        )
 
         // verify data integrity
         let updatesSql1 = "SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'"
@@ -400,7 +410,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v4.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -427,7 +438,7 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
 
         sqlite3_close(db)
 
-        let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: testDatabaseDir, migrations: [UpdatesDatabaseMigration4To5()])
+        let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(inDirectory: testDatabaseDir, migrations: [UpdatesDatabaseMigration4To5()], logger: UpdatesLogger())
 
         // verify data integrity
         let updatesSql1 = "SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'"
@@ -485,7 +496,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v5.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -515,7 +527,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // initialize a new database object the normal way and run migrations
         let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
           inDirectory: testDatabaseDir,
-          migrations: [UpdatesDatabaseMigration5To6()]
+          migrations: [UpdatesDatabaseMigration5To6()],
+          logger: UpdatesLogger()
         )
 
         // verify data integrity
@@ -595,7 +608,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v6.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -625,7 +639,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // initialize a new database object the normal way and run migrations
         let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
           inDirectory: testDatabaseDir,
-          migrations: [UpdatesDatabaseMigration6To7()]
+          migrations: [UpdatesDatabaseMigration6To7()],
+          logger: UpdatesLogger()
         )
 
         // verify data integrity
@@ -702,7 +717,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v7.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -721,7 +737,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // initialize a new database object the normal way and run migrations
         let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
           inDirectory: testDatabaseDir,
-          migrations: [UpdatesDatabaseMigration7To8()]
+          migrations: [UpdatesDatabaseMigration7To8()],
+          logger: UpdatesLogger()
         )
 
         let assetsSql1 = "SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL"
@@ -738,7 +755,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v8.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -757,7 +775,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // initialize a new database object the normal way and run migrations
         let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
           inDirectory: testDatabaseDir,
-          migrations: [UpdatesDatabaseMigration8To9()]
+          migrations: [UpdatesDatabaseMigration8To9()],
+          logger: UpdatesLogger()
         )
 
         let assetsSql1 = "SELECT * FROM `assets` WHERE `id` = 2 AND `url` = 'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e' AND `key` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `headers` IS NULL AND `type` = 'image/png' AND `metadata` IS NULL AND `download_time` = 1614137309295 AND `relative_path` = 'b56cf690e0afa93bd4dc7756d01edd3e.png' AND `hash` = 'c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL"
@@ -774,7 +793,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
           filename: "expo-v9.db",
           inDirectory: testDatabaseDir,
           shouldMigrate: false,
-          migrations: []
+          migrations: [],
+          logger: UpdatesLogger()
         )
 
         // insert test data
@@ -804,7 +824,8 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // initialize a new database object the normal way and run migrations
         let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
           inDirectory: testDatabaseDir,
-          migrations: [UpdatesDatabaseMigration9To10()]
+          migrations: [UpdatesDatabaseMigration9To10()],
+          logger: UpdatesLogger()
         )
 
         // verify data integrity

--- a/packages/expo-updates/ios/Tests/DatabaseIntegrityCheckSpec.swift
+++ b/packages/expo-updates/ios/Tests/DatabaseIntegrityCheckSpec.swift
@@ -29,7 +29,7 @@ class UpdatesDatabaseIntegrityCheckSpec : ExpoSpec {
       
       db = UpdatesDatabase()
       db.databaseQueue.sync {
-        try! db.openDatabase(inDirectory: testDatabaseDir)
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
       }
     }
     

--- a/packages/expo-updates/ios/Tests/ErrorRecoverySpec.swift
+++ b/packages/expo-updates/ios/Tests/ErrorRecoverySpec.swift
@@ -80,7 +80,7 @@ class ErrorRecoverySpec : ExpoSpec {
   override class func spec() {
     func setUp() -> (DispatchQueue, ErrorRecovery) {
       let testQueue = DispatchQueue(label: "expo.errorRecoveryTestQueue")
-      return (testQueue, ErrorRecovery(errorRecoveryQueue: testQueue, remoteLoadTimeout: 500))
+      return (testQueue, ErrorRecovery(logger: UpdatesLogger(), errorRecoveryQueue: testQueue, remoteLoadTimeout: 500))
     }
     
     describe("handleError") {

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -22,7 +22,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let contentType = "application/json"
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,
@@ -51,8 +51,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -93,8 +93,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -136,8 +136,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
           UpdatesConfig.EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey: true
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -173,8 +173,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -214,7 +214,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
 
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
@@ -247,7 +247,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
 
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
@@ -280,7 +280,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
 
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,
@@ -311,7 +311,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
 
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,
@@ -341,7 +341,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let contentType = "application/json"
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,
@@ -377,8 +377,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -426,7 +426,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let contentType = "application/json"
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,
@@ -463,8 +463,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           ],
           UpdatesConfig.EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey: true
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -513,8 +513,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           ],
           UpdatesConfig.EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey: true
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -559,8 +559,8 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           ],
           UpdatesConfig.EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey: true
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         let boundary = "blah"
         let contentType = "multipart/mixed; boundary=\(boundary)"
         let response = HTTPURLResponse(
@@ -603,7 +603,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
           UpdatesConfig.EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey: true
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let contentType = "application/json"
         let response = HTTPURLResponse(
           url: URL(string: "https://exp.host/@test/test")!,

--- a/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
@@ -24,7 +24,7 @@ class FileDownloaderSpec : ExpoSpec {
       
       db = UpdatesDatabase()
       db.databaseQueue.sync {
-        try! db.openDatabase(inDirectory: testDatabaseDir)
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
       }
 
       logger = UpdatesLogger()
@@ -44,7 +44,7 @@ class FileDownloaderSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1.0",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let actual = downloader.createManifestRequest(withURL: URL(string: "https://exp.host/@test/test")!, extraHeaders: nil)
         expect(actual.cachePolicy) == .useProtocolCachePolicy
         expect(actual.value(forHTTPHeaderField: "Cache-Control")).to(beNil())
@@ -55,7 +55,7 @@ class FileDownloaderSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://u.expo.dev/00000000-0000-0000-0000-000000000000",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1.0",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let actual = downloader.createManifestRequest(withURL: URL(string: "https://u.expo.dev/00000000-0000-0000-0000-000000000000")!, extraHeaders: nil)
         expect(actual.cachePolicy) == .useProtocolCachePolicy
         expect(actual.value(forHTTPHeaderField: "Cache-Control")).to(beNil())
@@ -68,7 +68,7 @@ class FileDownloaderSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://u.expo.dev/00000000-0000-0000-0000-000000000000",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1.0",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let extraHeaders = [
           "expo-string": "test",
           "expo-number": 47.5,
@@ -94,8 +94,8 @@ class FileDownloaderSpec : ExpoSpec {
             "expo-updates-environment": "custom"
           ]
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         // serverDefinedHeaders should not be able to override preset headers
         let extraHeaders = [
           "expo-platform": "android"
@@ -200,8 +200,8 @@ class FileDownloaderSpec : ExpoSpec {
             "expo-updates-environment": "custom"
           ]
         ])
-        let downloader = FileDownloader(config: config)
-        
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
+
         // serverDefinedHeaders should not be able to override preset headers
         let extraHeaders = [
           "expo-platform": "android"
@@ -218,7 +218,7 @@ class FileDownloaderSpec : ExpoSpec {
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://u.expo.dev/00000000-0000-0000-0000-000000000000",
           UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1.0",
         ])
-        let downloader = FileDownloader(config: config)
+        let downloader = FileDownloader(config: config, logger: UpdatesLogger())
         let extraHeaders = [
           "expo-string": "test",
           "expo-number": 47.5,

--- a/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
@@ -31,7 +31,7 @@ class UpdatesBuildDataSpec : ExpoSpec {
       
       db = UpdatesDatabase()
       db.databaseQueue.sync {
-        try! db.openDatabase(inDirectory: testDatabaseDir)
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
       }
 
       logger = UpdatesLogger()

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
@@ -24,7 +24,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
       
       db = UpdatesDatabase()
       db.databaseQueue.sync {
-        try! db.openDatabase(inDirectory: testDatabaseDir)
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
       }
       
       manifest = ExpoUpdatesManifest(rawManifestJSON: [

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -22,13 +22,13 @@ class UpdatesStateMachineSpec: ExpoSpec {
     describe("default state") {
       it("instantiates") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         expect(machine.getStateForTesting()) == .idle
       }
 
       it("sequence numbers") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         expect(machine.getStateForTesting()) == .idle
 
         expect(machine.context.sequenceNumber) == 0
@@ -43,7 +43,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("restart") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         expect(machine.getStateForTesting()) == .idle
 
         expect(machine.context.isRestarting) == false
@@ -59,7 +59,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle startStartup and endStartup") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(.startStartup)
         expect(machine.getStateForTesting()) == .idle
@@ -72,7 +72,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle check and checkCompleteAvailable") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(.check)
         expect(machine.getStateForTesting()) == .checking
@@ -92,7 +92,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle check and checkCompleteUnavailable") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(.check)
         expect(machine.getStateForTesting()) == .checking
@@ -108,7 +108,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle download and downloadComplete") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(.download)
         expect(machine.getStateForTesting()) == .downloading
@@ -126,7 +126,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle rollback") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         let commitTime = Date()
         machine.processEventForTesting(.check)
         expect(machine.getStateForTesting()) == .checking
@@ -143,7 +143,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("invalid transitions are handled as expected") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
         machine.processEventForTesting(.check)
         expect(machine.getStateForTesting()) == .checking
@@ -183,7 +183,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("invalid state values are handled as expected") {
         let testStateChangeEventManager = TestStateChangeEventManager()
-        let machine = UpdatesStateMachine(eventManager: testStateChangeEventManager, validUpdatesStateValues: [UpdatesStateValue.idle])
+        let machine = UpdatesStateMachine(logger: UpdatesLogger(), eventManager: testStateChangeEventManager, validUpdatesStateValues: [UpdatesStateValue.idle])
 
         expect(machine.processEventForTesting(.download)).to(throwAssertion())
         expect(machine.getStateForTesting()) == .idle


### PR DESCRIPTION
- Fix failure in `DataUint8ArrayConvertiblesSpec` async tests, by adding a new method to safely try JS eval
- Fix expo-updates unit tests to align with required changes coming from #34035 
- Adjust UpdatesLogger tests to ensure persistent log initialized before each test, other small changes
