### PR TITLE
[core] Enable compose build feature conditionally

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -112,7 +112,7 @@ android {
   buildFeatures {
     buildConfig true
     prefab true
-    compose true
+    compose KOTLIN_MAJOR_VERSION >= 2
   }
 
   if (KOTLIN_MAJOR_VERSION < 2) {


### PR DESCRIPTION
# Why
While testing prebuild with the sandbox app, I ran into an issue where expo modules core failed to build. This is because we only add the compose plugin if we are using kotlin 2.0 but enable the compose build feature regardless. 

# How
Only enable the compose buildFeature if we are using kotlin > 2

# Test Plan
Sandbox successfully builds

