### PR TITLE
[android][contacts] supporting changing isFavorite (starred) in updateContactAsync

### DIFF
--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -526,6 +526,26 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
       expect(result[Contacts.Fields.FirstName]).toEqual('Andy');
     });
 
+    it('Contacts.updateContactAsync() and toggle isFavorite', async () => {
+      const contacts = await Contacts.getContactsAsync({
+        fields: [Contacts.Fields.IsFavorite],
+      });
+      const favoriteContact = contacts.data.find((contact) => contact.isFavorite);
+      console.log('favoriteContact', favoriteContact);
+      expect(favoriteContact).toBeDefined();
+      expect(typeof favoriteContact.isFavorite).toBe('boolean');
+      expect(favoriteContact.isFavorite).toBe(true);
+      await Contacts.updateContactAsync({
+        id: favoriteContact.id,
+        [Contacts.Fields.IsFavorite]: false,
+      });
+      const modifiedContact = await Contacts.getContactByIdAsync(favoriteContact.id, [
+        Contacts.Fields.IsFavorite,
+      ]);
+      expect(typeof modifiedContact.isFavorite).toBe('boolean');
+      expect(modifiedContact.isFavorite).toBe(false);
+    });
+
     it('Contacts.removeContactAsync() finishes successfully', async () => {
       const contactId = await createSimpleContact('Hi', 'Joe');
 

--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -531,7 +531,6 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
         fields: [Contacts.Fields.IsFavorite],
       });
       const favoriteContact = contacts.data.find((contact) => contact.isFavorite);
-      console.log('favoriteContact', favoriteContact);
       expect(favoriteContact).toBeDefined();
       expect(typeof favoriteContact.isFavorite).toBe('boolean');
       expect(favoriteContact.isFavorite).toBe(true);

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- added the ability to change isFavorite property of contacts on Android (using updateContactAsync) ([#34483](https://github.com/expo/expo/pull/34483) by [@NorseGaud](https://github.com/NorseGaud))
 - added the ability to read and write starred property (as "isFavorite") of contacts on Android ([#33208](https://github.com/expo/expo/pull/33208) by [@NorseGaud](https://github.com/NorseGaud))
 - Add `presentAccessPickerAsync` function that presents the iOS 18.0+ picker for limited contacts access. ([#33771](https://github.com/expo/expo/pull/33771) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed `ContactAccessButton` from SwiftUI. ([#33782](https://github.com/expo/expo/pull/33782) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -287,6 +287,10 @@ class Contact(var contactId: String, var appContext: AppContext) {
           .build()
       )
     }
+    op = ContentProviderOperation.newUpdate(ContactsContract.Contacts.CONTENT_URI)
+      .withSelection("${ContactsContract.Contacts._ID}=?", arrayOf(contactId))
+      .withValue(ContactsContract.Contacts.STARRED, if (isFavorite) 1 else 0)
+    ops.add(op.build())
 
     // Flush all data from linked db
     rawContactId?.let { id ->


### PR DESCRIPTION
# Why

With the introduction of isFavorite, we need to allow updateContactAsync to change it

# How

Users can now:

```
      await Contacts.updateContactAsync({
        id: favoriteContact.id,
        [Contacts.Fields.IsFavorite]: false,
      });
```

# Test Plan

Added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
