### PR TITLE
[docs] Fix Cognito logout function

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -681,17 +681,33 @@ export default function App() {
   }, [discoveryDocument, request, response]);
 
   const logout = async () => {
-    const revokeResponse = await revokeAsync(
-      {
-        clientId: clientId,
-        token: authTokens.refreshToken,
-      },
-      discoveryDocument
-    );
-    if (revokeResponse) {
-      setAuthTokens(null);
+    if (!authTokens?.refreshToken || !discoveryDocument || !config.clientId) {
+      return;
     }
-  };
+    try {
+      const urlParams = new URLSearchParams({
+        client_id: config.clientId || '',
+        logout_uri: redirectUri,
+      });
+      // Open the logout page in the browser
+      await WebBrowser.openAuthSessionAsync(`${config.webBaseUrl}/logout?${urlParams.toString()}`);
+      // Revoke the refresh token
+      const revokeResponse = await revokeAsync(
+        {
+          clientId: config.clientId || '',
+          token: authTokens?.refreshToken,
+        },
+        discoveryDocument
+      );
+      if (revokeResponse) {
+        setAuthTokens(undefined);
+      }
+    } catch (error) {
+      // Log the error but don't throw it since we want to continue with clearing tokens
+      console.error('Error during token revocation:', error);
+    }
+  }
+  
   console.log('authTokens: ' + JSON.stringify(authTokens));
   return authTokens ? (
     <Button title="Logout" onPress={() => logout()} />


### PR DESCRIPTION
# Why

The current logout implementation is just revoking the refresh token. The auth session through the WebBrowser is still active and the logout has no impact on it. If you invoke logout / login just after it will automatically call the callback URI with the auth session in response.

# How

Looking at the Cognito docs we need to call a `/logout` endpoint to clear correctly the web session.
https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html

# Test Plan

- Invoke the `login` function
- Login through the Cognito form
- Once redirected, invoke again the `login` function to verify the session is really active on the web
- Invoke the `logout` function
- Invoke one more time the `login` function
- The web auth session has been cleared and you should land on the sign-in form

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
