### PR TITLE
Add docs for native server deployment

### DIFF
--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -4,6 +4,11 @@ sidebar_title: React Server Components
 description: Learn about rendering React components on the server in Expo.
 ---
 
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
+
 > Experimentally available in **SDK 52 and above**. This is a very early preview and not ready for production or wide use yet. This initial version is meant to help library authors understand universal React Server Components and add support in their libraries.
 
 React Server Components enable a number of exciting capabilities, including:
@@ -543,11 +548,29 @@ The CSS will be hoisted into the client bundle from the server.
 
 ### Web
 
-To deploy your website to production, run: `npx expo export -p web`. You can host the website locally with the [Express server adapter](/router/reference/api-routes/#express).
+First, build the web project:
+
+<Terminal cmd={['$ npx expo export -p web']} />
+
+Then you can host it locally with `npx expo serve` or deploy it to the cloud:
+
+<BoxLink
+  title="Deploy instantly with EAS"
+  description="EAS Hosting is the best way to deploy your Expo API routes and servers."
+  href="/eas/hosting/get-started"
+  Icon={Cloud01Icon}
+/>
 
 ### Native
 
-Production exports for React Server Components on native are not yet supported. This is planned for Expo SDK 53.
+You can experimentally deploy your native React Server Components by following the server deployment guide:
+
+<BoxLink
+  title="Deploy native servers to EAS"
+  description="Deploy and link versioned servers to your production native apps."
+  href="/router/reference/api-routes#native-deployment"
+  Icon={Cloud01Icon}
+/>
 
 ## Known limitations
 
@@ -555,10 +578,10 @@ Production exports for React Server Components on native are not yet supported. 
 
 - Expo Snack does not support bundling Server Components.
 - EAS Update does not work with Server Components yet.
-- DOM components cannot use Server Functions yet.
-- Production deployment is very limited and not recommended yet.
+- DOM components cannot use React Server Functions in production yet.
+- Production deployment is limited and not recommended yet.
 - Server Rendering RSC payloads to HTML is not supported yet. This means static and server output doesn't fully work yet.
 - [`generateStaticParams`](/router/reference/static-rendering/#generatestaticparams) is only partially supported in full React Server Components mode.
 - HTML `form` integration with Server Functions is not supported yet (this partially works automatically, but data is not encrypted).
 - `StyleSheet.create` and `Platform.OS` are not supported on native. Use standard objects for styles and `process.env.EXPO_OS` for platform detection.
-- Server Functions that invoke other Server Functions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.
+- React Server Functions that invoke other Server Functions are not supported on Hermes due to a limitation in the Hermes runtime. This may be resolved with Static Hermes.

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -225,14 +225,13 @@ Here's how to configure your native app to automatically deploy and link a versi
 
 <Step label="1">
 
-Ensure the `origin` field is **NOT** set in the `app.json` or in the `expo.extra.router.origin` field.
-Also ensure you aren't using `app.config.js` as this is not supported with automatically linked deployments yet.
+Ensure the `origin` field is **NOT** set in the **app.json** or in the `expo.extra.router.origin` field. Also, ensure you aren't using **app.config.js** as this is not supported with automatically linked deployments yet.
 
 </Step>
 
 <Step label="2">
 
-Setup [hosting](/eas/hosting/get-started) for the project by deploying once locally first.
+Setup [EAS Hosting](/eas/hosting/get-started) for the project by deploying once locally first.
 
 <Terminal cmd={['$ npx expo export -p web', '$ eas deploy']} />
 
@@ -263,7 +262,7 @@ EXPO_TOKEN=xxxxxxx
 
 <Step label="5">
 
-Set the `owner` field in the `app.json` to the owner of the project (this is usually your EAS username).
+Set the `owner` field in the **app.json** to the owner of the project (this is usually your EAS username).
 
 ```json app.json
 {
@@ -285,10 +284,11 @@ You can also run this locally with:
 
 <Terminal
   cmd={[
-    '# iOS',
-    '$ npx expo run:ios --configuration Release',
     '# Android',
     '$ npx expo run:android --variant release',
+    '',
+    '# iOS',
+    '$ npx expo run:ios --configuration Release',
   ]}
 />
 
@@ -309,7 +309,7 @@ It can often be useful to test the production build against a local dev server t
 
 <Step label="1">
 
-First, export the production server:
+Export the production server:
 
 <Terminal cmd={['$ npx expo export']} />
 
@@ -324,7 +324,7 @@ Host the production server locally:
 
 <Step label="3">
 
-Set the origin in the `app.json`'s `origin` field. Ensure no generated value is in `expo.extra.router.origin`. This should be `http://localhost:8081` (assuming `npx expo serve` is running on the default port).
+Set the origin in the **app.json**'s `origin` field. Ensure no generated value is in `expo.extra.router.origin`. This should be `http://localhost:8081` (assuming `npx expo serve` is running on the default port).
 
 ```json app.json
 {
@@ -341,7 +341,7 @@ Set the origin in the `app.json`'s `origin` field. Ensure no generated value is 
 }
 ```
 
-Remember to remove this `origin` value when deploying to production!
+Remember to remove this `origin` value when deploying to production.
 
 </Step>
 
@@ -355,9 +355,9 @@ Build the app in release mode on to a simulator:
 
 You should now see requests coming in to the local server. Use a tool like [Proxyman](https://proxyman.com/) to inspect network traffic for the simulator and gain better insight.
 
-You can experimentally change the URL and quickly rebuild for iOS using the `--unstable-rebundle` flag. This will swap out the app.json and client assets for a new ones, skipping the native rebuild.
+You can experimentally change the URL and quickly rebuild for iOS using the `--unstable-rebundle` flag. This will swap out the **app.json** and client assets for new ones, skipping the native rebuild.
 
-For example, you can run `eas deploy` to get a new deployment URL, add it to the `app.json`, then run `npx expo run:ios --unstable-rebundle --configuration Release` to quickly rebuild the app with the new URL.
+For example, you can run `eas deploy` to get a new deployment URL, add it to the **app.json**, then run `npx expo run:ios --unstable-rebundle --configuration Release` to quickly rebuild the app with the new URL.
 
 You will want to make a clean build before sending to the store to ensure no transient issues are present.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -211,6 +211,154 @@ You can deploy the server for production using [EAS Hosting](/eas/hosting/get-st
   Icon={Cloud01Icon}
 />
 
+### Native deployment
+
+> **warning**: This is an experimental feature starting in SDK 52 and above. The process will be more automated and have better support in future versions.
+
+Server features (API routes, and React Server Components) in Expo Router are centered around native implementations of `window.location` and `fetch` which point to the remote server. In development, we automatically point to the dev server running with `npx expo start`, but for production native builds to work you'll need to deploy the server to a secure host and set the `origin` property of the Expo Router Config Plugin.
+
+When configured, features like relative fetch requests `fetch('/my-endpoint')` will automatically point to the server origin.
+
+This deployment process can experimentally be automated to ensure correct versioning during native builds with the `EXPO_UNSTABLE_DEPLOY_SERVER=1` environment variable.
+
+Here's how to configure your native app to automatically deploy and link a versioned production server on build:
+
+<Step label="1">
+
+Ensure the `origin` field is **NOT** set in the `app.json` or in the `expo.extra.router.origin` field.
+Also ensure you aren't using `app.config.js` as this is not supported with automatically linked deployments yet.
+
+</Step>
+
+<Step label="2">
+
+Ensure [hosting](/eas/hosting/get-started) is setup for the project by deploying once locally first.
+
+<Terminal cmd={['$ npx expo export -p web', '$ eas deploy']} />
+
+</Step>
+
+<Step label="3">
+
+Set the `EXPO_UNSTABLE_DEPLOY_SERVER` environment variable in your `.env` file. This will be used to enable the experimental server deployment functionality during EAS Build.
+
+```sh .env
+EXPO_UNSTABLE_DEPLOY_SERVER=1
+```
+
+</Step>
+
+<Step label="4">
+
+Create an `EXPO_TOKEN` for the project and add it to the `.env` file. https://expo.dev/accounts/[account]/settings/access-tokens
+
+```sh .env
+EXPO_UNSTABLE_DEPLOY_SERVER=1
+EXPO_TOKEN=xxxxxxx
+```
+
+</Step>
+
+<Step label="5">
+
+Set the `owner` field in the `app.json` to the owner of the project (this is usually your EAS username).
+
+```json app.json
+{
+  "expo": {
+    "owner": "bacon"
+  }
+}
+```
+
+</Step>
+
+<Step label="6">
+
+You're now ready to use automatic server deployment!
+
+<Terminal cmd={['$ eas build']} />
+
+You can alternatively run this locally with:
+
+<Terminal
+  cmd={[
+    '# iOS',
+    '$ npx expo run:ios --configuration Release',
+    '# Android',
+    '$ npx expo run:android --variant release',
+  ]}
+/>
+
+</Step>
+
+- Server failures may occur during the `Bundle JavaScript` phase of EAS Build if something was not setup correctly.
+- You can manually deploy the server and set the `origin` URL before building the app if you'd like.
+- Automatic deployment can be force skipped with the environment variable `EXPO_NO_DEPLOY=1`.
+- Automatic deployment does not support `app.config.js` files yet.
+- Logs from the deployment will be written to `.expo/logs/deploy.log`.
+- Deployment will not run in `EXPO_OFFLINE` mode.
+
+### Testing the native production app locally
+
+It can often be useful to test the production build against a local dev server to ensure everything is working as expected. This can speed up the debugging process substantially.
+
+To do this, follow these steps:
+
+<Step label="1">
+
+Export the production server for your target platform:
+
+<Terminal cmd={['$ npx expo export']} />
+
+</Step>
+<Step label="2">
+
+Host the production server locally:
+
+<Terminal cmd={['$ npx expo serve']} />
+
+</Step>
+
+<Step label="3">
+
+Set the origin in the `app.json`'s `origin` field. Ensure no generated value is in `expo.extra.router.origin`. This should be `http://localhost:8081` (assuming `npx expo serve` is running on the default port).
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "origin": "http://localhost:8081"
+        }
+      ]
+    ]
+  }
+}
+```
+
+Remember to remove this `origin` value when deploying to production!
+
+</Step>
+
+<Step label="4">
+
+Build the app in release mode on to a simulator:
+
+<Terminal cmd={['$ EXPO_NO_DEPLOY=1 npx expo run:ios --configuration Release']} />
+
+</Step>
+
+You should now see requests coming in to the local server. Use a tool like [Proxyman](https://proxyman.com/) to inspect network traffic for the simulator and gain better insight.
+
+You can experimentally change the URL and quickly rebuild for iOS using the `--unstable-rebundle` flag. This will swap out the app.json and client assets for a new ones, skipping the native rebuild.
+
+For example, you can run `eas deploy` to get a new deployment URL, add it to the `app.json`, then run `npx expo run:ios --unstable-rebundle --configuration Release` to quickly rebuild the app with the new URL.
+
+You will want to make a clean build before sending to the store to ensure no transient issues are present.
+
 ## Hosting on third-party services
 
 > **warning** This is experimental and subject to breaking changes. We have no continuous tests against this configuration.

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -213,7 +213,7 @@ You can deploy the server for production using [EAS Hosting](/eas/hosting/get-st
 
 ### Native deployment
 
-> **warning**: This is an experimental feature starting in SDK 52 and above. The process will be more automated and have better support in future versions.
+> **warning** This is an experimental feature starting in SDK 52 and above. The process will be more automated and have better support in future versions.
 
 Server features (API routes, and React Server Components) in Expo Router are centered around native implementations of `window.location` and `fetch` which point to the remote server. In development, we automatically point to the dev server running with `npx expo start`, but for production native builds to work you'll need to deploy the server to a secure host and set the `origin` property of the Expo Router Config Plugin.
 
@@ -232,7 +232,7 @@ Also ensure you aren't using `app.config.js` as this is not supported with autom
 
 <Step label="2">
 
-Ensure [hosting](/eas/hosting/get-started) is setup for the project by deploying once locally first.
+Setup [hosting](/eas/hosting/get-started) for the project by deploying once locally first.
 
 <Terminal cmd={['$ npx expo export -p web', '$ eas deploy']} />
 
@@ -250,11 +250,13 @@ EXPO_UNSTABLE_DEPLOY_SERVER=1
 
 <Step label="4">
 
-Create an `EXPO_TOKEN` for the project and add it to the `.env` file. https://expo.dev/accounts/[account]/settings/access-tokens
+Create an `EXPO_TOKEN` for the project and add it to the `.env` file. See: [Access Tokens](https://expo.dev/accounts/[account]/settings/access-tokens).
 
 ```sh .env
 EXPO_UNSTABLE_DEPLOY_SERVER=1
+# @info <a target="_blank" href="https://expo.dev/accounts/[account]/settings/access-tokens" style="text-decoration:underline;">Setup the token</a> #
 EXPO_TOKEN=xxxxxxx
+# @end #
 ```
 
 </Step>
@@ -275,11 +277,11 @@ Set the `owner` field in the `app.json` to the owner of the project (this is usu
 
 <Step label="6">
 
-You're now ready to use automatic server deployment!
+You're now ready to use automatic server deployment! Run the build command to start the process.
 
 <Terminal cmd={['$ eas build']} />
 
-You can alternatively run this locally with:
+You can also run this locally with:
 
 <Terminal
   cmd={[
@@ -292,6 +294,8 @@ You can alternatively run this locally with:
 
 </Step>
 
+Notes about automatic server deployment for native apps:
+
 - Server failures may occur during the `Bundle JavaScript` phase of EAS Build if something was not setup correctly.
 - You can manually deploy the server and set the `origin` URL before building the app if you'd like.
 - Automatic deployment can be force skipped with the environment variable `EXPO_NO_DEPLOY=1`.
@@ -303,11 +307,9 @@ You can alternatively run this locally with:
 
 It can often be useful to test the production build against a local dev server to ensure everything is working as expected. This can speed up the debugging process substantially.
 
-To do this, follow these steps:
-
 <Step label="1">
 
-Export the production server for your target platform:
+First, export the production server:
 
 <Terminal cmd={['$ npx expo export']} />
 


### PR DESCRIPTION
# Why

Document the current process for deploying a native app with a linked server.

