### PR TITLE
[core] fix AppDelegate.mm methods not be called

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fixes `AppContext` is lost in nested converters. ([#34373](https://github.com/expo/expo/pull/34373) by [@lukmccall](https://github.com/lukmccall))
+- Fixed **AppDelegate.mm** methods not be called on iOS. ([#34464](https://github.com/expo/expo/pull/34464) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -24,7 +24,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    _expoAppDelegate = [[EXExpoAppDelegate alloc] init];
+    _expoAppDelegate = [[EXExpoAppDelegate alloc] initWithAppDelegate:self];
     _expoAppDelegate.shouldCallReactNativeSetup = NO;
   }
   return self;

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -24,6 +24,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
+    // TODO(kudo) to remove the `initWithAppDelegate` initializer when `EXAppDelegateWrapper` is removed
     _expoAppDelegate = [[EXExpoAppDelegate alloc] initWithAppDelegate:self];
     _expoAppDelegate.shouldCallReactNativeSetup = NO;
   }


### PR DESCRIPTION
# Why

regression from #33348 that delegate methods from AppDelegate.mm are not be called

# How

When using AppDelegate.mm, the `self` in ExpoAppInstance is not the true AppDelegate.mm, since the hierarchy is

```
AppDelegate.mm -> derive from ExpoAppDelegateWrapper -> composite ExpoAppInstance
```

where in AppDelegate.swift it's

```
AppDelegate.swift -> derive from ExpoAppDelegate -> derive from ExpoAppInstance
```

to make AppDelegate.mm case works, we pass the true AppDelegate to ExpoAppInstance and call it when it's available.

# Test Plan

- test `expo@52.0.27` with react-native-bootsplash and add a break point at `customizeRootView`
- ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)