### PR TITLE
Support deeper nested paths

### DIFF
--- a/packages/expo-constants/scripts/getAppConfig.js
+++ b/packages/expo-constants/scripts/getAppConfig.js
@@ -11,6 +11,10 @@ if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
   projectRoot = possibleProjectRoot;
 } else if (fs.existsSync(path.join(possibleProjectRoot, '..', 'package.json'))) {
   projectRoot = path.resolve(possibleProjectRoot, '..');
+} else if (fs.existsSync(path.join(possibleProjectRoot, '..', '..', 'package.json'))) {
+  projectRoot = path.resolve(possibleProjectRoot, '..', '..');
+} else if (fs.existsSync(path.join(possibleProjectRoot, '..', '..', '..', 'package.json'))) {
+  projectRoot = path.resolve(possibleProjectRoot, '..', '..', '..');
 }
 
 process.chdir(projectRoot);


### PR DESCRIPTION
# Why

Enables running android builds from folders deeper than simply ./android - for example if you wanted to have ./builds/android, it was previously not possible because of how this is written.

# How

It's just adding two more levels of parent path checking for project.json
