### PR TITLE
[updates] fix android unit test

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [iOS] Inject logger from controllers down to dependent objects. ([#34035](https://github.com/expo/expo/pull/34035) by [@wschurman](https://github.com/wschurman))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Fixed build error on iOS Expo Go. ([#34485](https://github.com/expo/expo/pull/34485) by [@kudo](https://github.com/kudo))
+- Fixed Android unit test errors in BuilDataTest. ([#34510](https://github.com/expo/expo/pull/34510) by [@kudo](https://github.com/kudo))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/db/BuildDataTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/db/BuildDataTest.kt
@@ -23,7 +23,7 @@ class BuildDataTest {
       put("expo-channel-name", "default")
     }
     val targetBuildData = JSONObject().apply {
-      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, "https://example.com")
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
     }
     Assert.assertTrue(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
@@ -41,7 +41,7 @@ class BuildDataTest {
       put("expo-channel-name", "preview")
     }
     val targetBuildData = JSONObject().apply {
-      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, "https://example.com")
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
     }
     Assert.assertFalse(BuildData.isBuildDataConsistent(sourceBuildData, targetBuildData))
@@ -59,7 +59,7 @@ class BuildDataTest {
       put("expo-channel-name", "default")
     }
     val targetBuildData = JSONObject().apply {
-      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, "https://example.com")
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, true)
     }
@@ -79,7 +79,7 @@ class BuildDataTest {
       put("expo-channel-name", "default")
     }
     val targetBuildData = JSONObject().apply {
-      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.parse("https://example.com"))
+      put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, "https://example.com")
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, targetRequestHeader)
       put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, false)
     }


### PR DESCRIPTION
# Why

fix android unit test: https://github.com/expo/expo/actions/runs/12996605229/job/36245740638

# How

it's a regression from #34426 of refactoring in between. this pr tries to align the updateUrl data between db and config

# Test Plan

android unit test pass: https://github.com/expo/expo/actions/runs/12998494170/job/36251756908

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
