### PR TITLE
[templates] promote prebuild

### DIFF
--- a/templates/expo-template-default/app/+html.tsx
+++ b/templates/expo-template-default/app/+html.tsx
@@ -1,0 +1,28 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+import { type PropsWithChildren } from 'react';
+
+// This file is web-only and used to configure the root HTML for every
+// web page during static rendering.
+// The contents of this function only run in Node.js environments and
+// do not have access to the DOM or browser APIs.
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+        {/*
+          `ScrollViewStyleReset` disables body scrolling on web. This makes ScrollView components on web work closer to how they do on native.
+          However, body scrolling can be nice to have, especially if you're building web-first.
+          If you want to enable it, remove this line.
+        */}
+        <ScrollViewStyleReset />
+
+        {/* Add any additional <head> elements that you want globally available on web... */}
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/templates/expo-template-default/gitignore
+++ b/templates/expo-template-default/gitignore
@@ -9,6 +9,10 @@ dist/
 web-build/
 expo-env.d.ts
 
+# prebuild generates the native directories, so we don't want to version them
+android/
+ios/
+
 # Native
 *.orig.*
 *.jks

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -5,12 +5,14 @@
   "version": "52.0.43",
   "scripts": {
     "start": "expo start",
+    "prebuild": "expo prebuild --clean",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "fix-dep-versions": "expo install --check"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
# Why

I did a bit of dogfooding on the web and overall I felt that the templates should be expanded a bit to advertise more some of our tools: 

- `prebuild` is essential and I think it ends up in every app's `scripts` section, so why not add it now. Expanded the gitignore for this because I've seen people unsure about whether the folders should be versioned.
- `expo install --check` - useful to know about especially for beginners
- added `+html.tsx` also because it was the solution for me figuring out why scrolling on a basic html website didn't work with expo router. I feel there are several implicit conventions that people need to discover in our docs or some other examples online and I think it's better to include some of those from the start.

I'm sure there's more that can be done :)

- TODO add atlas

# How

expanded the default template. Will expand the other ones when we agree on what to add.


# Test Plan

TODO create apps from the templates locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
