### PR TITLE
[docs] add max pending builds number to limitations page

### DIFF
--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -24,6 +24,10 @@ See [dependency caching](/build-reference/caching) for more information.
 
 If your build takes longer than 2 hours to run, it will be canceled. This limit is lower on the free plan, and the limit is subject to change in the future.
 
+## Maximum number of pending builds is 50 per platform per account
+
+If you have more than 50 builds pending for a platform, new builds will be rejected until the number of pending builds drops below the limit.
+
 ## Yarn workspaces is recommended for monorepos
 
 > **Note**: Official guidance for package managers other than Yarn is limited.


### PR DESCRIPTION
# Why

The user noticed that we don't specify this number in the limitations

# How

Add this information to the limitations

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
