### PR TITLE
[core][Android] Fix `AppContext` is lost in nested converters

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fixes `AppContext` is lost in nested converters.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fixes `AppContext` is lost in nested converters.
+- [Android] Fixes `AppContext` is lost in nested converters. ([#34373](https://github.com/expo/expo/pull/34373) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.records
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.allocators.ObjectConstructor
 import expo.modules.kotlin.allocators.ObjectConstructorFactory
 import expo.modules.kotlin.exception.FieldCastException
@@ -45,14 +46,15 @@ class RecordTypeConverter<T : Record>(
       .toMap()
   }
 
-  override fun convertFromDynamic(value: Dynamic): T = exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
-    val jsMap = value.asMap()
-    return convertFromReadableMap(jsMap)
-  }
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): T =
+    exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
+      val jsMap = value.asMap()
+      return convertFromReadableMap(jsMap, context)
+    }
 
-  override fun convertFromAny(value: Any): T {
+  override fun convertFromAny(value: Any, context: AppContext?): T {
     if (value is ReadableMap) {
-      return convertFromReadableMap(value)
+      return convertFromReadableMap(value, context)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -63,7 +65,7 @@ class RecordTypeConverter<T : Record>(
 
   override fun isTrivial(): Boolean = false
 
-  private fun convertFromReadableMap(jsMap: ReadableMap): T {
+  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?): T {
     val kClass = type.classifier as KClass<*>
     val instance = getObjectConstructor(kClass).construct()
 
@@ -83,7 +85,7 @@ class RecordTypeConverter<T : Record>(
           val javaField = property.javaField!!
 
           val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, type, cause) }) {
-            descriptor.typeConverter.convert(this)
+            descriptor.typeConverter.convert(this, context)
           }
 
           if (casted != null) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
@@ -12,7 +13,7 @@ import expo.modules.kotlin.jni.ExpectedType
  * In that way, we produce the same output for JSI and bridge implementation.
  */
 class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): Any {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Any {
     return when (value.type) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
@@ -23,7 +24,7 @@ class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(is
     }
   }
 
-  override fun convertFromAny(value: Any): Any = value
+  override fun convertFromAny(value: Any, context: AppContext?): Any = value
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
@@ -18,7 +19,7 @@ class ArrayTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic): Array<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Array<*> {
     val jsArray = value.asArray()
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
@@ -28,14 +29,14 @@ class ArrayTypeConverter(
           exceptionDecorator({ cause ->
             CollectionElementCastException(arrayType, arrayType.arguments.first().type!!, type, cause)
           }) {
-            arrayElementConverter.convert(this)
+            arrayElementConverter.convert(this, context)
           }
         }
     }
     return array
   }
 
-  override fun convertFromAny(value: Any): Array<*> {
+  override fun convertFromAny(value: Any, context: AppContext?): Array<*> {
     return if (arrayElementConverter.isTrivial()) {
       value as Array<*>
     } else {
@@ -48,7 +49,7 @@ class ArrayTypeConverter(
             cause
           )
         }) {
-          arrayElementConverter.convert(it)
+          arrayElementConverter.convert(it, context)
         }
       }.toTypedArray()
     }
@@ -68,7 +69,8 @@ class ArrayTypeConverter(
     ) as Array<Any?>
   }
 
-  override fun getCppRequiredTypes(): ExpectedType = ExpectedType.forPrimitiveArray(arrayElementConverter.getCppRequiredTypes())
+  override fun getCppRequiredTypes(): ExpectedType =
+    ExpectedType.forPrimitiveArray(arrayElementConverter.getCppRequiredTypes())
 
   override fun isTrivial() = arrayElementConverter.isTrivial()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -172,7 +173,7 @@ private val namedColors = mapOf(
 class ColorTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<Color>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): Color {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
       ReadableType.String -> colorFromString(value.asString())
@@ -184,7 +185,7 @@ class ColorTypeConverter(
     }
   }
 
-  override fun convertFromAny(value: Any): Color {
+  override fun convertFromAny(value: Any, context: AppContext?): Color {
     return when (value) {
       is Int -> {
         colorFromInt(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -15,7 +16,7 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalDate>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): LocalDate {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): LocalDate {
     return when (value.type) {
       ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
       ReadableType.Number -> convertFromLong(value.asDouble().toLong())
@@ -23,7 +24,7 @@ class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalD
     }
   }
 
-  override fun convertFromAny(value: Any): LocalDate {
+  override fun convertFromAny(value: Any, context: AppContext?): LocalDate {
     return when (value) {
       is String -> LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
       is Long -> convertFromLong(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import kotlin.time.Duration
@@ -9,14 +10,14 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 class DurationTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Duration>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): Duration {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Duration {
     if (value.type != ReadableType.Number) {
       throw IllegalArgumentException("Expected a number, but received ${value.type}")
     }
     return value.asDouble().toDuration(DurationUnit.SECONDS)
   }
 
-  override fun convertFromAny(value: Any): Duration {
+  override fun convertFromAny(value: Any, context: AppContext?): Duration {
     return (value as Double).toDuration(DurationUnit.SECONDS)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
 import expo.modules.kotlin.jni.ExpectedType
@@ -36,7 +37,7 @@ class EnumTypeConverter(
 
   override fun isTrivial() = false
 
-  override fun convertFromDynamic(value: Dynamic): Enum<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
       return convertEnumWithoutParameter(value.asString(), enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {
@@ -50,7 +51,7 @@ class EnumTypeConverter(
     throw IncompatibleArgTypeException(value.type.toKType(), enumClass.createType())
   }
 
-  override fun convertFromAny(value: Any): Enum<*> {
+  override fun convertFromAny(value: Any, context: AppContext?): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
       return convertEnumWithoutParameter(value as String, enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
@@ -19,7 +20,7 @@ class ListTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic): List<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): List<*> {
     if (value.type != ReadableType.Array) {
       return listOf(
         exceptionDecorator({ cause ->
@@ -30,16 +31,16 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(value)
+          elementConverter.convert(value, context)
         }
       )
     }
 
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray)
+    return convertFromReadableArray(jsArray, context)
   }
 
-  override fun convertFromAny(value: Any): List<*> {
+  override fun convertFromAny(value: Any, context: AppContext?): List<*> {
     return if (elementConverter.isTrivial()) {
       value as List<*>
     } else {
@@ -52,13 +53,13 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(it)
+          elementConverter.convert(it, context)
         }
       }
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray): List<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): List<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->
@@ -69,7 +70,7 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(this)
+          elementConverter.convert(this, context)
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
@@ -25,12 +26,12 @@ class MapTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic): Map<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Map<*, *> {
     val jsMap = value.asMap()
-    return convertFromReadableMap(jsMap)
+    return convertFromReadableMap(jsMap, context)
   }
 
-  override fun convertFromAny(value: Any): Map<*, *> {
+  override fun convertFromAny(value: Any, context: AppContext?): Map<*, *> {
     return if (valueConverter.isTrivial()) {
       value as Map<*, *>
     } else {
@@ -43,13 +44,13 @@ class MapTypeConverter(
             cause
           )
         }) {
-          valueConverter.convert(v)
+          valueConverter.convert(v, context)
         }
       }
     }
   }
 
-  private fun convertFromReadableMap(jsMap: ReadableMap): Map<*, *> {
+  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?): Map<*, *> {
     val result = mutableMapOf<String, Any?>()
 
     jsMap.entryIterator.forEach { (key, value) ->
@@ -57,7 +58,7 @@ class MapTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(mapType, mapType.arguments[1].type!!, type, cause)
         }) {
-          result[key] = valueConverter.convert(this)
+          result[key] = valueConverter.convert(this, context)
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.CppType
@@ -27,32 +28,32 @@ class PairTypeConverter(
     )
   )
 
-  override fun convertFromDynamic(value: Dynamic): Pair<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Pair<*, *> {
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray)
+    return convertFromReadableArray(jsArray, context)
   }
 
-  override fun convertFromAny(value: Any): Pair<*, *> {
+  override fun convertFromAny(value: Any, context: AppContext?): Pair<*, *> {
     if (value is ReadableArray) {
-      return convertFromReadableArray(value)
+      return convertFromReadableArray(value, context)
     }
 
     return value as Pair<*, *>
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray): Pair<*, *> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): Pair<*, *> {
     return Pair(
-      convertElement(jsArray, 0),
-      convertElement(jsArray, 1)
+      convertElement(context, jsArray, 0),
+      convertElement(context, jsArray, 1)
     )
   }
 
-  private fun convertElement(array: ReadableArray, index: Int): Any? {
+  private fun convertElement(context: AppContext?, array: ReadableArray, index: Int): Any? {
     return array.getDynamic(index).recycle {
       exceptionDecorator({ cause ->
         CollectionElementCastException(pairType, pairType.arguments[index].type!!, type, cause)
       }) {
-        converters[index].convert(this)
+        converters[index].convert(this, context)
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -4,17 +4,18 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.MapArguments
 import expo.modules.core.arguments.ReadableArguments
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class ReadableArgumentsTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<ReadableArguments>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): ReadableArguments {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): ReadableArguments {
     return MapArguments(value.asMap().toHashMap())
   }
 
-  override fun convertFromAny(value: Any): ReadableArguments {
+  override fun convertFromAny(value: Any, context: AppContext?): ReadableArguments {
     return MapArguments((value as ReadableMap).toHashMap())
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
@@ -18,12 +19,12 @@ class SetTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic): Set<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Set<*> {
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray)
+    return convertFromReadableArray(jsArray, context)
   }
 
-  override fun convertFromAny(value: Any): Set<*> {
+  override fun convertFromAny(value: Any, context: AppContext?): Set<*> {
     return if (elementConverter.isTrivial()) {
       (value as List<*>).toSet()
     } else {
@@ -36,13 +37,13 @@ class SetTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(it)
+          elementConverter.convert(it, context)
         }
       }.toSet()
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray): Set<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): Set<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->
@@ -53,7 +54,7 @@ class SetTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(this)
+          elementConverter.convert(this, context)
         }
       }
     }.toSet()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -64,13 +64,13 @@ abstract class NullAwareTypeConverter<Type : Any>(
 abstract class DynamicAwareTypeConverters<T : Any>(isOptional: Boolean) : NullAwareTypeConverter<T>(isOptional) {
   override fun convertNonOptional(value: Any, context: AppContext?): T =
     if (value is Dynamic) {
-      convertFromDynamic(value)
+      convertFromDynamic(value, context)
     } else {
-      convertFromAny(value)
+      convertFromAny(value, context)
     }
 
-  abstract fun convertFromDynamic(value: Dynamic): T
-  abstract fun convertFromAny(value: Any): T
+  abstract fun convertFromDynamic(value: Dynamic, context: AppContext?): T
+  abstract fun convertFromAny(value: Any, context: AppContext?): T
 }
 
 inline fun <reified T : Any> createTrivialTypeConverter(
@@ -79,8 +79,14 @@ inline fun <reified T : Any> createTrivialTypeConverter(
   crossinline dynamicFallback: (Dynamic) -> T = { throw UnsupportedClass(T::class) }
 ): TypeConverter<T> {
   return object : DynamicAwareTypeConverters<T>(isOptional) {
-    override fun convertFromDynamic(value: Dynamic): T = dynamicFallback(value)
+    override fun convertFromDynamic(value: Dynamic, context: AppContext?): T {
+      return dynamicFallback(value)
+    }
+
+    override fun convertFromAny(value: Any, context: AppContext?): T {
+      return value as T
+    }
+
     override fun getCppRequiredTypes(): ExpectedType = cppRequireType
-    override fun convertFromAny(value: Any): T = value as T
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
@@ -1,18 +1,19 @@
 package expo.modules.kotlin.types.io
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.io.File
 
 class FileTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<File>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): File {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): File {
     val path = value.asString()
     return File(path)
   }
 
-  override fun convertFromAny(value: Any): File {
+  override fun convertFromAny(value: Any, context: AppContext?): File {
     val path = value as String
     return File(path)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.types.io
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
@@ -11,12 +12,12 @@ import java.nio.file.Paths
 
 @RequiresApi(Build.VERSION_CODES.O)
 class PathTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Path>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): Path {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Path {
     val stringPath = value.asString()
     return Paths.get(stringPath)
   }
 
-  override fun convertFromAny(value: Any): Path {
+  override fun convertFromAny(value: Any, context: AppContext?): Path {
     val stringPath = value as String
     return Paths.get(stringPath)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
@@ -1,18 +1,19 @@
 package expo.modules.kotlin.types.net
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URL
 
 class URLTypConverter(isOptional: Boolean) : DynamicAwareTypeConverters<URL>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): URL {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): URL {
     val stringURL = value.asString()
     return URL(stringURL)
   }
 
-  override fun convertFromAny(value: Any): URL {
+  override fun convertFromAny(value: Any, context: AppContext?): URL {
     val stringURL = value as String
     return URL(stringURL)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
@@ -2,18 +2,19 @@ package expo.modules.kotlin.types.net
 
 import android.net.Uri
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URI
 
 class UriTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Uri>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): Uri {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Uri {
     val stringUri = value.asString()
     return Uri.parse(stringUri)
   }
 
-  override fun convertFromAny(value: Any): Uri {
+  override fun convertFromAny(value: Any, context: AppContext?): Uri {
     val stringUri = value as String
     return Uri.parse(stringUri)
   }
@@ -24,12 +25,12 @@ class UriTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Uri>(is
 }
 
 class JavaURITypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<URI>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic): URI {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?): URI {
     val stringUri = value.asString()
     return URI.create(stringUri)
   }
 
-  override fun convertFromAny(value: Any): URI {
+  override fun convertFromAny(value: Any, context: AppContext?): URI {
     val stringUri = value as String
     return URI.create(stringUri)
   }


### PR DESCRIPTION
# Why

Fixes `AppContext` is lost in nested converters.
Sometimes, when converting different structures, the `AppContext` gets lost, especially when switching between dynamic converters and "normal" once.   

# How

Made sure that `AppContext` is passed between converters.

# Test Plan

- `expo-maps-remake` ✅ 