### PR TITLE
[contacts][docs] Fix Android permissions section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app:
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -124,7 +124,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -124,7 +124,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app:
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app:
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/contacts.mdx
@@ -122,7 +122,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/contacts.mdx
@@ -122,7 +122,9 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](../config/app/#permissions) array.
+### Android
+
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 

--- a/docs/pages/versions/v52.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/contacts.mdx
@@ -124,7 +124,7 @@ import * as Contacts from 'expo-contacts';
 
 ### Android
 
-This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app.
+This library automatically adds `READ_CONTACTS` and `WRITE_CONTACTS` permissions to your app:
 
 <AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback in [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1737123695433189). Currently the Permissions > Android section states that the `READ_CONTACTS` and `WRITE_CONTACTS` permissions are to be added manually. However, looking at the config plugin's code for the `expo-contacts` library, those permissions are already added. This can also be verified by creating a new project, running `npx expo prebuild`, and checking the permission tags in `AndroidManifest.xml`:

![CleanShot 2025-01-21 at 18 27 12@2x](https://github.com/user-attachments/assets/b1769d2a-f186-4d48-b122-20aa7709ee2f)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Verify that Android permissions (`READ_CONTACTS` and `WRITE_CONTACTS`) are already added by the config plugin of the `expo-contacts` library for [SDK 52](https://github.com/expo/expo/blob/sdk-52/packages/expo-contacts/plugin/src/withContacts.ts), [SDK-51](https://github.com/expo/expo/blob/sdk-51/packages/expo-contacts/plugin/src/withContacts.ts), [SDK-50](https://github.com/expo/expo/blob/sdk-50/packages/expo-contacts/plugin/src/withContacts.ts), and [unversioned](https://github.com/expo/expo/blob/main/packages/expo-contacts/plugin/src/withContacts.ts).
- Update the Permissions section for Expo Contacts API reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-01-21 at 18 23 40@2x](https://github.com/user-attachments/assets/a0b6c151-c4d2-4362-91bb-19d1bc3a2d57)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
