### PR TITLE
[config-types] Sync with xdl-schemas for Updates.disableAntiBrickingMeasures

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -207,6 +207,10 @@ export interface ExpoConfig {
          * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
          */
         assetPatternsToBeBundled?: string[];
+        /**
+         * Whether to disable the built-in expo-updates anti-bricking measures. Defaults to false. If set to true, this will allow overriding certain configuration options from the JS API, which is liable to leave an app in a bricked state if not done carefully. This should not be used in production.
+         */
+        disableAntiBrickingMeasures?: boolean;
     };
     /**
      * Provide overrides by locale for System Dialog prompts like Permissions Boxes

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -209,6 +209,10 @@ export interface ExpoConfig {
      * Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/** /*.png', 'app/fonts/** /*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.
      */
     assetPatternsToBeBundled?: string[];
+    /**
+     * Whether to disable the built-in expo-updates anti-bricking measures. Defaults to false. If set to true, this will allow overriding certain configuration options from the JS API, which is liable to leave an app in a bricked state if not done carefully. This should not be used in production.
+     */
+    disableAntiBrickingMeasures?: boolean;
   };
   /**
    * Provide overrides by locale for System Dialog prompts like Permissions Boxes


### PR DESCRIPTION
# Why

This syncs config-types with https://app.graphite.dev/github/pr/expo/universe/18371/xdl-schemas-Add-updates-disableAntiBrickingMeasures

# How

`yarn generate --path ../../../../universe/server/www/xdl-schemas/UNVERSIONED-schema.json`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
