### PR TITLE
feat(expo-linking): Add basic support for App Clips.

### DIFF
--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add basic support for App Clips.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add basic support for App Clips.
+- [iOS] Add basic support for App Clips. ([#34327](https://github.com/expo/expo/pull/34327) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -1,9 +1,33 @@
 import ExpoModulesCore
 
 public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
+  private static let isAppClip: Bool = {
+    // Having an NSAppClip key is not technically required but it's how App Clips are generated and
+    // there was no other clear indicator without knowing the child bundle identifier ahead of time.
+    if let infoPlist = Bundle.main.infoDictionary, let _ = infoPlist["NSAppClip"] as? [String: Any] {
+      return true
+    }
+    return false
+  }()
+  
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     ExpoLinkingRegistry.shared.initialURL = url
     NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
+    return false
+  }
+  
+  public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void) -> Bool {
+    // The URL can be nullish when launching App Clips from Test Flight without custom invocations set.
+    if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL {
+      
+      // App Clips don't appear to invoke application:open:options: so we'll use this first request to assume the initial URL.
+      if ExpoLinkingRegistry.shared.initialURL == nil && LinkingAppDelegateSubscriber.isAppClip {
+        ExpoLinkingRegistry.shared.initialURL = url
+      }
+      
+      NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
+      return true
+    }
     return false
   }
 }

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -4,27 +4,29 @@ public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   private static let isAppClip: Bool = {
     // Having an NSAppClip key is not technically required but it's how App Clips are generated and
     // there was no other clear indicator without knowing the child bundle identifier ahead of time.
-    if let infoPlist = Bundle.main.infoDictionary, let _ = infoPlist["NSAppClip"] as? [String: Any] {
+    if let infoPlist = Bundle.main.infoDictionary, infoPlist["NSAppClip"] != nil {
       return true
     }
     return false
   }()
-  
+
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     ExpoLinkingRegistry.shared.initialURL = url
     NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
     return false
   }
-  
-  public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void) -> Bool {
+
+  public func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
     // The URL can be nullish when launching App Clips from Test Flight without custom invocations set.
     if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL {
-      
       // App Clips don't appear to invoke application:open:options: so we'll use this first request to assume the initial URL.
       if ExpoLinkingRegistry.shared.initialURL == nil && LinkingAppDelegateSubscriber.isAppClip {
         ExpoLinkingRegistry.shared.initialURL = url
       }
-      
       NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
       return true
     }


### PR DESCRIPTION
# Why

- I needed this for a side-project (https://pillarvalley.expo.app)
- App Clips are weird in how they handle deep links. The don't call the open: function so we need to use the continue user activity function. This could lead to a weird edge case where the app clip was launched without a URL (maybe an advanced invocation) then later visited with a URL, which would be treated as the initial URL at that point.

# How

- Implement the missing expo-linking AppDelegate function which we need regardless as it is invoked for subsequent URL changes and NSUserActivities.
- Add a simple check for if running in an app clip.
- Add the nullish URL check that can cause fatal RN crashes. I've upstreamed this change to RN already.

# Test Plan

- Run in an App Clip with `_XCAppClipURL` env var set in the Xcode configuration for the build. The URL cannot be the Apple default `https://appclip.apple.com/id?p=com.evanbacon.pillarvalley.clip` as this will trigger a crash due to some bug in Xcode.