### PR TITLE
fix: documentation for Android intent-filter action type

### DIFF
--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -445,7 +445,8 @@ export interface PluginConfigTypeAndroidQueries {
  */
 export interface PluginConfigTypeAndroidQueriesIntent {
   /**
-   * A string naming the action to perform. Usually one of the platform-defined values, such as `ACTION_SEND` or `ACTION_VIEW`.
+   * A string naming the action to perform. Usually one of the platform-defined values, such as `SEND` or `VIEW`.
+   * See https://developer.android.com/guide/topics/manifest/action-element
    */
   action?: string;
   /**


### PR DESCRIPTION
# Why

Using ACTION_VIEW instead of VIEW fails silently

# How

Updated the documentation with valid example + added link to documentation

# Test Plan

X

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
