### PR TITLE
[expo-router] Specify required version of query-string library in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,9 +508,7 @@ Package-specific changes not released in any SDK will be added here just before 
   - Add missing dependencies and follow proper dependency chains. ([#30500](https://github.com/expo/expo/pull/30500) by [@byCedric](https://github.com/byCedric))
 - **`expo-apple-authentication`**
   - Add missing `react-native` peer dependency. ([#30573](https://github.com/expo/expo/pull/30573) by [@byCedric](https://github.com/byCedric))
-- **`expo-router`**
-  - Add missing `query-string` dependency ([#34442](https://github.com/expo/expo/pull/34442)) by [@michbil](https://github.com/michbil)
-  
+
 ### 💡 Others
 
 - **`expo-web-browser`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,7 +508,9 @@ Package-specific changes not released in any SDK will be added here just before 
   - Add missing dependencies and follow proper dependency chains. ([#30500](https://github.com/expo/expo/pull/30500) by [@byCedric](https://github.com/byCedric))
 - **`expo-apple-authentication`**
   - Add missing `react-native` peer dependency. ([#30573](https://github.com/expo/expo/pull/30573) by [@byCedric](https://github.com/byCedric))
-
+- **`expo-router`**
+  - Add missing `query-string` dependency ([#34442](https://github.com/expo/expo/pull/34442)) by [@michbil](https://github.com/michbil)
+  
 ### 💡 Others
 
 - **`expo-web-browser`**

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix error 'WeakSet key must be an object' in fast-refresh for invalid exports like cpp host objects. ([#34026](https://github.com/expo/expo/pull/34026) by [@chrfalch](https://github.com/chrfalch))
 - Fix render store (unstable_headers) on native platforms. ([#33978](https://github.com/expo/expo/pull/33978) by [@EvanBacon](https://github.com/EvanBacon))
+- Add missing `query-string` dependency ([#34442](https://github.com/expo/expo/pull/34442)) by [@michbil](https://github.com/michbil)
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -110,6 +110,7 @@
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
     "client-only": "^0.0.1",
+    "query-string": "^7.1.3",
     "react-helmet-async": "^1.3.0",
     "react-native-helmet-async": "2.0.4",
     "react-native-is-edge-to-edge": "^1.1.6",


### PR DESCRIPTION
# Why

Currently expo-router does not specify required version of the query-string in it's package.json, which can lead to various problems in the future. In usual scenario version used by @react-navigation/core is used. Apart from that, when using pnpm it can resolve query-string version to version 9, which is incompatible with version 7 used by expo. One of possible scenarios is described here https://github.com/expo/expo/issues/34438

# How

Specify version of query-string in the package.json

# Test Plan


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
