### PR TITLE
[updates] Get the private config when syncing to ensure we have codesigning config

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
 - fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
-- Fix issue where syncing codesigning config for bare projects would clobber existing Expo.plist config
+- Fix issue where syncing codesigning config for bare projects would clobber existing Expo.plist config ([#34597](https://github.com/expo/expo/pull/34597) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix an issue where `launchFallbackUpdateFromDisk` is called from a foreground thread leading to ANRs. ([#33693](https://github.com/expo/expo/pull/33693) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
 - fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
+- Fix issue where syncing codesigning config for bare projects would clobber existing Expo.plist config
 
 ### 💡 Others
 

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
@@ -29,7 +29,7 @@ async function syncConfigurationToNativeAsync(options) {
 exports.syncConfigurationToNativeAsync = syncConfigurationToNativeAsync;
 async function syncConfigurationToNativeAndroidAsync(options) {
     const { exp } = (0, config_1.getConfig)(options.projectRoot, {
-        isPublicConfig: true,
+        isPublicConfig: false,
         skipSDKVersionRequirement: true,
     });
     // sync AndroidManifest.xml
@@ -50,7 +50,7 @@ async function syncConfigurationToNativeAndroidAsync(options) {
 }
 async function syncConfigurationToNativeIosAsync(options) {
     const { exp } = (0, config_1.getConfig)(options.projectRoot, {
-        isPublicConfig: true,
+        isPublicConfig: false,
         skipSDKVersionRequirement: true,
     });
     const expoPlist = await readExpoPlistAsync(options.projectRoot);

--- a/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
@@ -37,7 +37,7 @@ async function syncConfigurationToNativeAndroidAsync(
   options: SyncConfigurationToNativeOptions
 ): Promise<void> {
   const { exp } = getConfig(options.projectRoot, {
-    isPublicConfig: true,
+    isPublicConfig: false, // This must be false or it will drop codesigning config
     skipSDKVersionRequirement: true,
   });
 
@@ -84,7 +84,7 @@ async function syncConfigurationToNativeIosAsync(
   options: SyncConfigurationToNativeOptions
 ): Promise<void> {
   const { exp } = getConfig(options.projectRoot, {
-    isPublicConfig: true,
+    isPublicConfig: false, // This must be false or it will drop codesigning config
     skipSDKVersionRequirement: true,
   });
 


### PR DESCRIPTION
# Why

A developer reported that running `eas build` would remove the codesigning config from their bare project **Expo.plist**.

# How

I found that in our newly introduced script for syncing to native projects in expo-updates we use the public config rather than private config, and we strip codesigning fields from the "public" config.

# Test Plan

I ran this against the provided repro (create new project, configure build/update and codesigning, run `npx expo prebuild -p ios` then run `npx expo-updates configuration:syncnative --platform ios --workflow generic` without this patch. Notice it will remove codesigning fields from **Expo.plist**. Apply this diff and run it again, notice they will be there.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

# Follow up

Backport to sdk-52 and sdk-51
