### PR TITLE
fixed incorrect parameter name in console message

### DIFF
--- a/packages/expo-notifications/src/scheduleNotificationAsync.ts
+++ b/packages/expo-notifications/src/scheduleNotificationAsync.ts
@@ -165,7 +165,7 @@ function parseDateTrigger(trigger: NotificationTriggerInput): NativeDateTriggerI
     // TODO @vonovak this branch is not be used by people using TS
     // but was part of the public api previously so we keep it for a bit for JS users
     console.warn(
-      `You are using a deprecated parameter type (${trigger}) for the notification trigger. Use "{ type: 'date', timestamp: someValue }" instead.`
+      `You are using a deprecated parameter type (${trigger}) for the notification trigger. Use "{ type: 'date', date: someValue }" instead.`
     );
     return { type: 'date', timestamp: toTimestamp(trigger) };
   } else if (


### PR DESCRIPTION
I got the following message in the console:

```
You are using a deprecated parameter type (Wed Jan 29 2025 08:00:00 GMT+0100) for the notification trigger. Use "{ type: 'date', timestamp: someValue }" instead.
```

However, the correct parameter name is `date`. Thought I'd fix it to save someone else a trip to the documentation.