### PR TITLE
[video][docs] Improve `supportsPictureInPicture` configuration property description

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -53,7 +53,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsPictureInPicture',
       description:
-        'A boolean value to enable Picture-in-Picture on Android and iOS. Configures the `android:supportsPictureInPicture` property on Android and the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
+        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -53,7 +53,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsPictureInPicture',
       description:
-        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
+        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. If `false`, the key is removed. When `undefined`, the configuration is not modified.',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -53,7 +53,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsPictureInPicture',
       description:
-        'A boolean value to enable Picture-in-Picture on Android and iOS. Configures the `android:supportsPictureInPicture` property on Android and the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
+        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -53,7 +53,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsPictureInPicture',
       description:
-        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. When `undefined`, the configuration is not modified.',
+        'A boolean value to enable Picture-in-Picture on Android and iOS. If `true`, enables the `android:supportsPictureInPicture` property on Android and adds the `audio` key to the `UIBackgroundModes` array in the **Info.plist** file on iOS. If `false`, the key is removed. When `undefined`, the configuration is not modified.',
       default: 'undefined',
     },
   ]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on recent user feedback in Support Inbox where a user was confused about the changes `supportsPictureInPicture` does to the Info.plist on iOS.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Improve `supportsPictureInPicture` description to explicitly mention that an `audio` key is added `UIBackgroundModes` array for iOS when this property is set to `true`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Updated `unversioned` and SDK 52 docs.

![CleanShot 2025-01-28 at 01 36 06](https://github.com/user-attachments/assets/cc7d2a82-b563-4cf0-b03c-c8c25ff73950)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
