### PR TITLE
[core][Android] Migrate from `ExpoModulesCorePlugin` to `expo-module-gradle-plugin`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Show `UnimplementedExpoView` in place of SwiftUI views when the New Architecture is not enabled. ([#33901](https://github.com/expo/expo/pull/33901) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use REACT_NATIVE_PATH to determine react-native version ([#34042](https://github.com/expo/expo/pull/34042) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Allowed extending `process.env` types. ([#34112](https://github.com/expo/expo/pull/34112) by [@kudo](https://github.com/kudo))
+- [Android] Started using expo modules gradle plugin.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: 'com.android.library'
+apply plugin: 'expo-module-gradle-plugin'
 
 group = 'host.exp.exponent'
 version = '2.0.6'
@@ -8,9 +9,6 @@ version = '2.0.6'
 // List of features that are required by linked modules
 def coreFeatures = project.findProperty("coreFeatures") ?: []
 
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
 
 buildscript {
   ext.KOTLIN_MAJOR_VERSION = kotlinVersion.split("\\.")[0].toInteger()
@@ -30,8 +28,6 @@ if (KOTLIN_MAJOR_VERSION >= 2) {
   apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 }
 
-useDefaultAndroidSdkVersions()
-useExpoPublishing()
 
 def isExpoModulesCoreTests = {
   Gradle gradle = getGradle()
@@ -199,8 +195,8 @@ android {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion()}"
-  implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion()}"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
   implementation 'androidx.annotation:annotation:1.7.1'
 
   api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -27,7 +27,10 @@ internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
 }
 
 internal fun Project.applyDefaultDependencies() {
-  project.dependencies.add("implementation", project.project(":expo-modules-core"))
+  val modulesCore = project.project(":expo-modules-core")
+  if (project != modulesCore) {
+    project.dependencies.add("implementation", project.project(":expo-modules-core"))
+  }
 }
 
 internal fun Project.applyDefaultAndroidSdkVersions() {


### PR DESCRIPTION
# Why

Migrates from `ExpoModulesCorePlugin` to `expo-module-gradle-plugin`.


# Test Plan

- bare-expo ✅ 