### PR TITLE
[docs][location] clarify background location permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -139,7 +139,7 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 To use Background Location methods, the following requirements apply:
 
-- Location permissions must be granted. On iOS it must be granted with `Always` option.
+- Location permissions must be granted.
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 - <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be
   specified in **Info.plist** file. See [Background location
@@ -152,7 +152,7 @@ To use Background Location methods, the following requirements apply:
 
 To use Geofencing methods, the following requirements apply:
 
-- Location permissions must be granted. On iOS it must be granted with `Always` option.
+- Location permissions must be granted.
 - The Geofencing task must be defined in the top-level scope, using [TaskManager.defineTask](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 
 When using Geofencing, the following platform differences apply:
@@ -165,6 +165,13 @@ When using Geofencing, the following platform differences apply:
 - <PlatformTag platform="ios" /> There is a [limit of
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
+
+### Background Permissions
+
+To use location tracking or Geofencing in the background, you must request the appropriate permissions:
+
+- On iOS, it must be granted with the `Always` option using `requestBackgroundPermissionsAsync`.
+- On Android, you must request both foreground and background permissions.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -166,7 +166,7 @@ When using Geofencing, the following platform differences apply:
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
 
-### Background Permissions
+### Background permissions
 
 To use location tracking or Geofencing in the background, you must request the appropriate permissions:
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -170,8 +170,8 @@ When using Geofencing, the following platform differences apply:
 
 To use location tracking or Geofencing in the background, you must request the appropriate permissions:
 
-- On iOS, it must be granted with the `Always` option using `requestBackgroundPermissionsAsync`.
 - On Android, you must request both foreground and background permissions.
+- On iOS, it must be granted with the `Always` option using [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync).
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -139,7 +139,7 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 To use Background Location methods, the following requirements apply:
 
-- Location permissions must be granted. On iOS it must be granted with `Always` option.
+- Location permissions must be granted.
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 - <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be
   specified in **Info.plist** file. See [Background location
@@ -152,7 +152,7 @@ To use Background Location methods, the following requirements apply:
 
 To use Geofencing methods, the following requirements apply:
 
-- Location permissions must be granted. On iOS it must be granted with `Always` option.
+- Location permissions must be granted.
 - The Geofencing task must be defined in the top-level scope, using [TaskManager.defineTask](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
 
 When using Geofencing, the following platform differences apply:
@@ -165,6 +165,13 @@ When using Geofencing, the following platform differences apply:
 - <PlatformTag platform="ios" /> There is a [limit of
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
+
+### Background Permissions
+
+To use location tracking or Geofencing in the background, you must request the appropriate permissions:
+
+- On iOS, it must be granted with the `Always` option using `requestBackgroundPermissionsAsync`.
+- On Android, you must request both foreground and background permissions.
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -166,7 +166,7 @@ When using Geofencing, the following platform differences apply:
   20](https://developer.apple.com/documentation/corelocation/monitoring_the_user_s_proximity_to_geographic_regions)
   `regions` that can be simultaneously monitored.
 
-### Background Permissions
+### Background permissions
 
 To use location tracking or Geofencing in the background, you must request the appropriate permissions:
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -170,8 +170,8 @@ When using Geofencing, the following platform differences apply:
 
 To use location tracking or Geofencing in the background, you must request the appropriate permissions:
 
-- On iOS, it must be granted with the `Always` option using `requestBackgroundPermissionsAsync`.
 - On Android, you must request both foreground and background permissions.
+- On iOS, it must be granted with the `Always` option using [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync).
 
 ## Usage
 


### PR DESCRIPTION
#Why 

There are some differences on iOS/Android when it comes to permissions.

# How

This commit clarifies these.

- Updated location.mdx in both `unversioned` and `sdk-52`

Closes #33911

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
