### PR TITLE
[fingerprint] Fingerprint potentially reading wrong bytes on Windows

### DIFF
--- a/packages/@expo/fingerprint/src/Fingerprint.types.ts
+++ b/packages/@expo/fingerprint/src/Fingerprint.types.ts
@@ -13,6 +13,10 @@ export type FingerprintSource = HashSource & {
    * as opposed to programmatically.
    */
   debugInfo?: DebugInfo;
+  /**
+   * Whether the file is assumed to have CRLF line endings.
+   */
+  isCRLF?: boolean;
 };
 
 export interface Fingerprint {
@@ -139,6 +143,11 @@ export interface Options {
    * A custom hook function to transform file content sources before hashing.
    */
   fileHookTransform?: FileHookTransformFunction;
+
+  /**
+   * Don't warn about project files with CRLF line endings.
+   */
+  allowProjectFilesWithCRLF?: boolean;
 }
 
 type SourceSkipsKeys = keyof typeof SourceSkips;
@@ -275,6 +284,7 @@ export interface HashResultFile {
   id: string;
   hex: string;
   debugInfo?: DebugInfoFile;
+  isCRLF?: boolean;
 }
 
 export interface HashResultDir {


### PR DESCRIPTION
# Why
This isn't technically fixing a bug, but it would prevent developers in the future spending a lot of time figuring out why their fingerprint doesn't work.

### The problem
When running fingerprint locally, it will read the files on the filesystem as they are,  of course. On Windows, text files are often saved with CRLF line endings. However, files are often checked in to git with LF file endings, without the developer having to mind this themselves with `core.autocrlf=true` git config.

Even with `.gitattributes` pointing out all files that should be LF, with `core.autocrlf=true`,  you can still work with CRLF locally without noticing it.

In that case, which was the case for my team, running `npx @expo/fingerprint .` on the project gave us a different result than what the actual files checked in to git would yield. As a concrete example, our CI fingerprint check always failed, because it checked out the files as they were checked in (with LF) and thus the files had different bytes -> different fingerprint hash.

IMO if you are using git, running fingerprint on a completely clean git status **should not differ from machine to machine**.

Of course, this can be fixed manually by each developer by making sure the files saved locally have the same line endings as the checked in files. But it can be hard realizing this is the problem.

### The solution
I'm not confident that this is the best way to go, technically this introduced a breaking change, but only a breaking change for those who work with project files with CRLF.

Now, for each file we generate a hash for:
1. Make a guess if the file is binary or text file
2. If it is a text file and not within `node_modules`, check if it contains both CR and LF bytes 
   * (Not sure this assumption is correct either, that `filePath.startsWith('node_modules')` is correct for all setups)

If the user hasn't provided the new option 
```typescript
/**
 * Whether to allow fingerprint generation for project files with CRLF line endings.
 */
allowProjectFilesWithCRLF?: boolean;
```

The job will fail if any file had CRLF.


# How

See above

# Test Plan


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
