### PR TITLE
[updates] refactoring json data keys to enum

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Add new state machine context about startup procedure. ([#32433](https://github.com/expo/expo/pull/32433) by [@wschurman](https://github.com/wschurman))
-- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422), [#34423](https://github.com/expo/expo/pull/34423) by [@kudo](https://github.com/kudo), [@wschurman](https://github.com/wschurman))
+- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422), [#34423](https://github.com/expo/expo/pull/34423), [#34422](https://github.com/expo/expo/pull/34422), [#34425](https://github.com/expo/expo/pull/34425) by [@kudo](https://github.com/kudo), [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
@@ -3,6 +3,7 @@ package expo.modules.updates.db
 import android.net.Uri
 import expo.modules.jsonutils.getNullable
 import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.db.dao.JSONDataDao
 import org.json.JSONObject
 
 /**
@@ -27,8 +28,6 @@ import org.json.JSONObject
  *   UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
  */
 object BuildData {
-  private var staticBuildDataKey = "staticBuildData"
-
   fun ensureBuildDataIsConsistent(
     updatesConfiguration: UpdatesConfiguration,
     database: UpdatesDatabase
@@ -78,14 +77,14 @@ object BuildData {
   ) {
     val buildDataJSON = getBuildDataFromConfig(updatesConfiguration)
     database.jsonDataDao()?.setJSONStringForKey(
-      staticBuildDataKey,
+      JSONDataDao.JSONDataKey.STATIC_BUILD_DATA,
       buildDataJSON.toString(),
       updatesConfiguration.scopeKey
     )
   }
 
   fun getBuildDataFromDatabase(database: UpdatesDatabase, scopeKey: String): JSONObject? {
-    val buildJSONString = database.jsonDataDao()?.loadJSONStringForKey(staticBuildDataKey, scopeKey)
+    val buildJSONString = database.jsonDataDao()?.loadJSONStringForKey(JSONDataDao.JSONDataKey.STATIC_BUILD_DATA, scopeKey)
     return if (buildJSONString == null) null else JSONObject(buildJSONString)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
@@ -6,6 +6,7 @@ import expo.modules.structuredheaders.Dictionary
 import expo.modules.structuredheaders.StringItem
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
+import expo.modules.updates.db.dao.JSONDataDao
 import org.json.JSONObject
 
 /**
@@ -15,12 +16,8 @@ import org.json.JSONObject
 object ManifestMetadata {
   private val TAG = ManifestMetadata::class.java.simpleName
 
-  private const val EXTRA_PARAMS_KEY = "extraParams"
-  private const val MANIFEST_SERVER_DEFINED_HEADERS_KEY = "serverDefinedHeaders"
-  private const val MANIFEST_FILTERS_KEY = "manifestFilters"
-
   private fun getJSONObject(
-    key: String,
+    key: JSONDataDao.JSONDataKey,
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration
   ): JSONObject? {
@@ -38,21 +35,21 @@ object ManifestMetadata {
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration
   ): JSONObject? {
-    return getJSONObject(MANIFEST_SERVER_DEFINED_HEADERS_KEY, database, configuration)
+    return getJSONObject(JSONDataDao.JSONDataKey.MANIFEST_SERVER_DEFINED_HEADERS, database, configuration)
   }
 
   fun getManifestFilters(
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration
   ): JSONObject? {
-    return getJSONObject(MANIFEST_FILTERS_KEY, database, configuration)
+    return getJSONObject(JSONDataDao.JSONDataKey.MANIFEST_FILTERS, database, configuration)
   }
 
   fun getExtraParams(
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration
   ): Map<String, String>? {
-    return getJSONObject(EXTRA_PARAMS_KEY, database, configuration)?.asStringStringMap()
+    return getJSONObject(JSONDataDao.JSONDataKey.EXTRA_PARAMS, database, configuration)?.asStringStringMap()
   }
 
   fun setExtraParam(
@@ -62,7 +59,7 @@ object ManifestMetadata {
     value: String?
   ) {
     // this is done within a transaction to ensure consistency
-    database.jsonDataDao()!!.updateJSONStringForKey(EXTRA_PARAMS_KEY, configuration.scopeKey) { previousValue ->
+    database.jsonDataDao()!!.updateJSONStringForKey(JSONDataDao.JSONDataKey.EXTRA_PARAMS, configuration.scopeKey) { previousValue ->
       val jsonObject = previousValue?.let { JSONObject(it) }
       val extraParamsToWrite = (jsonObject?.asStringStringMap()?.toMutableMap() ?: mutableMapOf()).also {
         if (value != null) {
@@ -85,12 +82,12 @@ object ManifestMetadata {
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration
   ) {
-    val fieldsToSet = mutableMapOf<String, String>()
+    val fieldsToSet = mutableMapOf<JSONDataDao.JSONDataKey, String>()
     if (responseHeaderData.serverDefinedHeaders != null) {
-      fieldsToSet[MANIFEST_SERVER_DEFINED_HEADERS_KEY] = responseHeaderData.serverDefinedHeaders.toString()
+      fieldsToSet[JSONDataDao.JSONDataKey.MANIFEST_SERVER_DEFINED_HEADERS] = responseHeaderData.serverDefinedHeaders.toString()
     }
     if (responseHeaderData.manifestFilters != null) {
-      fieldsToSet[MANIFEST_FILTERS_KEY] = responseHeaderData.manifestFilters.toString()
+      fieldsToSet[JSONDataDao.JSONDataKey.MANIFEST_FILTERS] = responseHeaderData.manifestFilters.toString()
     }
     if (fieldsToSet.isNotEmpty()) {
       database.jsonDataDao()!!.setMultipleFields(fieldsToSet, configuration.scopeKey)

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -73,10 +73,12 @@ enum UpdatesDatabaseHashType: Int {
 @objc(EXUpdatesDatabase)
 @objcMembers
 public final class UpdatesDatabase: NSObject {
-  private static let ManifestFiltersKey = "manifestFilters"
-  private static let ServerDefinedHeadersKey = "serverDefinedHeaders"
-  private static let StaticBuildDataKey = "staticBuildData"
-  private static let ExtraParmasKey = "extraParams"
+  internal enum JSONDataKey: String {
+    case ManifestFiltersKey = "manifestFilters"
+    case ServerDefinedHeadersKey = "serverDefinedHeaders"
+    case StaticBuildDataKey = "staticBuildData"
+    case ExtraParmasKey = "extraParams"
+  }
 
   public let databaseQueue: DispatchQueue
   private var db: OpaquePointer?
@@ -482,11 +484,11 @@ public final class UpdatesDatabase: NSObject {
     return asset(withRow: rows.first!)
   }
 
-  private func jsonData(withKey key: String, scopeKey: String) throws -> [String: Any]? {
+  private func jsonData(withKey key: JSONDataKey, scopeKey: String) throws -> [String: Any]? {
     let sql = """
       SELECT * FROM json_data WHERE "key" = ?1 AND "scope_key" = ?2
     """
-    let rows = try execute(sql: sql, withArgs: [key, scopeKey])
+    let rows = try execute(sql: sql, withArgs: [key.rawValue, scopeKey])
     guard let firstRow = rows.first,
       let value = firstRow["value"] as? String else {
       return nil
@@ -495,7 +497,7 @@ public final class UpdatesDatabase: NSObject {
     return try JSONSerialization.jsonObject(with: value.data(using: .utf8)!) as? [String: Any]
   }
 
-  private func setJsonData(_ data: [String: Any], withKey key: String, scopeKey: String, isInTransaction: Bool) throws {
+  private func setJsonData(_ data: [String: Any], withKey key: JSONDataKey, scopeKey: String, isInTransaction: Bool) throws {
     if !isInTransaction {
       sqlite3_exec(db, "BEGIN;", nil, nil, nil)
     }
@@ -504,7 +506,7 @@ public final class UpdatesDatabase: NSObject {
       DELETE FROM json_data WHERE "key" = ?1 AND "scope_key" = ?2;
     """
     do {
-      _ = try execute(sql: deleteSql, withArgs: [key, scopeKey])
+      _ = try execute(sql: deleteSql, withArgs: [key.rawValue, scopeKey])
     } catch {
       if !isInTransaction {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
@@ -516,7 +518,7 @@ public final class UpdatesDatabase: NSObject {
       INSERT INTO json_data ("key", "value", "last_updated", "scope_key") VALUES (?1, ?2, ?3, ?4);
     """
     do {
-      _ = try execute(sql: insertSql, withArgs: [key, data, Date().timeIntervalSince1970 * 1000, scopeKey])
+      _ = try execute(sql: insertSql, withArgs: [key.rawValue, data, Date().timeIntervalSince1970 * 1000, scopeKey])
     } catch {
       if !isInTransaction {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
@@ -530,31 +532,31 @@ public final class UpdatesDatabase: NSObject {
   }
 
   public func serverDefinedHeaders(withScopeKey scopeKey: String) throws -> [String: Any]? {
-    return try jsonData(withKey: UpdatesDatabase.ServerDefinedHeadersKey, scopeKey: scopeKey)
+    return try jsonData(withKey: JSONDataKey.ServerDefinedHeadersKey, scopeKey: scopeKey)
   }
 
   public func manifestFilters(withScopeKey scopeKey: String) throws -> [String: Any]? {
-    return try jsonData(withKey: UpdatesDatabase.ManifestFiltersKey, scopeKey: scopeKey)
+    return try jsonData(withKey: JSONDataKey.ManifestFiltersKey, scopeKey: scopeKey)
   }
 
   public func staticBuildData(withScopeKey scopeKey: String) throws -> [String: Any]? {
-    return try jsonData(withKey: UpdatesDatabase.StaticBuildDataKey, scopeKey: scopeKey)
+    return try jsonData(withKey: JSONDataKey.StaticBuildDataKey, scopeKey: scopeKey)
   }
 
   public func extraParams(withScopeKey scopeKey: String) throws -> [String: String]? {
-    return try jsonData(withKey: UpdatesDatabase.ExtraParmasKey, scopeKey: scopeKey) as? [String: String]
+    return try jsonData(withKey: JSONDataKey.ExtraParmasKey, scopeKey: scopeKey) as? [String: String]
   }
 
   public func setServerDefinedHeaders(_ serverDefinedHeaders: [String: Any], withScopeKey scopeKey: String) throws {
-    return try setJsonData(serverDefinedHeaders, withKey: UpdatesDatabase.ServerDefinedHeadersKey, scopeKey: scopeKey, isInTransaction: false)
+    return try setJsonData(serverDefinedHeaders, withKey: JSONDataKey.ServerDefinedHeadersKey, scopeKey: scopeKey, isInTransaction: false)
   }
 
   public func setManifestFilters(_ manifestFilters: [String: Any], withScopeKey scopeKey: String) throws {
-    return try setJsonData(manifestFilters, withKey: UpdatesDatabase.ManifestFiltersKey, scopeKey: scopeKey, isInTransaction: false)
+    return try setJsonData(manifestFilters, withKey: JSONDataKey.ManifestFiltersKey, scopeKey: scopeKey, isInTransaction: false)
   }
 
   public func setStaticBuildData(_ staticBuildData: [String: Any], withScopeKey scopeKey: String) throws {
-    return try setJsonData(staticBuildData, withKey: UpdatesDatabase.StaticBuildDataKey, scopeKey: scopeKey, isInTransaction: false)
+    return try setJsonData(staticBuildData, withKey: JSONDataKey.StaticBuildDataKey, scopeKey: scopeKey, isInTransaction: false)
   }
 
   public func setExtraParam(key: String, value: String?, withScopeKey scopeKey: String) throws {
@@ -574,7 +576,7 @@ public final class UpdatesDatabase: NSObject {
         try StringItem(value: value)
       }))
 
-      _ = try setJsonData(extraParamsToWrite, withKey: UpdatesDatabase.ExtraParmasKey, scopeKey: scopeKey, isInTransaction: true)
+      _ = try setJsonData(extraParamsToWrite, withKey: JSONDataKey.ExtraParmasKey, scopeKey: scopeKey, isInTransaction: true)
     } catch {
       sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
       throw error
@@ -588,7 +590,7 @@ public final class UpdatesDatabase: NSObject {
 
     if let serverDefinedHeaders = responseHeaderData.serverDefinedHeaders {
       do {
-        _ = try setJsonData(serverDefinedHeaders, withKey: UpdatesDatabase.ServerDefinedHeadersKey, scopeKey: scopeKey, isInTransaction: true)
+        _ = try setJsonData(serverDefinedHeaders, withKey: JSONDataKey.ServerDefinedHeadersKey, scopeKey: scopeKey, isInTransaction: true)
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
         throw UpdatesDatabaseError.setJsonDataError(cause: error)
@@ -597,7 +599,7 @@ public final class UpdatesDatabase: NSObject {
 
     if let manifestFilters = responseHeaderData.manifestFilters {
       do {
-        _ = try setJsonData(manifestFilters, withKey: UpdatesDatabase.ManifestFiltersKey, scopeKey: scopeKey, isInTransaction: true)
+        _ = try setJsonData(manifestFilters, withKey: JSONDataKey.ManifestFiltersKey, scopeKey: scopeKey, isInTransaction: true)
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
         throw UpdatesDatabaseError.setJsonDataError(cause: error)


### PR DESCRIPTION
# Why

to override update url, we have to remove build data. this is the beforehand refactoring

# How

move the json data keys into a dedicated enum class

```
Co-authored-by: Will Schurman <wschurman@expo.io>
```

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
