### PR TITLE
[docs] Update llms-full.txt script to read instructions for Android and iOS development build setup

### DIFF
--- a/docs/scripts/generate-llms/llms-full-txt.js
+++ b/docs/scripts/generate-llms/llms-full-txt.js
@@ -8,8 +8,71 @@ import {
   DESCRIPTION,
   generateSectionMarkdown,
   processSection,
+  readFrontmatter,
 } from './utils.js';
 import { home, learn, general } from '../../constants/navigation.js';
+
+function readInstructions() {
+  const instructionsDir = path.join(
+    process.cwd(),
+    'scenes/get-started/set-up-your-environment/instructions'
+  );
+
+  const headerMapping = {
+    _androidEmulatorInstructions: 'Android Emulator Setup',
+    _androidStudioEnvironmentInstructions: 'Android Studio Environment Setup',
+    _androidStudioInstructions: 'Android Studio Setup',
+    _xcodeInstructions: 'Xcode Setup',
+    androidPhysicalDevelopmentBuild:
+      'Create a development build for a physical Android device with EAS',
+    androidPhysicalDevelopmentBuildLocal:
+      'Create a development build for a physical Android device locally',
+    androidPhysicalExpoGo: 'Run on a physical Android device with Expo Go',
+    androidSimulatedDevelopmentBuild: 'Create a development build for Android Emulator with EAS',
+    androidSimulatedDevelopmentBuildLocal:
+      'Create a development build for Android Emulator locally',
+    androidSimulatedExpoGo: 'Run on Android Emulator with Expo Go',
+    iosPhysicalDevelopmentBuild: 'Create a development build for a physical iOS device with EAS',
+    iosPhysicalDevelopmentBuildLocal:
+      'Create a development build for a physical iOS device locally',
+    iosPhysicalExpoGo: 'Run on a physical iOS device with Expo Go',
+    iosSimulatedDevelopmentBuild: 'Create a development build for iOS Simulator with EAS',
+    iosSimulatedDevelopmentBuildLocal: 'Create a development build for iOS Simulator locally',
+    iosSimulatedExpoGo: 'Run on iOS Simulator with Expo Go',
+  };
+
+  const instructionFiles = Object.keys(headerMapping);
+
+  return instructionFiles
+    .map(filename => {
+      const filePath = path.join(instructionsDir, `${filename}.mdx`);
+      if (fs.existsSync(filePath)) {
+        const { title, content } = readFrontmatter(filePath);
+        const header = headerMapping[filename] || title || filename;
+        return `# ${header}\n\n${content}\n\n`;
+      }
+      return '';
+    })
+    .join('');
+}
+
+function processEnvironmentPage(section) {
+  if (section.items) {
+    section.items = section.items.map(item => {
+      if (item.url && item.url.includes('set-up-your-environment')) {
+        const instructions = readInstructions();
+        item.content = item.content.replace('<DevelopmentEnvironmentInstructions />', instructions);
+      }
+      return item;
+    });
+  }
+
+  if (section.sections) {
+    section.sections = section.sections.map(processEnvironmentPage);
+  }
+
+  return section;
+}
 
 function generateFullMarkdown({ title, description, sections }) {
   return `# ${title}\n\n${description}\n\n` + sections.map(generateSectionMarkdown).join('');
@@ -21,7 +84,7 @@ export async function generateLlmsFullTxt() {
       ...home.map(section => ({ ...processSection(section), category: 'Home' })),
       ...learn.map(section => ({ ...processSection(section), category: 'Learn' })),
       ...general.map(section => ({ ...processSection(section), category: 'General' })),
-    ];
+    ].map(processEnvironmentPage);
 
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_EXPO_DOCS),

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -202,7 +202,9 @@ export function cleanContent(content) {
           return '```sh\n' + commands.join('\n') + '\n```';
         }
       )
-      .replace(/<br\s*\/?>/g, '');
+      .replace(/<br\s*\/?>/g, '')
+      .replace(/<PlatformAndDeviceForm\s*\/?>/g, '')
+      .replace(/<DevelopmentModeForm\s*\/?>/g, '');
 
     if (index % 2 === 0) {
       processed = processed.replace(/^import\s+.*?from\s+["'].*?["'];?\s*\n/gm, '');

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -204,7 +204,8 @@ export function cleanContent(content) {
       )
       .replace(/<br\s*\/?>/g, '')
       .replace(/<PlatformAndDeviceForm\s*\/?>/g, '')
-      .replace(/<DevelopmentModeForm\s*\/?>/g, '');
+      .replace(/<DevelopmentModeForm\s*\/?>/g, '')
+      .replace(/^(#{1,6}.*?)>\s*$/gm, '$1');
 
     if (index % 2 === 0) {
       processed = processed.replace(/^import\s+.*?from\s+["'].*?["'];?\s*\n/gm, '');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the llms-full.txt script does not include instructions for creating a development build for Android or iOS (instructions from this page: https://docs.expo.dev/get-started/set-up-your-environment/ since these are dynamic scenes).

Also, remove the extra `>` since some of the headers (mostly h4s) include this symbol by updating the regex pattern in the utils.js. An example shown below:

![Screenshot 2025-01-28 at 12 16 14](https://github.com/user-attachments/assets/ce332ecc-2c04-4b85-897c-2d7e3a703ade)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a function to map and include instructions from Set up your environment page in llms-full-txt.js file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn run generate-llms`
- Open `llms-full.txt` file created inside `public` directory
- View the contents as shown below to confirm the instructions are included:

![CleanShot 2025-01-31 at 00 58 29@2x](https://github.com/user-attachments/assets/55d759ca-a6e3-45d4-a8e8-c83dfdb89e65)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
