### PR TITLE
Add export to expo-splash-screen plugin config type

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add export to plugin config type ([#34534](https://github.com/expo/expo/pull/34534) by [@ChromeQ](https://github.com/ChromeQ))
+
 ### 🐛 Bug fixes
 
 - On `iOS`, show the splashscreen again when the app is reloaded. ([#33793](https://github.com/expo/expo/pull/33793) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.d.ts
@@ -1,7 +1,7 @@
 import { AndroidSplashConfig } from '@expo/prebuild-config/build/plugins/unversioned/expo-splash-screen/getAndroidSplashConfig';
 import { IOSSplashConfig } from '@expo/prebuild-config/build/plugins/unversioned/expo-splash-screen/getIosSplashConfig';
 import { ConfigPlugin } from 'expo/config-plugins';
-type PluginConfig = {
+export type PluginConfig = {
     backgroundColor: string;
     imageWidth?: number;
     enableFullScreenImage_legacy?: boolean;

--- a/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
+++ b/packages/expo-splash-screen/plugin/src/withSplashScreen.ts
@@ -6,7 +6,7 @@ import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
 const pkg = require('expo-splash-screen/package.json');
 
-type PluginConfig = {
+export type PluginConfig = {
   backgroundColor: string;
   imageWidth?: number;
   enableFullScreenImage_legacy?: boolean;


### PR DESCRIPTION
This will allow me to add types to avoid mistakes when adding plugins to the app.config.ts - Currently I do something like this:
```ts
import withSplashScreenPlugin from 'expo-splash-screen/plugin/build/withSplashScreen';

type ExpoSplashScreenPluginConfig = Parameters<typeof withSplashScreenPlugin>[1];

// config 👇️
plugins: [
  [
    'expo-splash-screen',
    {
      backgroundColor: appIconColor,
      image: './src/assets/icon-transparent.png',
      imageWidth: 192,
    } satisfies ExpoSplashScreenPluginConfig,
  ],
]
```

It would be nice to not require this extra type to get at the plugin options type and it should be exported here:
https://github.com/expo/expo/blob/87c104efd7c8346372fa713e1ef264517871375a/packages/expo-splash-screen/plugin/src/withSplashScreen.ts#L9
Splash screen is just one example but there may be other expo plugins which would benefit from this too.