### PR TITLE
[docs] Update Push notification icon

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -5,7 +5,7 @@ description: A list of common questions and limitations about Expo and related s
 
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
@@ -171,7 +171,7 @@ For more information on what current limitations exist with EAS, see the followi
   title="Notifications"
   description="Push Notifications are an important feature, no matter what kind of app you're building. In some situations, you might want to know about common issues when setting up push notifications with Expo. Learn more."
   href="/push-notifications/faq"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 #### EAS and bare React Native projects

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -5,7 +5,7 @@ description: An overview of Expo push notification service.
 hideTOC: true
 ---
 
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -25,33 +25,33 @@ Follow the video or links below to learn how to set up push notifications, send 
   title="What you need to know about notifications"
   description="Different kinds of notifications and notification behaviors you need to know before you get started."
   href="/push-notifications/what-you-need-to-know"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 <BoxLink
   title="Set up push notifications, get a push token and credentials"
   description="All you need to do to get started quickly."
   href="/push-notifications/push-notifications-setup"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 <BoxLink
   title="Send push notifications"
   description="See how to call Expo Push Service API to send push notifications from your server."
   href="/push-notifications/sending-notifications"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 <BoxLink
   title="Handle incoming notifications"
   description="Learn how to respond to a notification received by your app and take an action based on the event."
   href="/push-notifications/receiving-notifications"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 <BoxLink
   title="Troubleshooting and Frequently asked questions (FAQ)"
   description="A collection of common questions about Expo's push notification service."
   href="/push-notifications/faq"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -5,10 +5,10 @@ description: An overview of troubleshooting guides for app development with Expo
 ---
 
 import { RouterLogo } from '@expo/styleguide';
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
@@ -118,7 +118,7 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
   title="Push notifications: Troubleshooting and FAQ"
   description="A collection of common questions about Expo's push notification service."
   href="/push-notifications/faq/"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 ## EAS

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -7,7 +7,7 @@ iconUrl: '/static/images/packages/expo-notifications.png'
 platforms: ['android*', 'ios*']
 ---
 
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -26,7 +26,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
   title="Notification guides"
   description="Do not miss our guides on how to set up, send, and handle push notifications."
   href="/push-notifications/overview/"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 > **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` is unavailable in Expo Go from SDK 53. A [development build](/develop/development-builds/introduction/) is required to use push notifications. Local notifications (in-app notifications) remain available in Expo Go.

--- a/docs/pages/versions/v52.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/notifications.mdx
@@ -7,7 +7,7 @@ iconUrl: '/static/images/packages/expo-notifications.png'
 platforms: ['android*', 'ios*']
 ---
 
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -26,7 +26,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
   title="Notification guides"
   description="Do not miss our guides on how to set up, send, and handle push notifications."
   href="/push-notifications/overview/"
-  Icon={Bell03Icon}
+  Icon={NotificationBoxIcon}
 />
 
 > **warning** Push notifications (remote notifications) functionality provided by `expo-notifications` will be unavailable in Expo Go from SDK 53. A [development build](/develop/development-builds/introduction/) will be required to use push notifications. Local notifications (in-app notifications) will remain available in Expo Go.

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -3,7 +3,6 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { StoplightIcon } from '@expo/styleguide-icons/custom/StoplightIcon';
-import { Bell03Icon } from '@expo/styleguide-icons/outline/Bell03Icon';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
@@ -12,6 +11,7 @@ import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
 import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
+import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 import { Phone01Icon } from '@expo/styleguide-icons/outline/Phone01Icon';
 import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
@@ -220,7 +220,7 @@ function getIconElement(iconName?: string) {
     case 'Expo Router':
       return RouterLogo;
     case 'Push notifications':
-      return Bell03Icon;
+      return NotificationBoxIcon;
     case 'Distribution':
       return Phone01Icon;
     case 'UI programming':


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Push notification section icon does not match the one on expo.dev.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Push notification icon for section and BoxLinks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2025-02-02 at 16 56 08@2x](https://github.com/user-attachments/assets/637ba622-c2be-4301-a10b-124a2ff4e202)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
