### PR TITLE
[android][camera] Fix setting preview provider

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix `zoom` on Android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix setting the camera preview provider.
+- [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix `zoom` on Android and adjust the magnitude on iOS. ([#33319](https://github.com/expo/expo/pull/33319) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix setting the camera preview provider.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -337,15 +337,12 @@ class ExpoCameraView(
             is VideoRecordEvent.Pause -> {
               isRecording = false
             }
-
             is VideoRecordEvent.Resume -> {
               isRecording = true
             }
-
             is VideoRecordEvent.Start -> {
               isRecording = true
             }
-
             is VideoRecordEvent.Finalize -> {
               when (event.error) {
                 VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED,

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -337,12 +337,15 @@ class ExpoCameraView(
             is VideoRecordEvent.Pause -> {
               isRecording = false
             }
+
             is VideoRecordEvent.Resume -> {
               isRecording = true
             }
+
             is VideoRecordEvent.Start -> {
               isRecording = true
             }
+
             is VideoRecordEvent.Finalize -> {
               when (event.error) {
                 VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED,
@@ -409,6 +412,9 @@ class ExpoCameraView(
         val preview = Preview.Builder()
           .setResolutionSelector(resolutionSelector)
           .build()
+          .also {
+            it.surfaceProvider = previewView.surfaceProvider
+          }
 
         glSurfaceTexture?.let {
           it.setDefaultBufferSize(previewView.width, previewView.height)


### PR DESCRIPTION
# Why
Closes #34300
Fixes regression from #34174. Setting the surface provider should not have been removed. 

# How
Set the provider in `createCamera`

# Test Plan
Bare expo both the camera example and the gl example work as expected

