### PR TITLE
Add ESLint / VSCode working dir advice

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "stkb.rewrap"
+    "stkb.rewrap",
+    "unifiedjs.vscode-mdx"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.workingDirectories": ["./", "./docs", "./tools"]
+  "eslint.workingDirectories": [
+    "./docs",
+    "./tools",
+    { "pattern": "./packages/*/" },
+    { "pattern": "./apps/*/" }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "eslint.workingDirectories": ["./", "./docs", "./tools"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.workingDirectories": [
-    "./docs",
-    "./tools",
-    { "pattern": "./packages/*/" },
-    { "pattern": "./apps/*/" }
+    { "pattern": "*" },
   ]
 }

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -353,7 +353,7 @@ import { useEffect } from 'react';
 function useSize(callback: (size: { width: number; height: number }) => void) {
   useEffect(() => {
     // Observe window size changes
-    const observer = new ResizeObserver((entries) => {
+    const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
         callback({ width, height });
@@ -385,7 +385,7 @@ export default function DOMComponent({
 }
 ```
 
-Then update your native code to set the size in state whenever the DOM component reports a change in size: 
+Then update your native code to set the size in state whenever the DOM component reports a change in size:
 
 ```tsx App.tsx (native)
 import DOMComponent from '@/components/my-component';
@@ -402,10 +402,7 @@ export default function App() {
       <ScrollView>
         <DOMComponent
           onDOMLayout={async ({ width, height }) => {
-            if (
-              containerSize?.width !== width ||
-              containerSize?.height !== height
-            ) {
+            if (containerSize?.width !== width || containerSize?.height !== height) {
               setContainerSize({ width, height });
             }
           }}

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -83,7 +83,21 @@ export default function App() {
 
 ## WebView props
 
-To pass props to the underlying native **WebView**, use the `dom` prop on the component. This prop is built into every DOM component and accepts an object with any [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) that you would like to change.
+To pass props to the underlying native **WebView**, add a `dom` object to the component:
+
+```tsx my-component.tsx (web)
+'use dom';
+
+export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
+  return (
+    <div>
+      <h1>Hello, world!</h1>
+    </div>
+  );
+}
+```
+
+Now you can pass [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) to the DOM component:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -95,20 +109,6 @@ export default function App() {
         scrollEnabled: false,
       }}
     />
-  );
-}
-```
-
-On your DOM component, add the `dom` prop so it is recognized in TypeScript:
-
-```tsx my-component.tsx (web)
-'use dom';
-
-export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
-  return (
-    <div>
-      <h1>Hello, world!</h1>
-    </div>
   );
 }
 ```
@@ -313,7 +313,7 @@ You may want to measure the size of a DOM component and report it back to the na
 
 ### Automatically with `matchContents` prop
 
-You can use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view. This is particularly useful for certain layouts where the DOM component must have an intrinsic size in order to be displayed, such as when the component is centered within a parent view:
+You need to use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view coresponsingly:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -323,49 +323,57 @@ export default function Route() {
 }
 ```
 
-### Manually by specifying a size
+```tsx my-component.tsx (web)
+'use dom';
 
-You can also manually provide a size by passing it to the `WebView` `style` prop via the `dom` prop:
+export default function DOMComponent(_: { dom?: import('expo/dom').DOMProps }) {
+  return <div style={{ width: 500, height: 500, backgroundColor: 'blue' }} />;
+}
+```
+
+### Manually by resizing native action
+
+You can also manually measure the size of a DOM component and report it back to the native side using a native action:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
+import { useState } from 'react';
 
 export default function Route() {
+  const [height, setHeight] = useState(270);
   return (
     <DOMComponent
+      updateSize={async size => {
+        if (size[1] !== height) {
+          setHeight(size[1]);
+        }
+      }}
       dom={{
-        style: { width, height },
+        style: { height },
       }}
     />
   );
 }
 ```
 
-### Observing changes in size
-
-If you would like to report changes in the size of the DOM component back to the native side, you can add a native action to your DOM component that is called whenever the size is changed:
-
 ```tsx my-component.tsx (web)
 'use dom';
 
 import { useEffect } from 'react';
 
-function useSize(callback: (size: { width: number; height: number }) => void) {
+function useSize(callback: (size: [number, number]) => void) {
   useEffect(() => {
     // Observe window size changes
     const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
-        callback({ width, height });
+        callback([width, height]);
       }
     });
 
     observer.observe(document.body);
 
-    callback({
-      width: document.body.clientWidth,
-      height: document.body.clientHeight,
-    });
+    callback([document.body.clientWidth, document.body.clientHeight]);
 
     return () => {
       observer.disconnect();
@@ -374,48 +382,14 @@ function useSize(callback: (size: { width: number; height: number }) => void) {
 }
 
 export default function DOMComponent({
-  onDOMLayout,
+  onLayout,
 }: {
   dom?: import('expo/dom').DOMProps;
-  onDOMLayout: (size: { width: number; height: number }) => void;
+  onLayout(size: [number, number]);
 }) {
-  useSize(onDOMLayout);
+  useSize(onLayout);
 
-  return <div style={{ width: 500, height: 500, background: 'blue' }} />;
-}
-```
-
-Then update your native code to set the size in state whenever the DOM component reports a change in size:
-
-```tsx App.tsx (native)
-import DOMComponent from '@/components/my-component';
-import { useState } from 'react';
-import { View, ScrollView } from 'react-native';
-
-export default function App() {
-  const [containerSize, setContainerSize] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-  return (
-    <View style={{ flex: 1 }}>
-      <ScrollView>
-        <DOMComponent
-          onDOMLayout={async ({ width, height }) => {
-            if (containerSize?.width !== width || containerSize?.height !== height) {
-              setContainerSize({ width, height });
-            }
-          }}
-          dom={{
-            containerStyle:
-              containerSize != null
-                ? { width: containerSize.width, height: containerSize.height }
-                : null,
-          }}
-        />
-      </ScrollView>
-    </View>
-  );
+  return <div />;
 }
 ```
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -329,7 +329,6 @@ You can also manually provide a size by passing it to the `WebView` `style` prop
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
-import { useState } from 'react';
 
 export default function Route() {
   return (
@@ -342,46 +341,31 @@ export default function Route() {
 }
 ```
 
-#### Observing changes in size
+### Observing changes in size
 
-You can report the DOM component's size back to the native side with the `updateSize` prop and manage the size in the native component's state:
-
-```tsx App.tsx (native)
-export default function Route() {
-  const [height, setHeight] = useState(270);
-  return (
-    <DOMComponent
-      updateSize={async size => {
-        if (size[1] !== height) {
-          setHeight(size[1]);
-        }
-      }}
-      dom={{
-        style: { height },
-      }}
-    />
-  );
-}
-```
+If you would like to report changes in the size of the DOM component back to the native side, you can add a native action to your DOM component that is called whenever the size is changed:
 
 ```tsx my-component.tsx (web)
 'use dom';
 
 import { useEffect } from 'react';
 
-function useSize(callback: (size: [number, number]) => void) {
+function useSize(callback: (size: { width: number; height: number }) => void) {
   useEffect(() => {
     // Observe window size changes
-    const observer = new ResizeObserver(entries => {
+    const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
-        callback([width, height]);
+        callback({ width, height });
       }
     });
 
     observer.observe(document.body);
 
-    callback([document.body.clientWidth, document.body.clientHeight]);
+    callback({
+      width: document.body.clientWidth,
+      height: document.body.clientHeight,
+    });
 
     return () => {
       observer.disconnect();
@@ -390,14 +374,51 @@ function useSize(callback: (size: [number, number]) => void) {
 }
 
 export default function DOMComponent({
-  onLayout,
+  onDOMLayout,
 }: {
   dom?: import('expo/dom').DOMProps;
-  onLayout(size: [number, number]);
+  onDOMLayout: (size: { width: number; height: number }) => void;
 }) {
-  useSize(onLayout);
+  useSize(onDOMLayout);
 
-  return <div />;
+  return <div style={{ width: 500, height: 500, background: 'blue' }} />;
+}
+```
+
+Then update your native code to set the size in state whenever the DOM component reports a change in size: 
+
+```tsx App.tsx (native)
+import DOMComponent from '@/components/my-component';
+import { useState } from 'react';
+import { View, ScrollView } from 'react-native';
+
+export default function App() {
+  const [containerSize, setContainerSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  return (
+    <View style={{ flex: 1 }}>
+      <ScrollView>
+        <DOMComponent
+          onDOMLayout={async ({ width, height }) => {
+            if (
+              containerSize?.width !== width ||
+              containerSize?.height !== height
+            ) {
+              setContainerSize({ width, height });
+            }
+          }}
+          dom={{
+            containerStyle:
+              containerSize != null
+                ? { width: containerSize.width, height: containerSize.height }
+                : null,
+          }}
+        />
+      </ScrollView>
+    </View>
+  );
 }
 ```
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -83,21 +83,7 @@ export default function App() {
 
 ## WebView props
 
-To pass props to the underlying native **WebView**, add a `dom` object to the component:
-
-```tsx my-component.tsx (web)
-'use dom';
-
-export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
-  return (
-    <div>
-      <h1>Hello, world!</h1>
-    </div>
-  );
-}
-```
-
-Now you can pass [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) to the DOM component:
+To pass props to the underlying native **WebView**, use the `dom` prop on the component. This prop is built into every DOM component and accepts an object with any [`WebView` props](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md) that you would like to change.
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -109,6 +95,20 @@ export default function App() {
         scrollEnabled: false,
       }}
     />
+  );
+}
+```
+
+On your DOM component, add the `dom` prop so it is recognized in TypeScript:
+
+```tsx my-component.tsx (web)
+'use dom';
+
+export default function DOMComponent({}: { dom: import('expo/dom').DOMProps }) {
+  return (
+    <div>
+      <h1>Hello, world!</h1>
+    </div>
   );
 }
 ```
@@ -313,7 +313,7 @@ You may want to measure the size of a DOM component and report it back to the na
 
 ### Automatically with `matchContents` prop
 
-You need to use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view coresponsingly:
+You can use the `dom={{ matchContents: true }}` prop to measure the size of the DOM component automatically and resize the native view. This is particularly useful for certain layouts where the DOM component must have an intrinsic size in order to be displayed, such as when the component is centered within a parent view:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
@@ -323,22 +323,30 @@ export default function Route() {
 }
 ```
 
-```tsx my-component.tsx (web)
-'use dom';
+### Manually by specifying a size
 
-export default function DOMComponent(_: { dom?: import('expo/dom').DOMProps }) {
-  return <div style={{ width: 500, height: 500, backgroundColor: 'blue' }} />;
-}
-```
-
-### Manually by resizing native action
-
-You can also manually measure the size of a DOM component and report it back to the native side using a native action:
+You can also manually provide a size by passing it to the `WebView` `style` prop via the `dom` prop:
 
 ```tsx App.tsx (native)
 import DOMComponent from './my-component';
 import { useState } from 'react';
 
+export default function Route() {
+  return (
+    <DOMComponent
+      dom={{
+        style: { width, height },
+      }}
+    />
+  );
+}
+```
+
+#### Observing changes in size
+
+You can report the DOM component's size back to the native side with the `updateSize` prop and manage the size in the native component's state:
+
+```tsx App.tsx (native)
 export default function Route() {
   const [height, setHeight] = useState(270);
   return (


### PR DESCRIPTION
# Why
Whenever I clone fresh on another machine, I find my initial docs editing experience is kind of bad, with no syntax highlighting or squiggles. CI screams at me over and over as I miss basic formatting stuff. Since I don't do this all the time, I forget how I fixed it the last time.

I'll get to a point where I think I have all the needed extensions, only to find I'm _still_ missing docs squiggles. This time, I remembered to open the docs folder in a separate window and it was fixed. Maybe this is the canonical right way to update stuff, but, I dunno, it's easier to just have this repo open in one window all day and work across the all the different places I need to be inside of it.

# How
Added `eslint.workingDirectories` to VS Code workspace settings. This is supposed to cause the editor to respect the subfolder linter settings. There's an "auto" feature where the ESLint extension would try to guess, but there's also pattern support that should let us be precise. Added tools, docs, and patterns for apps and packages subfolders.

I thought there should technically be a `./` entry, since there is an ESLint config there, but that actually caused squiggles in places I didn't expect, so backed off there.

------

Not 100% related, but added `MDX` as a recommended extension, as well. MDX + Prettier + ESLint working dir seems like all you need for a great out-of-the-box docs editing experience.

# Test Plan
1. Open root folder in VS Code
2. Check that editor linting in a package in docs works (compared to before where it didn't)
3. Checked a few files in packages to make sure I didn't see unexpected squiggles or behavior where `yarn lint --fix` did something I didn't see in the editor. Seemed like no adverse effects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
