### PR TITLE
refactor(cli): setup React Native Dev Tools on localhost instead of LAN ip

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Add `EAI_AGAIN` DNS service errors to offline detection. ([#34014](https://github.com/expo/expo/pull/34014) by [@byCedric](https://github.com/byCedric))
 - Fix `static` and `server` projects not starting up correctly when project path contains URI-unsafe characters like spaces. ([#34289](https://github.com/expo/expo/pull/34289) by [@kitten](https://github.com/kitten))
 - Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
+- Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -17,7 +17,9 @@ export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
 
   const { middleware, websocketEndpoints } = createDevMiddleware({
     projectRoot: metroBundler.projectRoot,
-    serverBaseUrl: metroBundler.getUrlCreator().constructUrl({ scheme: 'http', hostType: 'lan' }),
+    serverBaseUrl: metroBundler
+      .getUrlCreator()
+      .constructUrl({ scheme: 'http', hostType: 'localhost' }),
     logger: createLogger(chalk.bold('Debug:')),
     unstable_customInspectorMessageHandler: createHandlersFactory(),
     unstable_experiments: {


### PR DESCRIPTION
# Why

Fixes #33833

Right now, React Native DevTools is a forked Chrome DevTools maintained by Meta and shipped as package within `@react-native/dev-middleware`. This means React Native DevTools is both versioned per Expo SDK/React Native version, as well as hosted locally from the development machine itself.

Previously, we always bind this debugging infrastructure to the LAN IP of the development machine. Unfortunately, this doesn't always work, especially on restricted corporate networks where every individual machine connected to the network can't be accessed, even from the same development machine.

# How

This changes the debugging infrastructure to always bind to localhost. Note that this does not affect `expo start`, which will still bind to any IP including LAN by default to allow opening the project on LAN-connected Expo Go or dev clients.

# Test Plan

- `bun create expo ./test-debugging`
- `cd ./test-debuggin`
- `bun expo start`
- `curl http://localhost:8081/json/list | jq` should show websocket connections coneccting to `..://localhost:8081/...`.
- Press `j` in terminal should open React Native DevTools, even on restricted networks/offline

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
