### PR TITLE
chore(router): Temporarily Remove RSC dependency.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- Temporarily Remove RSC dependency.
+- Temporarily Remove RSC dependency. ([#34505](https://github.com/expo/expo/pull/34505) by [@EvanBacon](https://github.com/EvanBacon))
 - Use `expo-linking` to synchronously get the initial URL. This fixes App Clips and improves RSC support. ([#34328](https://github.com/expo/expo/pull/34328) by [@EvanBacon](https://github.com/EvanBacon))
 - Polyfill relative fetch requests and `window.location` by default. ([#34169](https://github.com/expo/expo/pull/34169) by [@EvanBacon](https://github.com/EvanBacon))
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 💡 Others
 
+- Temporarily Remove RSC dependency.
 - Use `expo-linking` to synchronously get the initial URL. This fixes App Clips and improves RSC support. ([#34328](https://github.com/expo/expo/pull/34328) by [@EvanBacon](https://github.com/EvanBacon))
 - Polyfill relative fetch requests and `window.location` by default. ([#34169](https://github.com/expo/expo/pull/34169) by [@EvanBacon](https://github.com/EvanBacon))
 - Add less aggressive babel plugin migration warning. ([#33640](https://github.com/expo/expo/pull/33640) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -115,7 +115,6 @@
     "react-native-is-edge-to-edge": "^1.1.6",
     "schema-utils": "^4.0.1",
     "semver": "~7.6.3",
-    "server-only": "^0.0.1",
-    "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610"
+    "server-only": "^0.0.1"
   }
 }


### PR DESCRIPTION
# Why

- Make main safe to deploy from. https://exponent-internal.slack.com/archives/C5ERY0TAR/p1737577606371349
