### PR TITLE
[docs] Add hosting video to docs

### DIFF
--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -7,10 +7,13 @@ description: Learn how to deploy your Expo Router and React Native web apps to E
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 EAS Hosting allows you to deploy an exported Expo web build to a preview or production URL.
 
 This guide will walk you through the process of creating your first web deployment.
+
+<VideoBoxLink videoId="NaKsfWciJLo" title="Watch: Deploy your Expo Router web project" />
 
 ## Prerequisites
 


### PR DESCRIPTION
# Why

Dan asked for the hosting video to be added to the get started docs.

# How

<img width="1360" alt="Screenshot 2025-01-24 at 16 30 09" src="https://github.com/user-attachments/assets/d0b38878-7feb-40ca-9b06-a4d77ca3b4e8" />

# Test Plan

Tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
