### PR TITLE
[router]: Update Maestro to latest v1.39.9

### DIFF
--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install Maestro
         run: |
-          export MAESTRO_VERSION=1.36.0
+          export MAESTRO_VERSION=1.39.9
           curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
# Why

Bump Maestro to latest version in attempt to fix CI setup errors

https://github.com/expo/expo/actions/runs/12997076735/job/36247246696?pr=34505