### PR TITLE
[docs] Use .yml for file extensions

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -75,18 +75,18 @@ This is what the UI of the app created from the default Expo template looks like
 
 Let's create two simple Maestro flows for the example app. Start by creating a directory called **maestro** in the root of your project directory. This directory will contain the flows that you will configure and should be at the same level as **eas.json**.
 
-Inside, create a new file called **home.yaml**. This flow will launch the app and assert that the text "Welcome!" is visible on the home screen.
+Inside, create a new file called **home.yml**. This flow will launch the app and assert that the text "Welcome!" is visible on the home screen.
 
-```yaml maestro/home.yaml
+```yaml maestro/home.yml
 appId: dev.expo.eastestsexample # This is an example app id. Replace it with your app id.
 ---
 - launchApp
 - assertVisible: 'Welcome!'
 ```
 
-Next, create a new flow called **expand_test.yaml**. This flow will open the "Explore" screen in the example app, click on the "File-based routing" collapsible, and assert that the text "This app has two screens" is visible on the screen.
+Next, create a new flow called **expand_test.yml**. This flow will open the "Explore" screen in the example app, click on the "File-based routing" collapsible, and assert that the text "This app has two screens" is visible on the screen.
 
-```yaml maestro/expand_test.yaml
+```yaml maestro/expand_test.yml
 appId: dev.expo.eastestsexample # This is an example app id. Replace it with your app id.
 ---
 - launchApp
@@ -104,11 +104,9 @@ To run Maestro tests locally, install the Maestro CLI by following the instructi
 
 [Install your app on a local Android Emulator or iOS Simulator](/more/expo-cli/#compiling). Open a terminal, navigate to the Maestro directory, and run the following commands to start the tests with the Maestro CLI:
 
-<Terminal
-  cmd={['$ maestro test maestro/expand_test.yaml', '', '$ maestro test maestro/home.yaml']}
-/>
+<Terminal cmd={['$ maestro test maestro/expand_test.yml', '', '$ maestro test maestro/home.yml']} />
 
-The video below shows a successful run of the **maestro/expand_test.yaml** flow:
+The video below shows a successful run of the **maestro/expand_test.yml** flow:
 
 <ContentSpotlight file="guides/local-e2e.mp4" />
 
@@ -131,8 +129,8 @@ build:
     - eas/maestro_test:
         inputs:
           flow_path: |
-            maestro/home.yaml
-            maestro/expand_test.yaml
+            maestro/home.yml
+            maestro/expand_test.yml
 ```
 
 Now modify the **eas.json** by adding a new [build profile](/build/eas-json/#build-profiles) called `build-and-maestro-test`. It will be used to run the custom build config from the **build-and-maestro-test.yml** file. This configuration will build the emulator/simulator version of your app and run the Maestro tests on it.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -755,9 +755,9 @@ build:
     - eas/maestro_test:
         inputs:
           flow_path: |
-            maestro/sign_in.yaml
-            maestro/create_post.yaml
-            maestro/sign_out.yaml
+            maestro/sign_in.yml
+            maestro/create_post.yml
+            maestro/sign_out.yml
     # @end #
 ```
 
@@ -771,9 +771,9 @@ build:
         app_path: ./fixtures/my_app.app
         inputs:
           flow_path: |
-            maestro/sign_in.yaml
-            maestro/create_post.yaml
-            maestro/sign_out.yaml
+            maestro/sign_in.yml
+            maestro/create_post.yml
+            maestro/sign_out.yml
     # @end #
 ```
 
@@ -787,9 +787,9 @@ build:
         app_path: ./fixtures/my_app.apk
         inputs:
           flow_path: |
-            maestro/sign_in.yaml
-            maestro/create_post.yaml
-            maestro/sign_out.yaml
+            maestro/sign_in.yml
+            maestro/create_post.yml
+            maestro/sign_out.yml
     # @end #
 ```
 
@@ -841,7 +841,7 @@ build:
           fi
     - run:
         command: |
-          maestro test maestro/flow.yaml
+          maestro test maestro/flow.yml
     - eas/upload_artifact:
         name: Upload test artifact
         if: ${ always() }
@@ -884,7 +884,7 @@ steps:
         fi
   - run:
       command: |
-        maestro test maestro/flow.yaml
+        maestro test maestro/flow.yml
   - eas/upload_artifact:
       name: Upload test artifact
       if: ${ always() }

--- a/docs/pages/eas-workflows/control-flow.mdx
+++ b/docs/pages/eas-workflows/control-flow.mdx
@@ -9,7 +9,7 @@ You can control the flow of your workflows with conditions that run certain jobs
 
 You can add a list of previous job names using the `needs` keyword on a job. If any job from that list fails, the current job will be failed, and if any job from the list is skipped, the current job will be skipped as well.
 
-```yaml .eas/workflows/prerequisite.yaml
+```yaml .eas/workflows/prerequisite.yml
 jobs:
   build:
     type: build
@@ -23,14 +23,14 @@ jobs:
     type: maestro
     params:
       build_id: ${{ jobs.build.outputs.build_id }}
-      flow_path: ['./e2e/flow.yaml']
+      flow_path: ['./e2e/flow.yml']
 ```
 
 ## `after`
 
 You can add a list of previous job names using the `after` keyword on a job. Any job in the list will run after the current job completes, no matter if it succeeded or failed.
 
-```yaml .eas/workflows/after.yaml
+```yaml .eas/workflows/after.yml
 jobs:
   build:
     type: build
@@ -50,7 +50,7 @@ jobs:
 
 You can add a condition to a job with the `if` keyword. If the condition evaluates to `true`, the job will run. Otherwise, it will be skipped.
 
-```yaml .eas/workflows/conditional.yaml
+```yaml .eas/workflows/conditional.yml
 on:
 	push: {} # runs on all branches
 

--- a/docs/pages/eas-workflows/get-started.mdx
+++ b/docs/pages/eas-workflows/get-started.mdx
@@ -46,7 +46,7 @@ Finally, link the project you have locally with EAS:
   <Terminal cmd={['$ npx eas-cli@latest init']} />
 </Collapsible>
 
-Then, create a directory named **.eas/workflows** at the root of your project with a **.yaml** file inside of it. For example: **.eas/workflows/hello-world.yaml**.
+Then, create a directory named **.eas/workflows** at the root of your project with a YAML file inside of it. For example: **.eas/workflows/hello-world.yml**.
 
 ## Write a workflow
 
@@ -58,7 +58,7 @@ Each workflow consists of three top-level elements:
 
 Here's an example of a workflow that prints "Hello, world":
 
-```yaml .eas/workflows/hello-world.yaml
+```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
 on:
@@ -73,7 +73,7 @@ jobs:
 
 Here's another example that creates and submits an iOS build of a project on every push to every branch. This is similar to running `eas build --platform ios --profile production --auto-submit`:
 
-```yaml .eas/workflows/ios-build-and-submit.yaml
+```yaml .eas/workflows/ios-build-and-submit.yml
 name: Release iOS app
 
 on:
@@ -106,7 +106,7 @@ Once you have a workflow file and your project is connected to Expo's GitHub app
 
 Alternatively, you can trigger a workflow manually by running the following command:
 
-<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/<your-workflow-file>.yaml']} />
+<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/<your-workflow-file>.yml']} />
 
 Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
 

--- a/docs/pages/eas-workflows/jobs.mdx
+++ b/docs/pages/eas-workflows/jobs.mdx
@@ -13,7 +13,7 @@ Custom jobs are jobs that you write yourself. They are useful for any use case n
 
 This is a pre-packaged job that creates a build from a project:
 
-```yaml .eas/workflows/build.yaml
+```yaml .eas/workflows/build.yml
 jobs:
   build:
     type: build
@@ -31,7 +31,7 @@ This job outputs the following variables:
 
 This is a pre-packaged job that submits a build to an app store. Given a `build_id`, we'll choose the correct automation to submit the build to the correct store.
 
-```yaml .eas/workflows/submit.yaml
+```yaml .eas/workflows/submit.yml
 jobs:
   submit:
     type: submit
@@ -49,7 +49,7 @@ This job outputs the following variables:
 
 This is a pre-packaged job that publishes an update. If starting workflows via `eas workflow:run`, a hard coded branch name will be required. We recommending using `branch: ${{ github.ref_name || 'your-branch-name' }}` if you start workflows locally and via GitHub events.
 
-```yaml .eas/workflows/update.yaml
+```yaml .eas/workflows/update.yml
 jobs:
   update:
     type: update
@@ -64,7 +64,7 @@ jobs:
 
 This is a pre-packaged job that runs end-to-end tests with Maestro. Given a `build_id`, we'll choose the correct machine to run the tests on the correct platform.
 
-```yaml .eas/workflows/e2e-test.yaml
+```yaml .eas/workflows/e2e-test.yml
 jobs:
   e2e-test:
     type: maestro
@@ -77,7 +77,7 @@ jobs:
 
 Custom jobs are jobs that you write yourself. They are useful for any use case that isn't met by the pre-packaged jobs.
 
-```yaml .eas/workflows/custom-job.yaml
+```yaml .eas/workflows/custom-job.yml
 jobs:
   custom-job:
     type: custom # default: undefined
@@ -88,7 +88,7 @@ jobs:
 
 Within custom jobs, you can use our [built-in functions](/custom-builds/schema/#built-in-eas-functions), like `eas/checkout`, `eas/use_npm_token` to interact with the project. These need to be prefixed with the `uses:` keyword.
 
-```yaml .eas/workflows/custom-job.yaml
+```yaml .eas/workflows/custom-job.yml
 jobs:
   custom-job:
     type: custom

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -9,7 +9,7 @@ Triggers define when a workflow should kick off. When its conditions are met, th
 
 You can trigger a workflow on a push to a GitHub branch with the `push` trigger.
 
-```yaml .eas/workflows/hello-world.yaml
+```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
 on:
@@ -27,7 +27,7 @@ jobs:
 
 You can trigger a workflow on a pull request with the `pull_request` trigger.
 
-```yaml .eas/workflows/hello-world.yaml
+```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
 on:
@@ -44,7 +44,7 @@ jobs:
 
 EAS Workflows also support triggering on all branches, on both push and pull request events:
 
-```yaml .eas/workflows/hello-world.yaml
+```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
 on:

--- a/docs/pages/eas-workflows/variables.mdx
+++ b/docs/pages/eas-workflows/variables.mdx
@@ -8,7 +8,7 @@ Variables can be used in workflows to pass data between jobs or steps. They are 
 
 You can set variables in the workflow file with the `set-output` function:
 
-```yaml .eas/workflows/variables.yaml
+```yaml .eas/workflows/variables.yml
 jobs:
   fingerprint:
     outputs:


### PR DESCRIPTION
# Why

There's some inconsistency when documenting YAML files in our docs with both `.yaml` and `.yml` currently in use.

# How

Adopt the following convention:
- `.yml` for file extensions
- YAML when referring to the language or syntax

# Test Plan

Verify the docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
