### PR TITLE
[docs]: Update Tailwind docs for Tailwind v4

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -5,9 +5,9 @@ description: Learn how to configure and use Tailwind CSS in your Expo project.
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { FileTree } from '~/ui/components/FileTree';
+import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
-import { Terminal } from '~/ui/components/Snippet';
 
 > **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -16,7 +16,7 @@ import { Step } from '~/ui/components/Step';
 
 The following files will be modified to set the Tailwind CSS configuration:
 
-<FileTree files={['app.json', 'package.json', 'global.css', 'tailwind.config.js', 'index.js']} />
+<FileTree files={['app.json', 'package.json', 'global.css', 'index.js']} />
 
 Ensure that your project is using Metro for web. You can verify this by checking the `web.bundler` field which is set to `metro` in the **app.json** file.
 
@@ -34,21 +34,18 @@ Ensure that your project is using Metro for web. You can verify this by checking
 
 ## Configuration
 
-Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS documentation](https://tailwindcss.com/docs/installation/using-postcss).]
+Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS documentation](https://tailwindcss.com/docs/installation/using-postcss).
 
 <Step label="1">
 
-Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
+Install `tailwindcss` and its required peer dependencies.
 
 {/* vale off */}
 
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss postcss autoprefixer -- --dev',
-    '',
-    '# Create a Tailwind config file',
-    '$ npx tailwindcss init -p',
+    '$ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev',
   ]}
 />
 
@@ -58,53 +55,43 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 
 <Step label="2">
 
-Add paths to all of your template files inside **tailwind.config.js**.
+Add Tailwind to your PostCSS configuration
 
-```js tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    // Ensure this points to your source code
-    './app/**/*.{js,tsx,ts,jsx}',
-    // If you use a `src` directory, add: './src/**/*.{js,tsx,ts,jsx}'
-    // Do the same with `components`, `hooks`, `styles`, or any other top-level directories
-  ],
-  theme: {
-    extend: {},
+```js postcss.config.js
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
   },
-  plugins: [],
 };
 ```
-
-> If you are using Expo Router, consider using a root **src** directory to simplify this step. Learn more about [top-level src directory](/router/reference/src-directory/).
 
 </Step>
 
 <Step label="3">
 
-Create a **global.css** file in the root of your project and directives for each of Tailwind's layers:
+Create a CSS file that imports Tailwind CSS.
 
 ```css global.css
-/* This file adds the requisite utility classes for Tailwind to work. */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
 ```
+
+> **info** You can choose any name for this file. Using `global.css` is common practice.
 
 </Step>
 
 <Step label="4">
 
-Import the **global.css** file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+Import your CSS file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
 
 <CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
 
 ```tsx
+// If using Expo Router, import your CSS file in the app/_layout.tsx file
 import '../global.css';
 ```
 
 ```tsx
-// Import the global.css file in the index.js file:
+// Otherwise import your CSS file in the index.js file:
 import './global.css';
 ```
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -62,7 +62,7 @@ Install `tailwindcss` and its required peer dependencies:
 
 Add Tailwind to your PostCSS configuration
 
-```js postcss.config.mjs
+```js postcss.config.js
 export default {
   plugins: {
     '@tailwindcss/postcss': {},

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -127,7 +127,7 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss postcss autoprefixer -- --dev',
+    '$ npx expo add tailwindcss@3 postcss autoprefixer -- --dev',
     '',
     '# Create a Tailwind config file',
     '$ npx tailwindcss init -p',

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -5,8 +5,9 @@ description: Learn how to configure and use Tailwind CSS in your Expo project.
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **info** Standard Tailwind CSS supports only web platform. For universal support, use a library such as [NativeWind](https://www.nativewind.dev/), which allows creating styled React Native components with Tailwind CSS.
 
@@ -36,9 +37,13 @@ Ensure that your project is using Metro for web. You can verify this by checking
 
 Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS documentation](https://tailwindcss.com/docs/installation/using-postcss).
 
+<Tabs>
+
+<Tab label="v4">
+
 <Step label="1">
 
-Install `tailwindcss` and its required peer dependencies.
+Install `tailwindcss` and its required peer dependencies:
 
 {/* vale off */}
 
@@ -69,13 +74,13 @@ export default {
 
 <Step label="3">
 
-Create a CSS file that imports Tailwind CSS.
+Create a global CSS file that imports Tailwind CSS.
+
+You can choose any name for this file. Using **global.css** is common practice.
 
 ```css global.css
 @import 'tailwindcss';
 ```
-
-> **info** You can choose any name for this file. Using `global.css` is common practice.
 
 </Step>
 
@@ -108,6 +113,100 @@ You now start your project and use Tailwind CSS classes in your components.
 <Terminal cmd={['$ npx expo start']} />
 
 </Step>
+
+</Tab>
+
+<Tab label="v3">
+
+<Step label="1">
+
+Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
+
+{/* vale off */}
+
+<Terminal
+  cmd={[
+    '# Install Tailwind and its peer dependencies',
+    '$ npx expo add tailwindcss postcss autoprefixer -- --dev',
+    '',
+    '# Create a Tailwind config file',
+    '$ npx tailwindcss init -p',
+  ]}
+/>
+
+{/* vale on */}
+
+</Step>
+
+<Step label="2">
+
+Add paths to all of your template files inside **tailwind.config.js**.
+
+```js tailwind.config.js
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    // Ensure this points to your source code
+    './app/**/*.{js,tsx,ts,jsx}',
+    // If you use a `src` directory, add: './src/**/*.{js,tsx,ts,jsx}'
+    // Do the same with `components`, `hooks`, `styles`, or any other top-level directories
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+> If you are using Expo Router, consider using a root **src** directory to simplify this step. Learn more about [top-level src directory](/router/reference/src-directory/).
+
+</Step>
+
+<Step label="3">
+
+Create a **global.css** file in the root of your project and directives for each of Tailwind's layers:
+
+```css global.css
+/* This file adds the requisite utility classes for Tailwind to work. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+</Step>
+
+<Step label="4">
+
+Import the **global.css** file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+
+<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
+
+```tsx
+import '../global.css';
+```
+
+```tsx
+// Import the global.css file in the index.js file:
+import './global.css';
+```
+
+</CodeBlocksTable>
+
+> **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
+
+</Step>
+
+<Step label="5">
+
+You now start your project and use Tailwind CSS classes in your components.
+
+<Terminal cmd={['$ npx expo start']} />
+
+</Step>
+
+</Tab>
+
+</Tabs>
 
 ## Usage
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -39,83 +39,6 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 
 <Tabs>
 
-<Tab label="v4">
-
-<Step label="1">
-
-Install `tailwindcss` and its required peer dependencies:
-
-{/* vale off */}
-
-<Terminal
-  cmd={[
-    '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev',
-  ]}
-/>
-
-{/* vale on */}
-
-</Step>
-
-<Step label="2">
-
-Add Tailwind to your PostCSS configuration
-
-```js postcss.config.js
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};
-```
-
-</Step>
-
-<Step label="3">
-
-Create a global CSS file that imports Tailwind CSS.
-
-You can choose any name for this file. Using **global.css** is common practice.
-
-```css global.css
-@import 'tailwindcss';
-```
-
-</Step>
-
-<Step label="4">
-
-Import your CSS file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
-
-<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
-
-```tsx
-// If using Expo Router, import your CSS file in the app/_layout.tsx file
-import '../global.css';
-```
-
-```tsx
-// Otherwise import your CSS file in the index.js file:
-import './global.css';
-```
-
-</CodeBlocksTable>
-
-> **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
-
-</Step>
-
-<Step label="5">
-
-You now start your project and use Tailwind CSS classes in your components.
-
-<Terminal cmd={['$ npx expo start']} />
-
-</Step>
-
-</Tab>
-
 <Tab label="v3">
 
 <Step label="1">
@@ -187,6 +110,83 @@ import '../global.css';
 
 ```tsx
 // Import the global.css file in the index.js file:
+import './global.css';
+```
+
+</CodeBlocksTable>
+
+> **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
+
+</Step>
+
+<Step label="5">
+
+You now start your project and use Tailwind CSS classes in your components.
+
+<Terminal cmd={['$ npx expo start']} />
+
+</Step>
+
+</Tab>
+
+<Tab label="v4">
+
+<Step label="1">
+
+Install `tailwindcss` and its required peer dependencies:
+
+{/* vale off */}
+
+<Terminal
+  cmd={[
+    '# Install Tailwind and its peer dependencies',
+    '$ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev',
+  ]}
+/>
+
+{/* vale on */}
+
+</Step>
+
+<Step label="2">
+
+Add Tailwind to your PostCSS configuration
+
+```js postcss.config.mjs
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+</Step>
+
+<Step label="3">
+
+Create a global CSS file that imports Tailwind CSS.
+
+You can choose any name for this file. Using **global.css** is common practice.
+
+```css global.css
+@import 'tailwindcss';
+```
+
+</Step>
+
+<Step label="4">
+
+Import your CSS file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+
+<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
+
+```tsx
+// If using Expo Router, import your CSS file in the app/_layout.tsx file
+import '../global.css';
+```
+
+```tsx
+// Otherwise import your CSS file in the index.js file:
 import './global.css';
 ```
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -62,7 +62,7 @@ Install `tailwindcss` and its required peer dependencies:
 
 Add Tailwind to your PostCSS configuration
 
-```js postcss.config.js
+```js postcss.config.mjs
 export default {
   plugins: {
     '@tailwindcss/postcss': {},


### PR DESCRIPTION
# Why

Tailwind v4 no longer requires `tailwind.config.js`. I've updated the docs with the new setup instructions. Also clarified that the name `global.css` isn't required.
