### PR TITLE
[docs][location] removed reference to transistorsoft in docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -135,8 +135,6 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 ### Background location methods
 
-> **warning** **Warning:** Background location tracking support is provided as-is and is not guaranteed to work in all scenarios. We currently are not prioritizing resources to improve it, but we hope to in the future. You may want to use [`react-native-background-geolocation`](https://github.com/transistorsoft/react-native-background-geolocation) instead &mdash; it requires purchasing a license and is a well-maintained and supported library that includes a config plugin.
-
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted.

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -135,8 +135,6 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 ### Background location methods
 
-> **warning** **Warning:** Background location tracking support is provided as-is and is not guaranteed to work in all scenarios. We currently are not prioritizing resources to improve it, but we hope to in the future. You may want to use [`react-native-background-geolocation`](https://github.com/transistorsoft/react-native-background-geolocation) instead &mdash; it requires purchasing a license and is a well-maintained and supported library that includes a config plugin.
-
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted.


### PR DESCRIPTION
# Why

We've decided to stop suggesting users to move to transistorsoft's background location package for Android now that we have had some more time to test and clarify these libraries.

# How

This commit removes the suggestion from both unversioned and sdk-52 docs for background location.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
