### PR TITLE
[docs] add EAS tutorial videos

### DIFF
--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -9,10 +9,18 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll create a development build that can run on Android with EAS Build.
 
 The process for creating and running a build on Android devices or emulators is identical, with differences only in the installation of the development build.
+
+<VideoBoxLink
+  videoId="D612BUtvvl8"
+  title="Watch: How to create and run a cloud build for Android"
+/>
+
+---
 
 ## Create a build for the development profile
 

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -15,8 +15,8 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 In this chapter, we'll create our example app's production version and submit it to the Google Play Store. We'll also explore how to automate the creation and release of new app versions.
 
 <VideoBoxLink
-  videoId="-KZjr576tuE"
-  title="Watch: How to quickly publish to the App Store & Play Store with EAS Submit"
+  videoId="nxlt8uwqhpE"
+  title="Watch: Creating and releasing a production build for Android"
 />
 
 ---

--- a/docs/pages/tutorial/eas/configure-development-build.mdx
+++ b/docs/pages/tutorial/eas/configure-development-build.mdx
@@ -14,7 +14,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll set up and configure a development build with EAS for our example app.
 
-<VideoBoxLink videoId="LUFHXsBcW6w" title="Watch: How to make a development build with EAS Build" />
+<VideoBoxLink videoId="uQCE9zl3dXU" title="Watch: How to configure a development build" />
 
 ---
 

--- a/docs/pages/tutorial/eas/internal-distribution-builds.mdx
+++ b/docs/pages/tutorial/eas/internal-distribution-builds.mdx
@@ -11,8 +11,16 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn how to set up [internal distribution builds](/guides/sharing-preview-releases/#internal-distribution).
+
+<VideoBoxLink
+  videoId="1fQuGLHxWks"
+  title="Watch: How to create and share an internal distribution build"
+/>
+
+---
 
 ## Internal distribution build
 

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -9,10 +9,18 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll create a development build that can run on an iOS device with EAS Build.
 
 Development builds for iOS devices are generated in the **.ipa** format, which is standard for iOS app installations.
+
+<VideoBoxLink
+  videoId="HbfWU7_o4cU"
+  title="Watch: Creating a development build for iOS physical device"
+/>
+
+---
 
 ## Prerequisites
 

--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -9,10 +9,15 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll create a development build that can run on an iOS Simulator with EAS Build.
 
 Development builds for iOS Simulators are generated in the **.app** format which is different from iOS devices.
+
+<VideoBoxLink videoId="SgL97PFZctg" title="Watch: Creating a development build for iOS Simulator" />
+
+---
 
 ## Create a simulator build profile in eas.json
 

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -14,8 +14,8 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 In this chapter, we'll create our example app's production version and submit it for testing using TestFlight. After that, we'll submit them for App Store review to get it on the App Store.
 
 <VideoBoxLink
-  videoId="-KZjr576tuE"
-  title="Watch: How to quickly publish to the App Store & Play Store with EAS Submit"
+  videoId="VZL_e0cEwo8"
+  title="Watch: Creating and releasing a production build for iOS"
 />
 
 ---

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -11,7 +11,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn how EAS Build automatically manages the developer-facing app version for Android and iOS. Learning about it will be useful before we dive into production build in the next two chapters.
 
-<VideoBoxLink videoId="Gk7RHDWsLsQ" title="Watch: Automatic App Version Management" />
+<VideoBoxLink videoId="C8x4N9UmzS8" title="Watch: Automating app version code" />
 
 ---
 

--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -8,8 +8,13 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll configure our project to run multiple build types (development, preview, production) on a single device simultaneously. This setup will allow us to test various stages of our app development without the need to uninstall and reinstall different versions.
+
+<VideoBoxLink videoId="UtJJCAfrjIg" title="Watch: How to configure multiple app variants" />
+
+---
 
 Each variant requires a unique Android Application ID and iOS Bundle Identifier to enable simultaneous installations on one device. Here's how the IDs are set up in our **app.json** file:
 

--- a/docs/pages/tutorial/eas/team-development.mdx
+++ b/docs/pages/tutorial/eas/team-development.mdx
@@ -9,10 +9,15 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Updates generally fix small bugs and push small changes in between app store releases. They allow updating the non-native parts of our example app, such as JavaScript code, styling, and images.
 
 In this chapter, we'll use [EAS Update](/eas-update/introduction/) to share changes with our team. This will help [us and our team quickly share previews](/review/overview/) of the change.
+
+<VideoBoxLink videoId="vPKh-tNm-yI" title="Watch: How to share previews with your team" />
+
+---
 
 <Step label="1">
 

--- a/docs/pages/tutorial/eas/using-github.mdx
+++ b/docs/pages/tutorial/eas/using-github.mdx
@@ -7,10 +7,15 @@ description: Learn about the process of triggering builds from a GitHub reposito
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 [Expo GitHub App](/build/building-from-github/) automatically triggers builds from our GitHub projects with EAS. We can trigger builds for any build profile based on our development team's preferences. It also allows triggering builds for `git` push committed directly to a repository or a pull request.
 
 In this chapter, we'll configure this functionality. We already have a GitHub repository for our example app to demonstrate this.
+
+<VideoBoxLink videoId="fBLFEFC0ip0" title="Watch: How to trigger builds from a GitHub repository" />
+
+---
 
 <Step label="1">
 


### PR DESCRIPTION
# Why

[ENG-14804 [Docs] Embed EAS Tutorial videos](https://linear.app/expo/issue/ENG-14804/[docs]-embed-eas-tutorial-videos)

We're still working on creating thumbnails for the videos, but it would be great if we could get this PR approved so I can merge the changes as soon as the videos are live. Thanks a bunch! 🙏

# Test Plan

Ran locally and verify videos look good. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
