### PR TITLE
Fix condition to dismiss modal

### DIFF
--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -139,7 +139,7 @@ export default function Modal() {
     <View style={styles.container}>
       <Text>Modal screen</Text>
       /* @info On web, use <CODE>../</CODE> as a simple way to navigate to the root. This is not analogous to <CODE>goBack</CODE>.*/
-      {!isPresented && <Link href="../">Dismiss modal</Link>}
+      {isPresented && <Link href="../">Dismiss modal</Link>}
       /* @end */
     </View>
   );


### PR DESCRIPTION
# Why

This PR fixes the logic around the modal dismissal functionality in the component.

# How

The issue was resolved by updating the condition for rendering the dismissal Link component. Instead of rendering the Link when isPresented is false, we now correctly render it only when isPresented is true. This ensures that users will only see the "Dismiss modal" link when the modal is visible.

# Test Plan

1. Open the Modal: Ensure the modal appears with the "Dismiss modal" link visible.
2. Close the Modal: Ensure that the "Dismiss modal" link is not visible when the modal is not presented.
3. Inspect Navigation: Ensure that clicking the "Dismiss modal" link navigates correctly when the modal is presented.

Expected Behavior:

- When the modal is shown (isPresented is true), the dismiss link is displayed and functions correctly.
- When the modal is hidden (isPresented is false), the dismiss link is not displayed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
