### PR TITLE
[docs][location] clarify app termination

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -106,8 +106,8 @@ Background location allows your app to receive location updates while it is runn
 
 - Background location will stop if the user terminates the app.
 - Background location resumes if the user restarts the app.
-- On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
-- On iOS, the system will restart the terminated app when a new geofence event occurs. <PlatformTag platform="ios" />
+- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations.
+- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence event occurs.
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -106,8 +106,10 @@ Background location allows your app to receive location updates while it is runn
 
 - Background location will stop if the user terminates the app.
 - Background location resumes if the user restarts the app.
-- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations.
-- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence event occurs.
+- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location
+  or geofencing event occurs due to platform limitations.
+- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence
+  event occurs.
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -104,10 +104,10 @@ Learn how to configure the native projects in the [installation instructions in 
 
 Background location allows your app to receive location updates while it is running in the background and includes both location updates and region monitoring through geofencing. This feature is subject to platform API limitations and system constraints:
 
-* Background location will stop if the user terminates the app.
-* Background location resume if the user restarts the app.
-* On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
-* On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
+- Background location will stop if the user terminates the app.
+- Background location resume if the user restarts the app.
+- On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
+- On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -100,6 +100,17 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigReactNative>
 
+### Background location
+
+Background location allows your app to receive location updates while it is running in the background and includes both location updates and region monitoring through geofencing. This feature is subject to platform API limitations and system constraints:
+
+* Background location will stop if the user terminates the app.
+* Background location resume if the user restarts the app.
+* On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
+* On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
+
+> **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
+
 ### Background location configuration&ensp;<PlatformTag platform="ios" />
 
 To be able to run background location on iOS, you need to add the `location` value to the `UIBackgroundModes` array in your app's **Info.plist** file.

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -105,7 +105,7 @@ Learn how to configure the native projects in the [installation instructions in 
 Background location allows your app to receive location updates while it is running in the background and includes both location updates and region monitoring through geofencing. This feature is subject to platform API limitations and system constraints:
 
 - Background location will stop if the user terminates the app.
-- Background location resume if the user restarts the app.
+- Background location resumes if the user restarts the app.
 - On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
 - On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -107,7 +107,7 @@ Background location allows your app to receive location updates while it is runn
 - Background location will stop if the user terminates the app.
 - Background location resumes if the user restarts the app.
 - On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
-- On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
+- On iOS, the system will restart the terminated app when a new geofence event occurs. <PlatformTag platform="ios" />
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -100,6 +100,17 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigReactNative>
 
+### Background location
+
+Background location allows your app to receive location updates while it is running in the background and includes both location updates and region monitoring through geofencing. This feature is subject to platform API limitations and system constraints:
+
+- Background location will stop if the user terminates the app.
+- Background location resume if the user restarts the app.
+- On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
+- On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
+
+> **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
+
 ### Background location configuration&ensp;<PlatformTag platform="ios" />
 
 To be able to run background location on iOS, you need to add the `location` value to the `UIBackgroundModes` array in your app's **Info.plist** file.

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -106,8 +106,10 @@ Background location allows your app to receive location updates while it is runn
 
 - Background location will stop if the user terminates the app.
 - Background location resumes if the user restarts the app.
-- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations.
-- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence event occurs.
+- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location
+  or geofencing event occurs due to platform limitations.
+- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence
+  event occurs.
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -105,9 +105,9 @@ Learn how to configure the native projects in the [installation instructions in 
 Background location allows your app to receive location updates while it is running in the background and includes both location updates and region monitoring through geofencing. This feature is subject to platform API limitations and system constraints:
 
 - Background location will stop if the user terminates the app.
-- Background location resume if the user restarts the app.
-- On Android, a terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations. <PlatformTag platform="android" />
-- On iOS, terminated apps will be restarted by the system when new geofence event occurs. <PlatformTag platform="ios" />
+- Background location resumes if the user restarts the app.
+- <PlatformTag platform="android" /> A terminated app will not automatically restart when a location or geofencing event occurs due to platform limitations.
+- <PlatformTag platform="ios" /> The system will restart the terminated app when a new geofence event occurs.
 
 > **Info** On Android, the result of removing an app from the recent apps list varies by device vendor. For example, some implementations treat removing an app from the recent apps list as killing it. Read more about these differences here: [https://dontkillmyapp.com](https://dontkillmyapp.com).
 


### PR DESCRIPTION
# Why 

When an app is terminated there are some limitations on Android and iOS when it comes to background location.

# How

This update tries to clarify these changes a bit.

Updated both `unversioned` and `sdk-52`

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
