### PR TITLE
[docs][2/n] Update fingeprint links to point to fingerprint doc

### DIFF
--- a/docs/pages/eas-update/continuous-deployment.mdx
+++ b/docs/pages/eas-update/continuous-deployment.mdx
@@ -36,7 +36,7 @@ Running your GitHub workflows in debug mode will automatically add the `--debug`
 
 ### Fingerprint runtime versioning
 
-The [`fingerprint` runtime version policy](/versions/latest/sdk/updates/#fingerprint) uses the [`@expo/fingerprint`](https://github.com/expo/expo/tree/main/packages/%40expo/fingerprint) package to generate a hash of your project when making a build or publishing an update, and then uses that hash as the runtime version. The hash is calculated based on dependencies, custom native code, native project files, and configuration, amongst other things.
+The [`fingerprint` runtime version policy](/versions/latest/sdk/updates/#fingerprint) uses the [`@expo/fingerprint`](/versions/latest/sdk/fingerprint) package to generate a hash of your project when making a build or publishing an update, and then uses that hash as the runtime version. The hash is calculated based on dependencies, custom native code, native project files, and configuration, amongst other things.
 
 By automatically calculating the runtime version, you don't have to be concerned about native layer compatibility with the JavaScript application when deploying updates to builds.
 
@@ -53,7 +53,7 @@ To identify differences in fingerprints on different machines or environments:
   - [JSON Pretty Print](https://jsonformatter.org/json-pretty-print) to format the output.
   - [JSON Diff](https://www.jsondiff.com/) to compare the output and identify the files causing the discrepancies.
 
-To exclude files causing the differences, add them to the **.fingerprintignore** file as described in the [`@expo/fingerprint` README](https://www.npmjs.com/package/@expo/fingerprint).
+To exclude files causing the differences, add them to the **.fingerprintignore** file as described in the documentation for [`@expo/fingerprint`](/versions/latest/sdk/fingerprint).
 
 </Collapsible>
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -182,7 +182,7 @@ The `"fingerprint"` runtime version policy automatically calculates the runtime 
 }
 ```
 
-This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
+This policy works for both projects with and without custom native code. It works by using the [`@expo/fingerprint`](fingerprint) package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
 
 </Collapsible>
 

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -181,7 +181,7 @@ The `"fingerprint"` runtime version policy automatically calculates the runtime 
 }
 ```
 
-This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
+This policy works for both projects with and without custom native code. It works by using the [`@expo/fingerprint`](fingerprint) package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

This PR updates existing fingerprint links to point to the new doc added in the parent PR.

Closes ENG-14905.

# How

Grep and update links.

# Test Plan

navigate to http://localhost:3002/eas-update/continuous-deployment/ and http://localhost:3002/versions/unversioned/sdk/updates/#fingerprint and see links work correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
