### PR TITLE
[updates] add runtime URL and headers override on ios

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Add new state machine context about startup procedure. ([#32433](https://github.com/expo/expo/pull/32433) by [@wschurman](https://github.com/wschurman))
-- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422) by [@kudo](https://github.com/kudo))
+- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422), [#34423](https://github.com/expo/expo/pull/34423) by [@kudo](https://github.com/kudo), [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -172,6 +172,7 @@ public protocol InternalAppControllerInterface: AppControllerInterface {
     success successBlockArg: @escaping () -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   )
+  func setUpdatesURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws
 }
 
 @objc(EXUpdatesAppControllerDelegate)

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -346,6 +346,10 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   public func setExtraParam(key: String, value: String?, success successBlockArg: @escaping () -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
     errorBlockArg(NotAvailableInDevClientException("Updates.setExtraParamAsync()"))
   }
+
+  public func setUpdatesURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws {
+    throw NotAvailableInDevClientException("Updates.setUpdatesURLAndRequestHeadersOverride() is not supported in development builds.")
+  }
 }
 
 // swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -141,4 +141,8 @@ public class DisabledAppController: InternalAppControllerInterface {
   ) {
     errorBlockArg(UpdatesDisabledException("Updates.setExtraParamAsync()"))
   }
+
+  public func setUpdatesURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws {
+    throw UpdatesDisabledException("Updates.setUpdatesURLAndRequestHeadersOverride() is not supported when expo-updates is not enabled.")
+  }
 }

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -247,4 +247,11 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
   public func getEmbeddedUpdate() -> Update? {
     return EmbeddedAppLoader.embeddedManifest(withConfig: self.config, database: self.database)
   }
+
+  public func setUpdatesURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws {
+    if !config.disableAntiBrickingMeasures {
+      throw NotAllowedAntiBrickingMeasuresException()
+    }
+    UpdatesConfigOverride.save(configOverride)
+  }
 }

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -68,4 +68,14 @@ internal final class NotAvailableInDevClientException: Exception {
   }
 }
 
+internal final class NotAllowedAntiBrickingMeasuresException: Exception {
+  override var code: String {
+    "ERR_UPDATES_CONFIG_OVERRIDE"
+  }
+
+  override var reason: String {
+    "Must set disableAntiBrickingMeasures configuration to use updates overriding"
+  }
+}
+
 // swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -88,8 +88,6 @@ public final class UpdatesConfig: NSObject {
 
   public static let EXUpdatesConfigRuntimeVersionReadFingerprintFileSentinel = "file:fingerprint"
 
-  internal static let kUpdatesConfigOverride = "dev.expo.updates.updatesConfigOverride"
-
   public let scopeKey: String
   public let updateUrl: URL
   public let requestHeaders: [String: String]

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
@@ -6,11 +6,13 @@ import ExpoModulesCore
  `UpdatesConfig` values set at runtime that override build-time configuration.
  */
 public struct UpdatesConfigOverride: Codable {
+  private static let kUpdatesConfigOverride = "dev.expo.updates.updatesConfigOverride"
+
   let updateUrl: URL?
   let requestHeaders: [String: String]
 
   public static func load() -> UpdatesConfigOverride? {
-    guard let data = UserDefaults.standard.data(forKey: UpdatesConfig.kUpdatesConfigOverride) else {
+    guard let data = UserDefaults.standard.data(forKey: kUpdatesConfigOverride) else {
       return nil
     }
     let decoder = JSONDecoder()
@@ -23,24 +25,9 @@ public struct UpdatesConfigOverride: Codable {
       guard let data = try? encoder.encode(configOverride) else {
         return
       }
-      UserDefaults.standard.set(data, forKey: UpdatesConfig.kUpdatesConfigOverride)
+      UserDefaults.standard.set(data, forKey: kUpdatesConfigOverride)
     } else {
-      UserDefaults.standard.removeObject(forKey: UpdatesConfig.kUpdatesConfigOverride)
+      UserDefaults.standard.removeObject(forKey: kUpdatesConfigOverride)
     }
-  }
-}
-
-/**
- `UpdatesConfigOverride` parameters passing from JavaScript.
- */
-internal struct UpdatesConfigOverrideParam: Record {
-  @Field var updateUrl: URL?
-  @Field var requestHeaders: [String: String]
-
-  func toUpdatesConfigOverride() -> UpdatesConfigOverride {
-    return UpdatesConfigOverride(
-      updateUrl: updateUrl,
-      requestHeaders: requestHeaders
-    )
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
@@ -1,0 +1,46 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+/**
+ `UpdatesConfig` values set at runtime that override build-time configuration.
+ */
+public struct UpdatesConfigOverride: Codable {
+  let updateUrl: URL?
+  let requestHeaders: [String: String]
+
+  public static func load() -> UpdatesConfigOverride? {
+    guard let data = UserDefaults.standard.data(forKey: UpdatesConfig.kUpdatesConfigOverride) else {
+      return nil
+    }
+    let decoder = JSONDecoder()
+    return try? decoder.decode(UpdatesConfigOverride.self, from: Data(data))
+  }
+
+  internal static func save(_ configOverride: UpdatesConfigOverride?) {
+    if let configOverride {
+      let encoder = JSONEncoder()
+      guard let data = try? encoder.encode(configOverride) else {
+        return
+      }
+      UserDefaults.standard.set(data, forKey: UpdatesConfig.kUpdatesConfigOverride)
+    } else {
+      UserDefaults.standard.removeObject(forKey: UpdatesConfig.kUpdatesConfigOverride)
+    }
+  }
+}
+
+/**
+ `UpdatesConfigOverride` parameters passing from JavaScript.
+ */
+internal struct UpdatesConfigOverrideParam: Record {
+  @Field var updateUrl: URL?
+  @Field var requestHeaders: [String: String]
+
+  func toUpdatesConfigOverride() -> UpdatesConfigOverride {
+    return UpdatesConfigOverride(
+      updateUrl: updateUrl,
+      requestHeaders: requestHeaders
+    )
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -140,6 +140,10 @@ public final class UpdatesModule: Module, UpdatesEventManagerObserver {
         promise.reject(error)
       }
     }
+
+    Function("setUpdatesURLAndRequestHeadersOverride") { (configOverride: UpdatesConfigOverrideParam?) in
+      try AppController.sharedInstance.setUpdatesURLAndRequestHeadersOverride(configOverride?.toUpdatesConfigOverride())
+    }
   }
 
   public func onStateMachineContextEvent(context: UpdatesStateContext) {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -151,4 +151,16 @@ public final class UpdatesModule: Module, UpdatesEventManagerObserver {
       "context": context.json
     ])
   }
+
+  internal struct UpdatesConfigOverrideParam: Record {
+    @Field var updateUrl: URL?
+    @Field var requestHeaders: [String: String]
+
+    func toUpdatesConfigOverride() -> UpdatesConfigOverride {
+      return UpdatesConfigOverride(
+        updateUrl: updateUrl,
+        requestHeaders: requestHeaders
+      )
+    }
+  }
 }


### PR DESCRIPTION
# Why

#34422 for ios

# How

add ios implementation for #34422

```
Co-authored-by: Will Schurman <wschurman@expo.io>
```

# Test Plan

will has an e2e test later

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
