### PR TITLE
[expo-symbols][iOS] Fix tvOS compilation

### DIFF
--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tvOS compilation. ([#34556](https://github.com/expo/expo/pull/34556) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))

--- a/packages/expo-symbols/ios/SymbolEffects.swift
+++ b/packages/expo-symbols/ios/SymbolEffects.swift
@@ -1,9 +1,9 @@
-@available(iOS 17.0, *)
+@available(iOS 17.0, tvOS 17.0, *)
 internal protocol EffectAdding {
   func add(to view: UIImageView, with options: SymbolEffectOptions)
 }
 
-@available(iOS 17.0, *)
+@available(iOS 17.0, tvOS 17.0, *)
 internal struct BounceEffect: EffectAdding {
   private let effect: BounceSymbolEffect = .bounce
   let wholeSymbol: Bool?
@@ -23,7 +23,7 @@ internal struct BounceEffect: EffectAdding {
   }
 }
 
-@available(iOS 17.0, *)
+@available(iOS 17.0, tvOS 17.0, *)
 internal struct PulseEffect: EffectAdding {
   private let effect: PulseSymbolEffect = .pulse
   let wholeSymbol: Bool?
@@ -37,7 +37,7 @@ internal struct PulseEffect: EffectAdding {
   }
 }
 
-@available(iOS 17.0, *)
+@available(iOS 17.0, tvOS 17.0, *)
 internal struct ScaleEffect: EffectAdding {
   private let effect: ScaleSymbolEffect = .scale
   let wholeSymbol: Bool?

--- a/packages/expo-symbols/ios/SymbolRecords.swift
+++ b/packages/expo-symbols/ios/SymbolRecords.swift
@@ -139,7 +139,7 @@ internal struct AnimationEffect: Record {
   @Field var wholeSymbol: Bool?
   @Field var direction: AnimationDirection?
 
-  @available(iOS 17.0, *)
+  @available(iOS 17.0, tvOS 17.0, *)
   func toEffect() -> EffectAdding {
     switch type {
     case .bounce:
@@ -160,7 +160,7 @@ internal struct VariableColorSpec: Record {
   @Field var hideInactiveLayers: Bool?
   @Field var dimInactiveLayers: Bool?
 
-  @available(iOS 17.0, *)
+  @available(iOS 17.0, tvOS 17.0, *)
   func toVariableEffect() -> VariableColorSymbolEffect {
     var effect: VariableColorSymbolEffect = .variableColor
 

--- a/packages/expo-symbols/ios/SymbolView.swift
+++ b/packages/expo-symbols/ios/SymbolView.swift
@@ -38,7 +38,7 @@ class SymbolView: ExpoView {
     }
 
     // Effects need to be added last
-    if #available(iOS 17.0, *) {
+    if #available(iOS 17.0, tvOS 17.0, *) {
       imageView.removeAllSymbolEffects()
       if animated {
         addSymbolEffects()
@@ -46,7 +46,7 @@ class SymbolView: ExpoView {
     }
   }
 
-  @available(iOS 17.0, *)
+  @available(iOS 17.0, tvOS 17.0, *)
   private func addSymbolEffects() {
     if let animationSpec {
       let repeating = animationSpec.repeating ?? false
@@ -72,11 +72,15 @@ class SymbolView: ExpoView {
   }
 
   private func getSymbolConfig() -> UIImage.SymbolConfiguration {
+    #if os(tvOS)
+    var config = UIImage.SymbolConfiguration(pointSize: 18.0, weight: weight, scale: scale)
+    #else
     var config = UIImage.SymbolConfiguration(pointSize: UIFont.systemFontSize, weight: weight, scale: scale)
+    #endif
 
     switch symbolType {
     case .monochrome:
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, *) {
         config = config.applying(UIImage.SymbolConfiguration.preferringMonochrome())
       }
     case .hierarchical:

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -51,7 +51,6 @@ function getExpoDependencyChunks({
     ...(includeTV
       ? [
           [
-            'expo-ui',
             'expo-audio',
             'expo-av',
             'expo-blur',
@@ -62,6 +61,8 @@ function getExpoDependencyChunks({
             'expo-crypto',
             'expo-network',
             'expo-secure-store',
+            'expo-symbols',
+            'expo-ui',
             'expo-video',
           ],
         ]


### PR DESCRIPTION
# Why

`expo-symbols` is intended to work on Apple TV (the platform is enabled in the podspec), but actually does not compile.

# How

- Fix compile errors
- Add the package to TV compile test

# Test Plan

CI should pass

