### PR TITLE
[android][ci][e2e] fix missing interface declaration for 0.74-0.77

### DIFF
--- a/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
+++ b/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
@@ -4,11 +4,15 @@ package expo.modules.rncompatibility
 
 import com.facebook.react.config.ReactFeatureFlags
 
+interface IReactNativeFeatureFlagsProvider {
+  val enableBridgelessArchitecture: Boolean
+}
+
 /**
  * A compatibility helper of
  * `com.facebook.react.config.ReactFeatureFlags` and
  * `com.facebook.react.internal.featureflags.ReactNativeFeatureFlags`
  */
-object ReactNativeFeatureFlags {
+object ReactNativeFeatureFlags : IReactNativeFeatureFlagsProvider {
   val enableBridgelessArchitecture = ReactFeatureFlags.enableBridgelessArchitecture
 }


### PR DESCRIPTION
# Why

In the PR for fixing the e2e tests breaking now. This was a declaration I forgot since I was running under 0.77 when testing this.

When running e2e tests the cli is creating a new project which for now defaults to using 0.76.

The PR that introduced this was: #34363

# How

Added missing interface definition

# Test Plan

Run e2e tests without it failing...
