### PR TITLE
[docs] Fix step output syntax with workflows

### DIFF
--- a/docs/pages/eas-workflows/variables.mdx
+++ b/docs/pages/eas-workflows/variables.mdx
@@ -32,7 +32,7 @@ jobs:
       # @info Accesses the <CODE>fingerprint_hash</CODE> variable #
       - name: Print fingerprint hash
         run: |
-          echo "Fingerprint hash: ${ steps.fingerprint_hash_step.outputs.fingerprint_hash }"
+          echo "Fingerprint hash: ${{ steps.fingerprint_hash_step.outputs.fingerprint_hash }}"
       # @end #
   existing_build:
     needs: [fingerprint]

--- a/docs/pages/eas-workflows/variables.mdx
+++ b/docs/pages/eas-workflows/variables.mdx
@@ -32,7 +32,7 @@ jobs:
       # @info Accesses the <CODE>fingerprint_hash</CODE> variable #
       - name: Print fingerprint hash
         run: |
-          echo "Fingerprint hash: ${ steps.fingerprint_hash_step.fingerprint_hash }"
+          echo "Fingerprint hash: ${ steps.fingerprint_hash_step.outputs.fingerprint_hash }"
       # @end #
   existing_build:
     needs: [fingerprint]


### PR DESCRIPTION
Why
---
Workflow jobs need to access `steps.step_name.outputs.variable_name`.

I think the customizable steps in build jobs used a different syntax, hence this mixup.

How
---
Added missing "outputs".

Test Plan
---
Tested the old and new syntax with my own workflow run.
