### PR TITLE
fix(expo-camera): Update Camera.types.ts

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix TypeScript type for `CameraViewRef` `takePictureAsync` method. ([#34466](https://github.com/expo/expo/pull/34466) by [@thiskevinwang](https://github.com/thiskevinwang))
 
 ### 💡 Others
 

--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -439,7 +439,7 @@ export type CameraViewProps = ViewProps & {
  * @hidden
  */
 export interface CameraViewRef {
-  readonly takePicture: (options: CameraPictureOptions) => Promise<CameraCapturedPicture>;
+  readonly takePictureAsync: (options: CameraPictureOptions) => Promise<CameraCapturedPicture>;
   readonly getAvailablePictureSizes: () => Promise<string[]>;
   readonly record: (options?: CameraRecordingOptions) => Promise<{ uri: string }>;
   readonly toggleRecording: () => Promise<void>;


### PR DESCRIPTION
Renames `takePicture` method to [`takePictureAsync`](https://docs.expo.dev/versions/latest/sdk/camera/#takepictureasyncoptions)

# Why

`takePicture` doesn't exist ( `"expo-camera": "~16.0.14"`)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
