### PR TITLE
Add missing information to SecureStore documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. This library requires a real device for testing since simulators do not replicate biometric authentication when retrieving secrets.
 
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. This library requires a real device for testing since simulators do not replicate biometric authentication when retrieving secrets.
+`expo-secure-store` provides a way to encrypt and securely store key-value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. This library requires a real device for testing since simulators do not require biometric authentication when retrieving secrets unlike real iOS devices.
 
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 


### PR DESCRIPTION
# Why

When developing identified an ambiguous issue in UX as on device my app would scan the user's face ID 3 times during each login. I was unable to replicate the issue on the simulator and was able to conclude that on iOS simulator this library does not do biometric authentication to retrieve secrets but on iOS device it does.

# How

This fix clarifies the documentation improving DevEx by documenting a common corner case.

# Test Plan

This 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

-  [] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
