### PR TITLE
Force NODE_ENV during npx expo export and do not allow overwriting outside of `--dev` flag.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Force NODE_ENV during npx expo export and do not allow overwriting outside of `--dev` flag.
+- Force NODE_ENV during npx expo export and do not allow overwriting outside of `--dev` flag. ([#34533](https://github.com/expo/expo/pull/34533) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Force NODE_ENV during npx expo export and do not allow overwriting outside of `--dev` flag.
+
 ### 🎉 New features
 
 - Add basic support for API routes with React Server Components enabled. ([#34211](https://github.com/expo/expo/pull/34211) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -64,7 +64,11 @@ export async function exportAppAsync(
     | 'skipSSG'
   >
 ): Promise<void> {
-  setNodeEnv(dev ? 'development' : 'production');
+  // Force the environment during export and do not allow overriding it.
+  const environment = dev ? 'development' : 'production';
+  process.env.NODE_ENV = environment;
+  setNodeEnv(environment);
+
   require('@expo/env').load(projectRoot);
 
   const projectConfig = getConfig(projectRoot);


### PR DESCRIPTION
# Why

The current behavior for overwriting the NODE_ENV is confusing. When you run `npx expo export` you expect it to be `NODE_ENV=production` unless specified otherwise with `--dev`. Tools like vs code terminal can sometimes set the NODE_ENV to development which lead to weird exports where the wrong environment variables are used.
