### PR TITLE
[core][maps] Make compose integration compatible with Kotlin < 2

### DIFF
--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
-    includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+  // Linked manually to used version from our RN fork
+  includeBuild(new File(rootDir, "../../../react-native-lab/react-native/packages/gradle-plugin").toString())
 
   repositories {
     mavenCentral()
@@ -29,7 +30,8 @@ include ':app'
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
 apply from: new File(rootDir, "versioning_linking.gradle")
 
-includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+// Linked manually to used version from our RN fork
+includeBuild(new File(rootDir, "../../../react-native-lab/react-native/packages/gradle-plugin").toString())
 
 include ':expoview'
 include ':tools'

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -20,15 +20,21 @@ try {
 }
 
 buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
+  ext.KOTLIN_MAJOR_VERSION = kotlinVersion.split("\\.")[0].toInteger()
+
+  if (KOTLIN_MAJOR_VERSION >= 2) {
+    repositories {
+      mavenCentral()
+    }
+    dependencies {
+      classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
+    }
   }
 }
 
-apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+if (KOTLIN_MAJOR_VERSION >= 2) {
+  apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+}
 
 group = 'host.exp.exponent'
 version = '0.6.1'
@@ -41,6 +47,11 @@ android {
   }
   buildFeatures {
     compose true
+  }
+  if (KOTLIN_MAJOR_VERSION < 2) {
+    composeOptions {
+      kotlinCompilerExtensionVersion = "1.5.14"
+    }
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -13,22 +13,22 @@ apply from: expoModulesCorePlugin
 applyKotlinExpoModulesCorePlugin()
 
 buildscript {
-  def KOTLIN_MAJOR_VERSION = kotlinVersion.split("\\.")[0].toInteger()
-  if(KOTLIN_MAJOR_VERSION < 2) {
-    logger.warn("You need to use at least Kotlin 2.0.0 to enable jetpack compose support.")
-    return
-  }
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
+  ext.KOTLIN_MAJOR_VERSION = kotlinVersion.split("\\.")[0].toInteger()
+
+  if (KOTLIN_MAJOR_VERSION >= 2) {
+    repositories {
+      mavenCentral()
+    }
+
+    dependencies {
+      classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
+    }
   }
 }
 
-try {
+if (KOTLIN_MAJOR_VERSION >= 2) {
   apply plugin: 'org.jetbrains.kotlin.plugin.compose'
-} catch (ignored) {}
+}
 
 useDefaultAndroidSdkVersions()
 useExpoPublishing()
@@ -96,7 +96,7 @@ android {
 
     externalNativeBuild {
       cmake {
-        abiFilters (*reactNativeArchitectures())
+        abiFilters(*reactNativeArchitectures())
         arguments "-DANDROID_STL=c++_shared",
           "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
           "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}",
@@ -116,6 +116,13 @@ android {
   buildFeatures {
     buildConfig true
     prefab true
+    compose true
+  }
+
+  if (KOTLIN_MAJOR_VERSION < 2) {
+    composeOptions {
+      kotlinCompilerExtensionVersion = "1.5.14"
+    }
   }
 
   packagingOptions {


### PR DESCRIPTION
# Why

Makes the compose integration compatible with Kotlin versions lower than 2. 
In order to publish `expo-maps` from the SDK 52 branch, we want to ensure that the compose integration is compatible with both Kotlin versions 2.0.21 and 1.9.24.
# Test Plan

- SDK-52 branch ✅ 
