### PR TITLE
[docs] DOM components extra hints for sizing questions

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -353,7 +353,7 @@ import { useEffect } from 'react';
 function useSize(callback: (size: { width: number; height: number }) => void) {
   useEffect(() => {
     // Observe window size changes
-    const observer = new ResizeObserver((entries) => {
+    const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
         callback({ width, height });
@@ -385,7 +385,7 @@ export default function DOMComponent({
 }
 ```
 
-Then update your native code to set the size in state whenever the DOM component reports a change in size: 
+Then update your native code to set the size in state whenever the DOM component reports a change in size:
 
 ```tsx App.tsx (native)
 import DOMComponent from '@/components/my-component';
@@ -402,10 +402,7 @@ export default function App() {
       <ScrollView>
         <DOMComponent
           onDOMLayout={async ({ width, height }) => {
-            if (
-              containerSize?.width !== width ||
-              containerSize?.height !== height
-            ) {
+            if (containerSize?.width !== width || containerSize?.height !== height) {
               setContainerSize({ width, height });
             }
           }}

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -329,7 +329,6 @@ You can also manually provide a size by passing it to the `WebView` `style` prop
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
-import { useState } from 'react';
 
 export default function Route() {
   return (
@@ -342,46 +341,31 @@ export default function Route() {
 }
 ```
 
-#### Observing changes in size
+### Observing changes in size
 
-You can report the DOM component's size back to the native side with the `updateSize` prop and manage the size in the native component's state:
-
-```tsx App.tsx (native)
-export default function Route() {
-  const [height, setHeight] = useState(270);
-  return (
-    <DOMComponent
-      updateSize={async size => {
-        if (size[1] !== height) {
-          setHeight(size[1]);
-        }
-      }}
-      dom={{
-        style: { height },
-      }}
-    />
-  );
-}
-```
+If you would like to report changes in the size of the DOM component back to the native side, you can add a native action to your DOM component that is called whenever the size is changed:
 
 ```tsx my-component.tsx (web)
 'use dom';
 
 import { useEffect } from 'react';
 
-function useSize(callback: (size: [number, number]) => void) {
+function useSize(callback: (size: { width: number; height: number }) => void) {
   useEffect(() => {
     // Observe window size changes
-    const observer = new ResizeObserver(entries => {
+    const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
-        callback([width, height]);
+        callback({ width, height });
       }
     });
 
     observer.observe(document.body);
 
-    callback([document.body.clientWidth, document.body.clientHeight]);
+    callback({
+      width: document.body.clientWidth,
+      height: document.body.clientHeight,
+    });
 
     return () => {
       observer.disconnect();
@@ -390,14 +374,51 @@ function useSize(callback: (size: [number, number]) => void) {
 }
 
 export default function DOMComponent({
-  onLayout,
+  onDOMLayout,
 }: {
   dom?: import('expo/dom').DOMProps;
-  onLayout(size: [number, number]);
+  onDOMLayout: (size: { width: number; height: number }) => void;
 }) {
-  useSize(onLayout);
+  useSize(onDOMLayout);
 
-  return <div />;
+  return <div style={{ width: 500, height: 500, background: 'blue' }} />;
+}
+```
+
+Then update your native code to set the size in state whenever the DOM component reports a change in size: 
+
+```tsx App.tsx (native)
+import DOMComponent from '@/components/my-component';
+import { useState } from 'react';
+import { View, ScrollView } from 'react-native';
+
+export default function App() {
+  const [containerSize, setContainerSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  return (
+    <View style={{ flex: 1 }}>
+      <ScrollView>
+        <DOMComponent
+          onDOMLayout={async ({ width, height }) => {
+            if (
+              containerSize?.width !== width ||
+              containerSize?.height !== height
+            ) {
+              setContainerSize({ width, height });
+            }
+          }}
+          dom={{
+            containerStyle:
+              containerSize != null
+                ? { width: containerSize.width, height: containerSize.height }
+                : null,
+          }}
+        />
+      </ScrollView>
+    </View>
+  );
 }
 ```
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -83,21 +83,7 @@ export default function App() {
 
 ## WebView props
 
-To pass props to the underlying native **WebView**, add a `dom` object to the component:
-
-```tsx my-component.tsx (web)
-'use dom';
-
-export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
-  return (
-    <div>
-      <h1>Hello, world!</h1>
-    </div>
-  );
-}
-```
-
-Now you can pass [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) to the DOM component:
+To pass props to the underlying native **WebView**, use the `dom` prop on the component. This prop is built into every DOM component and accepts an object with any [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) that you would like to change.
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -109,6 +95,20 @@ export default function App() {
         scrollEnabled: false,
       }}
     />
+  );
+}
+```
+
+On your DOM component, add the `dom` prop so it is recognized in TypeScript:
+
+```tsx my-component.tsx (web)
+'use dom';
+
+export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
+  return (
+    <div>
+      <h1>Hello, world!</h1>
+    </div>
   );
 }
 ```
@@ -313,7 +313,7 @@ You may want to measure the size of a DOM component and report it back to the na
 
 ### Automatically with `matchContents` prop
 
-You need to use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view coresponsingly:
+You can use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view. This is particularly useful for certain layouts where the DOM component must have an intrinsic size in order to be displayed, such as when the component is centered within a parent view:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -323,22 +323,30 @@ export default function Route() {
 }
 ```
 
-```tsx my-component.tsx (web)
-'use dom';
+### Manually by specifying a size
 
-export default function DOMComponent(_: { dom?: import('expo/dom').DOMProps }) {
-  return <div style={{ width: 500, height: 500, backgroundColor: 'blue' }} />;
-}
-```
-
-### Manually by resizing native action
-
-You can also manually measure the size of a DOM component and report it back to the native side using a native action:
+You can also manually provide a size by passing it to the `WebView` `style` prop via the `dom` prop:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
 import { useState } from 'react';
 
+export default function Route() {
+  return (
+    <DOMComponent
+      dom={{
+        style: { width, height },
+      }}
+    />
+  );
+}
+```
+
+#### Observing changes in size
+
+You can report the DOM component's size back to the native side with the `updateSize` prop and manage the size in the native component's state:
+
+```tsx App.tsx (native)
 export default function Route() {
   const [height, setHeight] = useState(270);
   return (


### PR DESCRIPTION
# Why

Brings the examples for managing the size of a DOM component in line with the advice that will be shipping in: https://github.com/expo/expo/pull/34375 and further clarifies things you (don't) need to do.

# How
- `matchContent` example: the height/width within the component subtly suggested that these were necessary in order for `matchContent` to work. Originally, I was going to change the example to use something like `<div><h1>...</h1></div>` like other examples in order to more strongly imply that it will work with more than fixed heights. However, I then thought maybe it didn't need any example code at all for the DOM component itself, since `matchContents` should work with anything.
- Updated the "manual" example to match the suggested in the CLI warning above more closely. All you really need is to pass `height` one way. `updateSize` only comes into play when you want to know the size in other native code or otherwise manage it from the native side.
- Also updated the advice on implementing the `dom` prop to reinforce that the `dom` prop exists on all DOM components, and adding it to the DOM component props is just for satisfying TypeScript

# Test Plan

Tried the sample code, worked.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
