### PR TITLE
[expo-updates] Add e2e test for disableAntiBrickingMeasures configuration

### DIFF
--- a/.github/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/.github/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -1,0 +1,101 @@
+name: Updates e2e (bricking measures disabled) EAS
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e-bricking-measures-disabled.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e-bricking-measures-disabled.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+  schedule:
+    - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+        variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 80
+    env:
+      UPDATES_PORT: 4747
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🔧 Install eas-cli
+        run: yarn global add eas-cli
+      - name: 🌳 Add EXPO_REPO_ROOT to environment
+        run: echo "EXPO_REPO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: 🌐 Set updates host
+        run: echo "UPDATES_HOST=localhost" >> $GITHUB_ENV
+      - name: 🌐 Set updates port
+        run: echo "UPDATES_PORT=4747" >> $GITHUB_ENV
+      - name: 📦 Set platform for updates E2E build
+        run: echo "EAS_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
+      - name: 📦 Get artifacts path
+        run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
+      - name: 📦 Get commit message
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
+      - name: 📦 Set test project location
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
+      - name: 📦 Setup test project for updates E2E bricking measures disabled tests
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
+      - name: 🚀 Build with EAS for ${{ matrix.platform }}
+        uses: ./.github/actions/eas-build
+        id: build_eas
+        with:
+          platform: ${{ env.EAS_PLATFORM }}
+          profile: ${{ matrix.variant }}
+          projectRoot: '${{ runner.temp }}/updates-e2e'
+          expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
+      - name: On ${{ matrix.platform }} workflow canceled
+        if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
+        run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
+        working-directory: '${{ runner.temp }}/updates-e2e'
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -112,6 +112,13 @@ export default function App() {
     setExtraParamsString(JSON.stringify(params, null, 2));
   });
 
+  const handleSetUpdateURLAndRequestHeadersOverride = runBlockAsync(async () => {
+    Updates.setUpdateURLAndRequestHeadersOverride({
+      updateUrl: `${Constants.expoConfig?.updates?.url}-override`,
+      requestHeaders: {},
+    });
+  });
+
   const handleReadAssetFiles = runBlockAsync(async () => {
     const numFiles = await ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
     setNumAssetFiles(numFiles);
@@ -257,6 +264,10 @@ export default function App() {
             onPress={handleCheckAndDownloadAtSameTime}
           />
           <TestButton testID="reload" onPress={handleReload} />
+          <TestButton
+            testID="setUpdateURLAndRequestHeadersOverride"
+            onPress={handleSetUpdateURLAndRequestHeadersOverride}
+          />
         </View>
       </View>
 

--- a/packages/expo-updates/e2e/fixtures/Updates-bricking-measures-disabled.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-bricking-measures-disabled.e2e.ts
@@ -1,0 +1,77 @@
+import { by, device, element, waitFor } from 'detox';
+import jestExpect from 'expect';
+import { setTimeout } from 'timers/promises';
+
+import Server from './utils/server';
+import Update from './utils/update';
+
+const projectRoot = process.env.PROJECT_ROOT || process.cwd();
+const platform = device.getPlatform();
+const protocolVersion = 1;
+
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
+  return attributes?.text || '';
+};
+
+const pressTestButtonAsync = async (testID: string) => {
+  await element(by.id(testID)).tap();
+};
+
+const waitForAppToBecomeVisible = async () => {
+  await waitFor(element(by.id('updateString')))
+    .toBeVisible()
+    .withTimeout(3000);
+};
+
+describe('Basic tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+    Server.stop();
+  });
+
+  it('downloads and launches overridden URL and request headers', async () => {
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      [],
+      projectRoot
+    );
+
+    Server.start(Update.serverPort, protocolVersion, 0, /* shouldServeOverriddenUrl */ true);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+
+    // should not have updated (should have gotten 204 from server)
+    const message = await testElementValueAsync('updateString');
+    jestExpect(message).toBe('test');
+
+    await pressTestButtonAsync('setUpdateURLAndRequestHeadersOverride');
+
+    await setTimeout(1000);
+
+    await device.terminateApp();
+
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    // should not have updated (should have gotten 204 from server)
+    const message2 = await testElementValueAsync('updateString');
+    jestExpect(message2).toBe(newNotifyString);
+  });
+});

--- a/packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import {
+  initAsync,
+  setupUpdatesBrickingMeasuresDisabledE2EAppAsync,
+  transformAppJsonForE2EWithBrickingMeasuresDisabled,
+} from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT, 'EXPO_REPO_ROOT is not defined');
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: true,
+    transformAppJson: transformAppJsonForE2EWithBrickingMeasuresDisabled,
+  });
+
+  await setupUpdatesBrickingMeasuresDisabledE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -520,6 +520,30 @@ export function transformAppJsonForE2EWithFingerprint(
   };
 }
 
+export function transformAppJsonForE2EWithBrickingMeasuresDisabled(
+  appJson: any,
+  projectName: string,
+  runtimeVersion: string,
+  isTV: boolean
+) {
+  const transformedForE2E = transformAppJsonForE2EWithFallbackToCacheTimeout(
+    appJson,
+    projectName,
+    runtimeVersion,
+    isTV
+  );
+  return {
+    ...transformedForE2E,
+    expo: {
+      ...transformedForE2E.expo,
+      updates: {
+        ...transformedForE2E.expo.updates,
+        disableAntiBrickingMeasures: true,
+      },
+    },
+  };
+}
+
 /**
  * Modifies app.json in the E2E test app to add the properties we need, plus a fallback to cache timeout for testing startup procedure
  */
@@ -937,6 +961,29 @@ export async function setupUpdatesStartupE2EAppAsync(
   // Copy Detox test file to e2e/tests directory
   await fs.copyFile(
     path.resolve(dirName, '..', 'fixtures', 'Updates-startup.e2e.ts'),
+    path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
+  );
+}
+
+export async function setupUpdatesBrickingMeasuresDisabledE2EAppAsync(
+  projectRoot: string,
+  { localCliBin, repoRoot }: { localCliBin: string; repoRoot: string }
+) {
+  await copyCommonFixturesToProject(
+    projectRoot,
+    ['tsconfig.json', '.detoxrc.json', 'eas.json', 'eas-hooks', 'e2e', 'includedAssets', 'scripts'],
+    { appJsFileName: 'App.tsx', repoRoot, isTV: false }
+  );
+
+  // install extra fonts package
+  await spawnAsync(localCliBin, ['install', '@expo-google-fonts/inter'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  // Copy Detox test file to e2e/tests directory
+  await fs.copyFile(
+    path.resolve(dirName, '..', 'fixtures', 'Updates-bricking-measures-disabled.e2e.ts'),
     path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
