### PR TITLE
[expo-updates][android] Fix tests

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -119,7 +119,6 @@ dependencies {
   testImplementation 'androidx.test:core:1.5.0'
   testImplementation "io.mockk:mockk:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion()}"
-  testImplementation 'org.robolectric:robolectric:4.14.1'
 
   androidTestImplementation 'com.squareup.okio:okio:2.9.0'
   androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataConsistencyTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataConsistencyTest.kt
@@ -1,18 +1,18 @@
 package expo.modules.updates.db
 
 import android.net.Uri
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-class BuildDataTest {
+@RunWith(AndroidJUnit4ClassRunner::class)
+class BuildDataConsistencyTest {
   @Test
-  fun `isBuildDataConsistent should return true for same data`() {
+  fun test_isBuildDataConsistent_true_same_data() {
     val sourceBuildData = createUpdatesConfiguration(
       updateUrl = "https://example.com",
       requestHeaders = mapOf(
@@ -30,7 +30,7 @@ class BuildDataTest {
   }
 
   @Test
-  fun `isBuildDataConsistent should return false for EXUpdatesRequestHeaders change`() {
+  fun test_isBuildDataConsistent_false_headers_change() {
     val sourceBuildData = createUpdatesConfiguration(
       updateUrl = "https://example.com",
       requestHeaders = mapOf(
@@ -48,7 +48,7 @@ class BuildDataTest {
   }
 
   @Test
-  fun `isBuildDataConsistent support migration with new UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY key`() {
+  fun test_isBuildDataConsistent_migration_hasEmbeddedUpdate() {
     val sourceBuildData = createUpdatesConfiguration(
       updateUrl = "https://example.com",
       requestHeaders = mapOf(
@@ -67,7 +67,7 @@ class BuildDataTest {
   }
 
   @Test
-  fun `isBuildDataConsistent should not overwrite existing data from the default build data`() {
+  fun test_isBuildDataConsistent_does_not_override_existing_with_default() {
     val sourceBuildData = createUpdatesConfiguration(
       updateUrl = "https://example.com",
       requestHeaders = mapOf(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
@@ -22,6 +22,7 @@ import org.json.JSONObject
  * cause bugs when they do. The tracked fields are:
  *
  *   UPDATES_CONFIGURATION_UPDATE_URL_KEY
+ *   UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY
  *
  * and all of the values in json
  *


### PR DESCRIPTION
# Why

An attempt to fix BuildDataTest by converting it to an integration test instead of a robolectric test.

# How

Move test, convert.

# Test Plan

Wait for test run to see if it fixes it.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
