### PR TITLE
fix(cli): swap out React Native `setUpDeveloperTools` to re-enable terminal logs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
 - Added `--bytecode` option to `export:embed`. ([#33906](https://github.com/expo/expo/pull/33906) by [@kudo](https://github.com/kudo))
 - Exclude `@expo-google-fonts/*` packages from the New Architecture compatibility check. ([#34127](https://github.com/expo/expo/pull/34127) by [@Simek](https://github.com/Simek))
+- Re-enable terminal logs from React Native devices. ([#34393](https://github.com/expo/expo/pull/34393) by [@byCedric](https://github.com/byCedric))
 
 ## 0.22.7 - 2024-12-19
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoTerminalLogResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoTerminalLogResolver.ts
@@ -1,0 +1,48 @@
+import type { ResolutionContext } from 'metro-resolver';
+import path from 'node:path';
+
+import type { ExpoCustomMetroResolver } from './withMetroResolvers';
+
+const debug = require('debug')('expo:start:server:metro:multi-platform') as typeof console.log;
+
+/**
+ * React Native used to have logs from android/ios devices emitted in the terminal.
+ * This uses a now legacy logging API, which is disabled starting from React Native 0.77.
+ * To keep the terminal-emitted logs we temporarily swap out the following file:
+ *   - `react-native/Libraries/Core/setUpDeveloperTools.js`
+ * It allows us to disable the "logging is going away" warning, and re-enable the legacy logging system.
+ *
+ * In the future, this must be replaced by a CDP client connected from Expo CLI that listens for `Runtime.consoleAPICalled` events.
+ * Unfortunately this is not possible yet due to two major limitations in the current CDP implementation.
+ *   1. Expo CLI can't listen for new inspectable devices
+ *   2. Fuxebox / inspector proxy only allows 1 debugger to be connected simultaneously
+ */
+export function createExpoTerminalLogResolver(): ExpoCustomMetroResolver {
+  const setupDevtoolsModule = require.resolve(
+    '@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js'
+  );
+
+  return function requestExpoTerminalLogModule(context, moduleName, platform) {
+    if (
+      (platform === 'android' || platform === 'ios') &&
+      moduleIsSetupDevTools(context, moduleName)
+    ) {
+      debug('Redirecting module:', moduleName, '->', setupDevtoolsModule);
+
+      return {
+        type: 'sourceFile',
+        filePath: setupDevtoolsModule,
+      };
+    }
+
+    return null;
+  };
+}
+
+function moduleIsSetupDevTools(context: ResolutionContext, moduleName: string) {
+  return (
+    moduleName === 'react-native/Libraries/Core/setUpDeveloperTools' ||
+    (moduleName.endsWith('/setUpDeveloperTools') &&
+      path.dirname(context.originModulePath).endsWith('react-native/Libraries/Core'))
+  );
+}

--- a/packages/@expo/cli/src/start/server/metro/createExpoTerminalLogResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoTerminalLogResolver.ts
@@ -2,6 +2,7 @@ import type { Resolution, ResolutionContext } from 'metro-resolver';
 import path from 'node:path';
 
 import type { ExpoCustomMetroResolver } from './withMetroResolvers';
+import { env } from '../../../utils/env';
 
 const debug = require('debug')('expo:start:server:metro:multi-platform') as typeof console.log;
 
@@ -27,6 +28,10 @@ export function createExpoTerminalLogResolver({
 }: {
   getStrictResolver: ExpoStrictResolver;
 }): ExpoCustomMetroResolver {
+  if (env.EXPO_NO_TERMINAL_LOGS) {
+    return () => null;
+  }
+
   let originModulePath: string;
   const setupDevtoolsModule = require.resolve(
     '@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js'

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -569,7 +569,7 @@ export function withExtendedResolver(
     },
 
     // Enable (legacy) terminal logging without warnings
-    createExpoTerminalLogResolver(),
+    createExpoTerminalLogResolver({ getStrictResolver }),
 
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -32,6 +32,7 @@ import { loadTsConfigPathsAsync, TsConfigPaths } from '../../../utils/tsconfig/l
 import { resolveWithTsConfigPaths } from '../../../utils/tsconfig/resolveWithTsConfigPaths';
 import { isServerEnvironment } from '../middleware/metroOptions';
 import { PlatformBundlers } from '../platformBundlers';
+import { createExpoTerminalLogResolver } from './createExpoTerminalLogResolver';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -566,6 +567,9 @@ export function withExtendedResolver(
 
       return null;
     },
+
+    // Enable (legacy) terminal logging without warnings
+    createExpoTerminalLogResolver(),
 
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -808,6 +808,12 @@ export async function withMetroMultiPlatformAsync(
     if (isReactCanaryEnabled) {
       // @ts-expect-error: watchFolders is readonly
       config.watchFolders.push(path.join(require.resolve('@expo/cli/package.json'), '..'));
+    } else {
+      // If React Canary is disabled, only add the swapped modules
+      // @ts-expect-error: watchFolders is readonly
+      config.watchFolders.push(
+        path.join(require.resolve('@expo/cli/package.json'), '../static/virtual')
+      );
     }
   }
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -249,6 +249,11 @@ class Env {
   get EXPO_NO_DEPENDENCY_VALIDATION(): boolean {
     return boolish('EXPO_NO_DEPENDENCY_VALIDATION', false);
   }
+
+  /** Disable the terminal logs override within React Native that re-enables console logging in the terminal */
+  get EXPO_NO_TERMINAL_LOGS(): boolean {
+    return boolish('EXPO_NO_TERMINAL_LOGS', false);
+  }
 }
 
 export const env = new Env();

--- a/packages/@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -1,0 +1,91 @@
+// NOTE(cedric): `react-native/Libraries/Core/setUpDeveloperTools.js` warns and disables terminal logging.
+// Expo wants to keep terminal logs available, and overwrites the `__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__` check.
+// When the inspector proxy allows multiple debugger connections, and Expo receives the "inspectable device is avaible" event
+// we want to remove this override, and create a CLI-only system that uses CDP to emit logs to the terminal.
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import Platform from 'react-native/Libraries/Utilities/Platform';
+
+declare var console: {[string]: $FlowFixMe};
+
+/**
+ * Sets up developer tools for React Native.
+ * You can use this module directly, or just require InitializeCore.
+ */
+if (__DEV__) {
+  require('react-native/Libraries/Core/setUpReactDevTools');
+
+  // Set up inspector
+  const JSInspector = require('react-native/Libraries/JSInspector/JSInspector');
+  JSInspector.registerAgent(require('react-native/Libraries/JSInspector/NetworkAgent'));
+
+  // Note we can't check if console is "native" because it would appear "native" in JSC and Hermes.
+  // We also can't check any properties that don't exist in the Chrome worker environment.
+  // So we check a navigator property that's set to a particular value ("Netscape") in all real browsers.
+  const isLikelyARealBrowser =
+    global.navigator != null &&
+    /*              _
+     *             | |
+     *   _ __   ___| |_ ___  ___ __ _ _ __   ___
+     *  | '_ \ / _ \ __/ __|/ __/ _` | '_ \ / _ \
+     *  | | | |  __/ |_\__ \ (_| (_| | |_) |  __/
+     *  |_| |_|\___|\__|___/\___\__,_| .__/ \___|
+     *                               | |
+     *                               |_|
+     */
+    global.navigator.appName === 'Netscape'; // Any real browser
+
+  if (true || !Platform.isTesting) {
+    const HMRClient = require('react-native/Libraries/Utilities/HMRClient');
+
+    // NOTE(cedric): we both disable the Fusebox check and notification emitted by `notifyFuseboxConsoleEnabled`
+    // if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
+    //   HMRClient.unstable_notifyFuseboxConsoleEnabled();
+    // } else 
+    
+    if (console._isPolyfilled) {
+      // We assume full control over the console and send JavaScript logs to Metro.
+      [
+        'trace',
+        'info',
+        'warn',
+        'error',
+        'log',
+        'group',
+        'groupCollapsed',
+        'groupEnd',
+        'debug',
+      ].forEach(level => {
+        const originalFunction = console[level];
+        console[level] = function (...args: $ReadOnlyArray<mixed>) {
+          HMRClient.log(level, args);
+          originalFunction.apply(console, args);
+        };
+      });
+    } else {
+      // We assume the environment has a real rich console (like Chrome), and don't hijack it to log to Metro.
+      // It's likely the developer is using rich console to debug anyway, and hijacking it would
+      // lose the filenames in console.log calls: https://github.com/facebook/react-native/issues/26788.
+      HMRClient.log('log', [
+        `JavaScript logs will appear in your ${
+          isLikelyARealBrowser ? 'browser' : 'environment'
+        } nsole`,
+      ]);
+    }
+  }
+
+  require('react-native/Libraries/Core/setUpReactRefresh');
+
+  global[
+    `${global.__METRO_GLOBAL_PREFIX__ ?? ''}__loadBundleAsync`
+  ] = require('react-native/Libraries/Core/Devtools/loadBundleFromServer');
+}

--- a/packages/@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -3,6 +3,13 @@
 // When the inspector proxy allows multiple debugger connections, and Expo receives the "inspectable device is avaible" event
 // we want to remove this override, and create a CLI-only system that uses CDP to emit logs to the terminal.
 
+    // NOTE(cedric): we both disable the Fusebox check and notification emitted by `notifyFuseboxConsoleEnabled`
+    // if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
+    //   HMRClient.unstable_notifyFuseboxConsoleEnabled();
+    // } else 
+
+
+
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -13,7 +20,7 @@
  * @format
  */
 
-import Platform from 'react-native/Libraries/Utilities/Platform';
+import Platform from '../Utilities/Platform';
 
 declare var console: {[string]: $FlowFixMe};
 
@@ -22,11 +29,9 @@ declare var console: {[string]: $FlowFixMe};
  * You can use this module directly, or just require InitializeCore.
  */
 if (__DEV__) {
-  require('react-native/Libraries/Core/setUpReactDevTools');
-
   // Set up inspector
-  const JSInspector = require('react-native/Libraries/JSInspector/JSInspector');
-  JSInspector.registerAgent(require('react-native/Libraries/JSInspector/NetworkAgent'));
+  const JSInspector = require('../JSInspector/JSInspector');
+  JSInspector.registerAgent(require('../JSInspector/NetworkAgent'));
 
   // Note we can't check if console is "native" because it would appear "native" in JSC and Hermes.
   // We also can't check any properties that don't exist in the Chrome worker environment.
@@ -44,8 +49,8 @@ if (__DEV__) {
      */
     global.navigator.appName === 'Netscape'; // Any real browser
 
-  if (true || !Platform.isTesting) {
-    const HMRClient = require('react-native/Libraries/Utilities/HMRClient');
+  if (!Platform.isTesting) {
+    const HMRClient = require('../Utilities/HMRClient');
 
     // NOTE(cedric): we both disable the Fusebox check and notification emitted by `notifyFuseboxConsoleEnabled`
     // if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
@@ -78,14 +83,14 @@ if (__DEV__) {
       HMRClient.log('log', [
         `JavaScript logs will appear in your ${
           isLikelyARealBrowser ? 'browser' : 'environment'
-        } nsole`,
+        } console`,
       ]);
     }
   }
 
-  require('react-native/Libraries/Core/setUpReactRefresh');
+  require('./setUpReactRefresh');
 
   global[
     `${global.__METRO_GLOBAL_PREFIX__ ?? ''}__loadBundleAsync`
-  ] = require('react-native/Libraries/Core/Devtools/loadBundleFromServer');
+  ] = require('./Devtools/loadBundleFromServer');
 }


### PR DESCRIPTION
# Why

This disables the warning about "Logs will go away" in React Native 0.76 and 0.77 -- and re-enables the now-legacy polyfilled console logs.

![image](https://github.com/user-attachments/assets/5c8d33c9-eae4-45ac-9279-0bf0af33668c)

It's a workaround to keep the terminal logging feature alive within Expo projects. Ideally we would implement a terminal logger that consumes CDP events to make it future proof. Unfortunately, we are blocked by that due to two major Fusebox / inspector proxy limitations:
1. We have no way of listening whenever a new "inspectable device" is registered
2. There can only be a single debugger connected to a device

This means that we can't create a CDP-lite client that consumes `Runtime.consoleAPICalled` events and outputs these in the terminal.

# TODO

- Verify that we can't use actual virtual modules due us replacing a single file from a library - which seems to crash Metro when using virtual modules
- Verify the assumed name `@expo/cli/static/virtual/...` is ok, could also use `static/replaced` or `static/swapped`
- Add E2E test to ensure we receive logs
- Add opt-out env var to disable this behavior

# How

- Modified the resolver to swap `react-native/Libraries/Core/setUpDeveloperTools.js` for `@expo/cli/static/virtual/react-native/Libraries/Core/setUpDeveloperTools.js`.
- Kept the relative imports as is, and "faked" the `context.originModulePath` to match it's original path to resolve to the right `react-native/*` packages
  - Note that when I made all of these absolute, without changing `context.originModulePath` - we were resolving `expo/expo/node_modules/react-native/*` files.

# Test Plan

- `bun create expo ./test-terminal-log`
- `cd ./test-terminal-log`
- `bun expo start`
- Modify the code to trigger `console.log` or equivalent
- Ensure the log is visible in the terminal

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
