### PR TITLE
[document-picker] allow override of kv-store-identifier entitlement

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -63,7 +63,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     {
       name: 'kvStoreIdentifier',
       platorm: 'ios',
-      description: 
+      description:
         'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
       default: 'undefined',
     },

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -60,6 +60,11 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
         'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
+    {
+      name: 'kvStoreIdentifier',
+      platorm: 'ios',
+      description: 'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
+    }
   ]}
 />
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -63,8 +63,10 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     {
       name: 'kvStoreIdentifier',
       platorm: 'ios',
-      description: 'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
-    }
+      description: 
+        'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
+      default: 'undefined',
+    },
   ]}
 />
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Allow setting of the `com.apple.developer.ubiquity-kvstore-identifier` entitlement directly. ([#34338](https://github.com/expo/expo/pull/34338) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
@@ -8,6 +8,12 @@ export type IosProps = {
      * Available options: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment
      */
     iCloudContainerEnvironment?: 'Development' | 'Production';
+    /**
+     * By default, the `com.apple.developer.ubiquity-kvstore-identifier` entitlement is set to a concatenation
+     * of your Apple Team ID and the bundle identifier. However, this entitlement may need to reflect a previous Team ID if your
+     * app was transferred from another team. Use this option to set this entitlement value manually.
+     */
+    kvStoreIdentifier?: string;
 };
 export declare const withDocumentPickerIOS: ConfigPlugin<IosProps>;
-export declare function setICloudEntitlements(config: Pick<ExpoConfig, 'ios'>, { iCloudContainerEnvironment }: IosProps, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>): Record<string, any>;
+export declare function setICloudEntitlements(config: Pick<ExpoConfig, 'ios'>, { iCloudContainerEnvironment, kvStoreIdentifier }: IosProps, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>): Record<string, any>;

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
@@ -2,14 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setICloudEntitlements = exports.withDocumentPickerIOS = void 0;
 const config_plugins_1 = require("expo/config-plugins");
-const withDocumentPickerIOS = (config, { iCloudContainerEnvironment } = {}) => {
+const withDocumentPickerIOS = (config, { iCloudContainerEnvironment, kvStoreIdentifier } = {}) => {
     return (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
-        config.modResults = setICloudEntitlements(config, { iCloudContainerEnvironment }, config.modResults);
+        config.modResults = setICloudEntitlements(config, { iCloudContainerEnvironment, kvStoreIdentifier }, config.modResults);
         return config;
     });
 };
 exports.withDocumentPickerIOS = withDocumentPickerIOS;
-function setICloudEntitlements(config, { iCloudContainerEnvironment }, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }) {
+function setICloudEntitlements(config, { iCloudContainerEnvironment, kvStoreIdentifier }, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }) {
     if (config.ios?.usesIcloudStorage) {
         // Used for AdHoc iOS builds: https://github.com/expo/eas-cli/issues/693
         // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment
@@ -21,7 +21,7 @@ function setICloudEntitlements(config, { iCloudContainerEnvironment }, { 'com.ap
             `iCloud.${config.ios.bundleIdentifier}`,
         ];
         entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-            `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
+            kvStoreIdentifier || `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
         entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
     }
     return entitlements;

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
@@ -21,4 +21,20 @@ describe(setICloudEntitlements, () => {
       'com.apple.developer.ubiquity-kvstore-identifier': '$(TeamIdentifierPrefix)com.bacon.foobar',
     });
   });
+
+  it(`Overrides com.apple.developer.ubiquity-kvstore-identifier when kvStoreIdentifier is set`, () => {
+    expect(
+      setICloudEntitlements(
+        { ios: { usesIcloudStorage: true, bundleIdentifier: 'com.bacon.foobar' } },
+        { iCloudContainerEnvironment: 'Production', kvstoreIdentifier: 'ABC123.com.bacon.foobar' },
+        {}
+      )
+    ).toStrictEqual({
+      'com.apple.developer.icloud-container-environment': 'Production',
+      'com.apple.developer.icloud-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.icloud-services': ['CloudDocuments'],
+      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.ubiquity-kvstore-identifier': 'ABC123.com.bacon.foobar',
+    });
+  });
 });

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
@@ -26,7 +26,7 @@ describe(setICloudEntitlements, () => {
     expect(
       setICloudEntitlements(
         { ios: { usesIcloudStorage: true, bundleIdentifier: 'com.bacon.foobar' } },
-        { iCloudContainerEnvironment: 'Production', kvstoreIdentifier: 'ABC123.com.bacon.foobar' },
+        { iCloudContainerEnvironment: 'Production', kvStoreIdentifier: 'ABC123.com.bacon.foobar' },
         {}
       )
     ).toStrictEqual({

--- a/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
@@ -14,17 +14,17 @@ export type IosProps = {
    * of your Apple Team ID and the bundle identifier. However, this entitlement may need to reflect a previous Team ID if your
    * app was transferred from another team. Use this option to set this entitlement value manually.
    */
-  kvstoreIdentifier?: string;
+  kvStoreIdentifier?: string;
 };
 
 export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
   config,
-  { iCloudContainerEnvironment, kvstoreIdentifier } = {}
+  { iCloudContainerEnvironment, kvStoreIdentifier } = {}
 ) => {
   return withEntitlementsPlist(config, (config) => {
     config.modResults = setICloudEntitlements(
       config,
-      { iCloudContainerEnvironment, kvstoreIdentifier },
+      { iCloudContainerEnvironment, kvStoreIdentifier },
       config.modResults
     );
     return config;
@@ -33,7 +33,7 @@ export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
 
 export function setICloudEntitlements(
   config: Pick<ExpoConfig, 'ios'>,
-  { iCloudContainerEnvironment, kvstoreIdentifier }: IosProps,
+  { iCloudContainerEnvironment, kvStoreIdentifier }: IosProps,
   { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>
 ): Record<string, any> {
   if (config.ios?.usesIcloudStorage) {
@@ -48,7 +48,7 @@ export function setICloudEntitlements(
       `iCloud.${config.ios.bundleIdentifier}`,
     ];
     entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-      kvstoreIdentifier || `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
+      kvStoreIdentifier || `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
 
     entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
   }

--- a/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
@@ -9,16 +9,22 @@ export type IosProps = {
    * Available options: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment
    */
   iCloudContainerEnvironment?: 'Development' | 'Production';
+  /**
+   * By default, the `com.apple.developer.ubiquity-kvstore-identifier` entitlement is set to a concatenation
+   * of your Apple Team ID and the bundle identifier. However, this entitlement may need to reflect a previous Team ID if your
+   * app was transferred from another team. Use this option to set this entitlement value manually.
+   */
+  kvstoreIdentifier?: string;
 };
 
 export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
   config,
-  { iCloudContainerEnvironment } = {}
+  { iCloudContainerEnvironment, kvstoreIdentifier } = {}
 ) => {
   return withEntitlementsPlist(config, (config) => {
     config.modResults = setICloudEntitlements(
       config,
-      { iCloudContainerEnvironment },
+      { iCloudContainerEnvironment, kvstoreIdentifier },
       config.modResults
     );
     return config;
@@ -27,7 +33,7 @@ export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
 
 export function setICloudEntitlements(
   config: Pick<ExpoConfig, 'ios'>,
-  { iCloudContainerEnvironment }: IosProps,
+  { iCloudContainerEnvironment, kvstoreIdentifier }: IosProps,
   { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>
 ): Record<string, any> {
   if (config.ios?.usesIcloudStorage) {
@@ -42,7 +48,7 @@ export function setICloudEntitlements(
       `iCloud.${config.ios.bundleIdentifier}`,
     ];
     entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-      `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
+      kvstoreIdentifier || `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
 
     entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
   }


### PR DESCRIPTION
# Why
`expo-document-picker` plugin, when using iCloudStorage, sets some related entitlements based on Apple Team ID and bundle identifier. However, if your app was transferred to another team, your Team ID will change (of course), but `com.apple.developer.ubiquity-kvstore-identifier` will retain the old Team ID. This change allows this entitlement to be set directly.

Creating an actual scenario that would lead you to need to do this quite tricky, but multiple users have reached out about this and have successfully worked around it by patching the plugin, so this seems like a thing!

# How

Added an optional `kvStoreIdentifier` prop to fully-override this entitlement.

# Test Plan

- [x] try config plugin with and without extra prop

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
