### PR TITLE
[ios][maps] Fix cameraPosition reactivity

### DIFF
--- a/packages/expo-maps-remake/ios/AppleMapsView.swift
+++ b/packages/expo-maps-remake/ios/AppleMapsView.swift
@@ -101,7 +101,7 @@ struct AppleMapsView: View {
           MapUserLocationButton()
         }
       }
-      .onChange(of: props.cameraPosition) { oldValue, newValue in
+      .onChange(of: props.cameraPosition) { _, newValue in
           mapCameraPosition = convertToMapCamera(position: newValue)
       }
       .onMapCameraChange(frequency: .onEnd) { change in

--- a/packages/expo-maps-remake/ios/AppleMapsView.swift
+++ b/packages/expo-maps-remake/ios/AppleMapsView.swift
@@ -102,7 +102,7 @@ struct AppleMapsView: View {
         }
       }
       .onChange(of: props.cameraPosition) { _, newValue in
-          mapCameraPosition = convertToMapCamera(position: newValue)
+        mapCameraPosition = convertToMapCamera(position: newValue)
       }
       .onMapCameraChange(frequency: .onEnd) { change in
         let cameraPosition = change.region.center

--- a/packages/expo-maps-remake/ios/AppleMapsView.swift
+++ b/packages/expo-maps-remake/ios/AppleMapsView.swift
@@ -101,6 +101,9 @@ struct AppleMapsView: View {
           MapUserLocationButton()
         }
       }
+      .onChange(of: props.cameraPosition) { oldValue, newValue in
+          mapCameraPosition = convertToMapCamera(position: newValue)
+      }
       .onMapCameraChange(frequency: .onEnd) { change in
         let cameraPosition = change.region.center
         let zoomLevel = change.region.span.longitudeDelta

--- a/packages/expo-maps-remake/ios/MapRecords.swift
+++ b/packages/expo-maps-remake/ios/MapRecords.swift
@@ -31,9 +31,15 @@ struct MapMarker: Identifiable, Record {
   }
 }
 
-struct CameraPosition: Record {
+struct CameraPosition: Record, Equatable {
   @Field var coordinates: Coordinate
   @Field var zoom: Double = 1
+  
+  static func == (lhs: CameraPosition, rhs: CameraPosition) -> Bool {
+    return lhs.coordinates.latitude == rhs.coordinates.latitude &&
+    lhs.coordinates.longitude == rhs.coordinates.longitude &&
+    lhs.zoom == rhs.zoom
+  }
 }
 
 struct MapAnnotation: Record, Identifiable {

--- a/packages/expo-maps-remake/ios/MapRecords.swift
+++ b/packages/expo-maps-remake/ios/MapRecords.swift
@@ -34,7 +34,7 @@ struct MapMarker: Identifiable, Record {
 struct CameraPosition: Record, Equatable {
   @Field var coordinates: Coordinate
   @Field var zoom: Double = 1
-  
+
   static func == (lhs: CameraPosition, rhs: CameraPosition) -> Bool {
     return lhs.coordinates.latitude == rhs.coordinates.latitude &&
     lhs.coordinates.longitude == rhs.coordinates.longitude &&


### PR DESCRIPTION
# Why
Fixes the cameraPosition not being reactive and also stops it from resetting when UI elements are added or removed.

# How
Make the `CameraPosition` equatable and update the mapCameraPosition when it changes.

# Test Plan
bare-expo

