### PR TITLE
[expo-modules-core] Fix tvOS compile for SwiftUI

### DIFF
--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -27,7 +27,7 @@ extension ExpoSwiftUI {
     }
 
     public var body: some SwiftUI.View {
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, *) {
         content.fixedSize(horizontal: axis.contains(.horizontal), vertical: axis.contains(.vertical))
         .onGeometryChange(for: CGSize.self) { proxy in
           proxy.size
@@ -40,7 +40,7 @@ extension ExpoSwiftUI {
       } else {
         // TODO: throw a warning
         content.onAppear(perform: {
-          log.warn("AutoSizingStack is not supported on iOS < 16.0")
+          log.warn("AutoSizingStack is not supported on iOS/tvOS < 16.0")
         })
       }
     }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -44,7 +44,9 @@ extension ExpoSwiftUI {
       super.init(appContext: appContext)
 
       shadowNodeProxy.setViewSize = { size in
+        #if RCT_NEW_ARCH_ENABLED
         self.setViewSize(size)
+        #endif
       }
       shadowNodeProxy.objectWillChange.send()
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -365,8 +365,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.76.1-0',
-        '@react-native-tvos/config-tv': '^0.0.13',
+        'react-native': 'npm:react-native-tvos@~0.76.6-0',
+        '@react-native-tvos/config-tv': '^0.1.1',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

TV compile CI is failing due to recent changes in expo-modules-core SwiftUI support.

# How

- Check for iOS 16 in SwiftUI code should also check for tvOS 16
- A method in SwiftUIHostingVIew would fail to compile for non-Fabric builds (this affects iOS too)
- Bump React Native TV and config plugin version for the TV compile test

# Test Plan

CI should pass
