### PR TITLE
[android][camera] Fix activeRecording visibility in ExpoCameraView

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- [Android] Fix activeRecording visibility in ExpoCameraView ([#34290](https://github.com/expo/expo/pull/34290) by [@limbo56](https://github.com/limbo56))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -128,7 +128,6 @@ class ExpoCameraView(
   private var barcodeFormats: List<BarcodeType> = emptyList()
   private var glSurfaceTexture: SurfaceTexture? = null
 
-
   private var previewView = PreviewView(context).apply {
     elevation = 0f
   }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -117,7 +117,8 @@ class ExpoCameraView(
   }
 
   var camera: Camera? = null
-  private var activeRecording: Recording? = null
+  var activeRecording: Recording? = null
+    private set
 
   private var cameraProvider: ProcessCameraProvider? = null
   private val providerFuture = ProcessCameraProvider.getInstance(context)


### PR DESCRIPTION
# Why

This PR fixes an issue that was introduced by a previous PR ([android][camera] Fix pixelation with expo-gl #34174) during the build process of `expo-camera`. The error is occurring because the `activeRecording` property in `ExpoCameraView.kt` was made private, which caused a compilation failure when trying to access it in `CameraViewModule.kt`. 

The build error indicates that `activeRecording` was not accessible due to its private visibility:
```gradle
> Task :expo-camera:compileDebugKotlin FAILED
e: file:///app/node_modules/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt:257:14 Cannot access 'activeRecording': it is private in 'ExpoCameraView'

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':expo-camera:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details
```

# How

The visibility of the `activeRecording` property was changed in `ExpoCameraView.kt` to make it public for reading, while keeping the setter private. This resolves the compilation error by allowing external code to access the property while maintaining encapsulation for modifications.

# Test Plan

I tested this fix on my own project using a bare Expo workflow. The changes in this pull request resolve the error described above. You can also verify the fix by building the `apps/bare-expo` project.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
