### PR TITLE
[fix][filesystem] fix deleting nested folders on android

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -205,6 +205,19 @@ export async function test({ describe, expect, it, ...t }) {
         expect(folder.exists).toBe(false);
       });
 
+      it('Deletes a folder containing another folder', () => {
+        const folder = new Directory(testDirectory, 'newFolder2');
+        folder.create();
+
+        const child = new Directory(folder, 'child');
+        child.create();
+
+        expect(folder.exists).toBe(true);
+
+        folder.delete();
+        expect(folder.exists).toBe(false);
+      });
+
       describe('When copying a file', () => {
         it("Throws an error when it doesn't exist", () => {
           const src = new File(testDirectory, 'file.txt');

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] fixed issue with deleting a directory with children
 - Fix expo-updates breaking filesystem on Android API 24 and 25. ([#33694](https://github.com/expo/expo/pull/33694) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] fixed issue with deleting a directory with children
+- [Android] fixed issue with deleting a directory with children ([#34550](https://github.com/expo/expo/pull/34550) by [@chrfalch](https://github.com/chrfalch))
 - Fix expo-updates breaking filesystem on Android API 24 and 25. ([#33694](https://github.com/expo/expo/pull/33694) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -12,11 +12,25 @@ import kotlin.io.path.moveTo
 // The URL, URI classes seem like a less suitable choice.
 // https://stackoverflow.com/questions/27845223/whats-the-difference-between-a-resource-uri-url-path-and-file-in-java
 abstract class FileSystemPath(public var file: File) : SharedObject() {
-  fun delete() {
-    if (!file.exists()) {
-      throw UnableToDeleteException("path does not exist")
+  fun delete(fileOrDirectory: File = file) {
+    if (!fileOrDirectory.exists()) {
+      throw UnableToDeleteException("path '${fileOrDirectory.path}' does not exist")
     }
-    file.delete()
+    if (fileOrDirectory.isDirectory) {
+      fileOrDirectory.listFiles()?.forEach { child ->
+        if (child.isDirectory) {
+          // Recursively delete subdirectories
+          delete(child)
+        } else {
+          if(!child.delete()) {
+            throw UnableToDeleteException("failed to delete '${child.path}'")
+          }
+        }
+      }
+    }
+    if (!fileOrDirectory.delete()) {
+      throw UnableToDeleteException("failed to delete '${fileOrDirectory.path}'")
+    }
   }
 
   abstract fun validateType()


### PR DESCRIPTION
# Why

On Android calling `delete` on a directory with children will fail.

The reason is that we're using the File.delete() method in Kotlin which only deletes the current item - and fails if the current item is a directory with children.

Closes #34542 
Closes #ENG-14882

# How

This commit fixes this by checking if the path is a directory and tries to delete children before deleting itself.

- Added a fixed implementation
- Added a new unit test (that failed before this fix on Android) to test feature (succeeds on both iOS and Android now)
- Added throwing exceptions if a `delete` operation fails as iOS does.

# Test Plan

✅ Unit tests passing

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
