### PR TITLE
[android] fix: runtimeVersion not visible in dev-client #34090

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed issue with initialization of the dev client being wrong on the old architecture
 - [iOS] Fixed black stuck screen when loading an unreachable server from last opened url. ([#34067](https://github.com/expo/expo/pull/34067) by [@kudo](https://github.com/kudo))
 - [iOS] Read EAS project id and url from manifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Read EAS project id and url from AndroidManifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed issue with initialization of the dev client being wrong on the old architecture
+- [Android] Fixed issue with initialization of the dev client being wrong on the old architecture ([#34398](https://github.com/expo/expo/pull/34398) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed black stuck screen when loading an unreachable server from last opened url. ([#34067](https://github.com/expo/expo/pull/34067) by [@kudo](https://github.com/kudo))
 - [iOS] Read EAS project id and url from manifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Read EAS project id and url from AndroidManifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -148,7 +148,7 @@ class DevLauncherController private constructor() :
       val manifestParser = DevLauncherManifestParser(httpClient, parsedUrl, installationIDHelper.getOrCreateInstallationID(context))
       val appIntent = createAppIntent()
 
-      internalUpdatesInterface?.reset()
+      DevLauncherKoinContext.app.koin.getOrNull<UpdatesInterface>()?.reset()
 
       val appLoaderFactory = get<DevLauncherAppLoaderFactoryInterface>()
       val appLoader = appLoaderFactory.createAppLoader(parsedUrl, parsedProjectUrl, manifestParser)
@@ -435,11 +435,7 @@ class DevLauncherController private constructor() :
 
     @JvmStatic
     fun initialize(reactApplication: ReactApplication, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
-      // Call reactHost on application to ensure we initialise it correctly and only once before we pass it to the
-      // ReactHostWrapper. Calling reactApplication.reactHost has side effects that should be run independently of
-      // whether we're on the old or new architecture.
-      val reactHost = reactApplication.reactHost
-      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost) { reactHost })
+      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, { reactApplication.reactHost }))
       sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -435,7 +435,11 @@ class DevLauncherController private constructor() :
 
     @JvmStatic
     fun initialize(reactApplication: ReactApplication, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
-      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, { reactApplication.reactHost }))
+      // Call reactHost on application to ensure we initialise it correctly and only once before we pass it to the
+      // ReactHostWrapper. Calling reactApplication.reactHost has side effects that should be run independently of
+      // whether we're on the old or new architecture.
+      val reactHost = reactApplication.reactHost
+      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost) { reactHost })
       sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -18,8 +18,6 @@ import expo.modules.devlauncher.modules.DevLauncherAuth
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.modules.DevLauncherDevMenuExtension
 import expo.modules.devlauncher.react.DevLauncherReactNativeHostHandler
-import expo.modules.updatesinterface.UpdatesControllerRegistry
-import java.lang.ref.WeakReference
 
 object DevLauncherPackageDelegate {
   fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
@@ -36,10 +34,6 @@ object DevLauncherPackageDelegate {
         override fun onCreate(application: Application?) {
           check(application is ReactApplication)
           DevLauncherController.initialize(application)
-          UpdatesControllerRegistry.controller?.get()?.let {
-            DevLauncherController.instance.updatesInterface = it
-            it.updatesInterfaceCallbacks = WeakReference(DevLauncherController.instance)
-          }
         }
       }
     )

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherReactHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherReactHost.kt
@@ -60,7 +60,7 @@ object DevLauncherReactHost {
     )
 
     if (useDeveloperSupport) {
-      injectDevServerHelper(application.applicationContext, reactHost.devSupportManager, DevLauncherController.instance);
+      injectDevServerHelper(application.applicationContext, reactHost.devSupportManager, DevLauncherController.instance)
       val success = injectDebugServerHost(application.applicationContext, reactHost, launcherIp!!, jsMainModuleName)
       if (!success) {
         throw IllegalStateException("Failed to inject debug server host")

--- a/packages/expo-dev-launcher/android/src/rn74/debug/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
+++ b/packages/expo-dev-launcher/android/src/rn74/debug/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
@@ -16,8 +16,6 @@ import expo.modules.devlauncher.helpers.getProtectedFieldValue
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
-import expo.modules.devlauncher.react.DevLauncherBridgeDevSupportManager
-import expo.modules.devlauncher.react.DevLauncherBridgelessDevSupportManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject

--- a/packages/expo-dev-launcher/android/src/rn77/debug/expo/modules/devlauncher/react/DevLauncherBridgelessDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/rn77/debug/expo/modules/devlauncher/react/DevLauncherBridgelessDevSupportManager.kt
@@ -36,7 +36,8 @@ class DevLauncherBridgelessDevSupportManager(
   null,
   null,
   null
-), DevLauncherKoinComponent {
+),
+  DevLauncherKoinComponent {
   private val controller: DevLauncherControllerInterface? by optInject()
 
   init {

--- a/packages/expo-dev-launcher/android/src/rn77/debug/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
+++ b/packages/expo-dev-launcher/android/src/rn77/debug/expo/modules/devlauncher/react/DevLauncherDevSupportManagerSwapper.kt
@@ -16,8 +16,6 @@ import expo.modules.devlauncher.helpers.getProtectedFieldValue
 import expo.modules.devlauncher.helpers.setProtectedDeclaredField
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
-import expo.modules.devlauncher.react.DevLauncherBridgeDevSupportManager
-import expo.modules.devlauncher.react.DevLauncherBridgelessDevSupportManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject


### PR DESCRIPTION
# Why 

#34090 reports that the field `runtimeVersion` in the `expo-dev-client` wasn't displaying correctly under the old architecture on Android - it is fine and visible on the new architecture on both Android and iOS.

This was eventually confirmed after some back and forth I ended up with the following reasoning:

The field `runtimeVersion` comes from the `expo-updates` package and is read in `DevLauncherInternalModule.getUpdatesConfig()` method using the following statement:

```kt
private fun getUpdatesConfig(): WritableMap {
  // ...
  val runtimeVersion = controller.updatesInterface?.runtimeVersion
  // ...
}
```

The problem was that the dependency chain required a specific order of initialisation to ensure that both `controller` and `controller.updatesInterface` was correctly set before this would work.

The `controller` field is set in the `UpdatesController.initialiseWithoutStarting` method:

```kt
@JvmStatic fun initializeWithoutStarting(context: Context) {
  // ...
  if (BuildConfig.USE_DEV_CLIENT) {
    val devLauncherController = initializeAsDevLauncherWithoutStarting(context)
    singletonInstance = devLauncherController
    UpdatesControllerRegistry.controller = WeakReference(devLauncherController) // <----- HERE
  } else {
    singletonInstance = DisabledUpdatesController(context, null)
  }
  // ...
}
```

This code is called after we initialise the `DevLauncherController` and initialize the instance's `updatesInterface` member:

```kt
fun createApplicationLifecycleListeners(context: Context?): List<ApplicationLifecycleListener> =
  listOf(
    object : ApplicationLifecycleListener {
      override fun onCreate(application: Application?) {
        check(application is ReactApplication)
        DevLauncherController.initialize(application)
        UpdatesControllerRegistry.controller?.get()?.let {
          DevLauncherController.instance.updatesInterface = it  // <----- HERE
          it.updatesInterfaceCallbacks = WeakReference(DevLauncherController.instance)
        }
      }
    }
  )
```

For this to work the instance of the `DevLauncherController` has to be set - which is done as a sideeffect in `DevLauncherController.initialize(application)`.

*The problem is that this side effect was not called on the old architecture.*

The side effect is called from within the `ReactHostWrapper.kt` when calling the `reactHostProvider()` function argument on initialisation. When using the old architecture this was not done as a solution to a problem with multiple reloads that was addressed in #32532.

# How

This commit proposes a solution to this where the `DevLauncherController` making sure the necessary side effects is run at the correct time:

```kt
@JvmStatic
fun initialize(reactApplication: ReactApplication, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
  // ...
  val reactHost = reactApplication.reactHost
  initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost) { reactHost })
  // ...
}
```

Here we're calling the `reactHost` property *only once* and then pass a new lambda to the ReactHostWrapper so it can initialize without having to consider these side effects.

Closes #ENG-14823

# Test Plan

- We should be able to see the `runtimeVersion` field in the dev-client as noted in the original issue when running with the old architecture.
- We should be able to reload on the old architecture without the app reloading multiple times (#32532)

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
