### PR TITLE
[guides] Add info about linking to FYI pages in writing styleguide

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -206,6 +206,10 @@ Use [internal links](https://github.com/expo/expo/blob/main/docs/README.md#inter
 
 - When referencing Expo CLI in a standalone apps document, instead of going through the steps of installing the Expo CLI from scratch, mention that Expo CLI is required and use internal linking to Expo CLI installation steps mentioned in the "Getting Started" section.
 
+#### Linking to Expo FYI pages
+
+When linking to the [Expo FYI pages](https://github.com/expo/fyi), use shorthand links, such as https://expo.fyi/bundle-identifier instead of the full URL (https://github.com/expo/fyi/blob/main/bundle-identifier.md).
+
 ### Accessibility
 
 An accessible document is created to be as easily readable by a sighted reader as a low vision or non-sighted reader. One of the key points to keep in mind when writing documentation and using images and videos is to add an "alt" text to them.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in docs sync as we currently do not provide information on how to link Expo FYI pages in our docs.

Add information about how to link Expo FYI pages to use shorthand URLs in the writing style guide.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a sub-section called " Linking to Expo FYI pages" under "Linking to other docs".


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
