### PR TITLE
Ignore @expo/ui from expo-go

### DIFF
--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -70,6 +70,6 @@ useExpoModules([
         'expo-maps',
         'expo-network-addons',
         'expo-splash-screen',
-        'expo-ui'
+        '@expo/ui'
     ]
 ])


### PR DESCRIPTION
# Why

Expo Go is on Kotlin 1.9 and this breaks spotless – we need to fix this, but in the meantime let's fix the package name in exclude list.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
