### PR TITLE
[docs] Update `llms.txt` script to read links from additional resources page

### DIFF
--- a/docs/.eslintignore
+++ b/docs/.eslintignore
@@ -7,3 +7,4 @@ out
 node_modules
 pages/versions/latest
 public
+scripts/generate-llms/talks.js

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -28,3 +28,4 @@ out
 public/llms.txt
 public/llms-full.txt
 public/llms-eas.txt
+scripts/generate-llms/talks.js

--- a/docs/scripts/generate-llms/compileTalks.js
+++ b/docs/scripts/generate-llms/compileTalks.js
@@ -1,0 +1,52 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function compileTalksFile() {
+  try {
+    const projectRoot = path.resolve(__dirname, '../..');
+    const inputFile = path.join(projectRoot, 'public/static/talks.ts');
+    const outputDir = path.join(projectRoot, 'scripts/generate-llms');
+
+    const tempTsConfig = {
+      compilerOptions: {
+        target: 'ES2020',
+        module: 'ES2020',
+        moduleResolution: 'node',
+        esModuleInterop: true,
+        skipLibCheck: true,
+        jsx: 'react',
+        allowJs: true,
+        outDir: outputDir,
+        declaration: false,
+        noEmit: false,
+        isolatedModules: true,
+      },
+      include: [inputFile],
+      exclude: ['node_modules'],
+    };
+
+    const tempTsConfigPath = path.join(outputDir, 'temp-tsconfig.json');
+    fs.writeFileSync(tempTsConfigPath, JSON.stringify(tempTsConfig, null, 2));
+
+    execSync(`npx tsc --project ${tempTsConfigPath}`, {
+      stdio: 'inherit',
+    });
+
+    fs.unlinkSync(tempTsConfigPath);
+
+    const outputFile = path.join(outputDir, 'talks.js');
+    console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully compiled talks.ts to $talks.js`);
+    return outputFile;
+  } catch (error) {
+    console.error('Error compiling talks.ts:', error);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  compileTalksFile();
+}

--- a/docs/scripts/generate-llms/index.js
+++ b/docs/scripts/generate-llms/index.js
@@ -1,8 +1,11 @@
+import { compileTalksFile } from './compileTalks.js';
 import { generateLlmsEasTxt } from './llms-eas-txt.js';
 import { generateLlmsFullTxt } from './llms-full-txt.js';
 import { generateLlmsTxt } from './llms-txt.js';
 
-Promise.all([
+await compileTalksFile();
+
+Promise.allSettled([
   await generateLlmsEasTxt(),
   await generateLlmsFullTxt(),
   await generateLlmsTxt(),

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -61,7 +61,7 @@ export async function generateLlmsTxt() {
       .flat()
       .map(processSection)
       .filter(Boolean);
-    const talksData = exportTalksData();
+    const talksData = await exportTalksData();
     const allSections = [...docSections, ...talksData.sections];
 
     await fs.promises.writeFile(

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -7,6 +7,7 @@ import {
   TITLE,
   DESCRIPTION,
   processSection,
+  exportTalksData,
 } from './utils.js';
 import { home, learn, general, eas, reference } from '../../constants/navigation.js';
 
@@ -56,17 +57,19 @@ function generateFullMarkdown({ title, description, sections }) {
 
 export async function generateLlmsTxt() {
   try {
-    const sections = Object.values({ home, general, learn, eas, reference: reference.latest })
+    const docSections = Object.values({ home, general, learn, eas, reference: reference.latest })
       .flat()
       .map(processSection)
       .filter(Boolean);
+    const talksData = exportTalksData();
+    const allSections = [...docSections, ...talksData.sections];
 
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_LLMS_TXT),
       generateFullMarkdown({
         title: TITLE,
         description: DESCRIPTION,
-        sections,
+        sections: allSections,
       })
     );
 

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -2,6 +2,8 @@ import frontmatter from 'front-matter';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { compileTalksFile } from './compileTalks.js';
+
 export const OUTPUT_FILENAME_LLMS_TXT = 'llms.txt';
 export const OUTPUT_DIRECTORY_NAME = 'public';
 export const OUTPUT_FILENAME_EXPO_DOCS = 'llms-full.txt';
@@ -12,6 +14,8 @@ export const DESCRIPTION =
   'Expo is an open-source React Native framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app such as live updates, instantly sharing your app, and web support. The company behind Expo also offers Expo Application Services (EAS), which are deeply integrated cloud services for Expo and React Native apps.';
 export const DESCRIPTION_EAS =
   'Expo Application Services (EAS) are deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.';
+const compiledFilePath = compileTalksFile();
+const { TALKS, PODCASTS, LIVE_STREAMS } = await import(compiledFilePath);
 
 export function processPageData(pageHref, pageName) {
   if (!pageHref || pageHref.startsWith('http')) {
@@ -248,4 +252,51 @@ export function generateSectionMarkdown(section) {
   });
 
   return content;
+}
+
+function generateVideoUrl(videoId) {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+function processTalks(talks, type = 'video') {
+  return talks.map(talk => {
+    if (type === 'podcast' && talk.link) {
+      return {
+        title: talk.title,
+        url: talk.link,
+      };
+    }
+
+    return {
+      title: talk.title,
+      url: talk.videoId ? generateVideoUrl(talk.videoId) : '',
+    };
+  });
+}
+
+export function exportTalksData() {
+  return {
+    title: 'Additional Resources',
+    description: 'Collection of talks, podcasts, and live streams from the Expo team',
+    sections: [
+      {
+        title: 'Conference Talks',
+        items: processTalks(TALKS),
+        groups: [],
+        sections: [],
+      },
+      {
+        title: 'Podcasts',
+        items: processTalks(PODCASTS, 'podcast'),
+        groups: [],
+        sections: [],
+      },
+      {
+        title: 'Live Streams',
+        items: processTalks(LIVE_STREAMS),
+        groups: [],
+        sections: [],
+      },
+    ],
+  };
 }

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -2,8 +2,6 @@ import frontmatter from 'front-matter';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { compileTalksFile } from './compileTalks.js';
-
 export const OUTPUT_FILENAME_LLMS_TXT = 'llms.txt';
 export const OUTPUT_DIRECTORY_NAME = 'public';
 export const OUTPUT_FILENAME_EXPO_DOCS = 'llms-full.txt';
@@ -14,8 +12,6 @@ export const DESCRIPTION =
   'Expo is an open-source React Native framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app such as live updates, instantly sharing your app, and web support. The company behind Expo also offers Expo Application Services (EAS), which are deeply integrated cloud services for Expo and React Native apps.';
 export const DESCRIPTION_EAS =
   'Expo Application Services (EAS) are deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.';
-const compiledFilePath = compileTalksFile();
-const { TALKS, PODCASTS, LIVE_STREAMS } = await import(compiledFilePath);
 
 export function processPageData(pageHref, pageName) {
   if (!pageHref || pageHref.startsWith('http')) {
@@ -274,7 +270,8 @@ function processTalks(talks, type = 'video') {
   });
 }
 
-export function exportTalksData() {
+export async function exportTalksData() {
+  const { TALKS, PODCASTS, LIVE_STREAMS } = await import('./talks.js');
   return {
     title: 'Additional Resources',
     description: 'Collection of talks, podcasts, and live streams from the Expo team',


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the podcasts and YouTube video links from additional resources page aren't included in `llms.txt` file

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the `llms-txt.js` script and add helper methods to convert the `talks.ts` file and include links in the generated output.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn run generate-llms`
- In `public/llms-txt` file, the links from `talks.ts` file are now included:

![CleanShot 2025-02-03 at 01 51 46@2x](https://github.com/user-attachments/assets/ffa8f2a5-8644-453e-8383-d12942bf5bd2)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
