### PR TITLE
[android][0.77][ci] Fix unit tests after changing modules to support named views

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -14,6 +14,7 @@ on:
       - packages/expo-manifests/android/**
       - packages/expo-notifications/android/**
       - packages/expo-updates/android/**
+      - packages/expo-modules-core/**
       - tools/src/commands/AndroidNativeUnitTests.ts
       - yarn.lock
       - '!packages/@expo/cli/**'
@@ -28,6 +29,7 @@ on:
       - packages/expo-manifests/android/**
       - packages/expo-notifications/android/**
       - packages/expo-updates/android/**
+      - packages/expo-modules-core/**
       - tools/src/commands/AndroidNativeUnitTests.ts
       - yarn.lock
       - '!packages/@expo/cli/**'

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 💡 Others
 
+- [Android] Fixed failing unit tests after internal API change that adds support for named views.
 - [iOS] Enable named view exports. ([#34293](https://github.com/expo/expo/pull/34293) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Enable named view exports. ([#34161](https://github.com/expo/expo/pull/34161) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- [Android] Fixed failing unit tests after internal API change that adds support for named views.
+- [Android] Fixed failing unit tests after internal API change that adds support for named views. ([#34384](https://github.com/expo/expo/pull/34384) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Enable named view exports. ([#34293](https://github.com/expo/expo/pull/34293) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Enable named view exports. ([#34161](https://github.com/expo/expo/pull/34161) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Introduced the option to disabled `overflow: hidden` applied to each view by default. ([#33261](https://github.com/expo/expo/pull/33261) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptViewModule.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptViewModule.kt
@@ -11,7 +11,7 @@ class JavaScriptViewModule {
       AsyncFunction("anotherViewFunction") { 20 }
     }
   }) {
-    val viewFunctions = evaluateScript("Object.getOwnPropertyNames($moduleRef.ViewPrototype)")
+    val viewFunctions = evaluateScript("Object.getOwnPropertyNames($moduleRef.ViewPrototypes.TestModule_View)")
       .getArray()
       .map { it.getString() }
 
@@ -24,7 +24,7 @@ class JavaScriptViewModule {
       AsyncFunction("viewFunction") { 123 }
     }
   }) {
-    val result = callViewAsync("ViewPrototype", "viewFunction").getInt()
+    val result = callViewAsync("ViewPrototypes.TestModule_View", "viewFunction").getInt()
     Truth.assertThat(result).isEqualTo(123)
   }
 
@@ -40,7 +40,7 @@ class JavaScriptViewModule {
     val result = waitForAsyncFunction(
       """
       const nativeView = { nativeTag: 1 };
-      Object.assign(nativeView.__proto__, $moduleRef.ViewPrototype);
+      Object.assign(nativeView.__proto__, $moduleRef.ViewPrototypes.TestModule_View);
       nativeView.viewFunction()
       """.trimIndent()
     ).getInt()


### PR DESCRIPTION
# Why

After #34161 a few unit tests referencing a private module API that tests View Prototypes started to fail since the name of the internal JS API was changed from `ViewPrototype` to `ViewPrototypes`.

NOTE: In the review process - please verify that the change above is an internal API that has no useage outside these tests and the NativeViewManagerAdapter that contains the abstraction using this field.

# How

JS code in tests was changed to use the new API instead of the old one:

**From:**
`val viewFunctions = evaluateScript("Object.getOwnPropertyNames($moduleRef.ViewPrototype)")`

**To:**
`val viewFunctions = evaluateScript("Object.getOwnPropertyNames($moduleRef.ViewPrototypes.TestModule_View)")`

# Test Plan

None of the unit tests in the file `packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptViewModule.kt` should fail.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
