### PR TITLE
[android][contacts] fixed saving contacts with photos

### DIFF
--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -224,9 +224,6 @@ function ContactDetailView({
   }, [contact]);
 
   const onPressImage = async () => {
-    if (!isIos) {
-      return;
-    }
     _selectPhoto();
   };
 

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -224,6 +224,9 @@ function ContactDetailView({
   }, [contact]);
 
   const onPressImage = async () => {
+    if (!isIos) {
+      return;
+    }
     _selectPhoto();
   };
 

--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -648,5 +648,16 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
         }
       }
     });
+
+    it('Contacts.updateContactAsync() with image', async () => {
+      const contactId = await createContactWithImage({
+        [Contacts.Fields.FirstName]: 'Kenny',
+        [Contacts.Fields.LastName]: 'Bday guy',
+      });
+      expect(typeof contactId).toBe('string');
+      const contact = await Contacts.getContactByIdAsync(contactId);
+      const modifiedId = await Contacts.updateContactAsync(contact);
+      expect(typeof modifiedId).toBe('string');
+    });
   });
 }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed saving a contact with photos on Android.
 - Fixed `the native view manager required by name (ExpoContactAccessButton) from NativeViewManagerAdapter isn't exported` warning. ([#33993](https://github.com/expo/expo/pull/33993) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed saving a contact with photos on Android.
+- [Android] Fixed saving a contact with photos on Android. ([#34432](https://github.com/expo/expo/pull/34432) by [@chrfalch](https://github.com/chrfalch))
 - Fixed `the native view manager required by name (ExpoContactAccessButton) from NativeViewManagerAdapter isn't exported` warning. ([#33993](https://github.com/expo/expo/pull/33993) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -523,7 +523,7 @@ class Contact(var contactId: String, var appContext: AppContext) {
     }
 
   private fun getThumbnailBitmap(photoUri: String?): Bitmap {
-    val context = appContext.reactContext ?: throw Exceptions.AppContextLost()
+    val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
     val uri = Uri.parse(photoUri)
     context.contentResolver.openInputStream(uri).use { inputStream ->
       return BitmapFactory.decodeStream(inputStream)

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -22,6 +22,8 @@ import expo.modules.contacts.models.PhoneNumberModel
 import expo.modules.contacts.models.PostalAddressModel
 import expo.modules.contacts.models.RelationshipModel
 import expo.modules.contacts.models.UrlAddressModel
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
 import java.io.ByteArrayOutputStream
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -29,7 +31,7 @@ import java.util.Calendar
 import java.util.Locale
 
 // TODO: MaidenName Nickname
-class Contact(var contactId: String) {
+class Contact(var contactId: String, var appContext: AppContext) {
   private var rawContactId: String? = null
   var lookupKey: String? = null
   private var displayName: String? = null
@@ -521,7 +523,10 @@ class Contact(var contactId: String) {
     }
 
   private fun getThumbnailBitmap(photoUri: String?): Bitmap {
-    val path = Uri.parse(photoUri).path
-    return BitmapFactory.decodeFile(path)
+    val context = appContext.reactContext ?: throw Exceptions.AppContextLost()
+    val uri = Uri.parse(photoUri)
+    context.contentResolver.openInputStream(uri).use { inputStream ->
+      return BitmapFactory.decodeStream(inputStream)
+    }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -326,7 +326,7 @@ class ContactsModule : Module() {
     get() = (appContext.reactContext ?: throw Exceptions.ReactContextLost()).contentResolver
 
   private fun mutateContact(initContact: Contact?, data: Map<String, Any>): Contact {
-    val contact = initContact ?: Contact(UUID.randomUUID().toString())
+    val contact = initContact ?: Contact(UUID.randomUUID().toString(), appContext)
 
     data.safeGet<String>("firstName")?.let { contact.firstName = it }
     data.safeGet<String>("middleName")?.let { contact.middleName = it }
@@ -660,7 +660,7 @@ class ContactsModule : Module() {
       val contactId = cursor.getString(columnIndex)
 
       // add or update existing contact for iterating data based on contact id
-      val contact = map.getOrPut(contactId) { Contact(contactId) }
+      val contact = map.getOrPut(contactId) { Contact(contactId, appContext) }
       contact.fromCursor(cursor)
     }
     return map


### PR DESCRIPTION
# Why

On Android, when saving a contact that has a photo attached to it, the method will fail because we're not resolving the path to the photo correctly (not using a content resolver).

Note: This was previously solved in #32097 by [freeboub](https://github.com/freeboub) - thanks!

# How

- Added using contentResolver to get the correct inputstream to the photo in the Contact class
- Passed appContext from Contacts module to be able to use the contentResolver
- Added support for testing saving an image (ie. changing picture) on Android in BareExpo

Closes #ENG-14832

# Test Plan

Test in BareExpo:
- Open Contacts test screen
- Click contact image and select a new image (this will save the contact)
- Verify that the contact was successfully saved.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
