### PR TITLE
[ios][imagepicker] fix concurrency issue when selecting multiple items

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] fixed concurrency freeze on low-end iOS devices when selecting multiple images.
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] fixed concurrency freeze on low-end iOS devices when selecting multiple images.
+- [ios] fixed concurrency freeze on low-end iOS devices when selecting multiple images. ([#34585](https://github.com/expo/expo/pull/34585) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImagePickerUtils.swift
+++ b/packages/expo-image-picker/ios/ImagePickerUtils.swift
@@ -14,22 +14,3 @@ func asyncMap<ItemsType: Sequence, ResultType>(
   }
   return values
 }
-
-/**
- Concurrently maps the given sequence. todo: Remove - This function is no longer in use since it caused
- concurrency issues on low end devices when doing a lot of IO in parallell from the handleMultipleMedia
- function in the MediaHandler struct
- */
-func concurrentMap<ItemsType: Sequence, ResultType>(
-  _ items: ItemsType,
-  _ transform: @escaping (ItemsType.Element) async throws -> ResultType
-) async rethrows -> [ResultType] {
-  let tasks = items.map { item in
-    Task {
-      try await transform(item)
-    }
-  }
-  return try await asyncMap(tasks) { task in
-    try await task.value
-  }
-}

--- a/packages/expo-image-picker/ios/ImagePickerUtils.swift
+++ b/packages/expo-image-picker/ios/ImagePickerUtils.swift
@@ -16,7 +16,9 @@ func asyncMap<ItemsType: Sequence, ResultType>(
 }
 
 /**
- Concurrently maps the given sequence.
+ Concurrently maps the given sequence. todo: Remove - This function is no longer in use since it caused
+ concurrency issues on low end devices when doing a lot of IO in parallell from the handleMultipleMedia
+ function in the MediaHandler struct
  */
 func concurrentMap<ItemsType: Sequence, ResultType>(
   _ items: ItemsType,

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -23,7 +23,7 @@ internal struct MediaHandler {
   }
 
   internal func handleMultipleMedia(_ selection: [PHPickerResult]) async throws -> [AssetInfo] {
-    return try await concurrentMap(selection) { selectedItem in
+    return try await asyncMap(selection) { selectedItem in
       let itemProvider = selectedItem.itemProvider
 
       if itemProvider.canLoadObject(ofClass: PHLivePhoto.self) && options.mediaTypes.contains(.livePhotos) {


### PR DESCRIPTION
# Why

When selecting multiple items using the image picker the implementation processed the selected images in parallell - which doesn't work well on older devices - especially when doing "disk" IO.

It was easy to reproduce this error on a low end iOS device:

1. Run BareExpo
2. Open API/ImagePicker
3. Run `requireMediaLIbraryPermissionsAsync`
4. Under `launchImageLibraryAsync` ensure that `allowsMultipleSelection` is checked
5. Run `launchImageLibraryAsync` and select more than one image
6. Press "Add" button in the image picker

Observe: On low-end devices the function never returns and the app freezes. Inspection in XCode reveals that we have multiple threads running at once that are stuck waiting for each other.

Expected: All images are visible after selection

Closes #ENG-14894

# How

This commit fixes the above issue by using the `asyncMap` method instead of the `concurrentMap` that was previously used.

I also removed the unused `concurrentMap` function.

# Test Plan

✅ Tested on iPhone S which was not able to load even two images from the library at once - now it loads 8 images without any problem. The experience is also that it is fast enough.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
