### PR TITLE
[updates] add hasEmbeddedUpdate to build-data

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Add new state machine context about startup procedure. ([#32433](https://github.com/expo/expo/pull/32433) by [@wschurman](https://github.com/wschurman))
-- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422), [#34423](https://github.com/expo/expo/pull/34423), [#34422](https://github.com/expo/expo/pull/34422), [#34425](https://github.com/expo/expo/pull/34425) by [@kudo](https://github.com/kudo), [@wschurman](https://github.com/wschurman))
+- Added experimental `Updates.setUpdatesURLAndRequestHeadersOverride()` to allow update overrides. ([#34422](https://github.com/expo/expo/pull/34422), [#34423](https://github.com/expo/expo/pull/34423), [#34422](https://github.com/expo/expo/pull/34422), [#34425](https://github.com/expo/expo/pull/34425), [#34426](https://github.com/expo/expo/pull/34426) by [@kudo](https://github.com/kudo), [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -119,6 +119,7 @@ dependencies {
   testImplementation 'androidx.test:core:1.5.0'
   testImplementation "io.mockk:mockk:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion()}"
+  testImplementation 'org.robolectric:robolectric:4.14.1'
 
   androidTestImplementation 'com.squareup.okio:okio:2.9.0'
   androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
@@ -1,9 +1,9 @@
 package expo.modules.updates.db
 
-import android.net.Uri
-import expo.modules.jsonutils.getNullable
+import expo.modules.manifests.core.toMap
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.dao.JSONDataDao
+import expo.modules.updates.manifest.ManifestMetadata
 import org.json.JSONObject
 
 /**
@@ -38,6 +38,7 @@ object BuildData {
       setBuildDataInDatabase(database, updatesConfiguration)
     } else if (!isBuildDataConsistent(updatesConfiguration, buildJSON)) {
       clearAllUpdatesFromDatabase(database)
+      clearManifestMetadataFromDatabase(database)
       setBuildDataInDatabase(database, updatesConfiguration)
     }
   }
@@ -47,28 +48,17 @@ object BuildData {
     database.updateDao().deleteUpdates(allUpdates)
   }
 
+  fun clearManifestMetadataFromDatabase(database: UpdatesDatabase) {
+    ManifestMetadata.clearMetadataForBuildDataClearOperation(database)
+  }
+
   fun isBuildDataConsistent(
     updatesConfiguration: UpdatesConfiguration,
     databaseBuildData: JSONObject
   ): Boolean {
-    val configBuildData = getBuildDataFromConfig(updatesConfiguration)
-
-    val updateUrlKey = UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY
-    val requestHeadersKey = UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
-
-    // check equality of the two JSONObjects. The build data object is string valued with the
-    // exception of "requestHeaders" which is a string valued object.
-    return mutableListOf<Boolean>().apply {
-      add(databaseBuildData.get(updateUrlKey).let { Uri.parse(it.toString()) } == configBuildData.get(updateUrlKey))
-
-      // loop through keys from both requestHeaders objects.
-      for (key in configBuildData.getJSONObject(requestHeadersKey).keys()) {
-        add(databaseBuildData.getJSONObject(requestHeadersKey).getNullable<String>(key) == configBuildData.getJSONObject(requestHeadersKey).getNullable(key))
-      }
-      for (key in databaseBuildData.getJSONObject(requestHeadersKey).keys()) {
-        add(databaseBuildData.getJSONObject(requestHeadersKey).getNullable<String>(key) == configBuildData.getJSONObject(requestHeadersKey).getNullable(key))
-      }
-    }.all { it }
+    val configBuildData = defaultBuildData + getBuildDataFromConfig(updatesConfiguration).toMap()
+    val dbBuildData = defaultBuildData + databaseBuildData.toMap()
+    return configBuildData == dbBuildData
   }
 
   fun setBuildDataInDatabase(
@@ -93,9 +83,17 @@ object BuildData {
       for ((key, value) in updatesConfiguration.requestHeaders) put(key, value)
     }
     val buildData = JSONObject().apply {
-      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, updatesConfiguration.updateUrl)
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, updatesConfiguration.updateUrl.toString())
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, requestHeadersJSON)
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, updatesConfiguration.hasEmbeddedUpdate)
     }
     return buildData
   }
+
+  /**
+   * Fallback data specifically for migration while database data doesn't have these keys
+   */
+  private val defaultBuildData = mapOf(
+    UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY to true
+  )
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
@@ -28,6 +28,9 @@ abstract class JSONDataDao {
   @Query("DELETE FROM json_data WHERE `key` = :key AND scope_key = :scopeKey;")
   protected abstract fun deleteJSONDataForKeyInternal(key: String, scopeKey: String)
 
+  @Query("DELETE FROM json_data WHERE `key` IN (:keys)")
+  protected abstract fun deleteJSONDataForKeysForAllScopeKeysInternal(keys: List<String>)
+
   /**
    * for public use
    */
@@ -61,5 +64,10 @@ abstract class JSONDataDao {
     val previousValue = loadJSONStringForKey(key, scopeKey)
     deleteJSONDataForKeyInternal(key.key, scopeKey)
     insertJSONDataInternal(JSONDataEntity(key.key, updater(previousValue), Date(), scopeKey))
+  }
+
+  @Transaction
+  open fun deleteJSONDataForKeysForAllScopeKeys(keys: List<JSONDataKey>) {
+    deleteJSONDataForKeysForAllScopeKeysInternal(keys.map { it.key })
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
@@ -94,6 +94,16 @@ object ManifestMetadata {
     }
   }
 
+  fun clearMetadataForBuildDataClearOperation(database: UpdatesDatabase) {
+    database.jsonDataDao()!!.deleteJSONDataForKeysForAllScopeKeys(
+      listOf(
+        JSONDataDao.JSONDataKey.EXTRA_PARAMS,
+        JSONDataDao.JSONDataKey.MANIFEST_SERVER_DEFINED_HEADERS,
+        JSONDataDao.JSONDataKey.MANIFEST_FILTERS
+      )
+    )
+  }
+
   private fun JSONObject.asStringStringMap(): Map<String, String> {
     return buildMap {
       this@asStringStringMap.keys().asSequence().forEach { key ->

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/db/BuildDataTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/db/BuildDataTest.kt
@@ -1,0 +1,110 @@
+package expo.modules.updates.db
+
+import android.net.Uri
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BuildDataTest {
+  @Test
+  fun `isBuildDataConsistent should return true for same data`() {
+    val sourceBuildData = createUpdatesConfiguration(
+      updateUrl = "https://example.com",
+      requestHeaders = mapOf(
+        "expo-channel-name" to "default"
+      )
+    )
+    val targetRequestHeader = JSONObject().apply {
+      put("expo-channel-name", "default")
+    }
+    val targetBuildData = JSONObject().apply {
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
+    }
+    Assert.assertTrue(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
+  }
+
+  @Test
+  fun `isBuildDataConsistent should return false for EXUpdatesRequestHeaders change`() {
+    val sourceBuildData = createUpdatesConfiguration(
+      updateUrl = "https://example.com",
+      requestHeaders = mapOf(
+        "expo-channel-name" to "default"
+      )
+    )
+    val targetRequestHeader = JSONObject().apply {
+      put("expo-channel-name", "preview")
+    }
+    val targetBuildData = JSONObject().apply {
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
+    }
+    Assert.assertFalse(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
+  }
+
+  @Test
+  fun `isBuildDataConsistent support migration with new UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY key`() {
+    val sourceBuildData = createUpdatesConfiguration(
+      updateUrl = "https://example.com",
+      requestHeaders = mapOf(
+        "expo-channel-name" to "default"
+      )
+    )
+    val targetRequestHeader = JSONObject().apply {
+      put("expo-channel-name", "default")
+    }
+    val targetBuildData = JSONObject().apply {
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, true)
+    }
+    Assert.assertTrue(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
+  }
+
+  @Test
+  fun `isBuildDataConsistent should not overwrite existing data from the default build data`() {
+    val sourceBuildData = createUpdatesConfiguration(
+      updateUrl = "https://example.com",
+      requestHeaders = mapOf(
+        "expo-channel-name" to "default"
+      ),
+      hasEmbeddedUpdate = false
+    )
+    val targetRequestHeader = JSONObject().apply {
+      put("expo-channel-name", "default")
+    }
+    val targetBuildData = JSONObject().apply {
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, false)
+    }
+    Assert.assertTrue(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
+  }
+
+  private fun createUpdatesConfiguration(
+    updateUrl: String,
+    requestHeaders: Map<String, String>,
+    hasEmbeddedUpdate: Boolean = true
+  ): UpdatesConfiguration {
+    return UpdatesConfiguration(
+      scopeKey = updateUrl,
+      updateUrl = Uri.parse(updateUrl),
+      runtimeVersionRaw = "1.0.0",
+      launchWaitMs = 0,
+      checkOnLaunch = CheckAutomaticallyConfiguration.ALWAYS,
+      hasEmbeddedUpdate = hasEmbeddedUpdate,
+      requestHeaders = requestHeaders,
+      codeSigningCertificate = null,
+      codeSigningMetadata = emptyMap(),
+      codeSigningIncludeManifestResponseCertificateChain = false,
+      codeSigningAllowUnsignedManifests = false,
+      enableExpoUpdatesProtocolV0CompatibilityMode = false,
+      disableAntiBrickingMeasures = false
+    )
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesBuildData.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesBuildData.swift
@@ -36,14 +36,12 @@ internal final class UpdatesBuildData {
         logger.warn(message: "Error getting static build data: \(error.localizedDescription)")
         return
       }
+      let buildDataFromConfig = self.getBuildDataFromConfig(config)
 
-      if let staticBuildData = staticBuildData {
-        let impliedStaticBuildData = self.getBuildDataFromConfig(config)
-        // safest dictionary comparison conversion is still in objective-c
-        // swiftlint:disable:next legacy_objc_type
-        if !NSDictionary(dictionary: staticBuildData).isEqual(to: impliedStaticBuildData) {
-          clearAllUpdatesAndSetStaticBuildData(database: database, config: config, logger: logger, scopeKey: scopeKey)
-        }
+      if let staticBuildData,
+        !isBuildDataConsistent(staticBuildData, buildDataFromConfig) {
+        clearAllUpdatesAndSetStaticBuildData(database: database, config: config, logger: logger, scopeKey: scopeKey)
+        clearManifestMetadataFromDatabase(database: database, logger: logger)
       } else {
         do {
           try database.setStaticBuildData(getBuildDataFromConfig(config), withScopeKey: scopeKey)
@@ -55,10 +53,18 @@ internal final class UpdatesBuildData {
     }
   }
 
+  /**
+   Fallback data specifically for migration while database data doesn't have these keys
+   */
+  private static let defaultBuildData: [String: Any] = [
+    "EXUpdatesHasEmbeddedUpdate": true
+  ]
+
   static func getBuildDataFromConfig(_ config: UpdatesConfig) -> [String: Any] {
     return [
       "EXUpdatesURL": config.updateUrl.absoluteString,
-      "EXUpdatesRequestHeaders": config.requestHeaders
+      "EXUpdatesRequestHeaders": config.requestHeaders,
+      "EXUpdatesHasEmbeddedUpdate": config.hasEmbeddedUpdate
     ]
   }
 
@@ -84,5 +90,28 @@ internal final class UpdatesBuildData {
       logger.warn(message: "Error setting static build data: \(error.localizedDescription)")
       return
     }
+  }
+
+  private static func clearManifestMetadataFromDatabase(database: UpdatesDatabase, logger: UpdatesLogger) {
+    do {
+      try database.deleteJsonDataForAllScopeKeys(withKeys: [
+        UpdatesDatabase.JSONDataKey.ExtraParmasKey,
+        UpdatesDatabase.JSONDataKey.ServerDefinedHeadersKey,
+        UpdatesDatabase.JSONDataKey.ManifestFiltersKey
+      ])
+    } catch {
+      logger.warn(message: "Error deleting JSON data from database: \(error.localizedDescription)")
+      return
+    }
+  }
+
+  internal static func isBuildDataConsistent(_ lhs: [AnyHashable: Any], _ rhs: [AnyHashable: Any]) -> Bool {
+    let lhsWithDefault = lhs
+      .merging(defaultBuildData) { current, _ in current }
+    let rhsWithDefault = rhs
+      .merging(defaultBuildData) { current, _ in current }
+    // safest dictionary comparison conversion is still in objective-c
+    // swiftlint:disable:next legacy_objc_type
+    return NSDictionary(dictionary: lhsWithDefault).isEqual(to: rhsWithDefault)
   }
 }

--- a/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift
@@ -143,6 +143,109 @@ class UpdatesBuildDataSpec : ExpoSpec {
           expect(try! db.allUpdates(withConfig: configChannelTestTwo).count) == 0
         }
       }
+
+      it("updates are cleared and build data is set when override updateUrl") {
+        db.databaseQueue.sync {
+          expect(try! db.allUpdates(withConfig: configChannelTest).count) == 1
+          try! db.setStaticBuildData(UpdatesBuildData.getBuildDataFromConfig(configChannelTest), withScopeKey: configChannelTest.scopeKey)
+        }
+
+        // Even the updateUrl and requestHeaders not changing here,
+        // using configOverride would disable embedded update and having inconsistent build data.
+        let configOverride = UpdatesConfigOverride(
+          updateUrl: configChannelTest.updateUrl,
+          requestHeaders: configChannelTest.requestHeaders
+        )
+        let configWithDisableAntiBrickingMeasures = configChannelTestDictionary.merging([UpdatesConfig.EXUpdatesConfigDisableAntiBrickingMeasures: true]) { current, _ in current }
+        let configWithOverride = try! UpdatesConfig.config(
+          fromDictionary: configWithDisableAntiBrickingMeasures,
+          configOverride: configOverride)
+        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configWithOverride, logger: logger)
+
+        db.databaseQueue.sync {
+          let staticBuildData = try! db.staticBuildData(withScopeKey: scopeKey)
+          expect(
+            NSDictionary(dictionary: staticBuildData!).isEqual(to: UpdatesBuildData.getBuildDataFromConfig(configWithOverride))
+          ) == true
+          expect(try! db.allUpdates(withConfig: configWithOverride).count) == 0
+        }
+      }
+
+      it("updates are cleared and build data is set when override hasEmbeddedUpdate") {
+        db.databaseQueue.sync {
+          expect(try! db.allUpdates(withConfig: configChannelTest).count) == 1
+          try! db.setStaticBuildData(UpdatesBuildData.getBuildDataFromConfig(configChannelTest), withScopeKey: configChannelTest.scopeKey)
+        }
+
+        let configOverride = UpdatesConfigOverride(
+          updateUrl: URL(string: "https://example.com"),
+          requestHeaders: ["expo-channel-name": "fromOverride"]
+        )
+        let configWithDisableAntiBrickingMeasures = configChannelTestDictionary.merging([UpdatesConfig.EXUpdatesConfigDisableAntiBrickingMeasures: true]) { current, _ in current }
+        let configWithOverride = try! UpdatesConfig.config(
+          fromDictionary: configWithDisableAntiBrickingMeasures,
+          configOverride: configOverride)
+        UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: db, config: configWithOverride, logger: logger)
+
+        db.databaseQueue.sync {
+          let staticBuildData = try! db.staticBuildData(withScopeKey: scopeKey)
+          expect(
+            NSDictionary(dictionary: staticBuildData!).isEqual(to: UpdatesBuildData.getBuildDataFromConfig(configWithOverride))
+          ) == true
+          expect(try! db.allUpdates(withConfig: configWithOverride).count) == 0
+        }
+      }
+    }
+
+    describe("isBuildDataConsistent") {
+      it("should return true for same data") {
+        let sourceBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "default"],
+        ]
+        let targetBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "default"],
+        ]
+        expect(UpdatesBuildData.isBuildDataConsistent(sourceBuildData, targetBuildData)).to(beTrue())
+      }
+
+      it("should return false for EXUpdatesRequestHeaders change") {
+        let sourceBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "default"],
+        ]
+        let targetBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "preview"],
+        ]
+        expect(UpdatesBuildData.isBuildDataConsistent(sourceBuildData, targetBuildData)).to(beFalse())
+      }
+
+      it("should support migration with new EXUpdatesHasEmbeddedUpdate key") {
+        let sourceBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "default"],
+        ]
+        let targetBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesRequestHeaders": ["expo-channel-name": "default"],
+          "EXUpdatesHasEmbeddedUpdate": true
+        ]
+        expect(UpdatesBuildData.isBuildDataConsistent(sourceBuildData, targetBuildData)).to(beTrue())
+      }
+
+      it("should not overwrite existing data from the default build data") {
+        let sourceBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesHasEmbeddedUpdate": false
+        ]
+        let targetBuildData = [
+          "EXUpdatesURL": "https://example.com",
+          "EXUpdatesHasEmbeddedUpdate": false
+        ]
+        expect(UpdatesBuildData.isBuildDataConsistent(sourceBuildData, targetBuildData)).to(beTrue())
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

supporting #34422 and #34423

# How

- we have to purge database when hasEmbeddedUpdate is changed. this PR adds it to the builddata
- we have to handle backward compatibility where previous json data doesn't have the new key. this pr tries to add a default fallback key so that the json comparison is backward compatible.

```
Co-authored-by: Will Schurman <wschurman@expo.io>
```

# Test Plan

- will has an e2e test later
- add unit tests for build data compatible checks

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
