### PR TITLE
[core][Android] Use concrete type for props

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -14,7 +14,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
   context: Context,
   appContext: AppContext
 ) : ExpoView(context, appContext) {
-  open val props: ComposeProps? = null
+  open val props: T? = null
 
   override val shouldUseAndroidLayout = true
 


### PR DESCRIPTION
# Why

Uses more concrete type for props.
