### PR TITLE
[updates] Add update id headers to asset requests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed Android unit test errors in BuilDataTest. ([#34510](https://github.com/expo/expo/pull/34510) by [@kudo](https://github.com/kudo))
 - Fixed incorrect error log on Android. ([#34785](https://github.com/expo/expo/pull/34785) by [@kudo](https://github.com/kudo))
 - [Android] Started using expo modules gradle plugin. ([#34806](https://github.com/expo/expo/pull/34806) by [@lukmccall](https://github.com/lukmccall))
+- Add update id headers to asset requests ([#34453](https://github.com/expo/expo/pull/34453) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -76,7 +76,7 @@ class DatabaseLauncherTest {
     every { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
 
     val mockedFile = File(context.cacheDir, "test")
-    every { spyLauncher.ensureAssetExists(any(), any(), any()) } returns mockedFile
+    every { spyLauncher.ensureAssetExists(any(), any(), any(), any()) } returns mockedFile
 
     val mockedCallback = mockk<LauncherCallback>(relaxed = true)
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -76,7 +76,7 @@ class DatabaseLauncherTest {
     every { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
 
     val mockedFile = File(context.cacheDir, "test")
-    every { spyLauncher.ensureAssetExists(any(), any()) } returns mockedFile
+    every { spyLauncher.ensureAssetExists(any(), any(), any()) } returns mockedFile
 
     val mockedCallback = mockk<LauncherCallback>(relaxed = true)
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -114,7 +114,7 @@ class FileDownloaderTest {
     }
 
     // assetRequestHeaders should not be able to override preset headers
-    val actual = FileDownloader.createRequestForAsset(assetEntity, config, context)
+    val actual = FileDownloader.createRequestForAsset(assetEntity, JSONObject("{}"), config, context)
     Assert.assertEquals("android", actual.header("expo-platform"))
     Assert.assertEquals("custom", actual.header("expo-updates-environment"))
   }
@@ -142,7 +142,7 @@ class FileDownloaderTest {
     }
 
     // assetRequestHeaders should have their values coerced to strings
-    val actual = FileDownloader.createRequestForAsset(assetEntity, config, context)
+    val actual = FileDownloader.createRequestForAsset(assetEntity, JSONObject("{}"), config, context)
     Assert.assertEquals("test", actual.header("expo-string"))
     Assert.assertEquals("47.5", actual.header("expo-number"))
     Assert.assertEquals("true", actual.header("expo-boolean"))
@@ -239,6 +239,7 @@ class FileDownloaderTest {
     FileDownloader(context, config, logger, client).downloadAsset(
       assetEntity,
       File(context.cacheDir, "test"),
+      JSONObject("{}"),
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {
           error = e
@@ -288,6 +289,7 @@ class FileDownloaderTest {
     FileDownloader(context, config, logger, client).downloadAsset(
       assetEntity,
       File(context.cacheDir, "test"),
+      JSONObject("{}"),
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {
           error = e

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -80,7 +80,7 @@ class RemoteLoaderTest {
 
     every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(2)
+      val callback = arg<AssetDownloadCallback>(3)
       callback.onSuccess(asset, true)
     }
 
@@ -107,7 +107,7 @@ class RemoteLoaderTest {
   fun testRemoteLoader_FailureToDownloadAssets() {
     every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(2)
+      val callback = arg<AssetDownloadCallback>(3)
       callback.onFailure(IOException("mock failed to download asset"), asset)
     }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -78,7 +78,7 @@ class RemoteLoaderTest {
       )
     }
 
-    every { mockFileDownloader.downloadAsset(any(), any(), any()) } answers {
+    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
       val callback = arg<AssetDownloadCallback>(2)
       callback.onSuccess(asset, true)
@@ -94,7 +94,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -105,7 +105,7 @@ class RemoteLoaderTest {
 
   @Test
   fun testRemoteLoader_FailureToDownloadAssets() {
-    every { mockFileDownloader.downloadAsset(any(), any(), any()) } answers {
+    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
       val callback = arg<AssetDownloadCallback>(2)
       callback.onFailure(IOException("mock failed to download asset"), asset)
@@ -115,7 +115,7 @@ class RemoteLoaderTest {
 
     verify(exactly = 0) { mockCallback.onSuccess(any()) }
     verify { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -140,7 +140,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // only 1 asset (bundle) should be downloaded since the other asset already exists
-    verify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -167,7 +167,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // both assets should be downloaded regardless of what the database says
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -197,7 +197,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -221,7 +221,7 @@ class RemoteLoaderTest {
     verify(exactly = 0) { mockCallback.onFailure(any()) }
 
     // missing assets should still be downloaded
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -245,7 +245,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -275,7 +275,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -300,7 +300,7 @@ class RemoteLoaderTest {
 
     verify { mockCallback.onSuccess(Loader.LoaderResult(null, updateDirective)) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
+    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(0, updates.size)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -205,7 +205,7 @@ class DatabaseLauncher(
       // we still don't have the asset locally, so try downloading it remotely
       assetsToDownload++
 
-      val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(asset, launchedUpdate, embeddedUpdate?.updateEntity, requestedUpdate)
+      val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(launchedUpdate, embeddedUpdate?.updateEntity, requestedUpdate)
       fileDownloader.downloadAsset(
         asset,
         updatesDirectory,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -7,6 +7,7 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.UpdatesUtils
+import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
 import java.io.File
 import java.io.FileNotFoundException
@@ -71,6 +72,7 @@ class EmbeddedLoader internal constructor(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
+    requestedUpdate: UpdateEntity?,
     callback: AssetDownloadCallback
   ) {
     val filename = UpdatesUtils.createFilenameForAsset(assetEntity)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -73,6 +73,7 @@ class EmbeddedLoader internal constructor(
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
+    embeddedUpdate: UpdateEntity?,
     callback: AssetDownloadCallback
   ) {
     val filename = UpdatesUtils.createFilenameForAsset(assetEntity)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -602,6 +602,7 @@ class FileDownloader(
     ): Request {
       return Request.Builder()
         .url(assetEntity.url!!.toString())
+        .addHeadersFromJSONObject(assetEntity.extraRequestHeaders)
         .addHeadersFromJSONObject(extraHeaders)
         .header("Expo-Platform", "android")
         .header("Expo-Protocol-Version", "1")
@@ -705,12 +706,11 @@ class FileDownloader(
     }
 
     fun getExtraHeadersForRemoteAssetRequest(
-      assetEntity: AssetEntity,
       launchedUpdate: UpdateEntity?,
       embeddedUpdate: UpdateEntity?,
       requestedUpdate: UpdateEntity?
     ): JSONObject {
-      val extraHeaders = assetEntity.extraRequestHeaders ?: JSONObject()
+      val extraHeaders = JSONObject()
 
       launchedUpdate?.let {
         extraHeaders.put("Expo-Current-Update-ID", it.id.toString().lowercase())

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -450,6 +450,7 @@ class FileDownloader(
   fun downloadAsset(
     asset: AssetEntity,
     destinationDirectory: File?,
+    extraHeaders: JSONObject,
     callback: AssetDownloadCallback
   ) {
     if (asset.url == null) {
@@ -467,7 +468,7 @@ class FileDownloader(
     } else {
       try {
         downloadAssetAndVerifyHashAndWriteToPath(
-          createRequestForAsset(asset, configuration, context),
+          createRequestForAsset(asset, extraHeaders, configuration, context),
           asset.expectedHash,
           path,
           object : FileDownloadCallback {
@@ -595,12 +596,13 @@ class FileDownloader(
 
     internal fun createRequestForAsset(
       assetEntity: AssetEntity,
+      extraHeaders: JSONObject,
       configuration: UpdatesConfiguration,
       context: Context
     ): Request {
       return Request.Builder()
         .url(assetEntity.url!!.toString())
-        .addHeadersFromJSONObject(assetEntity.extraRequestHeaders)
+        .addHeadersFromJSONObject(extraHeaders)
         .header("Expo-Platform", "android")
         .header("Expo-Protocol-Version", "1")
         .header("Expo-API-Version", "1")
@@ -697,6 +699,27 @@ class FileDownloader(
             OuterList.valueOf(it.map { elem -> StringItem.valueOf(elem.toString()) }).serialize()
           )
         }
+      }
+
+      return extraHeaders
+    }
+
+    fun getExtraHeadersForRemoteAssetRequest(
+      assetEntity: AssetEntity,
+      launchedUpdate: UpdateEntity?,
+      embeddedUpdate: UpdateEntity?,
+      requestedUpdate: UpdateEntity?
+    ): JSONObject {
+      val extraHeaders = assetEntity.extraRequestHeaders ?: JSONObject()
+
+      launchedUpdate?.let {
+        extraHeaders.put("Expo-Current-Update-ID", it.id.toString().lowercase())
+      }
+      embeddedUpdate?.let {
+        extraHeaders.put("Expo-Embedded-Update-ID", it.id.toString().lowercase())
+      }
+      requestedUpdate?.let {
+        extraHeaders.put("Expo-Requested-Update-ID", it.id.toString().lowercase())
       }
 
       return extraHeaders

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -216,7 +216,7 @@ abstract class Loader protected constructor(
   }
 
   private fun downloadAllAssets(update: Update) {
-    val assetList: List<AssetEntity> = update.assetEntityList
+    val assetList = update.assetEntityList
     assetTotal = assetList.size
     for (assetEntityCur in assetList) {
       var assetEntity = assetEntityCur

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -86,6 +86,7 @@ abstract class Loader protected constructor(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
+    requestedUpdate: UpdateEntity?,
     callback: AssetDownloadCallback
   )
 
@@ -204,7 +205,7 @@ abstract class Loader protected constructor(
         // however, it's not ready, so we should try to download all the assets again.
         updateEntity = existingUpdateEntity
       }
-      downloadAllAssets(update.assetEntityList)
+      downloadAllAssets(update)
     }
   }
 
@@ -214,7 +215,8 @@ abstract class Loader protected constructor(
     ERRORED
   }
 
-  private fun downloadAllAssets(assetList: List<AssetEntity>) {
+  private fun downloadAllAssets(update: Update) {
+    val assetList: List<AssetEntity> = update.assetEntityList
     assetTotal = assetList.size
     for (assetEntityCur in assetList) {
       var assetEntity = assetEntityCur
@@ -243,6 +245,7 @@ abstract class Loader protected constructor(
         assetEntity,
         updatesDirectory,
         configuration,
+        requestedUpdate = update.updateEntity,
         object : AssetDownloadCallback {
           override fun onFailure(e: Exception, assetEntity: AssetEntity) {
             val identifier = if (assetEntity.hash != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -87,6 +87,7 @@ abstract class Loader protected constructor(
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
+    embeddedUpdate: UpdateEntity?,
     callback: AssetDownloadCallback
   )
 
@@ -218,6 +219,8 @@ abstract class Loader protected constructor(
   private fun downloadAllAssets(update: Update) {
     val assetList = update.assetEntityList
     assetTotal = assetList.size
+
+    val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)
     for (assetEntityCur in assetList) {
       var assetEntity = assetEntityCur
 
@@ -246,6 +249,7 @@ abstract class Loader protected constructor(
         updatesDirectory,
         configuration,
         requestedUpdate = update.updateEntity,
+        embeddedUpdate = embeddedUpdate?.updateEntity,
         object : AssetDownloadCallback {
           override fun onFailure(e: Exception, assetEntity: AssetEntity) {
             val identifier = if (assetEntity.hash != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -55,9 +55,12 @@ class RemoteLoader internal constructor(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
-    callback: AssetDownloadCallback
+    requestedUpdate: UpdateEntity?,
+    callback: AssetDownloadCallback,
   ) {
-    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, callback)
+    val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
+    val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(assetEntity, launchedUpdate, embeddedUpdate, requestedUpdate)
+    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, extraHeaders, callback)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -56,10 +56,10 @@ class RemoteLoader internal constructor(
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
+    embeddedUpdate: UpdateEntity?,
     callback: AssetDownloadCallback
   ) {
-    val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
-    val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(assetEntity, launchedUpdate, embeddedUpdate, requestedUpdate)
+    val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(launchedUpdate, embeddedUpdate, requestedUpdate)
     mFileDownloader.downloadAsset(assetEntity, updatesDirectory, extraHeaders, callback)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -56,7 +56,7 @@ class RemoteLoader internal constructor(
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
-    callback: AssetDownloadCallback,
+    callback: AssetDownloadCallback
   ) {
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(assetEntity, launchedUpdate, embeddedUpdate, requestedUpdate)

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -97,7 +97,7 @@ open class AppLoader: NSObject {
     preconditionFailure("Must override in concrete class")
   }
 
-  open func downloadAsset(_ asset: UpdateAsset) {
+  open func downloadAsset(_ asset: UpdateAsset, requestedUpdate: Update) {
     preconditionFailure("Must override in concrete class")
   }
 
@@ -226,11 +226,11 @@ open class AppLoader: NSObject {
                   self.handleAssetDownloadAlreadyExists(asset)
                 }
               } else {
-                self.downloadAsset(asset)
+                self.downloadAsset(asset, requestedUpdate: updateManifest)
               }
             }
           } else {
-            self.downloadAsset(asset)
+            self.downloadAsset(asset, requestedUpdate: updateManifest)
           }
         }
       } else {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -119,7 +119,7 @@ public final class EmbeddedAppLoader: AppLoader {
     ))
   }
 
-  override public func downloadAsset(_ asset: UpdateAsset, requestedUpdate: Update) {
+  override public func downloadAsset(_ asset: UpdateAsset, extraHeaders: [String: Any]) {
     FileDownloader.assetFilesQueue.async {
       self.handleAssetDownloadAlreadyExists(asset)
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -119,7 +119,7 @@ public final class EmbeddedAppLoader: AppLoader {
     ))
   }
 
-  override public func downloadAsset(_ asset: UpdateAsset) {
+  override public func downloadAsset(_ asset: UpdateAsset, requestedUpdate: Update) {
     FileDownloader.assetFilesQueue.async {
       self.handleAssetDownloadAlreadyExists(asset)
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -227,10 +227,9 @@ public final class FileDownloader {
   static func extraHeadersForRemoteAssetRequest(
     launchedUpdate: Update?,
     embeddedUpdate: Update?,
-    requestedUpdate: Update?,
-    assetExtraHeaders: [String: Any]?
+    requestedUpdate: Update?
   ) -> [String: Any] {
-    var extraHeaders: [String: Any] = assetExtraHeaders ?? [:]
+    var extraHeaders: [String: Any] = [:]
     if let launchedUpdate {
       extraHeaders["Expo-Current-Update-ID"] = launchedUpdate.updateId.uuidString.lowercased()
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -230,7 +230,6 @@ public final class FileDownloader {
     requestedUpdate: Update?,
     assetExtraHeaders: [String: Any]?
   ) -> [String: Any] {
-
     var extraHeaders: [String: Any] = assetExtraHeaders ?? [:]
     if let launchedUpdate = launchedUpdate {
       extraHeaders["Expo-Current-Update-ID"] = launchedUpdate.updateId.uuidString.lowercased()

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -231,15 +231,15 @@ public final class FileDownloader {
     assetExtraHeaders: [String: Any]?
   ) -> [String: Any] {
     var extraHeaders: [String: Any] = assetExtraHeaders ?? [:]
-    if let launchedUpdate = launchedUpdate {
+    if let launchedUpdate {
       extraHeaders["Expo-Current-Update-ID"] = launchedUpdate.updateId.uuidString.lowercased()
     }
 
-    if let embeddedUpdate = embeddedUpdate {
+    if let embeddedUpdate {
       extraHeaders["Expo-Embedded-Update-ID"] = embeddedUpdate.updateId.uuidString.lowercased()
     }
 
-    if let requestedUpdate = requestedUpdate {
+    if let requestedUpdate {
       extraHeaders["Expo-Requested-Update-ID"] = requestedUpdate.updateId.uuidString.lowercased()
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -221,6 +221,32 @@ public final class FileDownloader {
     return extraHeaders
   }
 
+   /**
+   * Get extra headers to pass into `downloadAsset:`
+   */
+  static func extraHeadersForRemoteAssetRequest(
+    launchedUpdate: Update?,
+    embeddedUpdate: Update?,
+    requestedUpdate: Update?,
+    assetExtraHeaders: [String: Any]?
+  ) -> [String: Any] {
+
+    var extraHeaders: [String: Any] = assetExtraHeaders ?? [:]
+    if let launchedUpdate = launchedUpdate {
+      extraHeaders["Expo-Current-Update-ID"] = launchedUpdate.updateId.uuidString.lowercased()
+    }
+
+    if let embeddedUpdate = embeddedUpdate {
+      extraHeaders["Expo-Embedded-Update-ID"] = embeddedUpdate.updateId.uuidString.lowercased()
+    }
+
+    if let requestedUpdate = requestedUpdate {
+      extraHeaders["Expo-Requested-Update-ID"] = requestedUpdate.updateId.uuidString.lowercased()
+    }
+
+    return extraHeaders
+  }
+
   private static func setHTTPHeaderFields(_ headers: [String: Any?]?, onRequest request: inout URLRequest) {
     guard let headers = headers else {
       return

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -84,7 +84,7 @@ public final class RemoteAppLoader: AppLoader {
     }
   }
 
-  override public func downloadAsset(_ asset: UpdateAsset, requestedUpdate: Update) {
+  override public func downloadAsset(_ asset: UpdateAsset, extraHeaders: [String: Any]) {
     let urlOnDisk = self.directory.appendingPathComponent(asset.filename)
 
     FileDownloader.assetFilesQueue.async {
@@ -101,30 +101,18 @@ public final class RemoteAppLoader: AppLoader {
           )
           return
         }
-        self.database.databaseQueue.async {
-          let embeddedUpdate = EmbeddedAppLoader.embeddedManifest(withConfig: self.config, database: self.database)
-          let extraHeaders = FileDownloader.extraHeadersForRemoteAssetRequest(
-            launchedUpdate: self.launchedUpdate,
-            embeddedUpdate: embeddedUpdate,
-            requestedUpdate: requestedUpdate,
-            assetExtraHeaders: asset.extraRequestHeaders
-          )
-
-          FileDownloader.assetFilesQueue.async {
-            self.downloader.downloadAsset(
-              fromURL: assetUrl,
-              verifyingHash: asset.expectedHash,
-              toPath: urlOnDisk.path,
-              extraHeaders: extraHeaders
-            ) { data, response, _ in
-              DispatchQueue.global().async {
-                self.handleAssetDownload(withData: data, response: response, asset: asset)
-              }
-            } errorBlock: { error in
-              DispatchQueue.global().async {
-                self.handleAssetDownload(withError: error, asset: asset)
-              }
-            }
+        self.downloader.downloadAsset(
+          fromURL: assetUrl,
+          verifyingHash: asset.expectedHash,
+          toPath: urlOnDisk.path,
+          extraHeaders: extraHeaders.merging(asset.extraRequestHeaders ?? [:]) { (current, _) in current }
+        ) { data, response, _ in
+          DispatchQueue.global().async {
+            self.handleAssetDownload(withData: data, response: response, asset: asset)
+          }
+        } errorBlock: { error in
+          DispatchQueue.global().async {
+            self.handleAssetDownload(withError: error, asset: asset)
           }
         }
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -110,18 +110,20 @@ public final class RemoteAppLoader: AppLoader {
             assetExtraHeaders: asset.extraRequestHeaders
           )
 
-          self.downloader.downloadAsset(
-            fromURL: assetUrl,
-            verifyingHash: asset.expectedHash,
-            toPath: urlOnDisk.path,
-            extraHeaders: extraHeaders
-          ) { data, response, _ in
-            DispatchQueue.global().async {
-              self.handleAssetDownload(withData: data, response: response, asset: asset)
-            }
-          } errorBlock: { error in
-            DispatchQueue.global().async {
-              self.handleAssetDownload(withError: error, asset: asset)
+          FileDownloader.assetFilesQueue.async {
+            self.downloader.downloadAsset(
+              fromURL: assetUrl,
+              verifyingHash: asset.expectedHash,
+              toPath: urlOnDisk.path,
+              extraHeaders: extraHeaders
+            ) { data, response, _ in
+              DispatchQueue.global().async {
+                self.handleAssetDownload(withData: data, response: response, asset: asset)
+              }
+            } errorBlock: { error in
+              DispatchQueue.global().async {
+                self.handleAssetDownload(withError: error, asset: asset)
+              }
             }
           }
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -105,7 +105,7 @@ public final class RemoteAppLoader: AppLoader {
           fromURL: assetUrl,
           verifyingHash: asset.expectedHash,
           toPath: urlOnDisk.path,
-          extraHeaders: extraHeaders.merging(asset.extraRequestHeaders ?? [:]) { (current, _) in current }
+          extraHeaders: extraHeaders.merging(asset.extraRequestHeaders ?? [:]) { current, _ in current }
         ) { data, response, _ in
           DispatchQueue.global().async {
             self.handleAssetDownload(withData: data, response: response, asset: asset)


### PR DESCRIPTION
# Why

In order to improve analysts and a better understanding of the current state of a device on expo updates we should send some additional headers when loading assets

# How

Add `Expo-Current-Update-ID`, `Expo-Embedded-Update-ID`, `Expo-Requested-Update-ID` headers to expo-updates asset requests

# Test Plan

Run locally on iOS and Android and inspected request headers

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
