### PR TITLE
[tools][docs] Update Volta config to use correct node versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -146,5 +146,8 @@
       "tailwindcss": {},
       "autoprefixer": {}
     }
+  },
+  "volta": {
+    "node": "22.13.1"
   }
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -101,5 +101,8 @@
     "prettier": "^3.3.3",
     "taskr": "1.1.0",
     "typescript": "^5.6.3"
+  },
+  "volta": {
+    "node": "22.13.1"
   }
 }


### PR DESCRIPTION
# Why

Root of expo/expo is set to use node@20, but tools/docs are tested against 22 and some things (like `gdad`) outright don't work in 20. Setting the version in Volta config in package.json isn't a full solution, since you still have to run commands from the tools folder in order for it to use the correct version, but at least means you won't stick on the wrong version when you're in that directly, so it's a stopgap until the node version is updated everywhere.

# How

Added volta config to package.json files. It would be fine to pin to ^22.0.0, but Volta demands a specific version in this config.

# Test Plan

Make sure node@22 is used when going to tools/docs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
