### PR TITLE
[apple] Migrate remaining expo-module.config.json to unified platform syntax 

### DIFF
--- a/apps/bare-expo/modules/benchmarking/expo-module.config.json
+++ b/apps/bare-expo/modules/benchmarking/expo-module.config.json
@@ -1,16 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android"
-  ],
+  "platforms": ["apple", "android"],
   "apple": {
-    "modules": [
-      "BenchmarkingExpoModule"
-    ]
+    "modules": ["BenchmarkingExpoModule"]
   },
   "android": {
-    "modules": [
-      "expo.modules.benchmark.BenchmarkingExpoModule"
-    ]
+    "modules": ["expo.modules.benchmark.BenchmarkingExpoModule"]
   }
 }

--- a/packages/@expo/dom-webview/expo-module.config.json
+++ b/packages/@expo/dom-webview/expo-module.config.json
@@ -1,9 +1,9 @@
 {
-  "platforms": ["android", "apple"],
-  "android": {
-    "modules": ["expo.modules.webview.DomWebViewModule"]
-  },
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["DomWebViewModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.webview.DomWebViewModule"]
   }
 }

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 7.1.2 — 2024-11-19
 
 ### 🐛 Bug fixes

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.1.2 — 2024-11-19
 

--- a/packages/expo-apple-authentication/expo-module.config.json
+++ b/packages/expo-apple-authentication/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-apple-authentication",
-  "platforms": ["ios"],
-  "ios": {
+  "platforms": ["apple"],
+  "apple": {
     "modules": ["AppleAuthenticationModule"]
   }
 }

--- a/packages/expo-apple-authentication/expo-module.config.json
+++ b/packages/expo-apple-authentication/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-apple-authentication",
   "platforms": ["apple"],
   "apple": {
     "modules": ["AppleAuthenticationModule"]

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - [Android] Add checks to methods that will throw without permissions being granted. ([#33986](https://github.com/expo/expo/pull/33986) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.3.1 - 2024-12-16
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - [Android] Add checks to methods that will throw without permissions being granted. ([#33986](https://github.com/expo/expo/pull/33986) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.3.1 - 2024-12-16
 

--- a/packages/expo-audio/expo-module.config.json
+++ b/packages/expo-audio/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "tvos", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["AudioModule"]
   },
   "android": {

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android]: aligned the executeTask method signature after adding package expo-background-task ([#33438](https://github.com/expo/expo/pull/33438) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.3 — 2024-11-13
 

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android]: aligned the executeTask method signature after adding package expo-background-task ([#33438](https://github.com/expo/expo/pull/33438) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.3 — 2024-11-13
 

--- a/packages/expo-background-fetch/expo-module.config.json
+++ b/packages/expo-background-fetch/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-background-fetch",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["BackgroundFetchModule"]

--- a/packages/expo-background-fetch/expo-module.config.json
+++ b/packages/expo-background-fetch/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-background-fetch",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["BackgroundFetchModule"]
   },
   "android": {

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.0.1 — 2025-01-21
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.0.1 — 2025-01-21
 
 ### 💡 Others

--- a/packages/expo-background-task/expo-module.config.json
+++ b/packages/expo-background-task/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-background-task",
   "platforms": ["apple", "android"],
   "apple": {
     "appDelegateSubscribers": ["BackgroundTaskAppDelegateSubscriber"],

--- a/packages/expo-background-task/expo-module.config.json
+++ b/packages/expo-background-task/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-background-task",
-  "platforms": [ "ios", "android" ],
-  "ios": {
+  "platforms": [ "apple", "android" ],
+  "apple": {
     "appDelegateSubscribers": [ "BackgroundTaskAppDelegateSubscriber" ],
     "modules": [ "BackgroundTaskModule" ]
   },

--- a/packages/expo-background-task/expo-module.config.json
+++ b/packages/expo-background-task/expo-module.config.json
@@ -1,11 +1,11 @@
 {
   "name": "expo-background-task",
-  "platforms": [ "apple", "android" ],
+  "platforms": ["apple", "android"],
   "apple": {
-    "appDelegateSubscribers": [ "BackgroundTaskAppDelegateSubscriber" ],
-    "modules": [ "BackgroundTaskModule" ]
+    "appDelegateSubscribers": ["BackgroundTaskAppDelegateSubscriber"],
+    "modules": ["BackgroundTaskModule"]
   },
   "android": {
-    "modules": [ "expo.modules.backgroundtask.BackgroundTaskModule" ]
+    "modules": ["expo.modules.backgroundtask.BackgroundTaskModule"]
   }
 }

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 9.0.1 — 2024-10-22
 

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 9.0.1 — 2024-10-22
 

--- a/packages/expo-battery/expo-module.config.json
+++ b/packages/expo-battery/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-battery",
-  "platforms": ["ios", "android", "web"],
-  "ios": {
+  "platforms": ["apple", "android", "web"],
+  "apple": {
     "modules": ["BatteryModule"]
   },
   "android": {

--- a/packages/expo-battery/expo-module.config.json
+++ b/packages/expo-battery/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-battery",
   "platforms": ["apple", "android", "web"],
   "apple": {
     "modules": ["BatteryModule"]

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34138](https://github.com/expo/expo/pull/34138) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-22
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34138](https://github.com/expo/expo/pull/34138) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-22
 

--- a/packages/expo-blur/expo-module.config.json
+++ b/packages/expo-blur/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-blur",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["BlurViewModule"]

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.2 — 2024-10-24
 

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.2 — 2024-10-24
 

--- a/packages/expo-brightness/expo-module.config.json
+++ b/packages/expo-brightness/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-brightness",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["BrightnessModule"]

--- a/packages/expo-brightness/expo-module.config.json
+++ b/packages/expo-brightness/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-brightness",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["BrightnessModule"]
   },
   "android": {

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [android][calendar] Add `EventRecurrenceUtils` unit tests. ([#33863](https://github.com/expo/expo/pull/33863) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.4 - 2024-11-29
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [android][calendar] Add `EventRecurrenceUtils` unit tests. ([#33863](https://github.com/expo/expo/pull/33863) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.4 - 2024-11-29
 

--- a/packages/expo-calendar/expo-module.config.json
+++ b/packages/expo-calendar/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-calendar",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["CalendarModule"]
   },
   "android": {

--- a/packages/expo-calendar/expo-module.config.json
+++ b/packages/expo-calendar/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-calendar",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["CalendarModule"]

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - On `Android`, parse the `pictureSize` prop safely to prevent invalid values causing exceptions. ([#33566](https://github.com/expo/expo/pull/33566) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 16.0.8 - 2024-11-29
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - On `Android`, parse the `pictureSize` prop safely to prevent invalid values causing exceptions. ([#33566](https://github.com/expo/expo/pull/33566) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 16.0.8 - 2024-11-29
 

--- a/packages/expo-camera/expo-module.config.json
+++ b/packages/expo-camera/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-camera",
   "platforms": ["apple", "android", "web"],
   "apple": {
     "modules": ["CameraViewModule"]

--- a/packages/expo-camera/expo-module.config.json
+++ b/packages/expo-camera/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-camera",
-  "platforms": ["ios", "android", "web"],
-  "ios": {
+  "platforms": ["apple", "android", "web"],
+  "apple": {
     "modules": ["CameraViewModule"]
   },
   "android": {

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.1 — 2024-10-22
 

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.1 — 2024-10-22
 

--- a/packages/expo-cellular/expo-module.config.json
+++ b/packages/expo-cellular/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-cellular",
   "platforms": ["apple", "android", "web"],
   "apple": {
     "modules": ["CellularModule"]

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.0 — 2024-10-22
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.0 — 2024-10-22
 

--- a/packages/expo-clipboard/expo-module.config.json
+++ b/packages/expo-clipboard/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-clipboard",
   "platforms": ["apple", "android", "web"],
   "apple": {
     "modules": ["ClipboardModule"]

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Use the `src` folder as the Metro target. ([#33781](https://github.com/expo/expo/pull/33781) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.2 — 2024-11-07
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Use the `src` folder as the Metro target. ([#33781](https://github.com/expo/expo/pull/33781) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.2 — 2024-11-07
 

--- a/packages/expo-contacts/expo-module.config.json
+++ b/packages/expo-contacts/expo-module.config.json
@@ -1,17 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android"
-  ],
-  "ios": {
-    "modules": [
-      "ContactsModule",
-      "ContactAccessButtonModule"
-    ]
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["ContactsModule", "ContactAccessButtonModule"]
   },
   "android": {
-    "modules": [
-      "expo.modules.contacts.ContactsModule"
-    ]
+    "modules": ["expo.modules.contacts.ContactsModule"]
   }
 }

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.7 - 2024-12-24
 

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.7 - 2024-12-24
 

--- a/packages/expo-dev-client/expo-module.config.json
+++ b/packages/expo-dev-client/expo-module.config.json
@@ -1,4 +1,4 @@
 {
   "name": "expo-dev-client",
-  "platforms": ["ios", "android"]
+  "platforms": ["apple", "android"]
 }

--- a/packages/expo-dev-client/expo-module.config.json
+++ b/packages/expo-dev-client/expo-module.config.json
@@ -1,4 +1,3 @@
 {
-  "name": "expo-dev-client",
   "platforms": ["apple", "android"]
 }

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [6/n] upgrade to react-native 0.77 - improve 0.76 compatibility ([#34078](https://github.com/expo/expo/pull/34078) by [@vonovak](https://github.com/vonovak))
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.21 - 2024-12-24
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [6/n] upgrade to react-native 0.77 - improve 0.76 compatibility ([#34078](https://github.com/expo/expo/pull/34078) by [@vonovak](https://github.com/vonovak))
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.21 - 2024-12-24
 

--- a/packages/expo-dev-launcher/expo-module.config.json
+++ b/packages/expo-dev-launcher/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-dev-launcher",
   "platforms": ["apple", "android"],
   "apple": {
     "podspecPath": "expo-dev-launcher.podspec",

--- a/packages/expo-dev-menu-interface/expo-module.config.json
+++ b/packages/expo-dev-menu-interface/expo-module.config.json
@@ -1,4 +1,4 @@
 {
   "name": "expo-dev-menu-interface",
-  "platforms": ["ios", "android"]
+  "platforms": ["apple", "android"]
 }

--- a/packages/expo-dev-menu-interface/expo-module.config.json
+++ b/packages/expo-dev-menu-interface/expo-module.config.json
@@ -1,4 +1,3 @@
 {
-  "name": "expo-dev-menu-interface",
   "platforms": ["apple", "android"]
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 6.0.14 - 2024-12-10
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed broken local UI development on Android. ([#33714](https://github.com/expo/expo/pull/33714) by [@kudo](https://github.com/kudo))
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 6.0.14 - 2024-12-10
 

--- a/packages/expo-dev-menu/expo-module.config.json
+++ b/packages/expo-dev-menu/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-dev-menu",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "podspecPath": "expo-dev-menu.podspec",
     "swiftModuleName": "EXDevMenu",
     "modules": [
@@ -15,7 +15,7 @@
   },
   "android": {
     "modules": [
-      "expo.modules.devmenu.modules.DevMenuModule", 
+      "expo.modules.devmenu.modules.DevMenuModule",
       "expo.modules.devmenu.modules.DevMenuPreferences"
     ]
   }

--- a/packages/expo-dev-menu/expo-module.config.json
+++ b/packages/expo-dev-menu/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-dev-menu",
   "platforms": ["apple", "android"],
   "apple": {
     "podspecPath": "expo-dev-menu.podspec",

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.1 — 2024-10-22
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.1 — 2024-10-22
 

--- a/packages/expo-document-picker/expo-module.config.json
+++ b/packages/expo-document-picker/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-document-picker",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["DocumentPickerModule"]
   },
   "android": {

--- a/packages/expo-document-picker/expo-module.config.json
+++ b/packages/expo-document-picker/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-document-picker",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["DocumentPickerModule"]

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 18.0.6 - 2024-12-16
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 18.0.6 - 2024-12-16
 

--- a/packages/expo-file-system/expo-module.config.json
+++ b/packages/expo-file-system/expo-module.config.json
@@ -1,16 +1,8 @@
 {
-  "platforms": [
-    "apple",
-    "android"
-  ],
+  "platforms": ["apple", "android"],
   "apple": {
-    "modules": [
-      "FileSystemModule",
-      "FileSystemNextModule"
-    ],
-    "appDelegateSubscribers": [
-      "FileSystemBackgroundSessionHandler"
-    ]
+    "modules": ["FileSystemModule", "FileSystemNextModule"],
+    "appDelegateSubscribers": ["FileSystemBackgroundSessionHandler"]
   },
   "android": {
     "modules": [

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.2 — 2024-11-14
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.2 — 2024-11-14
 

--- a/packages/expo-gl/expo-module.config.json
+++ b/packages/expo-gl/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-gl",
   "platforms": ["apple", "android"],
   "apple": {
     "podspecPath": "./ExpoGL.podspec",

--- a/packages/expo-gl/expo-module.config.json
+++ b/packages/expo-gl/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-gl",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "podspecPath": "./ExpoGL.podspec",
     "modules": ["GLViewModule"]
   },

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.0 — 2024-10-22
 

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.0 — 2024-10-22
 

--- a/packages/expo-haptics/expo-module.config.json
+++ b/packages/expo-haptics/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-haptics",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["HapticsModule"]
   },
   "android": {

--- a/packages/expo-haptics/expo-module.config.json
+++ b/packages/expo-haptics/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-haptics",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["HapticsModule"]

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.0 — 2024-10-22
 

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.0 — 2024-10-22
 

--- a/packages/expo-image-loader/expo-module.config.json
+++ b/packages/expo-image-loader/expo-module.config.json
@@ -1,3 +1,3 @@
 {
-  "platforms": ["ios", "android"]
+  "platforms": ["apple", "android"]
 }

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.5 — 2024-10-29
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.5 — 2024-10-29
 

--- a/packages/expo-image-manipulator/expo-module.config.json
+++ b/packages/expo-image-manipulator/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-image-manipulator",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["ImageManipulatorModule"]
   },
   "android": {

--- a/packages/expo-image-manipulator/expo-module.config.json
+++ b/packages/expo-image-manipulator/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-image-manipulator",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["ImageManipulatorModule"]

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 16.0.3 — 2024-11-22
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 16.0.3 — 2024-11-22
 

--- a/packages/expo-insights/expo-module.config.json
+++ b/packages/expo-insights/expo-module.config.json
@@ -1,9 +1,9 @@
 {
   "platforms": [
-    "ios",
+    "apple",
     "android"
   ],
-  "ios": {
+  "apple": {
     "modules": [
       "InsightsModule"
     ]

--- a/packages/expo-insights/expo-module.config.json
+++ b/packages/expo-insights/expo-module.config.json
@@ -1,16 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android"
-  ],
+  "platforms": ["apple", "android"],
   "apple": {
-    "modules": [
-      "InsightsModule"
-    ]
+    "modules": ["InsightsModule"]
   },
   "android": {
-    "modules": [
-      "expo.modules.insights.ExpoInsightsModule"
-    ]
+    "modules": ["expo.modules.insights.ExpoInsightsModule"]
   }
 }

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 12.0.1 — 2024-10-22
 

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 12.0.1 — 2024-10-22
 

--- a/packages/expo-intent-launcher/expo-module.config.json
+++ b/packages/expo-intent-launcher/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-intent-launcher",
   "platforms": ["android"],
   "android": {
     "modules": ["expo.modules.intentlauncher.IntentLauncherModule"]

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-25
 

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-25
 

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-linear-gradient",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["LinearGradientModule"]

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.3 — 2024-11-19
 

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.3 — 2024-11-19
 

--- a/packages/expo-linking/expo-module.config.json
+++ b/packages/expo-linking/expo-module.config.json
@@ -1,20 +1,10 @@
 {
-  "platforms": [
-    "apple",
-    "android",
-    "web"
-  ],
+  "platforms": ["apple", "android", "web"],
   "apple": {
-    "modules": [
-      "ExpoLinkingModule"
-    ],
-    "appDelegateSubscribers": [
-      "LinkingAppDelegateSubscriber"
-    ]
+    "modules": ["ExpoLinkingModule"],
+    "appDelegateSubscribers": ["LinkingAppDelegateSubscriber"]
   },
   "android": {
-    "modules": [
-      "expo.modules.linking.ExpoLinkingModule"
-    ]
+    "modules": ["expo.modules.linking.ExpoLinkingModule"]
   }
 }

--- a/packages/expo-linking/expo-module.config.json
+++ b/packages/expo-linking/expo-module.config.json
@@ -1,11 +1,10 @@
 {
   "platforms": [
-    "ios",
-    "tvos",
+    "apple",
     "android",
     "web"
   ],
-  "ios": {
+  "apple": {
     "modules": [
       "ExpoLinkingModule"
     ],

--- a/packages/expo-live-photo/CHANGELOG.md
+++ b/packages/expo-live-photo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.0.1 — 2024-10-22
 

--- a/packages/expo-live-photo/CHANGELOG.md
+++ b/packages/expo-live-photo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.0.1 — 2024-10-22
 
 ### 🎉 New features

--- a/packages/expo-live-photo/expo-module.config.json
+++ b/packages/expo-live-photo/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["apple"],
-  "ios": {
+  "apple": {
     "modules": ["LivePhotoModule"]
   }
 }

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.1 — 2024-10-22
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.1 — 2024-10-22
 

--- a/packages/expo-local-authentication/expo-module.config.json
+++ b/packages/expo-local-authentication/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-local-authentication",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["LocalAuthenticationModule"]

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-22
 

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-22
 

--- a/packages/expo-mail-composer/expo-module.config.json
+++ b/packages/expo-mail-composer/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-mail-composer",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["MailComposerModule"]

--- a/packages/expo-mail-composer/expo-module.config.json
+++ b/packages/expo-mail-composer/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-mail-composer",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["MailComposerModule"]
   },
   "android": {

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.6.1 — 2024-10-29
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.6.1 — 2024-10-29
 

--- a/packages/expo-maps/expo-module.config.json
+++ b/packages/expo-maps/expo-module.config.json
@@ -1,10 +1,9 @@
 {
-  "name": "expo-maps",
-  "platforms": ["android", "apple"],
+  "platforms": ["apple", "android"],
   "android": {
-    "modulesClassNames": ["expo.modules.maps.MapsModule"]
+    "modules": ["expo.modules.maps.MapsModule"]
   },
-  "ios": {
-    "modulesClassNames": ["MapsModule"]
+  "apple": {
+    "modules": ["MapsModule"]
   }
 }

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 17.0.4 - 2024-12-19
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 17.0.4 - 2024-12-19
 

--- a/packages/expo-media-library/expo-module.config.json
+++ b/packages/expo-media-library/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-media-library",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["MediaLibraryModule"]

--- a/packages/expo-media-library/expo-module.config.json
+++ b/packages/expo-media-library/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-media-library",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["MediaLibraryModule"]
   },
   "android": {

--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.2.0 - 2024-11-29
 
 ### 🎉 New features

--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.2.0 - 2024-11-29
 

--- a/packages/expo-mesh-gradient/expo-module.config.json
+++ b/packages/expo-mesh-gradient/expo-module.config.json
@@ -1,10 +1,6 @@
 {
-  "platforms": [
-    "apple"
-  ],
+  "platforms": ["apple"],
   "apple": {
-    "modules": [
-      "MeshGradientModule"
-    ]
+    "modules": ["MeshGradientModule"]
   }
 }

--- a/packages/expo-module-template-local/expo-module.config.json
+++ b/packages/expo-module-template-local/expo-module.config.json
@@ -1,17 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android",
-    "web"
-  ],
+  "platforms": ["apple", "android", "web"],
   "apple": {
-    "modules": [
-      "<%- project.moduleName %>"
-    ]
+    "modules": ["<%- project.moduleName %>"]
   },
   "android": {
-    "modules": [
-      "<%- project.package %>.<%- project.moduleName %>"
-    ]
+    "modules": ["<%- project.package %>.<%- project.moduleName %>"]
   }
 }

--- a/packages/expo-module-template/expo-module.config.json
+++ b/packages/expo-module-template/expo-module.config.json
@@ -1,17 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android",
-    "web"
-  ],
+  "platforms": ["apple", "android", "web"],
   "apple": {
-    "modules": [
-      "<%- project.moduleName %>"
-    ]
+    "modules": ["<%- project.moduleName %>"]
   },
   "android": {
-    "modules": [
-      "<%- project.package %>.<%- project.moduleName %>"
-    ]
+    "modules": ["<%- project.package %>.<%- project.moduleName %>"]
   }
 }

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Restricted color types to string to prevent the use of illegal color types (PlatformColor) until supported. ([#34053](https://github.com/expo/expo/pull/34053) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 4.0.6 - 2024-12-10
 

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Restricted color types to string to prevent the use of illegal color types (PlatformColor) until supported. ([#34053](https://github.com/expo/expo/pull/34053) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 4.0.6 - 2024-12-10
 

--- a/packages/expo-navigation-bar/expo-module.config.json
+++ b/packages/expo-navigation-bar/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-navigation-bar",
   "platforms": ["android"],
   "android": {
     "modules": ["expo.modules.navigationbar.NavigationBarModule"]

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.4 - 2024-12-16
 

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.4 - 2024-12-16
 

--- a/packages/expo-network/expo-module.config.json
+++ b/packages/expo-network/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["apple", "android", "web"],
-  "ios": {
+  "apple": {
     "modules": ["NetworkModule"]
   },
   "android": {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ### ⚠️ Notices
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ### ⚠️ Notices
 
 - [iOS] Swift conversion 1: badge and server registration. ([#32069](https://github.com/expo/expo/pull/32069) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-notifications/expo-module.config.json
+++ b/packages/expo-notifications/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-notifications",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["BadgeModule", "ServerRegistrationModule", "PushTokenModule", "SchedulerModule", "PresentationModule"],
     "appDelegateSubscribers": ["PushTokenAppDelegateSubscriber"]
   },

--- a/packages/expo-notifications/expo-module.config.json
+++ b/packages/expo-notifications/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-notifications",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": [

--- a/packages/expo-notifications/expo-module.config.json
+++ b/packages/expo-notifications/expo-module.config.json
@@ -2,7 +2,13 @@
   "name": "expo-notifications",
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": ["BadgeModule", "ServerRegistrationModule", "PushTokenModule", "SchedulerModule", "PresentationModule"],
+    "modules": [
+      "BadgeModule",
+      "ServerRegistrationModule",
+      "PushTokenModule",
+      "SchedulerModule",
+      "PresentationModule"
+    ],
     "appDelegateSubscribers": ["PushTokenAppDelegateSubscriber"]
   },
   "android": {

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.2 — 2024-10-25
 

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.2 — 2024-10-25
 

--- a/packages/expo-print/expo-module.config.json
+++ b/packages/expo-print/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["ExpoPrintModule"]
   },
   "android": {

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Polyfill relative fetch requests and `window.location` by default. ([#34169](https://github.com/expo/expo/pull/34169) by [@EvanBacon](https://github.com/EvanBacon))
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix linting errors ([#34033](https://github.com/expo/expo/pull/34033) by [@marklawlor](https://github.com/marklawlor))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Polyfill relative fetch requests and `window.location` by default. ([#34169](https://github.com/expo/expo/pull/34169) by [@EvanBacon](https://github.com/EvanBacon))
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix linting errors ([#34033](https://github.com/expo/expo/pull/34033) by [@marklawlor](https://github.com/marklawlor))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/expo-module.config.json
+++ b/packages/expo-router/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "web"],
-  "ios": {
+  "platforms": ["apple", "web"],
+  "apple": {
     "modules": ["ExpoHeadModule"],
     "appDelegateSubscribers": ["ExpoHeadAppDelegateSubscriber"]
   }

--- a/packages/expo-router/expo-module.config.json
+++ b/packages/expo-router/expo-module.config.json
@@ -5,4 +5,3 @@
     "appDelegateSubscribers": ["ExpoHeadAppDelegateSubscriber"]
   }
 }
-

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.0 — 2024-10-22
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.0 — 2024-10-22
 

--- a/packages/expo-screen-capture/expo-module.config.json
+++ b/packages/expo-screen-capture/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-screen-capture",
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["apple", "android", "web"],
   "android": {
     "modules": ["expo.modules.screencapture.ScreenCaptureModule"]
   },
-  "ios": {
+  "apple": {
     "modules": ["ScreenCaptureModule"]
   }
 }

--- a/packages/expo-screen-capture/expo-module.config.json
+++ b/packages/expo-screen-capture/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-screen-capture",
   "platforms": ["apple", "android", "web"],
   "android": {
     "modules": ["expo.modules.screencapture.ScreenCaptureModule"]

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 8.0.2 - 2024-12-19
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 8.0.2 - 2024-12-19
 

--- a/packages/expo-screen-orientation/expo-module.config.json
+++ b/packages/expo-screen-orientation/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-screen-orientation",
   "platforms": ["apple", "android"],
   "android": {
     "modules": ["expo.modules.screenorientation.ScreenOrientationModule"]

--- a/packages/expo-screen-orientation/expo-module.config.json
+++ b/packages/expo-screen-orientation/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-screen-orientation",
-  "platforms": ["ios", "android"],
+  "platforms": ["apple", "android"],
   "android": {
     "modules": ["expo.modules.screenorientation.ScreenOrientationModule"]
   },
-  "ios": {
+  "apple": {
     "appDelegateSubscribers": ["ScreenOrientationAppDelegate"],
     "reactDelegateHandlers": ["ScreenOrientationReactDelegateHandler"],
     "modules": ["ScreenOrientationModule"]

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-28
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-10-28
 

--- a/packages/expo-sensors/expo-module.config.json
+++ b/packages/expo-sensors/expo-module.config.json
@@ -1,9 +1,6 @@
 {
   "name": "expo-sensors",
-  "platforms": [
-    "apple",
-    "android"
-  ],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": [
       "AccelerometerModule",

--- a/packages/expo-sensors/expo-module.config.json
+++ b/packages/expo-sensors/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "name": "expo-sensors",
   "platforms": [
-    "ios",
+    "apple",
     "android"
   ],
-  "ios": {
+  "apple": {
     "modules": [
       "AccelerometerModule",
       "BarometerModule",

--- a/packages/expo-sensors/expo-module.config.json
+++ b/packages/expo-sensors/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-sensors",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": [

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-sharing/expo-module.config.json
+++ b/packages/expo-sharing/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-sharing",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["SharingModule"]

--- a/packages/expo-sharing/expo-module.config.json
+++ b/packages/expo-sharing/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-sharing",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["SharingModule"]
   },
   "android": {

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-sms/expo-module.config.json
+++ b/packages/expo-sms/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-sms",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["ExpoSMSModule"]
   },
   "android": {

--- a/packages/expo-sms/expo-module.config.json
+++ b/packages/expo-sms/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-sms",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["ExpoSMSModule"]

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2024-10-22
 

--- a/packages/expo-speech/expo-module.config.json
+++ b/packages/expo-speech/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-speech",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["SpeechModule"]

--- a/packages/expo-speech/expo-module.config.json
+++ b/packages/expo-speech/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-speech",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["SpeechModule"]
   },
   "android": {

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed unused `SQLite3Wrapper` code for legacy implementation on Android. ([#33565](https://github.com/expo/expo/pull/33565) by [@kudo](https://github.com/kudo))
 - Enforce input validations in `kv-store` operations. ([#33874](https://github.com/expo/expo/pull/33874) by [@rtorrente](https://github.com/rtorrente))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.3 — 2024-11-12
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Removed unused `SQLite3Wrapper` code for legacy implementation on Android. ([#33565](https://github.com/expo/expo/pull/33565) by [@kudo](https://github.com/kudo))
 - Enforce input validations in `kv-store` operations. ([#33874](https://github.com/expo/expo/pull/33874) by [@rtorrente](https://github.com/rtorrente))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 15.0.3 — 2024-11-12
 

--- a/packages/expo-sqlite/expo-module.config.json
+++ b/packages/expo-sqlite/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-sqlite",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["SQLiteModule"]

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 8.0.0 — 2024-10-22
 

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 8.0.0 — 2024-10-22
 

--- a/packages/expo-store-review/expo-module.config.json
+++ b/packages/expo-store-review/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-store-review",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["StoreReviewModule"]

--- a/packages/expo-store-review/expo-module.config.json
+++ b/packages/expo-store-review/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-store-review",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["StoreReviewModule"]
   },
   "android": {

--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.2.0 — 2024-10-22
 
 ### 🛠 Breaking changes

--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.2.0 — 2024-10-22
 

--- a/packages/expo-symbols/expo-module.config.json
+++ b/packages/expo-symbols/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["SymbolModule"]
   },
   "android": {

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 4.0.6 - 2024-12-10
 

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 4.0.6 - 2024-12-10
 

--- a/packages/expo-system-ui/expo-module.config.json
+++ b/packages/expo-system-ui/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-system-ui",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["ExpoSystemUIModule"]
   },
   "android": {

--- a/packages/expo-system-ui/expo-module.config.json
+++ b/packages/expo-system-ui/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-system-ui",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["ExpoSystemUIModule"]

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2025-01-21
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 13.0.0 — 2025-01-21
 

--- a/packages/expo-task-manager/expo-module.config.json
+++ b/packages/expo-task-manager/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-task-manager",
   "platforms": ["apple", "android"],
   "android": {
     "modules": ["expo.modules.taskManager.TaskManagerModule"]

--- a/packages/expo-task-manager/expo-module.config.json
+++ b/packages/expo-task-manager/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-task-manager",
-  "platforms": ["ios", "android"],
+  "platforms": ["apple", "android"],
   "android": {
     "modules": ["expo.modules.taskManager.TaskManagerModule"]
   }

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.1.0 - 2024-11-29
 

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.1.0 - 2024-11-29
 

--- a/packages/expo-tracking-transparency/expo-module.config.json
+++ b/packages/expo-tracking-transparency/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-tracking-transparency",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["TrackingTransparencyModule"]

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.0.1 — 2025-01-21
 
 ### 💡 Others

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.0.1 — 2025-01-21
 

--- a/packages/expo-ui/expo-module.config.json
+++ b/packages/expo-ui/expo-module.config.json
@@ -1,16 +1,9 @@
 {
-  "platforms": [
-    "apple",
-    "android"
-  ],
+  "platforms": ["apple", "android"],
   "android": {
-    "modules": [
-      "expo.modules.ui.ExpoUIModule"
-    ]
+    "modules": ["expo.modules.ui.ExpoUIModule"]
   },
   "apple": {
-    "modules": [
-      "ExpoUIModule"
-    ]
+    "modules": ["ExpoUIModule"]
   }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - [Android] Made ReactNativeFeatureFlags a parameter to the constructor of the ErrorRecovery class to be able to make tests pass ([#34363](https://github.com/expo/expo/pull/34363) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Inject logger from controllers down to dependent objects. ([#34035](https://github.com/expo/expo/pull/34035) by [@wschurman](https://github.com/wschurman))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - [Android] Made ReactNativeFeatureFlags a parameter to the constructor of the ErrorRecovery class to be able to make tests pass ([#34363](https://github.com/expo/expo/pull/34363) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Inject logger from controllers down to dependent objects. ([#34035](https://github.com/expo/expo/pull/34035) by [@wschurman](https://github.com/wschurman))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/expo-module.config.json
+++ b/packages/expo-updates/expo-module.config.json
@@ -5,9 +5,7 @@
     "reactDelegateHandlers": ["ExpoUpdatesReactDelegateHandler"]
   },
   "android": {
-    "modules": [
-      "expo.modules.updates.UpdatesModule"
-    ],
+    "modules": ["expo.modules.updates.UpdatesModule"],
     "gradlePlugins": [
       {
         "id": "expo-updates-gradle-plugin",

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 9.0.2 — 2024-11-13
 

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 9.0.2 — 2024-11-13
 

--- a/packages/expo-video-thumbnails/expo-module.config.json
+++ b/packages/expo-video-thumbnails/expo-module.config.json
@@ -1,5 +1,4 @@
 {
-  "name": "expo-video-thumbnails",
   "platforms": ["apple", "android"],
   "apple": {
     "modules": ["VideoThumbnailsModule"]

--- a/packages/expo-video-thumbnails/expo-module.config.json
+++ b/packages/expo-video-thumbnails/expo-module.config.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-video-thumbnails",
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modules": ["VideoThumbnailsModule"]
   },
   "android": {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed `generateThumbnailsAsync` not being available on Android in the types. ([#33491](https://github.com/expo/expo/pull/33491) by [@hirbod](https://github.com/hirbod))
 - Run VideoManager.setAppropriateAudioSessionOrWarn on a different queue for a lower load on the main thread. ([#33127](https://github.com/expo/expo/pull/33127) by [@behenate](https://github.com/behenate))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 2.0.3 - 2024-12-19
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `generateThumbnailsAsync` not being available on Android in the types. ([#33491](https://github.com/expo/expo/pull/33491) by [@hirbod](https://github.com/hirbod))
 - Run VideoManager.setAppropriateAudioSessionOrWarn on a different queue for a lower load on the main thread. ([#33127](https://github.com/expo/expo/pull/33127) by [@behenate](https://github.com/behenate))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 2.0.3 - 2024-12-19
 

--- a/packages/expo-video/expo-module.config.json
+++ b/packages/expo-video/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["apple", "android"],
-  "ios": {
+  "apple": {
     "modules": ["VideoModule"]
   },
   "android": {

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-11-14
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 14.0.1 — 2024-11-14
 

--- a/packages/expo-web-browser/expo-module.config.json
+++ b/packages/expo-web-browser/expo-module.config.json
@@ -1,9 +1,9 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modulesClassNames": ["WebBrowserModule"]
+    "modules": ["WebBrowserModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.webbrowser.WebBrowserModule"]
+    "modules": ["expo.modules.webbrowser.WebBrowserModule"]
   }
 }

--- a/packages/expo-web-browser/expo-module.config.json
+++ b/packages/expo-web-browser/expo-module.config.json
@@ -1,6 +1,6 @@
 {
-  "platforms": ["ios", "android"],
-  "ios": {
+  "platforms": ["apple", "android"],
+  "apple": {
     "modulesClassNames": ["WebBrowserModule"]
   },
   "android": {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
 - Added a debug only warning and style for zero height DOM components. ([#34375](https://github.com/expo/expo/pull/34375) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 52.0.23 - 2024-12-24
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed compatibility for React Native 0.78 nightlies. ([#33718](https://github.com/expo/expo/pull/33718) by [@kudo](https://github.com/kudo))
 - Added a debug only warning and style for zero height DOM components. ([#34375](https://github.com/expo/expo/pull/34375) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 52.0.23 - 2024-12-24
 

--- a/packages/expo/expo-module.config.json
+++ b/packages/expo/expo-module.config.json
@@ -1,10 +1,10 @@
 {
   "platforms": ["apple", "android"],
-  "android": {
-    "modules": ["expo.modules.fetch.ExpoFetchModule"]
-  },
   "apple": {
     "modules": ["ExpoFetchModule"],
     "podspecPath": "Expo.podspec"
+  },
+  "android": {
+    "modules": ["expo.modules.fetch.ExpoFetchModule"]
   }
 }

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.0 — 2024-10-22
 

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#33779](https://github.com/expo/expo/pull/33779) by [@reichhartd](https://github.com/reichhartd))
+- [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 
 ## 5.0.0 — 2024-10-22
 

--- a/packages/unimodules-app-loader/expo-module.config.json
+++ b/packages/unimodules-app-loader/expo-module.config.json
@@ -1,3 +1,3 @@
 {
-  "platforms": ["ios", "android"]
+  "platforms": ["apple", "android"]
 }


### PR DESCRIPTION
# Why

Rebased version of https://github.com/expo/expo/pull/33779
