### PR TITLE
[docs] [ENG-14844] Update workflow trigger docs

### DIFF
--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -9,6 +9,8 @@ Triggers define when a workflow should kick off. When its conditions are met, th
 
 You can trigger a workflow on a push to a GitHub branch with the `push` trigger.
 
+With the `branches` array you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']` only pushes to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on push events to all branches.
+
 ```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
@@ -25,16 +27,26 @@ jobs:
 
 ## On pull request
 
-You can trigger a workflow on a pull request with the `pull_request` trigger.
+You can trigger a workflow on a pull request events with the `pull_request` trigger.
+
+With the `branches` array you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']` only pull requests to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
+
+With the `types` array you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']` only the `pull_request.opened` event (sent when pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
+- `opened`
+- `reopened`
+- `synchronize`
 
 ```yaml .eas/workflows/hello-world.yml
 name: Hello World
 
 on:
   pull_request:
-	  branches:
-		  - 'main'
-		  # other branch names and globs
+    branches:
+      - 'main'
+      # other branch names and globs
+    types:
+      - 'opened'
+      # other event types
 
 jobs:
   # ...

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -9,7 +9,7 @@ Triggers define when a workflow should kick off. When its conditions are met, th
 
 You can trigger a workflow on a push to a GitHub branch with the `push` trigger.
 
-With the `branches` array you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']` only pushes to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on push events to all branches.
+With the `branches` array, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only push to the `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on push events to all branches.
 
 ```yaml .eas/workflows/hello-world.yml
 name: Hello World

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -32,6 +32,7 @@ You can trigger a workflow on a pull request events with the `pull_request` trig
 With the `branches` array you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']` only pull requests to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
 
 With the `types` array you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']` only the `pull_request.opened` event (sent when pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
+
 - `opened`
 - `reopened`
 - `synchronize`

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -29,7 +29,7 @@ jobs:
 
 You can trigger a workflow on a pull request event with the `pull_request` trigger.
 
-With the `branches` array you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']` only pull requests to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
+With the `branches` array, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to the `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
 
 With the `types` array you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']` only the `pull_request.opened` event (sent when pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
 

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -27,7 +27,7 @@ jobs:
 
 ## On pull request
 
-You can trigger a workflow on a pull request events with the `pull_request` trigger.
+You can trigger a workflow on a pull request event with the `pull_request` trigger.
 
 With the `branches` array you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']` only pull requests to `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
 

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -31,7 +31,7 @@ You can trigger a workflow on a pull request event with the `pull_request` trigg
 
 With the `branches` array, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to the `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
 
-With the `types` array you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']` only the `pull_request.opened` event (sent when pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
+With the `types` array, you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']`, only the `pull_request.opened` event (sent when a pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
 
 - `opened`
 - `reopened`

--- a/docs/pages/eas-workflows/triggers.mdx
+++ b/docs/pages/eas-workflows/triggers.mdx
@@ -16,10 +16,10 @@ name: Hello World
 
 on:
   push:
-	  branches:
-	    - 'main'
-	    - 'feature/**'
-	    # other branches names and globs
+    branches:
+      - 'main'
+      - 'feature/**'
+      # other branches names and globs
 
 jobs:
   # ...


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14844/add-gha-syntax-for-handling-pull-request-events
Companion to: https://github.com/expo/universe/pull/18412
Added support for event types, similar to how GHA does it
The docs were a bit lacking in regards to workflow triggers configuration

# How

Described in more detail what the `branches` and new `types` field do

# Test Plan

Tested manually

| Before | After |
| - | - |
| <img width="1130" alt="Screenshot 2025-01-28 at 16 19 49" src="https://github.com/user-attachments/assets/2eaaeec4-9989-48d8-a703-1e9a2ce8dda1" /> | <img width="1130" alt="Screenshot 2025-01-28 at 16 20 09" src="https://github.com/user-attachments/assets/ceb1499f-321a-43a3-95bb-b5139a1300fe" /> |
| <img width="1130" alt="Screenshot 2025-01-28 at 16 19 57" src="https://github.com/user-attachments/assets/f77803a7-5570-4285-95d9-3f767dfd3039" /> | <img width="1130" alt="Screenshot 2025-01-28 at 16 20 18" src="https://github.com/user-attachments/assets/dcb0fdd8-40a3-443c-803d-df093006a990" /> |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
