### PR TITLE
Add AutoSizingStack and shadow node support

### DIFF
--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
@@ -1,6 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 #include "ExpoViewComponentDescriptor.h"
+#include <react/renderer/core/ShadowNode.h>
 
 namespace expo {
 
@@ -14,6 +15,17 @@ facebook::react::ComponentHandle ExpoViewComponentDescriptor::getComponentHandle
 
 facebook::react::ComponentName ExpoViewComponentDescriptor::getComponentName() const {
   return std::static_pointer_cast<std::string const>(this->flavor_)->c_str();
+}
+
+void ExpoViewComponentDescriptor::adopt(facebook::react::ShadowNode &shadowNode) const {
+  react_native_assert(dynamic_cast<ExpoViewShadowNode *>(&shadowNode));
+
+  const auto snode = dynamic_cast<ExpoViewShadowNode *>(&shadowNode);
+  const auto state = snode->getStateData();
+  if(state._width >= 0 or state._height >= 0){
+    snode->setSize({state._width, state._height});
+  }
+  ConcreteComponentDescriptor::adopt(shadowNode);
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
@@ -23,7 +23,7 @@ void ExpoViewComponentDescriptor::adopt(facebook::react::ShadowNode &shadowNode)
 
   const auto snode = dynamic_cast<ExpoViewShadowNode *>(&shadowNode);
   const auto state = snode->getStateData();
-  if(!isnan(state._width) or !isnan(state._height)){
+  if (!isnan(state._width) or !isnan(state._height)) {
     snode->setSize({state._width, state._height});
   }
   ConcreteComponentDescriptor::adopt(shadowNode);

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.cpp
@@ -2,6 +2,7 @@
 
 #include "ExpoViewComponentDescriptor.h"
 #include <react/renderer/core/ShadowNode.h>
+#include <cmath>
 
 namespace expo {
 
@@ -22,7 +23,7 @@ void ExpoViewComponentDescriptor::adopt(facebook::react::ShadowNode &shadowNode)
 
   const auto snode = dynamic_cast<ExpoViewShadowNode *>(&shadowNode);
   const auto state = snode->getStateData();
-  if(state._width >= 0 or state._height >= 0){
+  if(!isnan(state._width) or !isnan(state._height)){
     snode->setSize({state._width, state._height});
   }
   ConcreteComponentDescriptor::adopt(shadowNode);

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
@@ -5,6 +5,7 @@
 #ifdef __cplusplus
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/core/ShadowNode.h>
 
 #include "ExpoViewShadowNode.h"
 
@@ -18,6 +19,8 @@ class ExpoViewComponentDescriptor : public facebook::react::ConcreteComponentDes
 
   facebook::react::ComponentHandle getComponentHandle() const override;
   facebook::react::ComponentName getComponentName() const override;
+
+  void adopt(facebook::react::ShadowNode &shadowNode) const override;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewState.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewState.h
@@ -17,12 +17,12 @@ public:
   ExpoViewState() {}
   
   ExpoViewState(float width, float height) {
-    if(width >= 0) {
+    if (width >= 0) {
       _width = width;
     } else {
       _width = std::numeric_limits<float>::quiet_NaN();
     }
-    if(height >= 0) {
+    if (height >= 0) {
       _height = height;
     } else {
       _height = std::numeric_limits<float>::quiet_NaN();

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewState.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewState.h
@@ -14,7 +14,20 @@ namespace expo {
 
 class ExpoViewState final {
 public:
-  ExpoViewState() {};
+  ExpoViewState() {}
+  
+  ExpoViewState(float width, float height) {
+    if(width >= 0) {
+      _width = width;
+    } else {
+      _width = std::numeric_limits<float>::quiet_NaN();
+    }
+    if(height >= 0) {
+      _height = height;
+    } else {
+      _height = std::numeric_limits<float>::quiet_NaN();
+    }
+  };
 
 #ifdef ANDROID
   ExpoViewState(ExpoViewState const &previousState, folly::dynamic data) {};
@@ -27,6 +40,9 @@ public:
     return facebook::react::MapBufferBuilder::EMPTY();
   };
 #endif
+  
+  float _width = std::numeric_limits<float>::quiet_NaN();
+  float _height = std::numeric_limits<float>::quiet_NaN();
 
 };
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -1,0 +1,47 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+extension ExpoSwiftUI {
+  
+  public struct AxisSet: OptionSet {
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+    public let rawValue: Int
+    
+    public static let horizontal = AxisSet(rawValue: 1 << 0)
+    public static let vertical = AxisSet(rawValue: 1 << 1)
+    
+    public static let both: AxisSet = [.horizontal, .vertical]
+  }
+  
+  public struct AutoSizingStack<Content: SwiftUI.View>: SwiftUI.View {
+    let content: Content
+    let viewUtils: ViewUtils
+    let axis: AxisSet
+    
+    public init(viewUtils: ViewUtils, axis: AxisSet = .both, @ViewBuilder _ content: () -> Content) {
+      self.viewUtils = viewUtils
+      self.content = content()
+      self.axis = axis
+    }
+    
+    public var body: some SwiftUI.View {
+      if #available(iOS 16.0, *) {
+        content.fixedSize(horizontal: axis.contains(.horizontal), vertical: axis.contains(.vertical))
+        .onGeometryChange(for: CGSize.self) { proxy in
+          proxy.size
+        } action: {
+          let size = CGSize(width: axis.contains(.horizontal) ? $0.width : -1, height: axis.contains(.vertical) ? $0.height : -1)
+          viewUtils.setViewSize?(size)
+        }
+      } else {
+        // TODO: throw a warning
+        content.onAppear(perform: {
+          log.warn("AutoSizingStack is not supported on iOS < 16.0")
+        })
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -32,7 +32,9 @@ extension ExpoSwiftUI {
         .onGeometryChange(for: CGSize.self) { proxy in
           proxy.size
         } action: {
-          let size = CGSize(width: axis.contains(.horizontal) ? $0.width : Double.nan, height: axis.contains(.vertical) ? $0.height : Double.nan)
+          let width = axis.contains(.horizontal) ? $0.width : ShadowNodeProxy.UNDEFINED_SIZE
+          let height = axis.contains(.vertical) ? $0.height : ShadowNodeProxy.UNDEFINED_SIZE
+          let size = CGSize(width: width, height: height)
           proxy.setViewSize?(size)
         }
       } else {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -3,30 +3,29 @@
 import SwiftUI
 
 extension ExpoSwiftUI {
-  
   public struct AxisSet: OptionSet {
     public init(rawValue: Int) {
       self.rawValue = rawValue
     }
     public let rawValue: Int
-    
+
     public static let horizontal = AxisSet(rawValue: 1 << 0)
     public static let vertical = AxisSet(rawValue: 1 << 1)
-    
+
     public static let both: AxisSet = [.horizontal, .vertical]
   }
-  
+
   public struct AutoSizingStack<Content: SwiftUI.View>: SwiftUI.View {
     let content: Content
     let viewUtils: ViewUtils
     let axis: AxisSet
-    
+
     public init(viewUtils: ViewUtils, axis: AxisSet = .both, @ViewBuilder _ content: () -> Content) {
       self.viewUtils = viewUtils
       self.content = content()
       self.axis = axis
     }
-    
+
     public var body: some SwiftUI.View {
       if #available(iOS 16.0, *) {
         content.fixedSize(horizontal: axis.contains(.horizontal), vertical: axis.contains(.vertical))

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -17,11 +17,11 @@ extension ExpoSwiftUI {
 
   public struct AutoSizingStack<Content: SwiftUI.View>: SwiftUI.View {
     let content: Content
-    let viewUtils: ViewUtils
+    let proxy: ShadowNodeProxy
     let axis: AxisSet
 
-    public init(viewUtils: ViewUtils, axis: AxisSet = .both, @ViewBuilder _ content: () -> Content) {
-      self.viewUtils = viewUtils
+    public init(shadowNodeProxy: ShadowNodeProxy, axis: AxisSet = .both, @ViewBuilder _ content: () -> Content) {
+      self.proxy = shadowNodeProxy
       self.content = content()
       self.axis = axis
     }
@@ -32,8 +32,8 @@ extension ExpoSwiftUI {
         .onGeometryChange(for: CGSize.self) { proxy in
           proxy.size
         } action: {
-          let size = CGSize(width: axis.contains(.horizontal) ? $0.width : -1, height: axis.contains(.vertical) ? $0.height : -1)
-          viewUtils.setViewSize?(size)
+          let size = CGSize(width: axis.contains(.horizontal) ? $0.width : Double.nan, height: axis.contains(.vertical) ? $0.height : Double.nan)
+          proxy.setViewSize?(size)
         }
       } else {
         // TODO: throw a warning

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -21,7 +21,7 @@ extension ExpoSwiftUI {
      It's an environment object that is observed by the content view.
      */
     private let props: Props
-    
+
     /**
      Additiional utilities for controlling shadow node behavior.
      */

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -21,6 +21,7 @@ extension ExpoSwiftUI {
      It's an environment object that is observed by the content view.
      */
     private let props: Props
+    
     /**
      Additiional utilities for controlling shadow node behavior.
      */

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -24,7 +24,7 @@ extension ExpoSwiftUI {
     /**
      Additiional utilities for controlling shadow node behavior.
      */
-    private let utils: ViewUtils = ViewUtils()
+    private let shadowNodeProxy: ShadowNodeProxy = ShadowNodeProxy()
 
     /**
      View controller that embeds the content view into the UIKit view hierarchy.
@@ -35,17 +35,17 @@ extension ExpoSwiftUI {
      Initializes a SwiftUI hosting view with the given SwiftUI view type.
      */
     init(viewType: ContentView.Type, props: Props, appContext: AppContext) {
-      let rootView = ContentView().environmentObject(props).environmentObject(utils)
+      let rootView = ContentView().environmentObject(props).environmentObject(shadowNodeProxy)
 
       self.props = props
       self.hostingController = UIHostingController(rootView: rootView)
 
       super.init(appContext: appContext)
 
-      utils.setViewSize = { size in
+      shadowNodeProxy.setViewSize = { size in
         self.setViewSize(size)
       }
-      utils.objectWillChange.send()
+      shadowNodeProxy.objectWillChange.send()
 
       #if os(iOS) || os(tvOS)
       // Hosting controller has white background by default,

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -21,6 +21,10 @@ extension ExpoSwiftUI {
      It's an environment object that is observed by the content view.
      */
     private let props: Props
+    /**
+     Additiional utilities for controlling shadow node behavior.
+     */
+    private let utils: ViewUtils = ViewUtils()
 
     /**
      View controller that embeds the content view into the UIKit view hierarchy.
@@ -31,12 +35,17 @@ extension ExpoSwiftUI {
      Initializes a SwiftUI hosting view with the given SwiftUI view type.
      */
     init(viewType: ContentView.Type, props: Props, appContext: AppContext) {
-      let rootView = ContentView().environmentObject(props)
+      let rootView = ContentView().environmentObject(props).environmentObject(utils)
 
       self.props = props
       self.hostingController = UIHostingController(rootView: rootView)
 
       super.init(appContext: appContext)
+
+      utils.setViewSize = { size in
+        self.setViewSize(size)
+      }
+      utils.objectWillChange.send()
 
       #if os(iOS) || os(tvOS)
       // Hosting controller has white background by default,

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
@@ -3,6 +3,9 @@ extension ExpoSwiftUI {
   open class ShadowNodeProxy: ObservableObject, Record {
     public required init() {}
 
+    // We use Double.nan to mark a dimension as unset. This value is passed to https://github.com/facebook/yoga/blob/49ee855f99fb67079c24d507a4ea1b6d80fa2ebf/yoga/style/StyleLength.h#L33
+    static let UNDEFINED_SIZE = Double.nan
+
     public var setViewSize: ((CGSize) -> Void)?
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
@@ -1,6 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 extension ExpoSwiftUI {
-  open class ViewUtils: ObservableObject, Record {
+  open class ShadowNodeProxy: ObservableObject, Record {
     public required init() {}
 
     public var setViewSize: ((CGSize) -> Void)?

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewUtils.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewUtils.swift
@@ -1,0 +1,8 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+extension ExpoSwiftUI {
+  open class ViewUtils: ObservableObject, Record {
+    public required init() {}
+
+    public var setViewSize: ((CGSize) -> Void)? = nil
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewUtils.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewUtils.swift
@@ -3,6 +3,6 @@ extension ExpoSwiftUI {
   open class ViewUtils: ObservableObject, Record {
     public required init() {}
 
-    public var setViewSize: ((CGSize) -> Void)? = nil
+    public var setViewSize: ((CGSize) -> Void)?
   }
 }

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -36,6 +36,10 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     super.init(frame: frame)
   }
 
+  public func setViewSize(_ size: CGSize) {
+    super.setShadowNodeSize(Float(size.width), height: Float(size.height))
+  }
+
   required public init(appContext: AppContext? = nil) {
     self.appContext = appContext
     super.init(frame: .zero)
@@ -68,6 +72,8 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   }
 
   // MARK: - ExpoFabricViewInterface
+  
+  
 
   public override func updateProps(_ props: [String: Any]) {
     guard let context = appContext, let propsDict = viewManagerPropDict else {

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -72,8 +72,6 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   }
 
   // MARK: - ExpoFabricViewInterface
-  
-  
 
   public override func updateProps(_ props: [String: Any]) {
     guard let context = appContext, let propsDict = viewManagerPropDict else {

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -38,6 +38,8 @@
 
 - (void)viewDidUpdateProps;
 
+- (void)setShadowNodeSize: (float) width height:(float) height;
+
 - (BOOL)supportsPropWithName:(nonnull NSString *)name;
 
 // MARK: - Derived from RCTComponentViewProtocol

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -38,7 +38,7 @@
 
 - (void)viewDidUpdateProps;
 
-- (void)setShadowNodeSize: (float) width height:(float) height;
+- (void)setShadowNodeSize:(float) width height:(float) height;
 
 - (BOOL)supportsPropWithName:(nonnull NSString *)name;
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -80,7 +80,9 @@ static NSString *normalizeEventName(NSString *eventName)
  */
 static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _componentFlavorsCache;
 
-@implementation ExpoFabricViewObjC
+@implementation ExpoFabricViewObjC {
+  ExpoViewShadowNode::ConcreteState::Shared _state;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -156,9 +158,21 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
   // Implemented in `ExpoFabricView.swift`
 }
 
+- (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
+{
+  _state = std::static_pointer_cast<const ExpoViewShadowNode::ConcreteState>(state);
+}
+
 - (void)viewDidUpdateProps
 {
   // Implemented in `ExpoFabricView.swift`
+}
+
+- (void)setShadowNodeSize: (float) width height:(float) height
+{
+  if(_state) {
+    _state->updateState(ExpoViewState(width,height));
+  }
 }
 
 - (BOOL)supportsPropWithName:(nonnull NSString *)name

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -168,9 +168,9 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
   // Implemented in `ExpoFabricView.swift`
 }
 
-- (void)setShadowNodeSize: (float) width height:(float) height
+- (void)setShadowNodeSize:(float)width height:(float)height
 {
-  if(_state) {
+  if (_state) {
     _state->updateState(ExpoViewState(width,height));
   }
 }

--- a/packages/expo-ui/ios/SwitchView.swift
+++ b/packages/expo-ui/ios/SwitchView.swift
@@ -12,27 +12,31 @@ class SwitchProps: ExpoSwiftUI.ViewProps {
 
 struct SwitchView: ExpoSwiftUI.View {
   @EnvironmentObject var props: SwitchProps
+  @EnvironmentObject var utils: ExpoSwiftUI.ViewUtils
   @State var checked: Bool = false
 
   var body: some View {
-    Toggle(isOn: $checked, label: { props.label != nil ? Text(props.label ?? "") : nil })
-    .onChange(of: checked, perform: { newValue in
-      if props.checked == newValue {
-        return
-      }
-      props.onCheckedChanged([
-        "checked": newValue
-      ])
-    })
-    .onReceive(props.objectWillChange, perform: {
-      checked = props.checked
-    })
-    .if(props.variant == "button", transform: {
-      $0.toggleStyle(.button)
-    })
-    .if(props.variant == "checkbox", transform: {
-      $0.toggleStyle(IOSCheckboxToggleStyle())
-    })
+    ExpoSwiftUI.AutoSizingStack(viewUtils: utils, axis: .both) {
+      Toggle(isOn: $checked, label: { props.label != nil ? Text(props.label ?? "") : nil })
+      .onChange(of: checked, perform: { newValue in
+        if props.checked == newValue {
+          return
+        }
+        props.onCheckedChanged([
+          "checked": newValue
+        ])
+      })
+      .onReceive(props.objectWillChange, perform: {
+        checked = props.checked
+      })
+      .if(props.variant == "button", transform: {
+        $0.toggleStyle(.button)
+      })
+      .if(props.variant == "checkbox", transform: {
+        $0.toggleStyle(IOSCheckboxToggleStyle())
+      })
+      .fixedSize()
+    }
   }
 }
 

--- a/packages/expo-ui/ios/SwitchView.swift
+++ b/packages/expo-ui/ios/SwitchView.swift
@@ -12,11 +12,11 @@ class SwitchProps: ExpoSwiftUI.ViewProps {
 
 struct SwitchView: ExpoSwiftUI.View {
   @EnvironmentObject var props: SwitchProps
-  @EnvironmentObject var utils: ExpoSwiftUI.ViewUtils
+  @EnvironmentObject var shadowNodeProxy: ExpoSwiftUI.ShadowNodeProxy
   @State var checked: Bool = false
 
   var body: some View {
-    ExpoSwiftUI.AutoSizingStack(viewUtils: utils, axis: .both) {
+    ExpoSwiftUI.AutoSizingStack(shadowNodeProxy: shadowNodeProxy, axis: .both) {
       Toggle(isOn: $checked, label: { props.label != nil ? Text(props.label ?? "") : nil })
       .onChange(of: checked, perform: { newValue in
         if props.checked == newValue {


### PR DESCRIPTION
# Why

We need it for stuff like checkboxes.

# How

Accessed the shadow node and set state based on SwiftUI geometry measure callback.

# Test Plan

Tested manually and it seems to work really well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
