### PR TITLE
[config-types] temp add updates.disableAntiBrickingMeasures

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -207,6 +207,11 @@ export interface ExpoConfig {
          * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
          */
         assetPatternsToBeBundled?: string[];
+        /**
+         * Allow expo-updates to be run in danger mode. This may allow for the app to be bricked if an update fails.
+         * @default false
+         */
+        disableAntiBrickingMeasures?: boolean;
     };
     /**
      * Provide overrides by locale for System Dialog prompts like Permissions Boxes

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -209,6 +209,11 @@ export interface ExpoConfig {
      * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
      */
     assetPatternsToBeBundled?: string[];
+    /**
+     * Allow expo-updates to be run in danger mode. This may allow for the app to be bricked if an update fails.
+     * @default false
+     */
+    disableAntiBrickingMeasures?: boolean;
   };
   /**
    * Provide overrides by locale for System Dialog prompts like Permissions Boxes


### PR DESCRIPTION
# Why

temporary pr to add `updates.disableAntiBrickingMeasures` type. would open a pr to update schema later and going back to generate config types

# How

add `updates.disableAntiBrickingMeasures`

```
Co-authored-by: Will Schurman <wschurman@expo.io>
```

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
