### PR TITLE
[expo-ui][ncl] Use separate screens for each component

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -11,6 +11,7 @@ import { Layout } from '../constants';
 import { CameraScreens } from '../screens/Camera/CameraScreen';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
 import { ImageScreens } from '../screens/Image/ImageScreen';
+import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
 import { ScreenConfig } from '../types/ScreenConfig';
 
@@ -378,7 +379,7 @@ export const Screens: ScreenConfig[] = [
   },
   {
     getComponent() {
-      return optionalRequire(() => require('../screens/UIScreen'));
+      return optionalRequire(() => require('../screens/UI/UIScreen'));
     },
     name: 'Expo UI',
   },
@@ -434,6 +435,7 @@ export const Screens: ScreenConfig[] = [
   ...CameraScreens,
   ...ImageScreens,
   ...VideoScreens,
+  ...UIScreens,
 ];
 
 function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {

--- a/apps/native-component-list/src/screens/UI/SingleChoiceSegmentedControlViewScreen.tsx
+++ b/apps/native-component-list/src/screens/UI/SingleChoiceSegmentedControlViewScreen.tsx
@@ -2,9 +2,9 @@ import { SingleChoiceSegmentedControlView } from 'expo-ui';
 import * as React from 'react';
 import { Platform, Text } from 'react-native';
 
-import { Page, Section } from '../components/Page';
+import { Page, Section } from '../../components/Page';
 
-export default function UIScreen() {
+export default function SingleChoiceSegmentedControlViewScreen() {
   const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null);
   return (
     <Page>
@@ -30,6 +30,6 @@ export default function UIScreen() {
   );
 }
 
-UIScreen.navigationOptions = {
-  title: 'Expo UI',
+SingleChoiceSegmentedControlViewScreen.navigationOptions = {
+  title: 'SingleChoiceSegmentedControlViewScreen',
 };

--- a/apps/native-component-list/src/screens/UI/SingleChoiceSegmentedControlViewScreen.tsx
+++ b/apps/native-component-list/src/screens/UI/SingleChoiceSegmentedControlViewScreen.tsx
@@ -1,4 +1,4 @@
-import { SingleChoiceSegmentedControlView } from 'expo-ui';
+import { SingleChoiceSegmentedControlView } from '@expo/ui';
 import * as React from 'react';
 import { Platform, Text } from 'react-native';
 

--- a/apps/native-component-list/src/screens/UI/UIScreen.tsx
+++ b/apps/native-component-list/src/screens/UI/UIScreen.tsx
@@ -1,0 +1,28 @@
+import { optionalRequire } from '../../navigation/routeBuilder';
+import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+
+export const UIScreens = [
+  {
+    name: 'SingleChoiceSegmentedControlView',
+    route: 'ui/single-choice-segmented-control-view',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./SingleChoiceSegmentedControlViewScreen'));
+    },
+  },
+];
+
+export default function UIScreen() {
+  const apis: ListElement[] = UIScreens.map((screen) => {
+    return {
+      name: screen.name,
+      isAvailable: true,
+      route: `/components/${screen.route}`,
+    };
+  });
+  return <ComponentListScreen apis={apis} sort={false} />;
+}
+
+UIScreen.navigationOptions = {
+  title: 'Expo UI',
+};


### PR DESCRIPTION
# Why

We will have a bunch of components, we should separate each one into a different screen.

# How

Create a screen with a list of components/features, like for `expo-image` and `expo-video`

# Test Plan

Tested in BareExpo on Android and iOS