### PR TITLE
[docs] [ENG-14636] Update build/submit profile docs

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -57,6 +57,8 @@ Build profiles can be extended to other build profile properties using the `exte
 
 For example, in the `preview` profile you might have `"extends": "production"`. This will make the `preview` profile inherit the configuration of the `production` profile.
 
+You can keep chaining profile extensions up to the depth of 5 as long as you avoid making circular dependencies.
+
 ## Common use cases
 
 Developers using Expo tools usually end up having three different types of builds: **development**, **preview**, and **production**.

--- a/docs/pages/submit/eas-json.mdx
+++ b/docs/pages/submit/eas-json.mdx
@@ -78,7 +78,11 @@ You can also use EAS CLI to pick up another `submit` profile by specifying it wi
 
 ## Share configuration between `submit` profiles
 
-A `submit` profile can extend another profile using the `extends` key. For example, in the `preview` profile you may have `"extends": "production"`. This makes the `preview` profile inherit the configuration of the `production` profile.
+A `submit` profile can extend another profile using the `extends` key.
+
+For example, in the `preview` profile you may have `"extends": "production"`. This makes the `preview` profile inherit the configuration of the `production` profile.
+
+You can keep chaining profile extensions up to the depth of 5 as long as you avoid making circular dependencies.
 
 ## Next step
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14636/allow-longer-profile-extend-chains-in-easjson
https://github.com/expo/eas-cli/issues/2793
A user complained that the max profile extension chain length is different for build and submit profiles, and for neither the limit is mentioned in the docs
Companion to: https://github.com/expo/eas-cli/pull/2831

# How

Updated the maximal length of extension chain for submit profile to 5, which makes it the same as for build profiles.
Updated the docs regarding the max length of the profile extension chain.

# Test Plan

Tested manually

Build Profile
| Before | After |
| - | - |
| <img width="1104" alt="Screenshot 2025-01-21 at 14 51 35" src="https://github.com/user-attachments/assets/7a14f4b6-268c-4b39-aea0-7a2b0eff26ce" /> | <img width="1104" alt="Screenshot 2025-01-21 at 14 50 50" src="https://github.com/user-attachments/assets/6c784725-2874-4389-ad39-54da0fc399fe" /> |

Submit Profile
| Before | After |
| - | - |
| <img width="1104" alt="Screenshot 2025-01-21 at 14 51 46" src="https://github.com/user-attachments/assets/0b03326b-5e35-4bef-b2f7-239285c342b4" /> | <img width="1104" alt="Screenshot 2025-01-21 at 14 51 16" src="https://github.com/user-attachments/assets/2c7aa570-1299-40da-aa98-3f57f82f4590" /> |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
