### PR TITLE
fix(cli): use POSIX path when converting route file name in API routes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix a build error when running `expo run:ios` consecutively without closing the app. ([#33236](https://github.com/expo/expo/pull/33236) by [@alanjhughes](https://github.com/alanjhughes))
 - Catch system errors when determining local IP addresses. ([#34043](https://github.com/expo/expo/pull/34043) by [@kitten](https://github.com/kitten))
 - Add `EAI_AGAIN` DNS service errors to offline detection. ([#34014](https://github.com/expo/expo/pull/34014) by [@byCedric](https://github.com/byCedric))
+- Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/export/__snapshots__/export-no-ssg.test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/export/__snapshots__/export-no-ssg.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`export-no-ssg has expected routes manifest entries 1`] = `
+{
+  "apiRoutes": [
+    {
+      "file": "_expo/functions/(a,b)/multi-group-api+api.js",
+      "namedRegex": "^(?:/\\((?:a|b)\\))?/multi\\-group\\-api(?:/)?$",
+      "page": "/(b)/multi-group-api",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/methods+api.js",
+      "namedRegex": "^/methods(?:/)?$",
+      "page": "/methods",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/json+api.js",
+      "namedRegex": "^/api/json(?:/)?$",
+      "page": "/api/json",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/empty+api.js",
+      "namedRegex": "^/api/empty(?:/)?$",
+      "page": "/api/empty",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/error+api.js",
+      "namedRegex": "^/api/error(?:/)?$",
+      "page": "/api/error",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/env-vars+api.js",
+      "namedRegex": "^/api/env\\-vars(?:/)?$",
+      "page": "/api/env-vars",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/redirect+api.js",
+      "namedRegex": "^/api/redirect(?:/)?$",
+      "page": "/api/redirect",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/externals+api.js",
+      "namedRegex": "^/api/externals(?:/)?$",
+      "page": "/api/externals",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/problematic+api.js",
+      "namedRegex": "^/api/problematic(?:/)?$",
+      "page": "/api/problematic",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/matching-route/alpha+api.js",
+      "namedRegex": "^/matching\\-route/alpha(?:/)?$",
+      "page": "/matching-route/alpha",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/[dynamic]+api.js",
+      "namedRegex": "^/api/(?<dynamic>[^/]+?)(?:/)?$",
+      "page": "/api/[dynamic]",
+      "routeKeys": {
+        "dynamic": "dynamic",
+      },
+    },
+    {
+      "file": "_expo/functions/api/a/[...spread]+api.js",
+      "namedRegex": "^/api/a(?:/(?<spread>.+?))?(?:/)?$",
+      "page": "/api/a/[...spread]",
+      "routeKeys": {
+        "spread": "spread",
+      },
+    },
+  ],
+  "htmlRoutes": [],
+  "notFoundRoutes": [],
+}
+`;

--- a/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`server-output has expected routes manifest entries 1`] = `
+{
+  "apiRoutes": [
+    {
+      "file": "_expo/functions/(a,b)/multi-group-api+api.js",
+      "namedRegex": "^(?:/\\((?:a|b)\\))?/multi\\-group\\-api(?:/)?$",
+      "page": "/(b)/multi-group-api",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/methods+api.js",
+      "namedRegex": "^/methods(?:/)?$",
+      "page": "/methods",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/json+api.js",
+      "namedRegex": "^/api/json(?:/)?$",
+      "page": "/api/json",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/empty+api.js",
+      "namedRegex": "^/api/empty(?:/)?$",
+      "page": "/api/empty",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/error+api.js",
+      "namedRegex": "^/api/error(?:/)?$",
+      "page": "/api/error",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/env-vars+api.js",
+      "namedRegex": "^/api/env\\-vars(?:/)?$",
+      "page": "/api/env-vars",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/redirect+api.js",
+      "namedRegex": "^/api/redirect(?:/)?$",
+      "page": "/api/redirect",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/externals+api.js",
+      "namedRegex": "^/api/externals(?:/)?$",
+      "page": "/api/externals",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/problematic+api.js",
+      "namedRegex": "^/api/problematic(?:/)?$",
+      "page": "/api/problematic",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/matching-route/alpha+api.js",
+      "namedRegex": "^/matching\\-route/alpha(?:/)?$",
+      "page": "/matching-route/alpha",
+      "routeKeys": {},
+    },
+    {
+      "file": "_expo/functions/api/[dynamic]+api.js",
+      "namedRegex": "^/api/(?<dynamic>[^/]+?)(?:/)?$",
+      "page": "/api/[dynamic]",
+      "routeKeys": {
+        "dynamic": "dynamic",
+      },
+    },
+    {
+      "file": "_expo/functions/api/a/[...spread]+api.js",
+      "namedRegex": "^/api/a(?:/(?<spread>.+?))?(?:/)?$",
+      "page": "/api/a/[...spread]",
+      "routeKeys": {
+        "spread": "spread",
+      },
+    },
+  ],
+  "htmlRoutes": [
+    {
+      "file": "./index.tsx",
+      "namedRegex": "^/(?:/)?$",
+      "page": "/index",
+      "routeKeys": {},
+    },
+    {
+      "file": "./(alpha)/beta.tsx",
+      "namedRegex": "^(?:/\\(alpha\\))?/beta(?:/)?$",
+      "page": "/(alpha)/beta",
+      "routeKeys": {},
+    },
+    {
+      "file": "./(alpha)/index.tsx",
+      "namedRegex": "^(?:/\\(alpha\\))?(?:/)?$",
+      "page": "/(alpha)/index",
+      "routeKeys": {},
+    },
+    {
+      "file": "./(a,b)/multi-group.tsx",
+      "namedRegex": "^(?:/\\(b\\))?/multi\\-group(?:/)?$",
+      "page": "/(b)/multi-group",
+      "routeKeys": {},
+    },
+    {
+      "file": "./(a,b)/multi-group.tsx",
+      "namedRegex": "^(?:/\\(a\\))?/multi\\-group(?:/)?$",
+      "page": "/(a)/multi-group",
+      "routeKeys": {},
+    },
+    {
+      "file": "expo-router/build/views/Sitemap.js",
+      "generated": true,
+      "namedRegex": "^/_sitemap(?:/)?$",
+      "page": "/_sitemap",
+      "routeKeys": {},
+    },
+    {
+      "file": "./blog-ssg/abc.tsx",
+      "namedRegex": "^/blog\\-ssg/abc(?:/)?$",
+      "page": "/blog-ssg/abc",
+      "routeKeys": {},
+    },
+    {
+      "file": "./matching-route/alpha.tsx",
+      "namedRegex": "^/matching\\-route/alpha(?:/)?$",
+      "page": "/matching-route/alpha",
+      "routeKeys": {},
+    },
+    {
+      "file": "./blog/[post].tsx",
+      "namedRegex": "^/blog/(?<post>[^/]+?)(?:/)?$",
+      "page": "/blog/[post]",
+      "routeKeys": {
+        "post": "post",
+      },
+    },
+    {
+      "file": "./blog-ssg/[post].tsx",
+      "namedRegex": "^/blog\\-ssg/(?<post>[^/]+?)(?:/)?$",
+      "page": "/blog-ssg/[post]",
+      "routeKeys": {
+        "post": "post",
+      },
+    },
+  ],
+  "notFoundRoutes": [
+    {
+      "file": "./+not-found.tsx",
+      "namedRegex": "^(?:/(?<notfound>.+?))?(?:/)?$",
+      "page": "/+not-found",
+      "routeKeys": {
+        "notfound": "not-found",
+      },
+    },
+  ],
+}
+`;

--- a/packages/@expo/cli/e2e/__tests__/export/export-no-ssg.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-no-ssg.test.ts
@@ -71,4 +71,12 @@ describe('export-no-ssg', () => {
     expect(json.htmlRoutes).toEqual([]);
     expect(json.notFoundRoutes).toEqual([]);
   });
+
+  // Ensure the `/server/_expo/routes.json` contains the right file paths and named regexes.
+  // This test is created to avoid and detect regressions on Windows
+  it('has expected routes manifest entries', async () => {
+    expect(
+      await JsonFile.readAsync(path.join(outputDir, 'server/_expo/routes.json'))
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import JsonFile from '@expo/json-file';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -287,5 +288,13 @@ describe('server-output', () => {
     // Normal routes
     expect(files).toContain('server/index.html');
     expect(files).toContain('server/blog/[post].html');
+  });
+
+  // Ensure the `/server/_expo/routes.json` contains the right file paths and named regexes.
+  // This test is created to avoid and detect regressions on Windows
+  it('has expected routes manifest entries', async () => {
+    expect(
+      await JsonFile.readAsync(path.join(outputDir, 'server/_expo/routes.json'))
+    ).toMatchSnapshot();
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -173,8 +173,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       const artifactFilename =
         route.page === rscPath
           ? // HACK: Add RSC renderer to the output...
-            path.join(outputDir, '.' + rscPath + '.js')
-          : path.join(outputDir, path.relative(appDir, filepath.replace(/\.[tj]sx?$/, '.js')));
+            convertPathToModuleSpecifier(path.join(outputDir, '.' + rscPath + '.js'))
+          : convertPathToModuleSpecifier(
+              path.join(outputDir, path.relative(appDir, filepath.replace(/\.[tj]sx?$/, '.js')))
+            );
 
       if (contents) {
         let src = contents.src;


### PR DESCRIPTION
# Why

The exported `dist/server/_expo/routes.json` _**must**_ be identical when exporting it on macOS, Linux, or Windows. If it's not identical, it may cause incompatibility issues when building + running Expo projects on different system OSes.

# How

- Added 2 snapshots of the **routes.json** file when exporting projects with `apiRoutes`, `htmlRoutes`, and/or `notFoundRoutes`.
- Fixed the incorrect path modification without POSIX path conversion in API routes export in `MetroBundlerDevServer`

# Test Plan

- See added test in E2E CI
- Export an Expo project on Windows (`bun expo export -p web`), and host it on a different OS (`eas deploy`)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
