### PR TITLE
[docs][audio] Add definition of `audioSource`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -77,6 +77,8 @@ import { useEffect, useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioPlayer } from 'expo-audio';
 
+const audioSource = require('./assets/Hello.mp3');
+
 export default function App() {
   const player = useAudioPlayer(audioSource);
 

--- a/docs/pages/versions/v52.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio.mdx
@@ -78,6 +78,8 @@ import { useEffect, useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioPlayer } from 'expo-audio';
 
+const audioSource = require('./assets/Hello.mp3');
+
 export default function App() {
   const player = useAudioPlayer(audioSource);
 


### PR DESCRIPTION
# Why
The example is the docs uses a variable `audioSource` but it is not defined anywhere.

# How
Add definition

# Test Plan
n/a

