### PR TITLE
[core][Android] Fix `NoSuchElementException` thrown by compose views

### DIFF
--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -29,3 +29,7 @@
 -keepclassmembers class * {
   expo.modules.kotlin.viewevent.ViewEventDelegate *;
 }
+
+-keep class * implements expo.modules.kotlin.views.ComposeProps {
+  *;
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ComposeProps.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ComposeProps.kt
@@ -1,0 +1,7 @@
+package expo.modules.kotlin.views
+
+/**
+ * A marker interface for props classes that are used to pass data to Compose views.
+ * Needed for the R8 to not remove needed  signatures that are used to receive prop types.
+ */
+interface ComposeProps

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -12,11 +12,11 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 /**
  * A base class that should be used by compose views.
  */
-abstract class ExpoComposeView<T : Any>(
+abstract class ExpoComposeView<T : ComposeProps>(
   context: Context,
   appContext: AppContext
 ) : ExpoView(context, appContext) {
-  open val props: T? = null
+  open val props: ComposeProps? = null
 
   override val shouldUseAndroidLayout = true
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SingleChoiceSegmentedControlView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SingleChoiceSegmentedControlView.kt
@@ -12,11 +12,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.ComposeProps
 
 data class SegmentedControlProps(
   val options: MutableState<Array<String>> = mutableStateOf(emptyArray()),
   val selectedIndex: MutableState<Int?> = mutableStateOf(null)
-)
+) : ComposeProps
 
 class SingleChoiceSegmentedControlView(context: Context, appContext: AppContext) : ExpoComposeView<SegmentedControlProps>(context, appContext) {
   override val props = SegmentedControlProps()


### PR DESCRIPTION
# Why

Fixes `NoSuchElementException` thrown by compose views.

# How

Added a new interface to mark compose props object. A connected ProGuard rule ensures that all metadata is retained. We need method signatures to receive the props types, otherwise the app will crash at the start. 

# Test Plan

- building `bare-expo` in release mode ✅ 