### PR TITLE
[docs] Add docs for defining environment for workflows

### DIFF
--- a/docs/pages/eas-workflows/jobs.mdx
+++ b/docs/pages/eas-workflows/jobs.mdx
@@ -14,6 +14,14 @@ All jobs support the following properties:
 - `needs` (optional): List of job keys that must complete successfully before this job runs
 - `after` (optional): List of job keys that must complete (success or failure) before this job runs
 
+You can also define an optional [`environment`](/eas/environment-variables/#environments) property in custom jobs of type:
+
+- `update`
+- `deploy`
+- `maestro`
+
+You can also specify an `environment` in custom jobs. The build job will use the environment specific to the selected profile.
+
 ## Build your app
 
 Creates a build from your project:
@@ -51,6 +59,7 @@ jobs:
   update:
     name: Publish Update
     type: update
+    environment: production | preview | development # optional, default: production
     params:
       message: string # optional - commit message used if not provided
       platform: android | ios | all # optional
@@ -67,6 +76,7 @@ jobs:
   e2e-test:
     name: Run E2E Tests
     type: maestro
+    environment: production | preview | development # optional, default: preview
     params:
       build_id: string # required - usually ${{ needs.build.outputs.build_id }}
       flow_path: string | string[] # required - path(s) to Maestro test file(s)
@@ -105,7 +115,7 @@ jobs:
   deploy:
     name: Deploy App
     type: deploy
-    environment: production | preview | development # optional
+    environment: production | preview | development # optional, default: production
     params:
       alias: string # optional - custom alias for the new deployment
       prod: boolean # optional - create a production deployment
@@ -122,6 +132,7 @@ jobs:
   custom-job:
     name: Custom Task
     runs_on: linux-medium | linux-large | macos-medium | macos-large | linux-medium-nested-virtualization | linux-large-nested-virtualization # optional, default: linux-medium
+    environment: production | preview | development # optional, default: production
     defaults:
       run:
         working_directory: string # optional - relative to app base directory or absolute from repo root


### PR DESCRIPTION
# Why

Document the new `environment` parameter in workflows.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
