### PR TITLE
[core][Android] Introduce per module converters

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.providers.AppContextProvider
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.TypeConverterProvider
 import kotlinx.coroutines.CoroutineScope
 
 abstract class Module : AppContextProvider {
@@ -49,6 +50,8 @@ abstract class Module : AppContextProvider {
   fun <T> sendEvent(enum: T, body: Map<String, Any?>? = null) where T : Enumerable, T : Enum<T> {
     moduleEventEmitter?.emit(convertEnumToString(enum), body)
   }
+
+  open fun customConverterProvider(): TypeConverterProvider? = null
 
   abstract fun definition(): ModuleDefinitionData
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -31,7 +31,12 @@ import kotlin.reflect.typeOf
 const val DEFAULT_MODULE_VIEW = "DEFAULT_MODULE_VIEW"
 
 @DefinitionMarker
-class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null) : ObjectDefinitionBuilder() {
+class ModuleDefinitionBuilder(
+  @PublishedApi internal val module: Module? = null
+) : ObjectDefinitionBuilder(
+  module
+    ?.customConverterProvider()
+) {
   @PublishedApi
   internal var name: String? = null
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -15,7 +15,6 @@ class ModuleDefinitionData(
   val registerContracts: (suspend AppContextActivityResultCaller.() -> Unit)? = null,
   val classData: List<ClassDefinitionData> = emptyList()
 ) {
-
   val constantsProvider = objectDefinition.constantsProvider
   val syncFunctions = objectDefinition.syncFunctions
   val asyncFunctions = objectDefinition.asyncFunctions

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -20,7 +20,9 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.modules.convertEnumToString
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
+import expo.modules.kotlin.types.mergeWithDefault
 import expo.modules.kotlin.types.toArgsArray
 import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.full.declaredMemberProperties
@@ -29,7 +31,10 @@ import kotlin.reflect.full.primaryConstructor
 /**
  * Base class for other definitions representing an object, such as `ModuleDefinition`.
  */
-open class ObjectDefinitionBuilder {
+open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = null) {
+  @PublishedApi
+  internal val converterProvider = customConverter.mergeWithDefault()
+
   private var constantsProvider = { emptyMap<String, Any?>() }
 
   @PublishedApi
@@ -117,7 +122,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0>(), toReturnType<R>()) { (p0) ->
+    return SyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converterProvider), toReturnType<R>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -145,35 +145,39 @@ object AnyTypeProvider {
   }
 }
 
-inline fun <reified T> (() -> KType).toAnyType() = AnyType(
-  LazyKType(
-    classifier = T::class,
-    isMarkedNullable = null is T,
-    kTypeProvider = this
+inline fun <reified T> (() -> KType).toAnyType(converterProvider: TypeConverterProvider? = null) =
+  AnyType(
+    LazyKType(
+      classifier = T::class,
+      isMarkedNullable = null is T,
+      kTypeProvider = this
+    ),
+    converterProvider
   )
-)
 
-inline fun <reified T> toAnyType(): AnyType {
-  return AnyTypeProvider.cachedAnyType<T>() ?: { typeOf<T>() }.toAnyType<T>()
+inline fun <reified T> toAnyType(converterProvider: TypeConverterProvider? = null): AnyType {
+  return AnyTypeProvider.cachedAnyType<T>() ?: { typeOf<T>() }.toAnyType<T>(converterProvider)
 }
 
 @Suppress("UNUSED_PARAMETER")
 inline fun <reified P0> toArgsArray(
-  p0: Class<P0> = P0::class.java
+  p0: Class<P0> = P0::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>()
+    toAnyType<P0>(converterProvider)
   )
 }
 
 @Suppress("UNUSED_PARAMETER")
 inline fun <reified P0, reified P1> toArgsArray(
   p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java
+  p1: Class<P1> = P1::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider)
   )
 }
 
@@ -181,12 +185,13 @@ inline fun <reified P0, reified P1> toArgsArray(
 inline fun <reified P0, reified P1, reified P2> toArgsArray(
   p0: Class<P0> = P0::class.java,
   p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java
+  p2: Class<P2> = P2::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider)
   )
 }
 
@@ -195,13 +200,14 @@ inline fun <reified P0, reified P1, reified P2, reified P3> toArgsArray(
   p0: Class<P0> = P0::class.java,
   p1: Class<P1> = P1::class.java,
   p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java
+  p3: Class<P3> = P3::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>(),
-    toAnyType<P3>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider)
   )
 }
 
@@ -211,14 +217,15 @@ inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> toArgsAr
   p1: Class<P1> = P1::class.java,
   p2: Class<P2> = P2::class.java,
   p3: Class<P3> = P3::class.java,
-  p4: Class<P4> = P4::class.java
+  p4: Class<P4> = P4::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>(),
-    toAnyType<P3>(),
-    toAnyType<P4>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider)
   )
 }
 
@@ -229,15 +236,16 @@ inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified 
   p2: Class<P2> = P2::class.java,
   p3: Class<P3> = P3::class.java,
   p4: Class<P4> = P4::class.java,
-  p5: Class<P5> = P5::class.java
+  p5: Class<P5> = P5::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>(),
-    toAnyType<P3>(),
-    toAnyType<P4>(),
-    toAnyType<P5>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider)
   )
 }
 
@@ -249,16 +257,17 @@ inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified 
   p3: Class<P3> = P3::class.java,
   p4: Class<P4> = P4::class.java,
   p5: Class<P5> = P5::class.java,
-  p6: Class<P6> = P6::class.java
+  p6: Class<P6> = P6::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>(),
-    toAnyType<P3>(),
-    toAnyType<P4>(),
-    toAnyType<P5>(),
-    toAnyType<P6>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider),
+    toAnyType<P6>(converterProvider)
   )
 }
 
@@ -271,26 +280,32 @@ inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified 
   p4: Class<P4> = P4::class.java,
   p5: Class<P5> = P5::class.java,
   p6: Class<P6> = P6::class.java,
-  p7: Class<P7> = P7::class.java
+  p7: Class<P7> = P7::class.java,
+  converterProvider: TypeConverterProvider? = null
 ): Array<AnyType> {
   return arrayOf(
-    toAnyType<P0>(),
-    toAnyType<P1>(),
-    toAnyType<P2>(),
-    toAnyType<P3>(),
-    toAnyType<P4>(),
-    toAnyType<P5>(),
-    toAnyType<P6>(),
-    toAnyType<P7>()
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider),
+    toAnyType<P6>(converterProvider),
+    toAnyType<P7>(converterProvider)
   )
 }
 
 class AnyType(
-  val kType: KType
+  val kType: KType,
+  val converterProvider: TypeConverterProvider? = null
 ) {
 
   private val converter: TypeConverter<*> by lazy {
-    TypeConverterProviderImpl.obtainTypeConverter(kType)
+    if (converterProvider != null) {
+      converterProvider.obtainTypeConverter(kType)
+    } else {
+      TypeConverterProviderImpl.obtainTypeConverter(kType)
+    }
   }
 
   fun convert(value: Any?, appContext: AppContext? = null): Any? =


### PR DESCRIPTION
# Why

Introduces per module converter that can be used to define custom converts.

# How

A new function inside the module class, which returns a custom converter provider, was added. All function definitions currently use it.

# Test Plan

- I've tried to use it inside the `expo-maps-remake` package ✅ 