### PR TITLE
[updates] fix ios expo-go build error

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Made ReactNativeFeatureFlags a parameter to the constructor of the ErrorRecovery class to be able to make tests pass ([#34363](https://github.com/expo/expo/pull/34363) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Inject logger from controllers down to dependent objects. ([#34035](https://github.com/expo/expo/pull/34035) by [@wschurman](https://github.com/wschurman))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- Fixed build error on iOS Expo Go. ([#34485](https://github.com/expo/expo/pull/34485) by [@kudo](https://github.com/kudo))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -199,9 +199,13 @@ public final class UpdatesConfig: NSObject {
     return try UpdatesConfig.config(fromDictionary: dictionary)
   }
 
-  public static func config(
+  public static func config(fromDictionary config: [String: Any]) throws -> UpdatesConfig {
+    return try UpdatesConfig.config(fromDictionary: config, configOverride: UpdatesConfigOverride.load())
+  }
+
+  private static func config(
     fromDictionary config: [String: Any],
-    configOverride: UpdatesConfigOverride? = UpdatesConfigOverride.load()
+    configOverride: UpdatesConfigOverride?
   ) throws -> UpdatesConfig {
     guard let updateUrl = getUpdateUrl(fromDictionary: config, configOverride: configOverride) else {
       throw UpdatesConfigError.ExpoUpdatesConfigMissingURLError


### PR DESCRIPTION
# Why

fix ios expo-go build error since #34423:
https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/builds/5c429614-1b37-4e45-a4de-5f0f8d777461

```
- no known class method for selector 'configFromDictionary:error:'
```

# How

since objective-c doesn't support swift default parameters, this pr tries to align android implementation, to use constructor overloading.

# Test Plan

ios expo-go build passed: https://github.com/expo/expo/actions/runs/12982867454/job/36203273821

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
