### PR TITLE
[docs] add missing Expo Orbit link

### DIFF
--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -106,7 +106,7 @@ In the terminal, once the build finishes, EAS CLI prompts us by asking whether w
 
 <Collapsible summary="Alternate: Use Expo Orbit">
 
-You can use [Expo Orbit] to install the development build. From **Build artifact** on the Expo dashboard, click **Open with Expo Orbit** to install the development build on the iOS Simulator.
+You can use [Expo Orbit](https://expo.dev/orbit) to install the development build. From **Build artifact** on the Expo dashboard, click **Open with Expo Orbit** to install the development build on the iOS Simulator.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why
the link to expo orbit was missing, so I added it.

# How

n/a

# Test Plan

- test of you can now click "expo orbit".

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
