### PR TITLE
[expo-font][android] add support for xml fonts

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -37,6 +37,7 @@ _This version does not introduce any user-facing changes._
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Add support for linking fonts as XML, this fixes issues with `fontStyle` and `fontWeight` ([#34620](https://github.com/expo/expo/pull/34620) by [@BalogunofAfrica](<(https://github.com/BalogunofAfrica)>))
 
 ## 13.0.4 - 2025-02-19
 

--- a/packages/expo-font/plugin/build/utils.d.ts
+++ b/packages/expo-font/plugin/build/utils.d.ts
@@ -1,4 +1,9 @@
+import type { FontFiles } from './withFontsAndroid';
 export declare function resolveFontPaths(fonts: string[], projectRoot: string): Promise<string[]>;
-export declare function getFontWeight(filename: string): number;
+export declare function resolveXmlFontPaths(fonts: FontFiles[], projectRoot: string): Promise<{
+    font: string;
+    fontStyle: "normal" | "italic";
+    fontWeight: `${number}`;
+}[]>;
 export declare function normalizeFilename(filename: string): string;
-export declare function generateFontFamilyXml(files: string[]): string;
+export declare function generateFontFamilyXml(files: FontFiles[]): string;

--- a/packages/expo-font/plugin/build/utils.d.ts
+++ b/packages/expo-font/plugin/build/utils.d.ts
@@ -1,3 +1,4 @@
 export declare function resolveFontPaths(fonts: string[], projectRoot: string): Promise<string[]>;
 export declare function getFontWeight(filename: string): number;
+export declare function normalizeFilename(filename: string): string;
 export declare function generateFontFamilyXml(files: string[]): string;

--- a/packages/expo-font/plugin/build/utils.d.ts
+++ b/packages/expo-font/plugin/build/utils.d.ts
@@ -1,1 +1,3 @@
 export declare function resolveFontPaths(fonts: string[], projectRoot: string): Promise<string[]>;
+export declare function getFontWeight(filename: string): number;
+export declare function generateFontFamilyXml(files: string[]): string;

--- a/packages/expo-font/plugin/build/utils.js
+++ b/packages/expo-font/plugin/build/utils.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.resolveFontPaths = resolveFontPaths;
+exports.generateFontFamilyXml = exports.getFontWeight = exports.resolveFontPaths = void 0;
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 async function resolveFontPaths(fonts, projectRoot) {
@@ -20,3 +20,42 @@ async function resolveFontPaths(fonts, projectRoot) {
         .flat()
         .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf') || p.endsWith('.woff') || p.endsWith('.woff2'));
 }
+exports.resolveFontPaths = resolveFontPaths;
+const weightMap = {
+    thin: 100,
+    extralight: 200,
+    ultralight: 200,
+    light: 300,
+    regular: 400,
+    normal: 400,
+    book: 400,
+    medium: 500,
+    semibold: 600,
+    demibold: 600,
+    bold: 700,
+    extrabold: 800,
+    ultrabold: 800,
+    black: 900,
+    heavy: 900,
+};
+function getFontWeight(filename) {
+    for (const weight in weightMap) {
+        if (filename.toLowerCase().includes(weight)) {
+            return weightMap[weight];
+        }
+    }
+    return 400;
+}
+exports.getFontWeight = getFontWeight;
+function generateFontFamilyXml(files) {
+    let xml = `<?xml version="1.0" encoding="utf-8"?>\n<font-family xmlns:app="http://schemas.android.com/apk/res-auto">\n`;
+    files.forEach((file) => {
+        const filename = path_1.default.basename(file, path_1.default.extname(file));
+        const fontWeight = getFontWeight(filename);
+        const fontStyle = filename.toLowerCase().includes('italic') ? 'italic' : 'normal';
+        xml += `    <font app:fontStyle="${fontStyle}" app:fontWeight="${fontWeight}" app:font="@font/${filename}" />\n`;
+    });
+    xml += `</font-family>\n`;
+    return xml;
+}
+exports.generateFontFamilyXml = generateFontFamilyXml;

--- a/packages/expo-font/plugin/build/withFonts.d.ts
+++ b/packages/expo-font/plugin/build/withFonts.d.ts
@@ -3,8 +3,8 @@ import { type XmlFonts } from './withFontsAndroid';
 export type FontProps = {
     fonts?: string[];
     android?: {
-        fonts?: string[];
-    } | XmlFonts[];
+        fonts?: (string | XmlFonts)[];
+    };
     ios?: {
         fonts?: string[];
     };

--- a/packages/expo-font/plugin/build/withFonts.d.ts
+++ b/packages/expo-font/plugin/build/withFonts.d.ts
@@ -1,9 +1,10 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
+import { type XmlFonts } from './withFontsAndroid';
 export type FontProps = {
     fonts?: string[];
     android?: {
         fonts?: string[];
-    };
+    } | XmlFonts[];
     ios?: {
         fonts?: string[];
     };

--- a/packages/expo-font/plugin/build/withFonts.js
+++ b/packages/expo-font/plugin/build/withFonts.js
@@ -12,14 +12,16 @@ const withFonts = (config, props) => {
     if (iosFonts.length > 0) {
         config = (0, withFontsIos_1.withFontsIos)(config, iosFonts);
     }
-    if (Array.isArray(props.android)) {
-        config = (0, withFontsAndroid_1.withXmlFontsAndroid)(config, props.android);
+    const xmlFonts = props.android?.fonts?.filter((item) => typeof item !== 'string') ?? [];
+    const assetFonts = [
+        ...(props.fonts ?? []),
+        ...(props.android?.fonts?.filter((item) => typeof item === 'string') ?? []),
+    ];
+    if (xmlFonts.length > 0) {
+        config = (0, withFontsAndroid_1.withXmlFontsAndroid)(config, xmlFonts);
     }
-    else {
-        const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
-        if (androidFonts.length > 0) {
-            config = (0, withFontsAndroid_1.withFontsAndroid)(config, androidFonts);
-        }
+    if (assetFonts.length > 0) {
+        config = (0, withFontsAndroid_1.withFontsAndroid)(config, assetFonts);
     }
     return config;
 };

--- a/packages/expo-font/plugin/build/withFonts.js
+++ b/packages/expo-font/plugin/build/withFonts.js
@@ -12,9 +12,14 @@ const withFonts = (config, props) => {
     if (iosFonts.length > 0) {
         config = (0, withFontsIos_1.withFontsIos)(config, iosFonts);
     }
-    const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
-    if (androidFonts.length > 0) {
-        config = (0, withFontsAndroid_1.withFontsAndroid)(config, androidFonts);
+    if (Array.isArray(props.android)) {
+        config = (0, withFontsAndroid_1.withXmlFontsAndroid)(config, props.android);
+    }
+    else {
+        const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
+        if (androidFonts.length > 0) {
+            config = (0, withFontsAndroid_1.withFontsAndroid)(config, androidFonts);
+        }
     }
     return config;
 };

--- a/packages/expo-font/plugin/build/withFontsAndroid.d.ts
+++ b/packages/expo-font/plugin/build/withFontsAndroid.d.ts
@@ -1,2 +1,7 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
+export type XmlFonts = {
+    fontFiles?: string[];
+    fontName?: string;
+};
 export declare const withFontsAndroid: ConfigPlugin<string[]>;
+export declare const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]>;

--- a/packages/expo-font/plugin/build/withFontsAndroid.d.ts
+++ b/packages/expo-font/plugin/build/withFontsAndroid.d.ts
@@ -1,7 +1,7 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
 export type XmlFonts = {
-    fontFiles?: string[];
-    fontName?: string;
+    fontFiles: string[];
+    fontName: string;
 };
 export declare const withFontsAndroid: ConfigPlugin<string[]>;
 export declare const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]>;

--- a/packages/expo-font/plugin/build/withFontsAndroid.d.ts
+++ b/packages/expo-font/plugin/build/withFontsAndroid.d.ts
@@ -1,6 +1,11 @@
 import { type ConfigPlugin } from 'expo/config-plugins';
+export type FontFiles = {
+    font: string;
+    fontStyle: 'normal' | 'italic';
+    fontWeight: `${number}`;
+};
 export type XmlFonts = {
-    fontFiles: string[];
+    files: FontFiles[];
     fontName: string;
 };
 export declare const withFontsAndroid: ConfigPlugin<string[]>;

--- a/packages/expo-font/plugin/build/withFontsAndroid.js
+++ b/packages/expo-font/plugin/build/withFontsAndroid.js
@@ -32,8 +32,9 @@ const withXmlFontsAndroid = (config, fonts) => {
     return (0, config_plugins_1.withMainApplication)(config, async (config) => {
         const fontsDir = path_1.default.join(config.modRequest.platformProjectRoot, 'app/src/main/res/font');
         await promises_1.default.mkdir(fontsDir, { recursive: true });
-        const isJava = config.modResults.language === 'java';
-        config.modResults.contents = (0, codeMod_1.addImports)(config.modResults.contents, ['com.facebook.react.common.assets.ReactFontManager'], isJava);
+        const modResults = config.modResults;
+        const isJava = modResults.language === 'java';
+        modResults.contents = (0, codeMod_1.addImports)(modResults.contents, ['com.facebook.react.common.assets.ReactFontManager'], isJava);
         Promise.all(fonts.map(async ({ fontName, files }) => {
             const xmlFileName = (0, utils_1.normalizeFilename)(fontName);
             const resolvedFonts = await (0, utils_1.resolveXmlFontPaths)(files, config.modRequest.projectRoot);
@@ -44,7 +45,7 @@ const withXmlFontsAndroid = (config, fonts) => {
                 const destPath = path_1.default.join(fontsDir, path_1.default.basename(file.font));
                 await promises_1.default.copyFile(path_1.default.resolve(__dirname, file.font), destPath);
             }));
-            config.modResults.contents = (0, codeMod_1.appendContentsInsideDeclarationBlock)(config.modResults.contents, 'onCreate', `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `);
+            modResults.contents = (0, codeMod_1.appendContentsInsideDeclarationBlock)(modResults.contents, 'onCreate', `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `);
         }));
         return config;
     });

--- a/packages/expo-font/plugin/build/withFontsAndroid.js
+++ b/packages/expo-font/plugin/build/withFontsAndroid.js
@@ -29,8 +29,8 @@ const withFontsAndroid = (config, fonts) => {
 };
 exports.withFontsAndroid = withFontsAndroid;
 const withXmlFontsAndroid = (config, fonts) => {
-    return (0, config_plugins_1.withMainApplication)(config, (config) => {
-        fonts.forEach(async ({ fontName, fontFiles }) => {
+    return (0, config_plugins_1.withMainApplication)(config, async (config) => {
+        for (const { fontName, fontFiles } of fonts) {
             const xmlFileName = fontName?.toLowerCase().replace(/ /g, '_');
             const fontXml = (0, utils_1.generateFontFamilyXml)(fontFiles);
             const fontsDir = path_1.default.join(config.modRequest.platformProjectRoot, 'app/src/main/res/font');
@@ -44,7 +44,7 @@ const withXmlFontsAndroid = (config, fonts) => {
             const isJava = config.modResults.language === 'java';
             config.modResults.contents = (0, codeMod_1.addImports)(config.modResults.contents, ['com.facebook.react.common.assets.ReactFontManager'], isJava);
             config.modResults.contents = (0, codeMod_1.appendContentsInsideDeclarationBlock)(config.modResults.contents, 'onCreate', `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `);
-        });
+        }
         return config;
     });
 };

--- a/packages/expo-font/plugin/build/withFontsAndroid.js
+++ b/packages/expo-font/plugin/build/withFontsAndroid.js
@@ -3,13 +3,15 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withFontsAndroid = void 0;
-const config_plugins_1 = require("expo/config-plugins");
+exports.withXmlFontsAndroid = exports.withFontsAndroid = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const codeMod_1 = require("@expo/config-plugins/build/android/codeMod");
+const config_plugins_2 = require("expo/config-plugins");
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
 const withFontsAndroid = (config, fonts) => {
-    return (0, config_plugins_1.withDangerousMod)(config, [
+    return (0, config_plugins_2.withDangerousMod)(config, [
         'android',
         async (config) => {
             const resolvedFonts = await (0, utils_1.resolveFontPaths)(fonts, config.modRequest.projectRoot);
@@ -26,3 +28,24 @@ const withFontsAndroid = (config, fonts) => {
     ]);
 };
 exports.withFontsAndroid = withFontsAndroid;
+const withXmlFontsAndroid = (config, fonts) => {
+    return (0, config_plugins_1.withMainApplication)(config, (config) => {
+        fonts.forEach(async ({ fontName, fontFiles }) => {
+            const xmlFileName = fontName?.toLowerCase().replace(/ /g, '_');
+            const fontXml = (0, utils_1.generateFontFamilyXml)(fontFiles);
+            const fontsDir = path_1.default.join(config.modRequest.platformProjectRoot, 'app/src/main/res/font');
+            await promises_1.default.mkdir(fontsDir, { recursive: true });
+            const xmlPath = path_1.default.join(fontsDir, `${xmlFileName}.xml`);
+            await promises_1.default.writeFile(xmlPath, fontXml);
+            await Promise.all(fontFiles.map(async (file) => {
+                const destPath = path_1.default.join(fontsDir, path_1.default.basename(file));
+                await promises_1.default.copyFile(path_1.default.resolve(__dirname, file), destPath);
+            }));
+            const isJava = config.modResults.language === 'java';
+            config.modResults.contents = (0, codeMod_1.addImports)(config.modResults.contents, ['com.facebook.react.common.assets.ReactFontManager'], isJava);
+            config.modResults.contents = (0, codeMod_1.appendContentsInsideDeclarationBlock)(config.modResults.contents, 'onCreate', `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `);
+        });
+        return config;
+    });
+};
+exports.withXmlFontsAndroid = withXmlFontsAndroid;

--- a/packages/expo-font/plugin/build/withFontsAndroid.js
+++ b/packages/expo-font/plugin/build/withFontsAndroid.js
@@ -34,15 +34,15 @@ const withXmlFontsAndroid = (config, fonts) => {
         await promises_1.default.mkdir(fontsDir, { recursive: true });
         const isJava = config.modResults.language === 'java';
         config.modResults.contents = (0, codeMod_1.addImports)(config.modResults.contents, ['com.facebook.react.common.assets.ReactFontManager'], isJava);
-        Promise.all(fonts.map(async ({ fontName, fontFiles }) => {
+        Promise.all(fonts.map(async ({ fontName, files }) => {
             const xmlFileName = (0, utils_1.normalizeFilename)(fontName);
-            const resolvedFonts = await (0, utils_1.resolveFontPaths)(fontFiles, config.modRequest.projectRoot);
+            const resolvedFonts = await (0, utils_1.resolveXmlFontPaths)(files, config.modRequest.projectRoot);
             const fontXml = (0, utils_1.generateFontFamilyXml)(resolvedFonts);
             const xmlPath = path_1.default.join(fontsDir, `${xmlFileName}.xml`);
             await promises_1.default.writeFile(xmlPath, fontXml);
             await Promise.all(resolvedFonts.map(async (file) => {
-                const destPath = path_1.default.join(fontsDir, path_1.default.basename(file));
-                await promises_1.default.copyFile(path_1.default.resolve(__dirname, file), destPath);
+                const destPath = path_1.default.join(fontsDir, path_1.default.basename(file.font));
+                await promises_1.default.copyFile(path_1.default.resolve(__dirname, file.font), destPath);
             }));
             config.modResults.contents = (0, codeMod_1.appendContentsInsideDeclarationBlock)(config.modResults.contents, 'onCreate', `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `);
         }));

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -36,9 +36,10 @@ const weightMap: Record<string, number> = {
   black: 900,
   heavy: 900,
 };
+const weights = Object.keys(weightMap).sort((a, b) => b.length - a.length);
 
 export function getFontWeight(filename: string) {
-  for (const weight in weightMap) {
+  for (const weight of weights) {
     if (filename.toLowerCase().includes(weight)) {
       return weightMap[weight];
     }

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -40,7 +40,7 @@ const weights = Object.keys(weightMap).sort((a, b) => b.length - a.length);
 
 export function getFontWeight(filename: string) {
   for (const weight of weights) {
-    if (filename.toLowerCase().includes(weight)) {
+    if (filename.replaceAll('_', '').includes(weight)) {
       return weightMap[weight];
     }
   }
@@ -48,13 +48,22 @@ export function getFontWeight(filename: string) {
   return 400;
 }
 
+export function normalizeFilename(filename: string): string {
+  return filename
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_')
+    .replace(/[^a-z0-9_]/g, '')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
 export function generateFontFamilyXml(files: string[]) {
   let xml = `<?xml version="1.0" encoding="utf-8"?>\n<font-family xmlns:app="http://schemas.android.com/apk/res-auto">\n`;
 
   files.forEach((file) => {
-    const filename = path.basename(file, path.extname(file));
+    const filename = normalizeFilename(path.basename(file, path.extname(file)));
     const fontWeight = getFontWeight(filename);
-    const fontStyle = filename.toLowerCase().includes('italic') ? 'italic' : 'normal';
+    const fontStyle = filename.includes('italic') ? 'italic' : 'normal';
 
     xml += `    <font app:fontStyle="${fontStyle}" app:fontWeight="${fontWeight}" app:font="@font/${filename}" />\n`;
   });

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -18,3 +18,46 @@ export async function resolveFontPaths(fonts: string[], projectRoot: string) {
       (p) => p.endsWith('.ttf') || p.endsWith('.otf') || p.endsWith('.woff') || p.endsWith('.woff2')
     );
 }
+
+const weightMap: Record<string, number> = {
+  thin: 100,
+  extralight: 200,
+  ultralight: 200,
+  light: 300,
+  regular: 400,
+  normal: 400,
+  book: 400,
+  medium: 500,
+  semibold: 600,
+  demibold: 600,
+  bold: 700,
+  extrabold: 800,
+  ultrabold: 800,
+  black: 900,
+  heavy: 900,
+};
+
+export function getFontWeight(filename: string) {
+  for (const weight in weightMap) {
+    if (filename.toLowerCase().includes(weight)) {
+      return weightMap[weight];
+    }
+  }
+
+  return 400;
+}
+
+export function generateFontFamilyXml(files: string[]) {
+  let xml = `<?xml version="1.0" encoding="utf-8"?>\n<font-family xmlns:app="http://schemas.android.com/apk/res-auto">\n`;
+
+  files.forEach((file) => {
+    const filename = path.basename(file, path.extname(file));
+    const fontWeight = getFontWeight(filename);
+    const fontStyle = filename.toLowerCase().includes('italic') ? 'italic' : 'normal';
+
+    xml += `    <font app:fontStyle="${fontStyle}" app:fontWeight="${fontWeight}" app:font="@font/${filename}" />\n`;
+  });
+
+  xml += `</font-family>\n`;
+  return xml;
+}

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -7,11 +7,9 @@ const pkg = require('expo-font/package.json');
 
 export type FontProps = {
   fonts?: string[];
-  android?:
-    | {
-        fonts?: string[];
-      }
-    | XmlFonts[];
+  android?: {
+    fonts?: (string | XmlFonts)[];
+  };
   ios?: {
     fonts?: string[];
   };
@@ -28,13 +26,18 @@ const withFonts: ConfigPlugin<FontProps> = (config, props) => {
     config = withFontsIos(config, iosFonts);
   }
 
-  if (Array.isArray(props.android)) {
-    config = withXmlFontsAndroid(config, props.android);
-  } else {
-    const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
-    if (androidFonts.length > 0) {
-      config = withFontsAndroid(config, androidFonts);
-    }
+  const xmlFonts = props.android?.fonts?.filter((item) => typeof item !== 'string') ?? [];
+  const assetFonts = [
+    ...(props.fonts ?? []),
+    ...(props.android?.fonts?.filter((item) => typeof item === 'string') ?? []),
+  ];
+
+  if (xmlFonts.length > 0) {
+    config = withXmlFontsAndroid(config, xmlFonts as XmlFonts[]);
+  }
+
+  if (assetFonts.length > 0) {
+    config = withFontsAndroid(config, assetFonts as string[]);
   }
 
   return config;

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -1,15 +1,17 @@
 import { type ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
-import { withFontsAndroid } from './withFontsAndroid';
+import { withXmlFontsAndroid, withFontsAndroid, type XmlFonts } from './withFontsAndroid';
 import { withFontsIos } from './withFontsIos';
 
 const pkg = require('expo-font/package.json');
 
 export type FontProps = {
   fonts?: string[];
-  android?: {
-    fonts?: string[];
-  };
+  android?:
+    | {
+        fonts?: string[];
+      }
+    | XmlFonts[];
   ios?: {
     fonts?: string[];
   };
@@ -26,10 +28,13 @@ const withFonts: ConfigPlugin<FontProps> = (config, props) => {
     config = withFontsIos(config, iosFonts);
   }
 
-  const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
-
-  if (androidFonts.length > 0) {
-    config = withFontsAndroid(config, androidFonts);
+  if (Array.isArray(props.android)) {
+    config = withXmlFontsAndroid(config, props.android);
+  } else {
+    const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
+    if (androidFonts.length > 0) {
+      config = withFontsAndroid(config, androidFonts);
+    }
   }
 
   return config;

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -41,15 +41,15 @@ export const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]> = (config, fonts) => 
   return withMainApplication(config, async (config) => {
     for (const { fontName, fontFiles } of fonts) {
       const xmlFileName = fontName?.toLowerCase().replace(/ /g, '_')!;
-
-      const fontXml = generateFontFamilyXml(fontFiles!);
+      const resolvedFonts = await resolveFontPaths(fontFiles!, config.modRequest.projectRoot);
+      const fontXml = generateFontFamilyXml(resolvedFonts);
       const fontsDir = path.join(config.modRequest.platformProjectRoot, 'app/src/main/res/font');
       await fs.mkdir(fontsDir, { recursive: true });
       const xmlPath = path.join(fontsDir, `${xmlFileName}.xml`);
       await fs.writeFile(xmlPath, fontXml);
 
       await Promise.all(
-        fontFiles!.map(async (file) => {
+        resolvedFonts.map(async (file) => {
           const destPath = path.join(fontsDir, path.basename(file));
           await fs.copyFile(path.resolve(__dirname, file), destPath);
         })

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -38,8 +38,8 @@ export const withFontsAndroid: ConfigPlugin<string[]> = (config, fonts) => {
 };
 
 export const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]> = (config, fonts) => {
-  return withMainApplication(config, (config) => {
-    fonts.forEach(async ({ fontName, fontFiles }) => {
+  return withMainApplication(config, async (config) => {
+    for (const { fontName, fontFiles } of fonts) {
       const xmlFileName = fontName?.toLowerCase().replace(/ /g, '_')!;
 
       const fontXml = generateFontFamilyXml(fontFiles!);
@@ -66,7 +66,7 @@ export const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]> = (config, fonts) => 
         'onCreate',
         `  ReactFontManager.getInstance().addCustomFont(this, "${fontName}", R.font.${xmlFileName})${isJava ? ';' : ''}\n  `
       );
-    });
+    }
 
     return config;
   });

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -7,7 +7,7 @@ import { type ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { generateFontFamilyXml, resolveFontPaths } from './utils';
+import { generateFontFamilyXml, normalizeFilename, resolveFontPaths } from './utils';
 
 export type XmlFonts = {
   fontFiles: string[];
@@ -51,7 +51,7 @@ export const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]> = (config, fonts) => 
 
     Promise.all(
       fonts.map(async ({ fontName, fontFiles }) => {
-        const xmlFileName = fontName.toLowerCase().replace(/ /g, '_')!;
+        const xmlFileName = normalizeFilename(fontName);
         const resolvedFonts = await resolveFontPaths(fontFiles, config.modRequest.projectRoot);
         const fontXml = generateFontFamilyXml(resolvedFonts);
         const xmlPath = path.join(fontsDir, `${xmlFileName}.xml`);

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -10,8 +10,8 @@ import path from 'path';
 import { generateFontFamilyXml, resolveFontPaths } from './utils';
 
 export type XmlFonts = {
-  fontFiles?: string[];
-  fontName?: string;
+  fontFiles: string[];
+  fontName: string;
 };
 
 export const withFontsAndroid: ConfigPlugin<string[]> = (config, fonts) => {
@@ -40,8 +40,8 @@ export const withFontsAndroid: ConfigPlugin<string[]> = (config, fonts) => {
 export const withXmlFontsAndroid: ConfigPlugin<XmlFonts[]> = (config, fonts) => {
   return withMainApplication(config, async (config) => {
     for (const { fontName, fontFiles } of fonts) {
-      const xmlFileName = fontName?.toLowerCase().replace(/ /g, '_')!;
-      const resolvedFonts = await resolveFontPaths(fontFiles!, config.modRequest.projectRoot);
+      const xmlFileName = fontName.toLowerCase().replace(/ /g, '_')!;
+      const resolvedFonts = await resolveFontPaths(fontFiles, config.modRequest.projectRoot);
       const fontXml = generateFontFamilyXml(resolvedFonts);
       const fontsDir = path.join(config.modRequest.platformProjectRoot, 'app/src/main/res/font');
       await fs.mkdir(fontsDir, { recursive: true });


### PR DESCRIPTION
# Why
Add support for linking fonts as an [XML resource](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml "Android XML font"). 

Currently on Android with the way fonts are linked, if we want to use a particular weight or style of our font, we would have to explicitly pass the `fontFamily` for that weight/style as the `TextStyle`'s `fontWeight` and `fontStyle` have no effect.

Before, with fonts linked on Android simply as an asset:
```tsx
// This would work on iOS and Web but not Android
<Text style={{ fontFamily: 'Inter', fontWeight: '100', fontStyle: 'italic'  }}>Expo is great!</Text>

// This would work on Android
<Text style={{ fontFamily: 'Inter-ThinItalic'  }}>Expo is great!</Text>
```

After, with fonts linked on Android as an XML font:
```tsx
// This would work on all platforms (Android, iOS, Web)
<Text style={{ fontFamily: 'Inter', fontWeight: '100', fontStyle: 'italic'  }}>Expo is great!</Text>
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->
The fix is to link the font as an xml file and then add it using `ReactFontManager` in the `onCreate` method of `MainApplication`.

The config plugin would still work the same as it currently does. That is this is still valid:
```js
[
  'expo-font',
  {
    android: {
      fonts: ['./assets/fonts/inter/Inter-ThinItalic.otf'],
    },
    ios: {
      fonts: ['./assets/fonts/inter/Inter-ThinItalic.otf'],
    },
    fonts: ['./assets/fonts/inter/Inter-ThinItalic.otf'],
  },
]
```

But for the Android, we can also supply font files like so:
```js
[
  'expo-font',
  {
    android: [
      {
        fontName: 'Inter',
        fontFiles: ['./assets/fonts/inter_thinitalic.otf'],
      },
    ],
    fonts: ['./assets/fonts/inter/Inter-ThinItalic.otf'],
  },
]
```

Two things to note, when linking fonts like this:
1. We must know the actual name (not file name) of the font which is passed as the property `fontName`. This can be gotten using tools like `otfinfo` or `fc-query` on Mac.
```shell
otfinfo --family ./inter_regular.otf
```
OR 
```shell
fc-query -f "%{family[0]}\n" ./inter_regular.otf
```

2. ~The font files need to be named based on the convention for Android resource names i.e all lowercase, 0-9 numbers, and underscore(_) for separation~. The file names are normalised to fit with Android resource naming constraints (all lowercase, 0-9 numbers, and underscore(_) for separation)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
