### PR TITLE
[docs][custom-tabs] Missing default export in layout

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -28,7 +28,7 @@ A bare minimum structure of a custom tab layout would consist of a `TabList` (co
 import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';
 
 // Defining the layout of the custom tab navigator
-export function Layout() {
+export default function Layout() {
   return (
     <Tabs>
       <TabSlot />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The basic example of custom tabs is lacking a `default` export in the Layout.

https://docs.expo.dev/router/advanced/custom-tabs/#anatomy-of-custom-tabs-components

![image](https://github.com/user-attachments/assets/72df7e4e-f285-49a8-a438-ec775417ef02)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the docs and made the export default
![image](https://github.com/user-attachments/assets/7dd28815-088c-458b-b9c6-5f5653c38fc1)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
