### PR TITLE
[dev-launcher][android] Read EAS project id and url from AndroidManifest instead of updates interface

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Fixed black stuck screen when loading an unreachable server from last opened url. ([#34067](https://github.com/expo/expo/pull/34067) by [@kudo](https://github.com/kudo))
 - [iOS] Read EAS project id and url from manifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Read EAS project id and url from AndroidManifest instead of updates interface. ([#34342](https://github.com/expo/expo/pull/34342) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import expo.modules.core.utilities.EmulatorUtilities
+import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherController.Companion.wasInitialized
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
@@ -60,7 +61,9 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
     val map = Arguments.createMap()
 
     val runtimeVersion = controller.updatesInterface?.runtimeVersion
-    val projectUri = controller.updatesInterface?.updateUrl
+    val projectUrl = DevLauncherController.getMetadataValue(reactApplicationContext, "expo.modules.updates.EXPO_UPDATE_URL")
+
+    val projectUri = Uri.parse(projectUrl)
     val appId = projectUri?.lastPathSegment ?: ""
 
     val isModernManifestProtocol = projectUri?.host.equals("u.expo.dev") || projectUri?.host.equals("staging-u.expo.dev")


### PR DESCRIPTION
# Why

Closes [ENG-14761](https://linear.app/expo/issue/ENG-14761)
Follow up of https://github.com/expo/expo/pull/34342 but for android

# How

This is a temporary fix for re loading updates with dev-launcher while we don't migrate the `DevLauncherInternalModule` to use the Expo Modules API. This basically just reverts the `getUpdatesConfig` changes of https://github.com/expo/expo/pull/31453 

# Test Plan

Run dev-launcher locally through fabric-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
