### PR TITLE
fix(cli): Add fallback module resolver for `expo` and `expo-router` dependencies

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix `static` and `server` projects not starting up correctly when project path contains URI-unsafe characters like spaces. ([#34289](https://github.com/expo/expo/pull/34289) by [@kitten](https://github.com/kitten))
 - Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
 - Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
+- Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -4,11 +4,12 @@ import path from 'path';
 import type { StrictResolverFactory } from './withMetroMultiPlatform';
 import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 
+/** A record of dependencies that we know are only used for scripts and config-plugins */
 const EXCLUDE_ORIGIN_MODULES: Record<string, true | undefined> = {
   '@expo/config': true,
   '@expo/config-plugins': true,
-  'schema-utils': true,
-  semver: true,
+  'schema-utils': true, // Used by `expo-router/plugin`
+  semver: true, // Used by `expo-router/doctor`
 };
 
 interface PackageMetaPeerDependenciesMetaEntry {
@@ -31,14 +32,18 @@ interface ModuleDescription {
 
 const debug = require('debug')('expo:start:server:metro:fallback-resolver') as typeof console.log;
 
+/** Converts a list of module names to a regex that may either match bare module names or sub-modules of modules */
 const dependenciesToRegex = (dependencies: string[]) =>
   new RegExp(`^(?:${dependencies.join('|')})(?:$|/)`);
 
+/** Resolves an origin module and outputs a filter regex and target path for it */
 const getModuleDescription = (originModuleName: string): ModuleDescription | null => {
   const metaPath = path.join(originModuleName, 'package.json');
   let originModulePath: string;
   let packageMeta: PackageMeta;
   try {
+    // We attempt to resolve all origin modules via `@expo/cli`. Due to normal Node resolution
+    // this may include dependencies of `@expo/cli` or of the project.
     originModulePath = path.dirname(require.resolve(metaPath));
     packageMeta = require(metaPath);
   } catch (error: any) {
@@ -50,6 +55,13 @@ const getModuleDescription = (originModuleName: string): ModuleDescription | nul
   if (packageMeta.peerDependencies) {
     const peerDependenciesMeta = packageMeta.peerDependenciesMeta;
     let peerDependencies = Object.keys(packageMeta.peerDependencies);
+    // We explicitly include non-optional peer dependencies. Non-optional peer dependencies of
+    // `expo` and `expo-router` are either expected to be accessible on a project-level, since
+    // both are meant to be installed is direct dependencies, or shouldn't be accessible when
+    // they're fulfilled as isolated dependencies.
+    // The exception are only *optional* peer dependencies, since when they're installed
+    // automatically by newer package manager behaviour, they may become isolated dependencies
+    // that we still wish to access.
     if (peerDependenciesMeta) {
       peerDependencies = peerDependencies.filter((dependency) => {
         const peerMeta = peerDependenciesMeta[dependency];
@@ -58,6 +70,7 @@ const getModuleDescription = (originModuleName: string): ModuleDescription | nul
     }
     dependencies.push(...peerDependencies);
   }
+  // We deduplicate the dependencies and exclude modules that we know are only used for scripts or config-plugins
   dependencies = dependencies.filter((moduleName, index, dependenciesArr) => {
     if (EXCLUDE_ORIGIN_MODULES[moduleName]) return false;
     return dependenciesArr.indexOf(moduleName) === index;
@@ -67,6 +80,21 @@ const getModuleDescription = (originModuleName: string): ModuleDescription | nul
     : null;
 };
 
+/** Creates a fallback module resolver that resolves dependencis of modules named in `originModuleNames` via their path.
+ * @remarks
+ * The fallback resolver targets modules dependended on by modules named in `originModuleNames` and resolves
+ * them from the module root of these origin modules instead.
+ * It should only be used as a fallback after normal Node resolution (and other resolvers) have failed for:
+ * - the `expo` package
+ * - the `expo-router` package
+ * Dependencies mentioned as either optional peer dependencies or direct dependencies by these modules may be isolated
+ * and inaccessible via standard Node module resolution. This may happen when either transpilation adds these
+ * dependencies to other parts of the tree (e.g. `@babel/runtime`) or when a dependency fails to hoist due to either
+ * a corrupted dependency tree or when a peer dependency is fulfilled incorrectly (e.g. `expo-asset`)
+ * @privateRemarks
+ * This does NOT follow Node resolution and is *only* intended to provide a fallback for modules that we depend on
+ * ourselves and know we can resolve (via expo or expo-router)!
+ */
 export function createFallbackModuleResolver({
   originModuleNames,
   getStrictResolver,
@@ -81,12 +109,14 @@ export function createFallbackModuleResolver({
     );
 
   return function requestFallbackModule(immutableContext, moduleName, platform) {
+    // Early return if `moduleName` cannot be a module specifier
     if (moduleName[0] === '.' || moduleName[0] === '/') {
       return null;
     }
 
     for (const { originModuleName, originModulePath, moduleTestRe } of moduleDescriptions) {
       if (moduleTestRe.test(moduleName)) {
+        // We instead resolve as if it was depended on by the `originModulePath` (the module named in `originModuleNames`)
         const context: ResolutionContext = {
           ...immutableContext,
           nodeModulesPaths: [originModulePath],

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -14,15 +14,15 @@ import type { StrictResolver, StrictResolverFactory } from './withMetroMultiPlat
 import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 
 /** A record of dependencies that we know are only used for scripts and config-plugins
-  * @privateRemarks
-  * This includes dependencies we never resolve indirectly. Generally, we only want
-  * to add fallback resolutions for dependencies of `expo` and `expo-router` that
-  * are either transpiled into output code or resolved from other Expo packages
-  * without them having direct dependencies on these dependencies.
-  * Meaning: If you update this list, exclude what a user might use when they
-  * forget to specify their own dependencies, rather than what we use ourselves
-  * only in `expo` and `expo-router`.
-  */
+ * @privateRemarks
+ * This includes dependencies we never resolve indirectly. Generally, we only want
+ * to add fallback resolutions for dependencies of `expo` and `expo-router` that
+ * are either transpiled into output code or resolved from other Expo packages
+ * without them having direct dependencies on these dependencies.
+ * Meaning: If you update this list, exclude what a user might use when they
+ * forget to specify their own dependencies, rather than what we use ourselves
+ * only in `expo` and `expo-router`.
+ */
 const EXCLUDE_ORIGIN_MODULES: Record<string, true | undefined> = {
   '@expo/config': true,
   '@expo/config-plugins': true,
@@ -42,7 +42,10 @@ interface PackageMeta {
   readonly exports?: any; // unused
   readonly dependencies?: Record<string, unknown>;
   readonly peerDependencies?: Record<string, unknown>;
-  readonly peerDependenciesMeta?: Record<string, PackageMetaPeerDependenciesMetaEntry | undefined | null>;
+  readonly peerDependenciesMeta?: Record<
+    string,
+    PackageMetaPeerDependenciesMetaEntry | undefined | null
+  >;
 }
 
 interface ModuleDescription {
@@ -140,7 +143,7 @@ export function createFallbackModuleResolver({
   const getModuleDescription = (
     immutableContext: ResolutionContext,
     originModuleName: string,
-    platform: string | null,
+    platform: string | null
   ) => {
     if (_moduleDescriptionsCache[originModuleName] !== undefined) {
       return _moduleDescriptionsCache[originModuleName];
@@ -153,13 +156,17 @@ export function createFallbackModuleResolver({
     return (_moduleDescriptionsCache[originModuleName] = getModuleDescriptionWithResolver(
       context,
       getStrictResolver(context, platform),
-      originModuleName,
+      originModuleName
     ));
   };
 
+  const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
+
   return function requestFallbackModule(immutableContext, moduleName, platform) {
     // Early return if `moduleName` cannot be a module specifier
-    if (moduleName[0] === '.' || moduleName[0] === '/') {
+    // This doesn't have to be accurate as this resolver is a fallback for failed resolutions and
+    // we're only doing this to avoid unnecessary resolution work
+    if (fileSpecifierRe.test(moduleName)) {
       return null;
     }
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -41,7 +41,7 @@ const getModuleDescriptionWithResolver = (
   resolve: StrictResolver,
   originModuleName: string
 ): ModuleDescription | null => {
-  let filePath: string;
+  let filePath: string | undefined;
   let packageMeta: PackageMeta;
   try {
     const resolution = resolve(`${originModuleName}/package.json`);
@@ -52,7 +52,9 @@ const getModuleDescriptionWithResolver = (
     filePath = resolution.filePath;
     packageMeta = JSON.parse(fs.readFileSync(resolution.filePath, 'utf8'));
   } catch (error: any) {
-    debug(`Fallback module resolution threw: ${error.constructor.name}. (module: ${filePath})`);
+    debug(
+      `Fallback module resolution threw: ${error.constructor.name}. (module: ${filePath || originModuleName})`
+    );
     return null;
   }
   let dependencies: string[] = [];

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import type { ResolutionContext } from 'metro-resolver';
 import path from 'path';
 
@@ -40,15 +41,14 @@ const getModuleDescriptionWithResolver = (
   resolve: StrictResolver,
   originModuleName: string
 ): ModuleDescription | null => {
-  const metaPath = path.join(originModuleName, 'package.json');
-  const resolution = resolve(metaPath);
+  const resolution = resolve(`${originModuleName}/package.json`);
   if (resolution.type !== 'sourceFile') {
     debug(`Fallback module resolution failed for origin module: ${originModuleName})`);
     return null;
   }
   let packageMeta: PackageMeta;
   try {
-    packageMeta = require(resolution.filePath);
+    packageMeta = JSON.parse(fs.readFileSync(resolution.filePath, 'utf8'));
   } catch (error: any) {
     debug(
       `Fallback module resolution threw: ${error.constructor.name}. (module: ${resolution.filePath})`

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -1,0 +1,105 @@
+import type { ResolutionContext } from 'metro-resolver';
+import path from 'path';
+
+import type { StrictResolverFactory } from './withMetroMultiPlatform';
+import type { ExpoCustomMetroResolver } from './withMetroResolvers';
+
+const EXCLUDE_ORIGIN_MODULES: Record<string, true | undefined> = {
+  '@expo/config': true,
+  '@expo/config-plugins': true,
+  'schema-utils': true,
+  semver: true,
+};
+
+interface PackageMetaPeerDependenciesMetaEntry {
+  [propName: string]: unknown;
+  optional?: boolean;
+}
+
+interface PackageMeta {
+  [propName: string]: unknown;
+  dependencies?: Record<string, unknown>;
+  peerDependencies?: Record<string, unknown>;
+  peerDependenciesMeta?: Record<string, PackageMetaPeerDependenciesMetaEntry | undefined | null>;
+}
+
+interface ModuleDescription {
+  originModuleName: string;
+  originModulePath: string;
+  moduleTestRe: RegExp;
+}
+
+const debug = require('debug')('expo:start:server:metro:fallback-resolver') as typeof console.log;
+
+const dependenciesToRegex = (dependencies: string[]) =>
+  new RegExp(`^(?:${dependencies.join('|')})(?:$|/)`);
+
+const getModuleDescription = (originModuleName: string): ModuleDescription | null => {
+  const metaPath = path.join(originModuleName, 'package.json');
+  let originModulePath: string;
+  let packageMeta: PackageMeta;
+  try {
+    originModulePath = path.dirname(require.resolve(metaPath));
+    packageMeta = require(metaPath);
+  } catch (error: any) {
+    debug(`Node module resolution threw: ${error.constructor.name}. (module: ${originModuleName})`);
+    return null;
+  }
+  let dependencies: string[] = [];
+  if (packageMeta.dependencies) dependencies.push(...Object.keys(packageMeta.dependencies));
+  if (packageMeta.peerDependencies) {
+    const peerDependenciesMeta = packageMeta.peerDependenciesMeta;
+    let peerDependencies = Object.keys(packageMeta.peerDependencies);
+    if (peerDependenciesMeta) {
+      peerDependencies = peerDependencies.filter((dependency) => {
+        const peerMeta = peerDependenciesMeta[dependency];
+        return peerMeta && typeof peerMeta === 'object' && peerMeta.optional === true;
+      });
+    }
+    dependencies.push(...peerDependencies);
+  }
+  dependencies = dependencies.filter((moduleName, index, dependenciesArr) => {
+    if (EXCLUDE_ORIGIN_MODULES[moduleName]) return false;
+    return dependenciesArr.indexOf(moduleName) === index;
+  });
+  return dependencies.length
+    ? { originModuleName, originModulePath, moduleTestRe: dependenciesToRegex(dependencies) }
+    : null;
+};
+
+export function createFallbackModuleResolver({
+  originModuleNames,
+  getStrictResolver,
+}: {
+  originModuleNames: string[];
+  getStrictResolver: StrictResolverFactory;
+}): ExpoCustomMetroResolver {
+  const moduleDescriptions = originModuleNames
+    .map(getModuleDescription)
+    .filter(
+      (moduleDescription): moduleDescription is ModuleDescription => moduleDescription != null
+    );
+
+  return function requestFallbackModule(immutableContext, moduleName, platform) {
+    if (moduleName[0] === '.' || moduleName[0] === '/') {
+      return null;
+    }
+
+    for (const { originModuleName, originModulePath, moduleTestRe } of moduleDescriptions) {
+      if (moduleTestRe.test(moduleName)) {
+        const context: ResolutionContext = {
+          ...immutableContext,
+          nodeModulesPaths: [originModulePath],
+          originModulePath,
+        };
+        const res = getStrictResolver(context, platform)(moduleName);
+        debug(
+          `Fallback resolution for ${platform}: ${moduleName} -> from origin: ${originModuleName}`
+        );
+        return res;
+      }
+    }
+
+    return null;
+  };
+}

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -1,3 +1,12 @@
+// This file creates the fallback resolver
+// The fallback resolver applies only to module imports and should be the last resolver
+// in the chain. It applies to failed Node module resolution of modules and will attempt
+// to resolve them to `expo` and `expo-router` dependencies that couldn't be resolved.
+// This resolves isolated dependency issues, where we expect dependencies of `expo`
+// and `expo-router` to be resolvable, due to hoisting, but they aren't hoisted in
+// a user's project.
+// See: https://github.com/expo/expo/pull/34286
+
 import fs from 'fs';
 import type { ResolutionContext } from 'metro-resolver';
 import path from 'path';
@@ -5,7 +14,16 @@ import path from 'path';
 import type { StrictResolver, StrictResolverFactory } from './withMetroMultiPlatform';
 import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 
-/** A record of dependencies that we know are only used for scripts and config-plugins */
+/** A record of dependencies that we know are only used for scripts and config-plugins
+  * @privateRemarks
+  * This includes dependencies we never resolve indirectly. Generally, we only want
+  * to add fallback resolutions for dependencies of `expo` and `expo-router` that
+  * are either transpiled into output code or resolved from other Expo packages
+  * without them having direct dependencies on these dependencies.
+  * Meaning: If you update this list, exclude what a user might use when they
+  * forget to specify their own dependencies, rather than what we use ourselves
+  * only in `expo` and `expo-router`.
+  */
 const EXCLUDE_ORIGIN_MODULES: Record<string, true | undefined> = {
   '@expo/config': true,
   '@expo/config-plugins': true,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -35,6 +35,12 @@ import { PlatformBundlers } from '../platformBundlers';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
+export type StrictResolver = (moduleName: string) => Resolution;
+export type StrictResolverFactory = (
+  context: ResolutionContext,
+  platform: string | null
+) => StrictResolver;
+
 const ASSET_REGISTRY_SRC = `const assets=[];module.exports={registerAsset:s=>assets.push(s),getAssetByID:s=>assets[s-1]};`;
 
 const debug = require('debug')('expo:start:server:metro:multi-platform') as typeof console.log;
@@ -258,14 +264,14 @@ export function withExtendedResolver(
 
   let nodejsSourceExtensions: string[] | null = null;
 
-  function getStrictResolver(
-    { resolveRequest, ...context }: ResolutionContext,
-    platform: string | null
-  ) {
+  const getStrictResolver: StrictResolverFactory = (
+    { resolveRequest, ...context },
+    platform
+  ): StrictResolver => {
     return function doResolve(moduleName: string): Resolution {
       return resolver(context, moduleName, platform);
     };
-  }
+  };
 
   function getOptionalResolver(context: ResolutionContext, platform: string | null) {
     const doResolve = getStrictResolver(context, platform);

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -678,6 +678,8 @@ export function withExtendedResolver(
       return result;
     },
 
+    // If at this point, we haven't resolved a module yet, if it's a module specifier for a known dependency
+    // of either `expo` or `expo-router`, attempt to resolve it from these origin modules instead
     createFallbackModuleResolver({
       originModuleNames: ['expo', 'expo-router'],
       getStrictResolver,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -13,6 +13,7 @@ import * as metroResolver from 'metro-resolver';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
+import { createFallbackModuleResolver } from './createExpoFallbackResolver';
 import { createFastResolver, FailedToResolvePathError } from './createExpoMetroResolver';
 import { isNodeExternal, shouldCreateVirtualCanary, shouldCreateVirtualShim } from './externals';
 import { isFailedToResolveNameError, isFailedToResolvePathError } from './metroErrors';
@@ -676,6 +677,11 @@ export function withExtendedResolver(
 
       return result;
     },
+
+    createFallbackModuleResolver({
+      originModuleNames: ['expo', 'expo-router'],
+      getStrictResolver,
+    }),
   ]);
 
   // Ensure we mutate the resolution context to include the custom resolver options for server and web.

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -382,7 +382,11 @@ export function withExtendedResolver(
 
   const metroConfigWithCustomResolver = withMetroResolvers(config, [
     // Mock out production react imports in development.
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestDevMockProdReact(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       // This resolution is dev-only to prevent bundling the production React packages in development.
       if (!context.dev) return null;
 
@@ -410,7 +414,11 @@ export function withExtendedResolver(
       return null;
     },
     // tsconfig paths
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestTsconfigPaths(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       return (
         tsConfigResolve?.(
           {
@@ -423,7 +431,11 @@ export function withExtendedResolver(
     },
 
     // Node.js externals support
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestNodeExternals(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       const isServer =
         context.customResolverOptions?.environment === 'node' ||
         context.customResolverOptions?.environment === 'react-server';
@@ -468,7 +480,11 @@ export function withExtendedResolver(
     },
 
     // Custom externals support
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestCustomExternals(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       // We don't support this in the resolver at the moment.
       if (moduleName.endsWith('/package.json')) {
         return null;
@@ -532,7 +548,7 @@ export function withExtendedResolver(
     },
 
     // Basic moduleId aliases
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestAlias(context: ResolutionContext, moduleName: string, platform: string | null) {
       // Conditionally remap `react-native` to `react-native-web` on web in
       // a way that doesn't require Babel to resolve the alias.
       if (platform && platform in aliases && aliases[platform][moduleName]) {
@@ -557,7 +573,11 @@ export function withExtendedResolver(
     },
 
     // Polyfill for asset registry
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestStableAssetRegistry(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       if (/^@react-native\/assets-registry\/registry(\.js)?$/.test(moduleName)) {
         return getAssetRegistryModule();
       }
@@ -575,7 +595,11 @@ export function withExtendedResolver(
 
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.
-    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    function requestPostRewrites(
+      context: ResolutionContext,
+      moduleName: string,
+      platform: string | null
+    ) {
       const doResolve = getStrictResolver(context, platform);
 
       const result = doResolve(moduleName);

--- a/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
@@ -86,7 +86,7 @@ export function withMetroResolvers(
                   throw error;
                 }
                 debug(
-                  `Custom resolver threw: ${error.constructor.name}. (module: ${moduleName}, platform: ${platform}, env: ${ctx.customResolverOptions?.environment}, origin: ${ctx.originModulePath})`
+                  `Custom resolver (${resolver.name || '<anonymous>'}) threw: ${error.constructor.name}. (module: ${moduleName}, platform: ${platform}, env: ${ctx.customResolverOptions?.environment}, origin: ${ctx.originModulePath})`
                 );
               }
             }


### PR DESCRIPTION
# Why

This adds a fallback module resolution strategy to our `withMetroMultiPlatform` resolver chain, which is intended to provide fallbacks when a failed resolution occurs via normal Node module resolution.

The dependencies and optional peer dependencies in `expo` and `expo-router` are special. Several package manager issues, quirks, or the isolated dependency strategy can cause their dependencies to either become inaccessible or not be hoisted. There are several cases in which this may happen.

> [!NOTE]
> Unlike the [sticky resolution strategy](https://github.com/expo/expo/pull/31750). This does not prevent duplicate dependencies, since it serves as a fallback. While sticky resolution is useful for **native module** dependencies (since only one may be built into an app at a time), it's too aggressive for missing module resolutions that occur due to package manager bugs, invalid hoisting trees, and isolated dependencies for non-native modules.

<details>
<summary><strong>Reminder Note:</strong> What are isolated dependencies?</summary>

For a reminder re. isolated dependencies. This is an installation strategy used by `pnpm`. In this installation structure it enforces that hoisted dependencies (and direct dependencies) are isolated to the actual dependencies that these modules specify.

In this strategy, modules that specify dependencies are linked to a central `node_modules/.pnpm` folder. In this folder, each dependency is placed in its own sub folder and its dependencies are recursively linked to other folders of this style.

This effectively means that no dependencies that aren't specified are accessible, avoiding "implicit transitive" dependencies, which can otherwise lead to bugs when hoisting differs due to conflicts.

</details>

### Isolated dependencies with transformations

Output ASTs are transformed using Babel. This may leave `@babel/runtime` helpers around. `@babel/runtime` is generally an entrypoint into several output helpers that Babel places into output bundles.

However, due to isolated dependencies, without this fallback resolvers, users will have to install `@babel/runtime` directly and rely on deduplication. This doesn't apply with hoisting, so it's unexpected and a repository can fail when the package manager is changed over to `pnpm` without the hoisted linker.

### Unhoisted dependencies

If any dependency of `expo` or `expo-router` isn't hoisted, it becomes inaccessible to the user. While this is expected, if this is either the result of a transformation or the result of transitive dependency rules, the module won't be resolved.

This occurred for `expo-asset/tools/hashAssetFiles` (which will be removed) in non-isolated dependencies cases too due to invalid hoisting. This is an intermittent error, where the dependency tree isn't technically incorrect, but hoisting is skipped for a dependency.

### Isolated/unhoisted peer dependencies that are auto-installed

Due to a quirk in modern package manager behaviour. Peer Dependencies may be auto-installed but not hoisted in some cases. This depends on the package managers' configuration.

We have several optional peer dependencies in `expo` and `expo-router` that may become inaccessible from the project root due to this problem, and if they're imported in the project, rather than in their own module code, an error will occur. This is usually user error, but also unexpected and hard to spot.

# How

The resolver created by `createExpoFallbackResolver` is added as the last one in our chain of custom resolvers. Importantly, it's placed after `requestPostRewrites` (previously unnamed), the prior last resolver, which always returns a resolution (or throws).
Hence, the fallback resolver is only used when normal Node module resolution fails.

`createExpoFallbackResolver` accepts a list of `originModuleNames` (we pass `'expo'` and `'expo-router'`). It then:
- resolves the root of these origin modules via a regular `require.resolve` call (meaning, all origin modules must be accessible via `@expo/cli` and/or the project, which is expected for `expo` and optionally `expo-router`)
- loads these modules' `package.json` and creates a regex for modules that are either their dependencies or optional peer dependencies

The resolver it creates then activates when we cannot resolve a module prior and:
- checks that the `moduleName` is a module specifier
- checks the `moduleName` against the regexes created above
- if a match occurs, it resolves the `moduleName` from the origin module's installation folder instead

## Set of changes

- Create type for `StrictResolver` and `StrictResolverFactory`
- Give names to resolvers passed to `withMetroResolvers` and add their names to the `debug` error message
- Add `createExpoFallbackResolver`

# Test Plan

- Added resolution tests to `withMetroMultiPlatform`'s tests

**Reproduction:**
- Clone https://github.com/kitten/expo-pnpm-monorepo-reproduction
  - _Note:_ The reproduction is a regular pnpm workspace with an Expo template app added to it as a workspace package. **Note that there's no `.npmrc` containing a hoisted dependency setting.** This triggers the related bug due to isolated dependencies.
- Run `pnpm install`
- Go to `apps/native-app/`
- Run `pnpm start --clear` and open the app (iOS or Android)
  - _Note:_ This will reproduce the related build error and will show `Unable to resolve "@babel/runtime/helpers/interopRequireDefault"...`

**Verification:**
- You can verify that `@babel/runtime` is not a direct dependency of the app (either through `pnpm list @babel/runtime` or by checking that `node_modules/@babel/runtime` does not exist)
- Adding `pnpm add @babel/runtime` would resolve this, since it manually provides a resolution (If you do this, make sure to reset this before testing the fix)

**Testing this fix:**
- Run `git checkout pr-34286 `
  - _Note:_ This branch contains this PR's changes applied as a pnpm patch (patch-package change)
- Run `pnpm install`
- Run `pnpm start --clear`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
