### PR TITLE
Replaced double quotes with single quotes

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -28,7 +28,7 @@ To get gesture interactions to work in the app, we'll render `<GestureHandlerRoo
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx
 // ... rest of the import statements remain same
-/* @tutinfo Import <CODE>GestureHandlerRootView</CODE> from <CODE>react-native-gesture-handler-library</CODE>. */import { GestureHandlerRootView } from "react-native-gesture-handler";/* @end */
+/* @tutinfo Import <CODE>GestureHandlerRootView</CODE> from <CODE>react-native-gesture-handler-library</CODE>. */import { GestureHandlerRootView } from 'react-native-gesture-handler';/* @end */
 
 export default function Index() {
   return (

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -57,7 +57,7 @@ An `Animated` component looks at the `style` prop of the component and determine
 {/* prettier-ignore */}
 ```tsx components/EmojiSticker.tsx
 import { View } from 'react-native';
-import Animated from 'react-native-reanimated';
+/* @tutinfo Import <CODE>Animated</CODE> from <CODE>react-native-reanimated</CODE>. */import Animated from 'react-native-reanimated';/* @end */
 import { type ImageSource } from "expo-image";
 
 type Props = {


### PR DESCRIPTION
Replaced double quotes with single quotes in the import statement for GestureHandlerRootView from react-native-gesture-handler for consistency