### PR TITLE
[expo-constants]: fix regneration of app config

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [android][ios] Updated Gradle build and Podspec files to ensure app.json/app.config.js values are correctly updated during each native build.
+- [android][ios] Updated Gradle build and Podspec files to ensure app.json/app.config.js values are correctly updated during each native build. ([#34228](https://github.com/expo/expo/pull/34228) by [@chrfalch](https://github.com/chrfalch))
 
 ## 17.0.3 — 2024-11-14
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [android][ios] Updated Gradle build and Podspec files to ensure app.json/app.config.js values are correctly updated during each native build.
+
 ## 17.0.3 — 2024-11-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -37,7 +37,9 @@ Pod::Spec.new do |s|
   s.script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
     :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh"',
-    :execution_position => :before_compile
+    :execution_position => :before_compile,
+    # always run the script without warning
+    :always_out_of_date => "1"
   }
 
   # Generate EXConstants.bundle without existing resources

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -23,6 +23,9 @@ afterEvaluate {
       assetsDir.mkdirs()
     }
 
+    // Mark the task as always out-of-date so it always runs - ie. regenerate app.config on every build
+    outputs.upToDateWhen { false }
+
     // Add generated assetsDir into assets.srcDirs
     project.android.sourceSets.main.assets.srcDirs += assetsDir
 


### PR DESCRIPTION
# Why

There are scripts in both the podspec and gradle file in expo-constants that recreates the app.config file with values from the app.json file. These scripts are not reliably run when the app is being rebuild on Android, and on iOS the script is configured so that it runs on each build but emits a warning.

Closes #33692

# How

This fixes this by:

iOS: Added `:always_out_of_date => "1"` to the script phase defining the script in the podspec file

Android: Added `outputs.upToDateWhen { false }` to the gradle task that rebuilds the config file.

# Test Plan

Rerun reproduction in original issue and change the extra-field in the app.json file before building. Each change should be reflected in the native code after building and running the app.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
