### PR TITLE
[dev-launcher][iOS] Read EAS project id and url from manifest instead of updates interface

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed black stuck screen when loading an unreachable server from last opened url. ([#34067](https://github.com/expo/expo/pull/34067) by [@kudo](https://github.com/kudo))
+- [iOS] Read EAS project id and url from manifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/DevLauncherInternal.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherInternal.swift
@@ -20,7 +20,7 @@ public class DevLauncherInternal: Module, EXDevLauncherPendingDeepLinkListener {
         "clientUrlScheme": findClientUrlScheme,
         "installationID": EXDevLauncherController.sharedInstance().installationIDHelper().getOrCreateInstallationID(),
         "isDevice": isDevice,
-        "updatesConfig": EXDevLauncherController.sharedInstance().getUpdatesConfig()
+        "updatesConfig": EXDevLauncherController.sharedInstance().getUpdatesConfig(appContext?.constants?.constants())
       ]
     }
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)copyToClipboard:(NSString *)content;
 
-- (NSDictionary *)getUpdatesConfig;
+- (NSDictionary *)getUpdatesConfig: (nullable NSDictionary *) constants;
 
 @end
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -775,7 +775,7 @@
   manager.currentManifestURL = nil;
 }
 
--(NSDictionary *)getUpdatesConfig
+-(NSDictionary *)getUpdatesConfig: (nullable NSDictionary *) constants
 {
   NSMutableDictionary *updatesConfig = [NSMutableDictionary new];
 
@@ -784,19 +784,19 @@
     runtimeVersion = _updatesInterface.runtimeVersion ?: @"";
   }
 
-  // url structure for EASUpdates: `http://u.expo.dev/{appId}`
-  // this url field is added to app.json.updates when running `eas update:configure`
+  // the project url field is added to app.json.updates when running `eas update:configure`
   // the `u.expo.dev` determines that it is the modern manifest protocol
   NSString *projectUrl = @"";
   if (_updatesInterface) {
-    projectUrl = [_updatesInterface.updateURL absoluteString] ?: @"";
+    projectUrl = [constants valueForKeyPath:@"manifest.updates.url"];
   }
 
   NSURL *url = [NSURL URLWithString:projectUrl];
-  NSString *appId = [[url pathComponents] lastObject];
 
   BOOL isModernManifestProtocol = [[url host] isEqualToString:@"u.expo.dev"] || [[url host] isEqualToString:@"staging-u.expo.dev"];
   BOOL expoUpdatesInstalled = EXDevLauncherController.sharedInstance.updatesInterface != nil;
+
+  NSString *appId = [constants valueForKeyPath:@"manifest.extra.eas.projectId"] ?: @"";
   BOOL hasAppId = appId.length > 0;
 
   BOOL usesEASUpdates = isModernManifestProtocol && expoUpdatesInstalled && hasAppId;


### PR DESCRIPTION
# Why

Closes ENG-14761

# How

Instead of reading `appId` and `projectUrl` from the expo updates interface, we should use the values from the embedded manifest,  as the interface values are updated each time a user launches an update

# Test Plan

Run dev-launcher locally through fabric-tester 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
