### PR TITLE
[docs] Add a client-side redirect for `/sdk`

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -466,4 +466,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/latest/config/app/name/': '/versions/latest/config/app/#name',
   '/bare/': '/bare/overview/',
   '/accounts/working-together/': '/accounts/account-types/',
+
+  '/sdk/': '/versions/latest/',
 };

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -46,14 +46,14 @@ export function getRedirectPath(redirectPath: string): string {
     redirectPath = removeVersionFromPath(redirectPath);
   }
 
-  // Handle the specific /sdk or /sdk/ root paths
-  if (redirectPath === '/sdk/' || redirectPath === '/sdk') {
-    redirectPath = '/versions/latest/';
-  }
-
   // Catch any redirects to sdk paths without versions and send to the latest version
-  if (redirectPath.startsWith('/sdk/')) {
-    redirectPath = `/versions/latest${redirectPath}`;
+  if (redirectPath.startsWith('/sdk')) {
+    const hasDestination = !/^\/sdk\/?$/.test(redirectPath);
+    if (hasDestination) {
+      redirectPath = `/versions/latest${redirectPath}`;
+    } else {
+      redirectPath = `/versions/latest`;
+    }
   }
 
   // If a page is missing for react-native paths we redirect to react-native docs

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -46,6 +46,11 @@ export function getRedirectPath(redirectPath: string): string {
     redirectPath = removeVersionFromPath(redirectPath);
   }
 
+  // Handle the specific /sdk or /sdk/ root paths
+  if (redirectPath === '/sdk/' || redirectPath === '/sdk') {
+    redirectPath = '/versions/latest/';
+  }
+
   // Catch any redirects to sdk paths without versions and send to the latest version
   if (redirectPath.startsWith('/sdk/')) {
     redirectPath = `/versions/latest${redirectPath}`;
@@ -466,6 +471,4 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/latest/config/app/name/': '/versions/latest/config/app/#name',
   '/bare/': '/bare/overview/',
   '/accounts/working-together/': '/accounts/account-types/',
-
-  '/sdk/': '/versions/latest/',
 };

--- a/docs/ui/components/RedirectNotification.tsx
+++ b/docs/ui/components/RedirectNotification.tsx
@@ -11,8 +11,11 @@ export default function RedirectNotification({ showForQuery = 'redirected', chil
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
+    const referrer = document.referrer;
+    const isFromSdk = referrer?.endsWith('/sdk') || referrer?.endsWith('/sdk/');
+
     if (router?.query) {
-      setVisible(router.query.hasOwnProperty(showForQuery));
+      setVisible(!isFromSdk && router.query.hasOwnProperty(showForQuery));
     }
   }, [router?.query]);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @keith-kurak.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a redirectPath for `/sdk` and `/sdk/` that redirects to the index page under Reference under special cases in the `error-utilities.ts` file
- Update RedirectNotification to not show a warning when the redircting from `/sdk` or `/sdk/` as the root path.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally: `yarn start dev`
- Visit: `http://localhost:3002/sdk` which should redirect to `http://localhost:3002/versions/latest/`


https://github.com/user-attachments/assets/66f18a7b-842e-47f3-9d03-0a56de1a7775



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
